### PR TITLE
feat: add NativeSelect component

### DIFF
--- a/.changeset/native-select.md
+++ b/.changeset/native-select.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add NativeSelect component - a native HTML select element styled to match the Kumo design system. Use when you need native OS behavior (especially on mobile) or browser autofill support.

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -45,6 +45,7 @@ const componentItems: NavItem[] = [
   { label: "Loader", href: "/components/loader" },
   { label: "MenuBar", href: "/components/menubar" },
   { label: "Meter", href: "/components/meter" },
+  { label: "Native Select", href: "/components/native-select" },
   { label: "Pagination", href: "/components/pagination" },
   { label: "Popover", href: "/components/popover" },
   { label: "Radio", href: "/components/radio" },

--- a/packages/kumo-docs-astro/src/components/demos/NativeSelectDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/NativeSelectDemo.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { NativeSelect, Input } from "@cloudflare/kumo";
+
+export function NativeSelectBasicDemo() {
+  const [value, setValue] = useState("apple");
+
+  return (
+    <NativeSelect
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+        setValue(e.target.value)
+      }
+      aria-label="Select a fruit"
+      className="w-[200px]"
+    >
+      <option value="apple">Apple</option>
+      <option value="banana">Banana</option>
+      <option value="cherry">Cherry</option>
+      <option value="date">Date</option>
+    </NativeSelect>
+  );
+}
+
+export function NativeSelectWithLabelDemo() {
+  const [value, setValue] = useState("");
+
+  return (
+    <NativeSelect
+      label="Country"
+      description="Where you're located"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+        setValue(e.target.value)
+      }
+      className="w-[280px]"
+    >
+      <option value="">Select a country</option>
+      <option value="us">United States</option>
+      <option value="ca">Canada</option>
+      <option value="uk">United Kingdom</option>
+      <option value="au">Australia</option>
+    </NativeSelect>
+  );
+}
+
+export function NativeSelectSizesDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <NativeSelect size="xs" aria-label="Extra small" className="w-[160px]">
+        <option>Extra Small</option>
+        <option>Option 2</option>
+      </NativeSelect>
+      <NativeSelect size="sm" aria-label="Small" className="w-[180px]">
+        <option>Small</option>
+        <option>Option 2</option>
+      </NativeSelect>
+      <NativeSelect size="base" aria-label="Base" className="w-[200px]">
+        <option>Base (default)</option>
+        <option>Option 2</option>
+      </NativeSelect>
+      <NativeSelect size="lg" aria-label="Large" className="w-[220px]">
+        <option>Large</option>
+        <option>Option 2</option>
+      </NativeSelect>
+    </div>
+  );
+}
+
+export function NativeSelectDisabledDemo() {
+  return (
+    <NativeSelect label="Disabled select" disabled className="w-[200px]">
+      <option>Cannot change</option>
+      <option>Option 2</option>
+    </NativeSelect>
+  );
+}
+
+export function NativeSelectErrorDemo() {
+  return (
+    <NativeSelect
+      label="Category"
+      error="Please select a category"
+      className="w-[200px]"
+    >
+      <option value="">Select category</option>
+      <option value="bug">Bug</option>
+      <option value="feature">Feature</option>
+    </NativeSelect>
+  );
+}
+
+export function NativeSelectOptionalDemo() {
+  return (
+    <NativeSelect
+      label="Preferred contact method"
+      required={false}
+      className="w-[280px]"
+    >
+      <option value="">No preference</option>
+      <option value="email">Email</option>
+      <option value="phone">Phone</option>
+      <option value="mail">Mail</option>
+    </NativeSelect>
+  );
+}
+
+export function NativeSelectComparisonDemo() {
+  const [nativeValue, setNativeValue] = useState("apple");
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="mb-2 text-sm text-kumo-subtle">
+          NativeSelect (uses native OS picker on mobile)
+        </p>
+        <NativeSelect
+          value={nativeValue}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            setNativeValue(e.target.value)
+          }
+          aria-label="Native select"
+          className="w-[200px]"
+        >
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="cherry">Cherry</option>
+        </NativeSelect>
+      </div>
+    </div>
+  );
+}
+
+export function NativeSelectAutofillDemo() {
+  return (
+    <form className="flex max-w-sm flex-col gap-4">
+      <Input
+        label="Street address"
+        name="street-address"
+        autoComplete="street-address"
+        placeholder="123 Main St"
+      />
+      <NativeSelect
+        label="Country"
+        name="country"
+        autoComplete="country"
+        className="w-full"
+      >
+        <option value="">Select a country</option>
+        <option value="US">United States</option>
+        <option value="CA">Canada</option>
+        <option value="GB">United Kingdom</option>
+        <option value="AU">Australia</option>
+        <option value="DE">Germany</option>
+        <option value="FR">France</option>
+        <option value="JP">Japan</option>
+      </NativeSelect>
+
+      <div className="rounded-lg bg-kumo-elevated p-3">
+        <p className="mb-2 text-xs font-medium text-kumo-default">
+          How to test autofill:
+        </p>
+        <ol className="list-inside list-decimal space-y-1 text-xs text-kumo-subtle">
+          <li>Click on the Street address input</li>
+          <li>Chrome will offer to autofill from saved addresses</li>
+          <li>Accept autofill - the Country select will be filled too</li>
+        </ol>
+      </div>
+    </form>
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/components/native-select.astro
+++ b/packages/kumo-docs-astro/src/pages/components/native-select.astro
@@ -1,0 +1,264 @@
+---
+import DocLayout from "../../layouts/DocLayout.astro";
+import ComponentSection from "../../components/docs/ComponentSection.astro";
+import ComponentExample from "../../components/docs/ComponentExample.astro";
+import PropsTable from "../../components/docs/PropsTable.astro";
+import {
+  NativeSelectBasicDemo,
+  NativeSelectWithLabelDemo,
+  NativeSelectSizesDemo,
+  NativeSelectDisabledDemo,
+  NativeSelectErrorDemo,
+  NativeSelectOptionalDemo,
+  NativeSelectComparisonDemo,
+  NativeSelectAutofillDemo,
+} from "../../components/demos/NativeSelectDemo";
+---
+
+<DocLayout
+  title="NativeSelect"
+  description="A native HTML select element styled to match the Kumo design system. Use when you need native OS behavior, especially on mobile devices."
+  sourceFile="components/native-select"
+>
+  <!-- Basic Usage -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">Basic Usage</span>
+      <span class="text-kumo-strong">
+        A native select element that looks identical to the Select component trigger.
+        Uses the native OS picker on mobile devices for better UX.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`import { NativeSelect } from "@cloudflare/kumo";
+
+function App() {
+  const [value, setValue] = useState("apple");
+
+  return (
+    <NativeSelect
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      aria-label="Select a fruit"
+    >
+      <option value="apple">Apple</option>
+      <option value="banana">Banana</option>
+      <option value="cherry">Cherry</option>
+    </NativeSelect>
+  );
+}`}
+    >
+      <NativeSelectBasicDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- With Label -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">With Label and Description</span>
+      <span class="text-kumo-strong">
+        When you provide a <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code> prop,
+        NativeSelect automatically wraps itself in a Field component with proper accessibility associations.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`import { NativeSelect } from "@cloudflare/kumo";
+
+function App() {
+  const [value, setValue] = useState("");
+
+  return (
+    <NativeSelect
+      label="Country"
+      description="Where you're located"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <option value="">Select a country</option>
+      <option value="us">United States</option>
+      <option value="ca">Canada</option>
+      <option value="uk">United Kingdom</option>
+    </NativeSelect>
+  );
+}`}
+    >
+      <NativeSelectWithLabelDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- Sizes -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">Sizes</span>
+      <span class="text-kumo-strong">
+        NativeSelect supports the same size variants as other form controls:
+        <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">xs</code>,
+        <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">sm</code>,
+        <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">base</code> (default), and
+        <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">lg</code>.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`<NativeSelect size="xs">...</NativeSelect>
+<NativeSelect size="sm">...</NativeSelect>
+<NativeSelect size="base">...</NativeSelect>
+<NativeSelect size="lg">...</NativeSelect>`}
+    >
+      <NativeSelectSizesDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- Disabled -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">Disabled State</span>
+      <span class="text-kumo-strong">
+        Use the native <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> attribute
+        to prevent user interaction.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`<NativeSelect label="Disabled select" disabled>
+  <option>Cannot change</option>
+</NativeSelect>`}
+    >
+      <NativeSelectDisabledDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- Error State -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">Error State</span>
+      <span class="text-kumo-strong">
+        Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">error</code> prop
+        to display validation errors.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`<NativeSelect
+  label="Category"
+  error="Please select a category"
+>
+  <option value="">Select category</option>
+  <option value="bug">Bug</option>
+  <option value="feature">Feature</option>
+</NativeSelect>`}
+    >
+      <NativeSelectErrorDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- Optional Field -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">Optional Field</span>
+      <span class="text-kumo-strong">
+        Set <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">required={`{false}`}</code>
+        to show an "(optional)" indicator next to the label.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`<NativeSelect
+  label="Preferred contact method"
+  required={false}
+>
+  <option value="">No preference</option>
+  <option value="email">Email</option>
+  <option value="phone">Phone</option>
+</NativeSelect>`}
+    >
+      <NativeSelectOptionalDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- Browser Autofill -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">Browser Autofill</span>
+      <span class="text-kumo-strong">
+        NativeSelect supports browser autofill through the standard HTML
+        <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">autoComplete</code> attribute.
+        This is critical for payment forms, address forms, and any other forms where users
+        expect the browser to fill in saved values.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`// Autofill triggers from text inputs and fills the whole form
+<form>
+  <Input
+    label="Street address"
+    name="street-address"
+    autoComplete="street-address"
+  />
+  <NativeSelect
+    label="Country"
+    name="country"
+    autoComplete="country"
+  >
+    <option value="">Select a country</option>
+    <option value="US">United States</option>
+    <option value="CA">Canada</option>
+  </NativeSelect>
+</form>`}
+    >
+      <NativeSelectAutofillDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- When to use -->
+  <ComponentSection>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-xl font-semibold">When to Use NativeSelect vs Select</span>
+    </p>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="rounded-lg border border-kumo-line p-4">
+        <h4 class="mb-2 font-semibold text-kumo-default">Use NativeSelect when:</h4>
+        <ul class="list-inside list-disc space-y-1 text-kumo-strong">
+          <li>Mobile UX is a priority (native OS picker)</li>
+          <li>You don't need custom option rendering</li>
+          <li>You want simpler, lighter-weight markup</li>
+          <li>Form submission with native form data</li>
+        </ul>
+      </div>
+      <div class="rounded-lg border border-kumo-line p-4">
+        <h4 class="mb-2 font-semibold text-kumo-default">Use Select when:</h4>
+        <ul class="list-inside list-disc space-y-1 text-kumo-strong">
+          <li>You need custom option rendering (icons, avatars, etc.)</li>
+          <li>You need complex object values</li>
+          <li>You need multi-select with chips</li>
+          <li>You need loading states</li>
+          <li>Consistent desktop/mobile appearance is required</li>
+        </ul>
+      </div>
+    </div>
+
+    <ComponentExample
+      code={`// Both look identical when closed
+<NativeSelect aria-label="Native">
+  <option>Apple</option>
+</NativeSelect>
+
+<Select aria-label="Custom">
+  <Select.Option value="apple">Apple</Select.Option>
+</Select>`}
+    >
+      <NativeSelectComparisonDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- API Reference -->
+  <ComponentSection>
+    <h2 class="mb-4 text-2xl font-bold">API Reference</h2>
+    <h3 class="mb-3 text-lg font-semibold">NativeSelect</h3>
+    <PropsTable component="NativeSelect" />
+  </ComponentSection>
+</DocLayout>

--- a/packages/kumo/ai/component-registry.json
+++ b/packages/kumo/ai/component-registry.json
@@ -849,8 +849,8 @@
         }
       },
       "examples": [
-        "<Collapsible label=\"What is Kumo?\" open={isOpen} onOpenChange={setIsOpen}>\n      Kumo is Cloudflare's new design system.\n    </Collapsible>",
-        "<Collapsible label=\"What is Kumo?\" open={isOpen} onOpenChange={setIsOpen}>\n      Kumo is Cloudflare's new design system.\n    </Collapsible>",
+        "<div className=\"w-full\">\n      <Collapsible label=\"What is Kumo?\" open={isOpen} onOpenChange={setIsOpen}>\n        Kumo is Cloudflare's new design system.\n      </Collapsible>\n    </div>",
+        "<div className=\"w-full\">\n      <Collapsible label=\"What is Kumo?\" open={isOpen} onOpenChange={setIsOpen}>\n        Kumo is Cloudflare's new design system.\n      </Collapsible>\n    </div>",
         "<div className=\"w-full space-y-2\">\n      <Collapsible label=\"What is Kumo?\" open={open1} onOpenChange={setOpen1}>\n        Kumo is Cloudflare's new design system.\n      </Collapsible>\n      <Collapsible\n        label=\"How do I use it?\"\n        open={open2}\n        onOpenChange={setOpen2}\n      >\n        Install the components and import them into your project.\n      </Collapsible>\n      <Collapsible\n        label=\"Is it open source?\"\n        open={open3}\n        onOpenChange={setOpen3}\n      >\n        Check the repository for license information.\n      </Collapsible>\n    </div>"
       ],
       "colors": [
@@ -2162,11 +2162,11 @@
         }
       },
       "examples": [
-        "<div className=\"text-base grid md:grid-cols-3 gap-y-4 gap-x-6\">\n      <Link href=\"#\">Default inline link</Link>\n      <Link href=\"#\" variant=\"current\">\n        Current color link\n      </Link>\n      <Link href=\"#\" variant=\"plain\">\n        Plain inline link\n      </Link>\n    </div>",
-        "<p className=\"text-surface text-base max-w-md mx-auto leading-relaxed\">\n      This is a paragraph with an <Link href=\"#\">inline link</Link> that flows\n      naturally with the surrounding text. Links maintain proper underline\n      offset for readability.\n    </p>",
+        "<div className=\"grid gap-x-6 gap-y-4 text-base md:grid-cols-3\">\n      <Link href=\"#\">Default inline link</Link>\n      <Link href=\"#\" variant=\"current\">\n        Current color link\n      </Link>\n      <Link href=\"#\" variant=\"plain\">\n        Plain inline link\n      </Link>\n    </div>",
+        "<p className=\"mx-auto max-w-md text-base leading-relaxed text-kumo-default\">\n      This is a paragraph with an <Link href=\"#\">inline link</Link> that flows\n      naturally with the surrounding text. Links maintain proper underline\n      offset for readability.\n    </p>",
         "<Link\n      href=\"https://cloudflare.com\"\n      target=\"_blank\"\n      rel=\"noopener noreferrer\"\n      className=\"text-base\"\n    >\n      Visit Cloudflare <Link.ExternalIcon />\n    </Link>",
-        "<p className=\"text-error text-base\">\n      This error message contains a{\" \"}\n      <Link href=\"#\" variant=\"current\">\n        link\n      </Link>{\" \"}\n      that inherits the red color from its parent.\n    </p>",
-        "<div className=\"flex flex-col md:flex-row gap-x-6 gap-y-4 text-base\">\n      <Link render={<CustomRouterLink href=\"/dashboard\" />} variant=\"inline\">\n        Dashboard (via render)\n      </Link>\n      <Link\n        render={\n          <CustomRouterLink\n            href=\"https://developers.cloudflare.com\"\n            target=\"_blank\"\n            rel=\"noopener noreferrer\"\n          />\n        }\n        variant=\"inline\"\n      >\n        Cloudflare Docs <Link.ExternalIcon />\n      </Link>\n    </div>"
+        "<p className=\"text-base text-kumo-danger\">\n      This error message contains a{\" \"}\n      <Link href=\"#\" variant=\"current\">\n        link\n      </Link>{\" \"}\n      that inherits the red color from its parent.\n    </p>",
+        "<div className=\"flex flex-col gap-x-6 gap-y-4 text-base md:flex-row\">\n      <Link render={<CustomRouterLink href=\"/dashboard\" />} variant=\"inline\">\n        Dashboard (via render)\n      </Link>\n      <Link\n        render={\n          <CustomRouterLink\n            href=\"https://developers.cloudflare.com\"\n            target=\"_blank\"\n            rel=\"noopener noreferrer\"\n          />\n        }\n        variant=\"inline\"\n      >\n        Cloudflare Docs <Link.ExternalIcon />\n      </Link>\n    </div>"
       ],
       "colors": [],
       "subComponents": {
@@ -2313,6 +2313,163 @@
         "text-kumo-strong"
       ]
     },
+    "NativeSelect": {
+      "name": "NativeSelect",
+      "type": "component",
+      "description": "NativeSelect component",
+      "importPath": "@cloudflare/kumo",
+      "category": "Other",
+      "props": {
+        "autoComplete": {
+          "type": "string",
+          "optional": true
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true
+        },
+        "name": {
+          "type": "string",
+          "optional": true
+        },
+        "required": {
+          "type": "boolean",
+          "optional": true
+        },
+        "value": {
+          "type": "string | string[] | number",
+          "optional": true
+        },
+        "className": {
+          "type": "string",
+          "optional": true
+        },
+        "id": {
+          "type": "string",
+          "optional": true
+        },
+        "lang": {
+          "type": "string",
+          "optional": true
+        },
+        "title": {
+          "type": "string",
+          "optional": true
+        },
+        "children": {
+          "type": "ReactNode",
+          "optional": true
+        },
+        "size": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "xs",
+            "sm",
+            "base",
+            "lg"
+          ],
+          "descriptions": {
+            "xs": "Extra small select for compact UIs",
+            "sm": "Small select for secondary fields",
+            "base": "Default select size",
+            "lg": "Large select for prominent fields"
+          },
+          "classes": {
+            "xs": "h-5 text-xs rounded-sm px-1.5 pr-6",
+            "sm": "h-6.5 text-xs rounded-md px-2 pr-7",
+            "base": "h-9 text-base rounded-lg px-3 pr-8",
+            "lg": "h-10 text-base rounded-lg px-4 pr-9"
+          },
+          "default": "base"
+        },
+        "label": {
+          "type": "ReactNode",
+          "optional": true,
+          "description": "Label content for the select (enables Field wrapper) - can be a string or any React node"
+        },
+        "labelTooltip": {
+          "type": "ReactNode",
+          "optional": true,
+          "description": "Tooltip content to display next to the label via an info icon"
+        },
+        "description": {
+          "type": "ReactNode",
+          "optional": true,
+          "description": "Helper text displayed below the select"
+        },
+        "error": {
+          "type": "string | object",
+          "optional": true,
+          "description": "Error message or validation error object"
+        }
+      },
+      "examples": [
+        "<NativeSelect\n      value={value}\n      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>\n        setValue(e.target.value)\n      }\n      aria-label=\"Select a fruit\"\n      className=\"w-[200px]\"\n    >\n      <option value=\"apple\">Apple</option>\n      <option value=\"banana\">Banana</option>\n      <option value=\"cherry\">Cherry</option>\n      <option value=\"date\">Date</option>\n    </NativeSelect>",
+        "<NativeSelect\n      label=\"Country\"\n      description=\"Where you're located\"\n      value={value}\n      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>\n        setValue(e.target.value)\n      }\n      className=\"w-[280px]\"\n    >\n      <option value=\"\">Select a country</option>\n      <option value=\"us\">United States</option>\n      <option value=\"ca\">Canada</option>\n      <option value=\"uk\">United Kingdom</option>\n      <option value=\"au\">Australia</option>\n    </NativeSelect>",
+        "<div className=\"flex flex-col gap-4\">\n      <NativeSelect size=\"xs\" aria-label=\"Extra small\" className=\"w-[160px]\">\n        <option>Extra Small</option>\n        <option>Option 2</option>\n      </NativeSelect>\n      <NativeSelect size=\"sm\" aria-label=\"Small\" className=\"w-[180px]\">\n        <option>Small</option>\n        <option>Option 2</option>\n      </NativeSelect>\n      <NativeSelect size=\"base\" aria-label=\"Base\" className=\"w-[200px]\">\n        <option>Base (default)</option>\n        <option>Option 2</option>\n      </NativeSelect>\n      <NativeSelect size=\"lg\" aria-label=\"Large\" className=\"w-[220px]\">\n        <option>Large</option>\n        <option>Option 2</option>\n      </NativeSelect>\n    </div>",
+        "<NativeSelect label=\"Disabled select\" disabled className=\"w-[200px]\">\n      <option>Cannot change</option>\n      <option>Option 2</option>\n    </NativeSelect>",
+        "<NativeSelect\n      label=\"Category\"\n      error=\"Please select a category\"\n      className=\"w-[200px]\"\n    >\n      <option value=\"\">Select category</option>\n      <option value=\"bug\">Bug</option>\n      <option value=\"feature\">Feature</option>\n    </NativeSelect>",
+        "<NativeSelect\n      label=\"Preferred contact method\"\n      required={false}\n      className=\"w-[280px]\"\n    >\n      <option value=\"\">No preference</option>\n      <option value=\"email\">Email</option>\n      <option value=\"phone\">Phone</option>\n      <option value=\"mail\">Mail</option>\n    </NativeSelect>",
+        "<div className=\"flex flex-col gap-6\">\n      <div>\n        <p className=\"mb-2 text-sm text-kumo-subtle\">\n          NativeSelect (uses native OS picker on mobile)\n        </p>\n        <NativeSelect\n          value={nativeValue}\n          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>\n            setNativeValue(e.target.value)\n          }\n          aria-label=\"Native select\"\n          className=\"w-[200px]\"\n        >\n          <option value=\"apple\">Apple</option>\n          <option value=\"banana\">Banana</option>\n          <option value=\"cherry\">Cherry</option>\n        </NativeSelect>\n      </div>\n    </div>"
+      ],
+      "colors": [
+        "text-kumo-danger",
+        "text-kumo-default",
+        "text-kumo-subtle"
+      ],
+      "styling": {
+        "dimensions": {
+          "xs": {
+            "height": 20,
+            "paddingX": 6,
+            "paddingRight": 24,
+            "fontSize": 12,
+            "borderRadius": 2
+          },
+          "sm": {
+            "height": 26,
+            "paddingX": 8,
+            "paddingRight": 28,
+            "fontSize": 12,
+            "borderRadius": 6
+          },
+          "base": {
+            "height": 36,
+            "paddingX": 12,
+            "paddingRight": 32,
+            "fontSize": 16,
+            "borderRadius": 8
+          },
+          "lg": {
+            "height": 40,
+            "paddingX": 16,
+            "paddingRight": 36,
+            "fontSize": 16,
+            "borderRadius": 8
+          }
+        },
+        "baseTokens": {
+          "background": "color-secondary",
+          "text": "text-color-surface",
+          "ring": "color-border"
+        },
+        "stateTokens": {
+          "focus": {
+            "ring": "color-active"
+          },
+          "disabled": {
+            "opacity": 0.5
+          }
+        },
+        "icons": {
+          "caret": {
+            "name": "ph-caret-up-down",
+            "size": 20
+          }
+        }
+      }
+    },
     "Pagination": {
       "name": "Pagination",
       "type": "component",
@@ -2402,7 +2559,8 @@
         "<Popover>\n      <Popover.Trigger asChild>\n        <Button>Open Popover</Button>\n      </Popover.Trigger>\n      <Popover.Content>\n        <Popover.Title>Popover Title</Popover.Title>\n        <Popover.Description>\n          This is a basic popover with a title and description.\n        </Popover.Description>\n      </Popover.Content>\n    </Popover>",
         "<Popover>\n      <Popover.Trigger asChild>\n        <Button>Open Settings</Button>\n      </Popover.Trigger>\n      <Popover.Content>\n        <Popover.Title>Settings</Popover.Title>\n        <Popover.Description>\n          Configure your preferences below.\n        </Popover.Description>\n        <div className=\"mt-3\">\n          <Popover.Close asChild>\n            <Button variant=\"secondary\" size=\"sm\">\n              Close\n            </Button>\n          </Popover.Close>\n        </div>\n      </Popover.Content>\n    </Popover>",
         "<div className=\"flex flex-wrap gap-4\">\n      <Popover>\n        <Popover.Trigger asChild>\n          <Button variant=\"secondary\">Bottom</Button>\n        </Popover.Trigger>\n        <Popover.Content side=\"bottom\">\n          <Popover.Title>Bottom</Popover.Title>\n          <Popover.Description>\n            Popover on bottom (default).\n          </Popover.Description>\n        </Popover.Content>\n      </Popover>\n\n      <Popover>\n        <Popover.Trigger asChild>\n          <Button variant=\"secondary\">Top</Button>\n        </Popover.Trigger>\n        <Popover.Content side=\"top\">\n          <Popover.Title>Top</Popover.Title>\n          <Popover.Description>Popover on top.</Popover.Description>\n        </Popover.Content>\n      </Popover>\n\n      <Popover>\n        <Popover.Trigger asChild>\n          <Button variant=\"secondary\">Left</Button>\n        </Popover.Trigger>\n        <Popover.Content side=\"left\">\n          <Popover.Title>Left</Popover.Title>\n          <Popover.Description>Popover on left.</Popover.Description>\n        </Popover.Content>\n      </Popover>\n\n      <Popover>\n        <Popover.Trigger asChild>\n          <Button variant=\"secondary\">Right</Button>\n        </Popover.Trigger>\n        <Popover.Content side=\"right\">\n          <Popover.Title>Right</Popover.Title>\n          <Popover.Description>Popover on right.</Popover.Description>\n        </Popover.Content>\n      </Popover>\n    </div>",
-        "<Popover>\n      <Popover.Trigger asChild>\n        <Button>User Profile</Button>\n      </Popover.Trigger>\n      <Popover.Content className=\"w-64\">\n        <div className=\"flex items-center gap-3\">\n          <div className=\"size-10 rounded-full bg-kumo-recessed\" />\n          <div>\n            <Popover.Title>Jane Doe</Popover.Title>\n            <p className=\"text-sm text-kumo-subtle\">jane@example.com</p>\n          </div>\n        </div>\n        <div className=\"mt-3 flex gap-2 border-t border-kumo-line pt-3\">\n          <Button variant=\"secondary\" size=\"sm\" className=\"flex-1\">\n            Profile\n          </Button>\n          <Popover.Close asChild>\n            <Button variant=\"ghost\" size=\"sm\" className=\"flex-1\">\n              Sign Out\n            </Button>\n          </Popover.Close>\n        </div>\n      </Popover.Content>\n    </Popover>"
+        "<Popover>\n      <Popover.Trigger asChild>\n        <Button>User Profile</Button>\n      </Popover.Trigger>\n      <Popover.Content className=\"w-64\">\n        <div className=\"flex items-center gap-3\">\n          <div className=\"size-10 rounded-full bg-kumo-recessed\" />\n          <div>\n            <Popover.Title>Jane Doe</Popover.Title>\n            <p className=\"text-sm text-kumo-subtle\">jane@example.com</p>\n          </div>\n        </div>\n        <div className=\"mt-3 flex gap-2 border-t border-kumo-line pt-3\">\n          <Button variant=\"secondary\" size=\"sm\" className=\"flex-1\">\n            Profile\n          </Button>\n          <Popover.Close asChild>\n            <Button variant=\"ghost\" size=\"sm\" className=\"flex-1\">\n              Sign Out\n            </Button>\n          </Popover.Close>\n        </div>\n      </Popover.Content>\n    </Popover>",
+        "<Popover>\n      <Popover.Trigger openOnHover delay={200} asChild>\n        <Button variant=\"secondary\">Hover Me</Button>\n      </Popover.Trigger>\n      <Popover.Content>\n        <Popover.Title>Hover Triggered</Popover.Title>\n        <Popover.Description>\n          This popover opens on hover with a 200ms delay. It can still contain\n          interactive content like buttons and links.\n        </Popover.Description>\n        <div className=\"mt-3\">\n          <Popover.Close asChild>\n            <Button variant=\"secondary\" size=\"sm\">\n              Got it\n            </Button>\n          </Popover.Close>\n        </div>\n      </Popover.Content>\n    </Popover>"
       ],
       "colors": [
         "bg-kumo-base",
@@ -3663,6 +3821,7 @@
       "Other": [
         "Label",
         "Link",
+        "NativeSelect",
         "SensitiveInput",
         "Table"
       ]
@@ -3691,6 +3850,7 @@
       "Loader",
       "MenuBar",
       "Meter",
+      "NativeSelect",
       "PageHeader",
       "Pagination",
       "Popover",
@@ -3731,6 +3891,7 @@
         "Loader",
         "MenuBar",
         "Meter",
+        "NativeSelect",
         "Pagination",
         "Popover",
         "Radio",

--- a/packages/kumo/ai/component-registry.md
+++ b/packages/kumo/ai/component-registry.md
@@ -648,9 +648,11 @@ Collapsible component for showing/hiding content.  Features: - Animated chevron 
 **Examples:**
 
 ```tsx
