### PR TITLE
fix: value for combobox on demo frontpage could not be selected.

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -104,6 +104,7 @@ function ToastTriggerButton() {
 export function HomeGrid() {
   const [switchToggled, setSwitchToggled] = useState(true);
   const [checked, setChecked] = useState(true);
+  const [value, setValue] = useState<{ id: string; value: string; } | null>(null);
 
   const components: Array<{
     name: string;
@@ -167,6 +168,8 @@ export function HomeGrid() {
             { id: "help-wanted", value: "help wanted" },
             { id: "good-first-issue", value: "good first issue" },
           ]}
+          onValueChange={setValue}
+          value={value}
         >
           <Combobox.TriggerInput placeholder="Select an issue..." />
           <Combobox.Content>


### PR DESCRIPTION
### Summary
Combobox on demo frontpage could not be selected. Adds a useState to HomeGrid component for the value and value and onValueChange attributes to the combobox