### PR TITLE
fix(docs): resolve double scrollbar and jittery scroll issue

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/CLIDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CLIDemo.tsx
@@ -539,7 +539,7 @@ export const CLITerminal: FC = () => {
 
   // Focus input on click
   const handleTerminalClick = useCallback(() => {
-    inputRef.current?.focus();
+    inputRef.current?.focus({ preventScroll: true });
   }, []);
 
   const handleSubmit = useCallback(() => {
@@ -632,7 +632,7 @@ export const CLITerminal: FC = () => {
               type="button"
               onClick={() => {
                 setCurrentInput(cmd);
-                inputRef.current?.focus();
+                inputRef.current?.focus({ preventScroll: true });
               }}
               className="rounded bg-kumo-overlay px-2 py-1 font-mono text-xs text-kumo-default transition-colors hover:bg-kumo-recessed"
             >
@@ -646,7 +646,7 @@ export const CLITerminal: FC = () => {
         ref={terminalRef}
         onClick={handleTerminalClick}
         onKeyDown={undefined}
-        className="h-[500px] w-full max-w-[800px] cursor-text overflow-x-auto overflow-y-scroll rounded-lg bg-kumo-contrast p-4 font-mono text-sm text-kumo-inverse"
+        className="relative h-[500px] w-full max-w-[800px] cursor-text overflow-x-auto overflow-y-auto overscroll-contain rounded-lg bg-kumo-contrast p-4 font-mono text-sm text-kumo-inverse"
       >
         {/* Output lines */}
         {lines.map((line, i) => {

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -242,7 +242,7 @@ export function HomeGrid() {
       name: "Dropdown",
       id: "dropdown",
       Component: (
-        <DropdownMenu open modal={false}>
+        <DropdownMenu>
           <DropdownMenu.Trigger render={<Button icon={PlusIcon}>Add</Button>} />
           <DropdownMenu.Content>
             <DropdownMenu.Item>Worker</DropdownMenu.Item>

--- a/packages/kumo-docs-astro/src/components/docs/StickyDocHeader.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/StickyDocHeader.tsx
@@ -49,6 +49,7 @@ export function StickyDocHeader({
   // Watch for page header visibility
   useEffect(() => {
     const pageHeader = document.getElementById("page-header");
+    const mainContent = document.getElementById("main-content");
     if (!pageHeader) return;
 
     const observer = new IntersectionObserver(
@@ -56,7 +57,11 @@ export function StickyDocHeader({
         // Show sticky title when page header is not visible
         setShowStickyTitle(!entry.isIntersecting);
       },
-      { threshold: 0, rootMargin: `-${STICKY_HEADER_HEIGHT}px 0px 0px 0px` },
+      {
+        root: mainContent, // Use main-content as scroll container
+        threshold: 0,
+        rootMargin: `-${STICKY_HEADER_HEIGHT}px 0px 0px 0px`,
+      },
     );
 
     observer.observe(pageHeader);

--- a/packages/kumo-docs-astro/src/layouts/DocLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/DocLayout.astro
@@ -30,7 +30,7 @@ const githubSourceUrl = sourceFile
 ---
 
 <MainLayout title={`${title} - Kumo`} description={description}>
-  <div class="flex min-h-screen flex-col">
+  <div class="flex flex-col">
     
     <StickyDocHeader
       title={title}

--- a/packages/kumo-docs-astro/src/layouts/MainLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/MainLayout.astro
@@ -13,7 +13,7 @@ const currentPath = Astro.url.pathname;
 ---
 
 <BaseLayout title={title} description={description}>
-  <div class="min-h-screen isolate">
+  <div class="isolate">
     <SidebarNav currentPath={currentPath} client:load />
 
     <!-- Theme toggle: fixed in top right corner -->

--- a/packages/kumo-docs-astro/src/pages/accessibility.astro
+++ b/packages/kumo-docs-astro/src/pages/accessibility.astro
@@ -7,7 +7,7 @@ import Header from "../components/Header.astro";
   title="Accessibility - Kumo"
   description="Learn how to make the most of Kumo's accessibility features and guidelines."
 >
-  <div class="flex min-h-screen flex-col">
+  <div class="flex flex-col">
     <Header />
 
     <!-- Page Header -->

--- a/packages/kumo-docs-astro/src/pages/index.astro
+++ b/packages/kumo-docs-astro/src/pages/index.astro
@@ -5,7 +5,7 @@ import { HomeGrid } from "../components/demos/HomeGrid";
 ---
 
 <MainLayout title="Kumo" description="Kumo – a modern component library">
-  <div class="flex min-h-screen flex-col">
+  <div class="flex flex-col">
     <Header />
     <main class="flex grow flex-col pr-12">
       <div

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -20,8 +20,3 @@
 html {
   font-display: optional;
 }
-
-/* Prevent layout shift on page load */
-body {
-  overflow-y: scroll;
-}


### PR DESCRIPTION
## Summary

Fixes the double scrollbar, jittery scroll behavior, and CLI terminal focus issues on the docs site.

## Changes

- **global.css**: Remove conflicting `overflow-y: scroll` from body - `#main-content` now handles all scrolling
- **MainLayout.astro**: Remove redundant `min-h-screen` from wrapper div
- **index.astro, accessibility.astro, DocLayout.astro**: Remove redundant `min-h-screen` from nested containers
- **HomeGrid.tsx**: Fix dropdown autofocus bug by removing `open` prop (was causing focus to jump on page load)
- **CLIDemo.tsx**: Fix scroll jump when clicking example commands:
  - Added `relative` class to terminal container
  - Added `overscroll-contain` to prevent scroll escape
  - Added `preventScroll: true` to focus calls
- **StickyDocHeader.tsx**: Fix IntersectionObserver to use `#main-content` as root for proper sticky header detection

## Root Cause

The docs site had two conflicting scroll containers:
1. `body` with `overflow-y: scroll` 
2. `#main-content` with `h-screen overflow-y-auto`

This caused double scrollbars and jittery behavior as the browser fought between which container should scroll.

## Result

- Single scroll container (`#main-content`) while the sidebar stays fixed
- Clean, smooth scrolling with no jitter
- CLI terminal commands work without page jumping