### PR TITLE
Fix double scrollbar issue in documentation site

### DIFF
--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -21,7 +21,7 @@ html {
   font-display: optional;
 }
 
-/* Prevent layout shift on page load */
+/* Prevent layout shift on page load - scrolling handled by #main-content container */
 body {
-  overflow-y: scroll;
+  overflow: hidden;
 }


### PR DESCRIPTION
Problem:
The documentation site was displaying two vertical scrollbars on the right side, creating a confusing user experience where users could scroll using either scrollbar.

fix before:
<img width="1753" height="800" alt="image" src="https://github.com/user-attachments/assets/31f41a07-af7c-4750-b7f0-71a6aa6dcf8e" />

fix after:
<img width="1763" height="688" alt="image" src="https://github.com/user-attachments/assets/1cef5d81-72d7-40d2-ba26-c89c93feebb2" />


Root Cause:
There were two nested scrollable containers:
1. The body element had `overflow-y: scroll` (global.css:26)
2. The #main-content container had `overflow-y-auto` (MainLayout.astro:29)

This created a double-scrolling scenario where both the body and the main content area could scroll independently.

Solution:
Changed body overflow from `overflow-y: scroll` to `overflow: hidden`, making #main-content the single source of scrolling for the entire application.

Why This Approach:
This follows the modern app-layout pattern where:
- Fixed sidebar (SidebarNav) remains visible at all times
- Fixed theme toggle stays in the top-right corner
- Only the main content area scrolls
- Consistent with modern web applications (VS Code, GitHub, etc.)

This approach provides better UX by having a single, predictable scroll container while maintaining the fixed positioning of navigation elements.