### PR TITLE
refactor(docs): use kumo components directly for instant reload

### DIFF
--- a/packages/kumo-docs-astro/astro.config.mjs
+++ b/packages/kumo-docs-astro/astro.config.mjs
@@ -65,6 +65,22 @@ export default defineConfig({
     // @ts-expect-error - Vite version mismatch between Astro and @tailwindcss/vite
     plugins: [tailwindcss(), kumoColorsPlugin(), kumoRegistryPlugin()],
 
+    resolve: {
+      alias: {
+        "@cloudflare/kumo/styles": resolve(__dirname, "../kumo/src/styles"),
+        "@cloudflare/kumo": resolve(__dirname, "../kumo/src/index.ts"),
+      },
+    },
+    server: {
+      fs: {
+        allow: [
+          resolve(__dirname),
+          resolve(__dirname, "../kumo"),
+          "../../node_modules",
+        ],
+      },
+    },
+
     define: {
       __KUMO_VERSION__: JSON.stringify(buildInfo.kumoVersion),
       __DOCS_VERSION__: JSON.stringify(buildInfo.docsVersion),

--- a/packages/kumo-docs-astro/src/lib/component-registry.ts
+++ b/packages/kumo-docs-astro/src/lib/component-registry.ts
@@ -4,7 +4,7 @@
  */
 
 // Import the registry JSON from the kumo package export
-import registry from "@cloudflare/kumo/ai/component-registry.json";
+import { readFileSync } from "node:fs";
 
 // Import shared types from @cloudflare/kumo
 import type {
@@ -22,6 +22,13 @@ export type ComponentData = ComponentSchema;
 export type { ComponentRegistry };
 
 // Cast through unknown since the JSON structure may have extra fields
+
+const registry = JSON.parse(
+  readFileSync(
+    new URL("../../../kumo/ai/component-registry.json", import.meta.url),
+    "utf8",
+  ),
+) as unknown as ComponentRegistry;
 const typedRegistry = registry as unknown as ComponentRegistry;
 
 /**

--- a/packages/kumo-docs-astro/src/pages/api/component-registry.ts
+++ b/packages/kumo-docs-astro/src/pages/api/component-registry.ts
@@ -1,5 +1,12 @@
 import type { APIRoute } from "astro";
-import componentRegistry from "@cloudflare/kumo/ai/component-registry.json";
+import { readFileSync } from "node:fs";
+
+const componentRegistry = JSON.parse(
+  readFileSync(
+    new URL("../../../../kumo/ai/component-registry.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 export const GET: APIRoute = () => {
   return new Response(JSON.stringify(componentRegistry), {

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -1,5 +1,5 @@
-@source "../../../kumo/dist/**/*.{js,jsx,ts,tsx}";
-@import "@cloudflare/kumo/styles";
+@source "../../../kumo/src/**/*.{js,jsx,ts,tsx}";
+@import "../../../kumo/src/styles/kumo.css";
 @import "tailwindcss";
 
 @custom-variant dark (&:where([data-mode="dark"], [data-mode="dark"] *));

--- a/packages/kumo-docs-astro/tsconfig.json
+++ b/packages/kumo-docs-astro/tsconfig.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"]
+      "~/*": ["src/*"],
+      "@cloudflare/kumo": ["../kumo/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR refactors the `kumo-docs-astro` package to import Kumo components directly from source files instead of the built distribution, enabling instant hot module reloading during development.

**Key Changes:**

- Direct source imports: Updated Vite configuration to alias `@cloudflare/kumo` to `../kumo/src/index.ts` instead of the built package
- Component registry loading: Switched from importing the packaged JSON to dynamically reading the registry file using readFileSync
- Tailwind CSS source scanning: Updated source directive to scan `../kumo/src/**/*.{js,jsx,ts,tsx}` instead of `dist/`
- Style imports: Changed CSS import to point directly to source (`../kumo/src/styles/kumo.css`)
- TypeScript configuration: Added path mapping for `@cloudflare/kumo` to resolve to source files
- Dev server configuration: Added filesystem access permissions for the sibling kumo package

## Benefits:
- ⚡ Instant reload: Changes to Kumo components now hot-reload immediately in the docs site without rebuilding the package
- 🔄 Better DX: Eliminates the need to run pnpm build in the kumo package during development
- 🛠️ Faster iteration: Component development is significantly faster with instant feedback