-<Collapsible label="What is Kumo?" open={isOpen} onOpenChange={setIsOpen}>
-      Kumo is Cloudflare's new design system.
-    </Collapsible>
+<div className="w-full">
+      <Collapsible label="What is Kumo?" open={isOpen} onOpenChange={setIsOpen}>
+        Kumo is Cloudflare's new design system.
+      </Collapsible>
+    </div>
 ```
 
 ```tsx
@@ -2410,7 +2412,7 @@ ExternalIcon sub-component
 **Examples:**
 
 ```tsx
-<div className="text-base grid md:grid-cols-3 gap-y-4 gap-x-6">
+<div className="grid gap-x-6 gap-y-4 text-base md:grid-cols-3">
       <Link href="#">Default inline link</Link>
       <Link href="#" variant="current">
         Current color link
@@ -2422,7 +2424,7 @@ ExternalIcon sub-component
 ```
 
 ```tsx
-<p className="text-surface text-base max-w-md mx-auto leading-relaxed">
+<p className="mx-auto max-w-md text-base leading-relaxed text-kumo-default">
       This is a paragraph with an <Link href="#">inline link</Link> that flows
       naturally with the surrounding text. Links maintain proper underline
       offset for readability.
@@ -2441,7 +2443,7 @@ ExternalIcon sub-component
 ```
 
 ```tsx
-<p className="text-error text-base">
+<p className="text-base text-kumo-danger">
       This error message contains a{" "}
       <Link href="#" variant="current">
         link
@@ -2451,7 +2453,7 @@ ExternalIcon sub-component
 ```
 
 ```tsx
-<div className="flex flex-col md:flex-row gap-x-6 gap-y-4 text-base">
+<div className="flex flex-col gap-x-6 gap-y-4 text-base md:flex-row">
       <Link render={<CustomRouterLink href="/dashboard" />} variant="inline">
         Dashboard (via render)
       </Link>
@@ -2606,6 +2608,164 @@ Meter component
       value={80}
       indicatorClassName="from-green-500 via-green-500 to-green-500"
     />
+```
+
+
+---
+
+### NativeSelect
+
+NativeSelect component
+
+**Type:** component
+
+**Import:** `import { NativeSelect } from "@cloudflare/kumo";`
+
+**Category:** Other
+
+**Props:**
+
+- `autoComplete`: string
+- `disabled`: boolean
+- `name`: string
+- `required`: boolean
+- `value`: string | string[] | number
+- `className`: string
+- `id`: string
+- `lang`: string
+- `title`: string
+- `children`: ReactNode
+- `size`: enum [default: base]
+  - `"xs"`: Extra small select for compact UIs
+  - `"sm"`: Small select for secondary fields
+  - `"base"`: Default select size
+  - `"lg"`: Large select for prominent fields
+- `label`: ReactNode
+  Label content for the select (enables Field wrapper) - can be a string or any React node
+- `labelTooltip`: ReactNode
+  Tooltip content to display next to the label via an info icon
+- `description`: ReactNode
+  Helper text displayed below the select
+- `error`: string | object
+  Error message or validation error object
+
+**Colors (kumo tokens used):**
+
+`text-kumo-danger`, `text-kumo-default`, `text-kumo-subtle`
+
+**Styling:**
+
+- **Dimensions:** `[object Object]`
+
+**Examples:**
+
+```tsx
+<NativeSelect
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+        setValue(e.target.value)
+      }
+      aria-label="Select a fruit"
+      className="w-[200px]"
+    >
+      <option value="apple">Apple</option>
+      <option value="banana">Banana</option>
+      <option value="cherry">Cherry</option>
+      <option value="date">Date</option>
+    </NativeSelect>
+```
+
+```tsx
+<NativeSelect
+      label="Country"
+      description="Where you're located"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+        setValue(e.target.value)
+      }
+      className="w-[280px]"
+    >
+      <option value="">Select a country</option>
+      <option value="us">United States</option>
+      <option value="ca">Canada</option>
+      <option value="uk">United Kingdom</option>
+      <option value="au">Australia</option>
+    </NativeSelect>
+```
+
+```tsx
+<div className="flex flex-col gap-4">
+      <NativeSelect size="xs" aria-label="Extra small" className="w-[160px]">
+        <option>Extra Small</option>
+        <option>Option 2</option>
+      </NativeSelect>
+      <NativeSelect size="sm" aria-label="Small" className="w-[180px]">
+        <option>Small</option>
+        <option>Option 2</option>
+      </NativeSelect>
+      <NativeSelect size="base" aria-label="Base" className="w-[200px]">
+        <option>Base (default)</option>
+        <option>Option 2</option>
+      </NativeSelect>
+      <NativeSelect size="lg" aria-label="Large" className="w-[220px]">
+        <option>Large</option>
+        <option>Option 2</option>
+      </NativeSelect>
+    </div>
+```
+
+```tsx
+<NativeSelect label="Disabled select" disabled className="w-[200px]">
+      <option>Cannot change</option>
+      <option>Option 2</option>
+    </NativeSelect>
+```
+
+```tsx
+<NativeSelect
+      label="Category"
+      error="Please select a category"
+      className="w-[200px]"
+    >
+      <option value="">Select category</option>
+      <option value="bug">Bug</option>
+      <option value="feature">Feature</option>
+    </NativeSelect>
+```
+
+```tsx
+<NativeSelect
+      label="Preferred contact method"
+      required={false}
+      className="w-[280px]"
+    >
+      <option value="">No preference</option>
+      <option value="email">Email</option>
+      <option value="phone">Phone</option>
+      <option value="mail">Mail</option>
+    </NativeSelect>
+```
+
+```tsx
+<div className="flex flex-col gap-6">
+      <div>
+        <p className="mb-2 text-sm text-kumo-subtle">
+          NativeSelect (uses native OS picker on mobile)
+        </p>
+        <NativeSelect
+          value={nativeValue}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            setNativeValue(e.target.value)
+          }
+          aria-label="Native select"
+          className="w-[200px]"
+        >
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="cherry">Cherry</option>
+        </NativeSelect>
+      </div>
+    </div>
 ```
 
 
