### PR TITLE
fix(cli): resolve registry path for docs and ls commands

### DIFF
--- a/.changeset/two-bobcats-shop.md
+++ b/.changeset/two-bobcats-shop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(cli): resolve registry path for docs and ls commands

--- a/packages/kumo/src/command-line/commands/doc.ts
+++ b/packages/kumo/src/command-line/commands/doc.ts
@@ -45,8 +45,8 @@ interface ComponentRegistry {
  */
 function getRegistryPath(): string {
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  // When bundled and running from dist/command-line/, go up 2 levels to package root then into catalog/
-  return join(__dirname, "..", "..", "catalog", "component-registry.json");
+  // When bundled and running from dist/command-line/, go up 2 levels to package root then into ai/
+  return join(__dirname, "..", "..", "ai", "component-registry.json");
 }
 
 /**

--- a/packages/kumo/src/command-line/commands/ls.ts
+++ b/packages/kumo/src/command-line/commands/ls.ts
@@ -25,8 +25,8 @@ interface ComponentRegistry {
  */
 function getRegistryPath(): string {
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  // When bundled and running from dist/command-line/, go up 2 levels to package root then into catalog/
-  return join(__dirname, "..", "..", "catalog", "component-registry.json");
+  // When bundled and running from dist/command-line/, go up 2 levels to package root then into ai/
+  return join(__dirname, "..", "..", "ai", "component-registry.json");
 }
 
 /**


### PR DESCRIPTION
## what this fixes

`kumo docs` / `kumo doc` / `kumo ls` were looking for the registry in `catalog/component-registry.json`, but the published package ships it in `ai/component-registry.json`.

So on fresh installs, those commands were failing with:

`Error: Component registry not found. Run 'pnpm build:ai-metadata' first.`

## what changed

- updated registry path in:
  - `packages/kumo/src/command-line/commands/doc.ts`
  - `packages/kumo/src/command-line/commands/ls.ts`
- switched `catalog` -> `ai` in `getRegistryPath()`

## tested

- `pnpm --filter @cloudflare/kumo build` ✅
- manual check with built CLI:
  - `node packages/kumo/bin/kumo.js docs` ✅ (prints full docs output)
  - `node packages/kumo/bin/kumo.js ls` ✅ (lists components)


