### PR TITLE
chore: release @cloudflare/kumo@1.1.0

### DIFF
--- a/.changeset/bright-chairs-smash.md
+++ b/.changeset/bright-chairs-smash.md
@@ -1,5 +1,0 @@
----
-"@cloudflare/kumo": patch
----
-
-Fix `kumo` CLI bin resolution in repo checkouts so `pnpm install` doesn't warn when `dist/` hasn't been built yet.

--- a/.changeset/tiny-views-bathe.md
+++ b/.changeset/tiny-views-bathe.md
@@ -1,6 +1,0 @@
----
-"@cloudflare/kumo-figma": minor
-"@cloudflare/kumo": minor
----
-
-fixes to figma plugin init + zod v4 in kumo

--- a/packages/kumo-docs-astro/CHANGELOG.md
+++ b/packages/kumo-docs-astro/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @cloudflare/kumo-docs-astro
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies [6dc9a73]
+- Updated dependencies [001f9e7]
+  - @cloudflare/kumo@1.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/kumo-docs-astro/package.json
+++ b/packages/kumo-docs-astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/kumo-docs-astro",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/kumo-figma/CHANGELOG.md
+++ b/packages/kumo-figma/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @cloudflare/figma-plugin
 
+## 0.3.0
+
+### Minor Changes
+
+- 001f9e7: fixes to figma plugin init + zod v4 in kumo
+
+### Patch Changes
+
+- Updated dependencies [6dc9a73]
+- Updated dependencies [001f9e7]
+  - @cloudflare/kumo@1.1.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/kumo-figma/package.json
+++ b/packages/kumo-figma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/kumo-figma",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Figma plugin for generating Kumo UI Kit components",

--- a/packages/kumo/CHANGELOG.md
+++ b/packages/kumo/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @cloudflare/kumo
 
+## 1.1.0
+
+### Minor Changes
+
+- 001f9e7: fixes to figma plugin init + zod v4 in kumo
+
+### Patch Changes
+
+- 6dc9a73: Fix `kumo` CLI bin resolution in repo checkouts so `pnpm install` doesn't warn when `dist/` hasn't been built yet.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/kumo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "type": "module",
   "description": "Kumo - Cloudflare's component library for building modern web applications",


### PR DESCRIPTION
## Summary

- Consumes pending changesets and bumps `@cloudflare/kumo` from `1.0.0` to `1.1.0`
- Bumps `@cloudflare/kumo-figma` to `0.3.0`
- Updates CHANGELOGs for all affected packages
- Package already published to npm: `@cloudflare/kumo@1.1.0`

### Changes included in 1.1.0

- **Minor**: Fixes to figma plugin init + zod v4 in kumo
- **Patch**: Fix `kumo` CLI bin resolution in repo checkouts