@@ -2822,6 +2982,28 @@ Close sub-component
           <Popover.Close asChild>
             <Button variant="ghost" size="sm" className="flex-1">
               Sign Out
+            </Button>
+          </Popover.Close>
+        </div>
+      </Popover.Content>
+    </Popover>
+```
+
+```tsx
+<Popover>
+      <Popover.Trigger openOnHover delay={200} asChild>
+        <Button variant="secondary">Hover Me</Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Popover.Title>Hover Triggered</Popover.Title>
+        <Popover.Description>
+          This popover opens on hover with a 200ms delay. It can still contain
+          interactive content like buttons and links.
+        </Popover.Description>
+        <div className="mt-3">
+          <Popover.Close asChild>
+            <Button variant="secondary" size="sm">
+              Got it
             </Button>
           </Popover.Close>
         </div>
@@ -3995,4 +4177,4 @@ Multi-line textarea input with Input variants and InputArea-specific dimensions
 - **Navigation:** CommandPalette, MenuBar, Pagination, Tabs
 - **Overlay:** Dialog, DropdownMenu, Popover, Tooltip
 - **Layout:** Grid, Surface, PageHeader, ResourceListPage
-- **Other:** Label, Link, SensitiveInput, Table
+- **Other:** Label, Link, NativeSelect, SensitiveInput, Table

