### PR TITLE
fix(dropdown): improve external link detection

### DIFF
--- a/.changeset/tired-radios-write.md
+++ b/.changeset/tired-radios-write.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(dropdown): improve external link detection to handle http:// and protocol-relative urls
+
+updated the external link check to use a regex that matches `https://`, `http://`, and protocol-relative URLs (`//`). previously only `https://` links opened in a new tab.

--- a/packages/kumo/src/components/dropdown/dropdown.tsx
+++ b/packages/kumo/src/components/dropdown/dropdown.tsx
@@ -154,7 +154,8 @@ const DropdownMenuItem = React.forwardRef<
 
       if (!href) return innerContent;
 
-      const isExternal = href.startsWith("https://");
+      // Matches http://, https://, or protocol-relative //
+      const isExternal = /^(https?:)?\/\//.test(href);
       const styles = cn(
         "flex items-center",
         variant === "danger" &&


### PR DESCRIPTION
## Description

- Fix external link detection in Dropdown to also check for `http://` and `//` (protocol-relative URLs)
- Previously only `https://` links opened in a new tab

## Problem

The `DropdownMenuItem` component's external link detection only checked for `https://`:

```tsx
const isExternal = href.startsWith("https://");
```

This meant `http://` links and protocol-relative URLs (`//example.com`) were incorrectly treated as internal links and routed through `LinkComponent` instead of opening in a new tab.

## Solution

Use a regex to match all external URL patterns:

```tsx
const isExternal = /^(https?:)?\/\//.test(href);
```

| Pattern | Matches |
|---------|---------|
| `https://example.com` | External |
| `http://example.com` | External |
| `//example.com` | External |
| `/dashboard` | Internal |