--- a/packages/kumo/ai/schemas.ts
+++ b/packages/kumo/ai/schemas.ts
@@ -314,6 +314,24 @@ export const MeterPropsSchema = z.object({
   min: z.number().optional(), // Minimum value of the meter (default: 0)
 });
 
+export const NativeSelectPropsSchema = z.object({
+  autoComplete: z.string().optional(),
+  disabled: z.boolean().optional(),
+  name: z.string().optional(),
+  required: z.boolean().optional(),
+  value: z.unknown().optional(),
+  className: z.string().optional(),
+  id: z.string().optional(),
+  lang: z.string().optional(),
+  title: z.string().optional(),
+  children: z.union([z.string(), z.number(), z.boolean(), z.null(), DynamicValueSchema]).optional(),
+  size: z.enum(["xs", "sm", "base", "lg"]).optional(),
+  label: z.union([z.string(), z.number(), z.boolean(), z.null(), DynamicValueSchema]).optional(), // Label content for the select (enables Field wrapper) - can be a string or any React node
+  labelTooltip: z.union([z.string(), z.number(), z.boolean(), z.null(), DynamicValueSchema]).optional(), // Tooltip content to display next to the label via an info icon
+  description: z.union([z.string(), z.number(), z.boolean(), z.null(), DynamicValueSchema]).optional(), // Helper text displayed below the select
+  error: z.unknown().optional(), // Error message or validation error object
+});
+
 export const PaginationPropsSchema = z.object({
   controls: z.enum(["full", "simple"]).optional(),
   setPage: z.unknown(), // Callback when page changes
@@ -454,7 +472,7 @@ export const TooltipPropsSchema = z.object({
 /**
  * All valid component type names
  */
-export type KumoComponentType = "Badge" | "Banner" | "Breadcrumbs" | "Button" | "Checkbox" | "ClipboardText" | "Code" | "Collapsible" | "Combobox" | "CommandPalette" | "DateRangePicker" | "Dialog" | "DropdownMenu" | "Empty" | "Field" | "Grid" | "Input" | "InputArea" | "Label" | "LayerCard" | "Link" | "Loader" | "MenuBar" | "Meter" | "Pagination" | "Popover" | "Radio" | "Select" | "SensitiveInput" | "Surface" | "Switch" | "Table" | "Tabs" | "Text" | "Toasty" | "Tooltip";
+export type KumoComponentType = "Badge" | "Banner" | "Breadcrumbs" | "Button" | "Checkbox" | "ClipboardText" | "Code" | "Collapsible" | "Combobox" | "CommandPalette" | "DateRangePicker" | "Dialog" | "DropdownMenu" | "Empty" | "Field" | "Grid" | "Input" | "InputArea" | "Label" | "LayerCard" | "Link" | "Loader" | "MenuBar" | "Meter" | "NativeSelect" | "Pagination" | "Popover" | "Radio" | "Select" | "SensitiveInput" | "Surface" | "Switch" | "Table" | "Tabs" | "Text" | "Toasty" | "Tooltip";
 
 export const KumoComponentTypeSchema = z.enum([
   "Badge",
@@ -481,6 +499,7 @@ export const KumoComponentTypeSchema = z.enum([
   "Loader",
   "MenuBar",
   "Meter",
+  "NativeSelect",
   "Pagination",
   "Popover",
   "Radio",
@@ -523,6 +542,7 @@ export const ComponentPropsSchemas = {
   Loader: LoaderPropsSchema,
   MenuBar: MenuBarPropsSchema,
   Meter: MeterPropsSchema,
+  NativeSelect: NativeSelectPropsSchema,
   Pagination: PaginationPropsSchema,
   Popover: PopoverPropsSchema,
   Radio: RadioPropsSchema,
@@ -591,4 +611,4 @@ export function validateUITree(tree: unknown): z.SafeParseReturnType<unknown, UI
 /**
  * List of all component names (for catalog generation)
  */
-export const KUMO_COMPONENT_NAMES = ["Badge", "Banner", "Breadcrumbs", "Button", "Checkbox", "ClipboardText", "Code", "Collapsible", "Combobox", "CommandPalette", "DateRangePicker", "Dialog", "DropdownMenu", "Empty", "Field", "Grid", "Input", "InputArea", "Label", "LayerCard", "Link", "Loader", "MenuBar", "Meter", "Pagination", "Popover", "Radio", "Select", "SensitiveInput", "Surface", "Switch", "Table", "Tabs", "Text", "Toasty", "Tooltip"] as const;
+export const KUMO_COMPONENT_NAMES = ["Badge", "Banner", "Breadcrumbs", "Button", "Checkbox", "ClipboardText", "Code", "Collapsible", "Combobox", "CommandPalette", "DateRangePicker", "Dialog", "DropdownMenu", "Empty", "Field", "Grid", "Input", "InputArea", "Label", "LayerCard", "Link", "Loader", "MenuBar", "Meter", "NativeSelect", "Pagination", "Popover", "Radio", "Select", "SensitiveInput", "Surface", "Switch", "Table", "Tabs", "Text", "Toasty", "Tooltip"] as const;

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -96,6 +96,10 @@
       "types": "./dist/src/components/meter/index.d.ts",
       "import": "./dist/components/meter.js"
     },
+    "./components/native-select": {
+      "types": "./dist/src/components/native-select/index.d.ts",
+      "import": "./dist/components/native-select.js"
+    },
     "./components/pagination": {
       "types": "./dist/src/components/pagination/index.d.ts",
       "import": "./dist/components/pagination.js"

--- a/packages/kumo/src/components/native-select/index.ts
+++ b/packages/kumo/src/components/native-select/index.ts
@@ -1,0 +1,10 @@
+export {
+  NativeSelect,
+  nativeSelectVariants,
+  type NativeSelectProps,
+  type KumoNativeSelectSize,
+  type KumoNativeSelectVariantsProps,
+  KUMO_NATIVE_SELECT_VARIANTS,
+  KUMO_NATIVE_SELECT_DEFAULT_VARIANTS,
+  KUMO_NATIVE_SELECT_STYLING,
+} from "./native-select";

--- a/packages/kumo/src/components/native-select/native-select.tsx
+++ b/packages/kumo/src/components/native-select/native-select.tsx
@@ -1,0 +1,249 @@
+import {
+  forwardRef,
+  useId,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { Field as FieldBase } from "@base-ui/react/field";
+import { CaretUpDownIcon } from "@phosphor-icons/react";
+import { cn } from "../../utils/cn";
+import { buttonVariants } from "../button";
+import { Label } from "../label";
+import { type FieldErrorMatch } from "../field/field";
+
+export const KUMO_NATIVE_SELECT_VARIANTS = {
+  size: {
+    xs: {
+      classes: "h-5 text-xs rounded-sm px-1.5 pr-6",
+      description: "Extra small select for compact UIs",
+    },
+    sm: {
+      classes: "h-6.5 text-xs rounded-md px-2 pr-7",
+      description: "Small select for secondary fields",
+    },
+    base: {
+      classes: "h-9 text-base rounded-lg px-3 pr-8",
+      description: "Default select size",
+    },
+    lg: {
+      classes: "h-10 text-base rounded-lg px-4 pr-9",
+      description: "Large select for prominent fields",
+    },
+  },
+} as const;
+
+export const KUMO_NATIVE_SELECT_DEFAULT_VARIANTS = {
+  size: "base",
+} as const;
+
+/**
+ * NativeSelect component styling metadata for Figma plugin code generation
+ */
+export const KUMO_NATIVE_SELECT_STYLING = {
+  dimensions: {
+    xs: {
+      height: 20,
+      paddingX: 6,
+      paddingRight: 24,
+      fontSize: 12,
+      borderRadius: 2,
+    },
+    sm: {
+      height: 26,
+      paddingX: 8,
+      paddingRight: 28,
+      fontSize: 12,
+      borderRadius: 6,
+    },
+    base: {
+      height: 36,
+      paddingX: 12,
+      paddingRight: 32,
+      fontSize: 16,
+      borderRadius: 8,
+    },
+    lg: {
+      height: 40,
+      paddingX: 16,
+      paddingRight: 36,
+      fontSize: 16,
+      borderRadius: 8,
+    },
+  },
+  baseTokens: {
+    background: "color-secondary",
+    text: "text-color-surface",
+    ring: "color-border",
+  },
+  stateTokens: {
+    focus: { ring: "color-active" },
+    disabled: { opacity: 0.5 },
+  },
+  icons: {
+    caret: { name: "ph-caret-up-down", size: 20 },
+  },
+} as const;
+
+// Derived types from KUMO_NATIVE_SELECT_VARIANTS
+export type KumoNativeSelectSize =
+  keyof typeof KUMO_NATIVE_SELECT_VARIANTS.size;
+
+export interface KumoNativeSelectVariantsProps {
+  size?: KumoNativeSelectSize;
+}
+
+// Omit native `size` attribute (number) to avoid conflict with our custom `size` variant
+type BaseSelectProps = Omit<ComponentPropsWithoutRef<"select">, "size">;
+
+export function nativeSelectVariants({
+  size = KUMO_NATIVE_SELECT_DEFAULT_VARIANTS.size,
+}: KumoNativeSelectVariantsProps = {}) {
+  return cn(
+    // Use button secondary variant as base for visual parity with Select
+    buttonVariants({ variant: "secondary" }),
+    // Override button defaults for select behavior
+    "w-full cursor-pointer appearance-none text-left font-normal",
+    // Size-specific styles
+    KUMO_NATIVE_SELECT_VARIANTS.size[size].classes,
+  );
+}
+
+/**
+ * NativeSelect component props.
+ *
+ * A native HTML select element styled to match the Kumo Select component.
+ * Use this when you need native OS select behavior (especially on mobile)
+ * or when you don't need custom option rendering.
+ *
+ * @example
+ * // Basic usage
+ * <NativeSelect value={country} onChange={(e) => setCountry(e.target.value)}>
+ *   <option value="">Select a country</option>
+ *   <option value="us">United States</option>
+ *   <option value="ca">Canada</option>
+ * </NativeSelect>
+ *
+ * @example
+ * // With Field wrapper (label, description, error)
+ * <NativeSelect
+ *   label="Country"
+ *   description="Where you're located"
+ *   value={country}
+ *   onChange={handleChange}
+ * >
+ *   <option value="us">United States</option>
+ * </NativeSelect>
+ */
+export interface NativeSelectProps
+  extends KumoNativeSelectVariantsProps,
+    BaseSelectProps {
+  /** Label content for the select (enables Field wrapper) - can be a string or any React node */
+  label?: ReactNode;
+  /** Tooltip content to display next to the label via an info icon */
+  labelTooltip?: ReactNode;
+  /** Helper text displayed below the select */
+  description?: ReactNode;
+  /** Error message or validation error object */
+  error?: string | { message: ReactNode; match: FieldErrorMatch };
+}
+
+export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
+  (
+    {
+      className,
+      size = "base",
+      label,
+      labelTooltip,
+      description,
+      error,
+      children,
+      disabled,
+      required,
+      id: providedId,
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const selectId = providedId ?? generatedId;
+
+    // Icon sizes matching the select sizes
+    const iconConfig = {
+      xs: { size: 14, right: "right-1" },
+      sm: { size: 16, right: "right-1.5" },
+      base: { size: 20, right: "right-2.5" },
+      lg: { size: 20, right: "right-3" },
+    } as const;
+
+    const { size: iconSize, right: iconRight } = iconConfig[size];
+
+    const selectElement = (
+      <div
+        data-kumo-native-select-wrapper
+        className={cn("relative inline-flex", className)}
+      >
+        <select
+          ref={ref}
+          id={selectId}
+          data-kumo-native-select
+          className={cn(
+            nativeSelectVariants({ size }),
+            disabled && "cursor-not-allowed opacity-50",
+          )}
+          disabled={disabled}
+          required={required}
+          {...props}
+        >
+          {children}
+        </select>
+        {/* Caret icon overlay - matches Select component */}
+        <CaretUpDownIcon
+          className={cn(
+            "pointer-events-none absolute top-1/2 -translate-y-1/2 text-kumo-subtle",
+            iconRight,
+          )}
+          size={iconSize}
+        />
+      </div>
+    );
+
+    // Render with Field wrapper if label is provided
+    if (label) {
+      // Show "(optional)" when required is explicitly false
+      const showOptional = required === false;
+
+      return (
+        <FieldBase.Root className="grid gap-2">
+          <FieldBase.Label
+            htmlFor={selectId}
+            className="text-base font-medium text-kumo-default"
+          >
+            <Label showOptional={showOptional} tooltip={labelTooltip} asContent>
+              {label}
+            </Label>
+          </FieldBase.Label>
+          {selectElement}
+          {error ? (
+            <FieldBase.Error
+              className="col-span-full text-sm text-kumo-danger"
+              match={typeof error === "string" ? true : error.match}
+            >
+              {typeof error === "string" ? error : error.message}
+            </FieldBase.Error>
+          ) : (
+            description && (
+              <FieldBase.Description className="col-span-full text-sm leading-snug text-kumo-subtle">
+                {description}
+              </FieldBase.Description>
+            )
+          )}
+        </FieldBase.Root>
+      );
+    }
+
+    // Render bare select without Field wrapper
+    return selectElement;
+  },
+);
+
+NativeSelect.displayName = "NativeSelect";

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -60,6 +60,16 @@ export { MenuBar, useMenuNavigation } from "./components/menubar";
 export { Meter } from "./components/meter";
 export { Pagination } from "./components/pagination";
 export { Select } from "./components/select";
+export {
+  NativeSelect,
+  nativeSelectVariants,
+  type NativeSelectProps,
+  type KumoNativeSelectSize,
+  type KumoNativeSelectVariantsProps,
+  KUMO_NATIVE_SELECT_VARIANTS,
+  KUMO_NATIVE_SELECT_DEFAULT_VARIANTS,
+  KUMO_NATIVE_SELECT_STYLING,
+} from "./components/native-select";
 export { Surface } from "./components/surface";
 export { Switch } from "./components/switch";
 export { Tabs, type TabsProps, type TabsItem } from "./components/tabs";

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -131,6 +131,10 @@ export default defineConfig(({ mode }) => {
             __dirname,
             "src/components/select/index.ts",
           ),
+          "components/native-select": resolve(
+            __dirname,
+            "src/components/native-select/index.ts",
+          ),
           "components/surface": resolve(
             __dirname,
             "src/components/surface/index.ts",
@@ -169,10 +173,7 @@ export default defineConfig(({ mode }) => {
             __dirname,
             "src/components/command-palette/index.ts",
           ),
-          "components/link": resolve(
-            __dirname,
-            "src/components/link/index.ts",
-          ),
+          "components/link": resolve(__dirname, "src/components/link/index.ts"),
           "components/breadcrumbs": resolve(
             __dirname,
             "src/components/breadcrumbs/index.ts",


### PR DESCRIPTION
## Summary

Adds a `NativeSelect` component - a native HTML `<select>` element styled to match the Kumo design system.

<img width="1050" height="669" alt="Screenshot 2026-02-04 at 10 56 40 AM" src="https://github.com/user-attachments/assets/a534b478-98b0-456d-b2fc-44d4f1358a93" />


## Motivation

While Kumo's `Select` component provides a fully customizable dropdown experience, there are scenarios where native browser behavior is preferable:

- **Mobile UX**: Native OS pickers provide familiar, optimized interfaces on iOS/Android
- **Browser autofill**: Critical for address/payment forms where users expect saved data to populate
- **Simpler use cases**: When you don't need custom option rendering, icons, or multi-select
- **Accessibility**: Native selects have built-in screen reader support

## Features

- **Visual parity**: Identical appearance to `Select` trigger when closed
- **Size variants**: `xs`, `sm`, `base` (default), `lg` - matching other form controls
- **Field wrapper integration**: Pass `label`, `description`, `error`, `labelTooltip` props for automatic Field wrapping with proper accessibility associations
- **Optional field indicator**: Set `required={false}` to show "(optional)" badge
- **Full autofill support**: Works with `autoComplete` attribute for address, payment, and other standard form fields

## Usage

```tsx
// Basic usage
<NativeSelect value={country} onChange={(e) => setCountry(e.target.value)}>
  <option value="">Select a country</option>
  <option value="us">United States</option>
  <option value="ca">Canada</option>
</NativeSelect>

// With Field wrapper
<NativeSelect
  label="Country"
  description="Where you're located"
  error={errors.country}
  value={country}
  onChange={handleChange}
>
  <option value="us">United States</option>
</NativeSelect>

// With browser autofill
<NativeSelect
  label="Country"
  name="country"
  autoComplete="country"
>
  <option value="US">United States</option>
</NativeSelect>
```

## When to use NativeSelect vs Select

| Use NativeSelect when... | Use Select when... |
|--------------------------|-------------------|
| Mobile UX is a priority | Custom option rendering needed (icons, avatars) |
| Browser autofill is required | Complex object values |
| Simple string options | Multi-select with chips |
| Lighter-weight markup preferred | Loading states needed |
| Native form submission | Consistent desktop/mobile appearance required |

## Checklist

- [x] Component implementation with TypeScript types
- [x] Size variants (`xs`, `sm`, `base`, `lg`)
- [x] Field wrapper integration (label, description, error)
- [x] Documentation page with examples
- [x] Demo components
- [x] Component registry updated
- [x] Package exports configured
- [x] Changeset added
- [x] All tests passing