### PR TITLE
fix(a11y): add accessible labels to icon-only controls

### DIFF
--- a/.changeset/odd-states-attend.md
+++ b/.changeset/odd-states-attend.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(a11y): add accessible labels to icon-only controls

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -331,6 +331,7 @@ function TriggerInput(props: ComboboxBase.Input.Props) {
       />
 
       <ComboboxBase.Clear
+        aria-label="Clear selection"
         className={cn(
           "absolute top-1/2 flex -translate-y-1/2 cursor-pointer bg-transparent p-0",
           "data-[disabled]:pointer-events-none data-[disabled]:opacity-0",
@@ -341,6 +342,7 @@ function TriggerInput(props: ComboboxBase.Input.Props) {
       </ComboboxBase.Clear>
 
       <ComboboxBase.Trigger
+        aria-label="Show options"
         className={cn(
           "absolute top-1/2 -translate-y-1/2 flex items-center justify-center cursor-pointer text-kumo-subtle",
           "m-0 bg-transparent p-0", // Reset Stratus global button styles
@@ -444,6 +446,7 @@ function Chip(props: ComboboxBase.Chip.Props) {
     >
       {props.children}
       <ComboboxBase.ChipRemove
+        aria-label="Remove selection"
         className={cn(
           "cursor-pointer rounded-md p-1 hover:bg-kumo-fill-hover",
           "bg-transparent flex",

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -308,7 +308,20 @@ const triggerInputIconStyles: Record<
   },
 };
 
-function TriggerInput(props: ComboboxBase.Input.Props) {
+function TriggerInput({
+  clearLabel = "Clear selection",
+  showOptionsLabel = "Show options",
+  ...props
+}: ComboboxBase.Input.Props & {
+  /** Accessible label for the clear button. Pass a translated string for i18n.
+   * @default "Clear selection"
+   */
+  clearLabel?: string;
+  /** Accessible label for the dropdown trigger. Pass a translated string for i18n.
+   * @default "Show options"
+   */
+  showOptionsLabel?: string;
+}) {
   const size = useContext(ComboboxSizeContext);
   const iconStyles = triggerInputIconStyles[size];
 
@@ -331,7 +344,7 @@ function TriggerInput(props: ComboboxBase.Input.Props) {
       />
 
       <ComboboxBase.Clear
-        aria-label="Clear selection"
+        aria-label={clearLabel}
         className={cn(
           "absolute top-1/2 flex -translate-y-1/2 cursor-pointer bg-transparent p-0",
           "data-[disabled]:pointer-events-none data-[disabled]:opacity-0",
@@ -342,7 +355,7 @@ function TriggerInput(props: ComboboxBase.Input.Props) {
       </ComboboxBase.Clear>
 
       <ComboboxBase.Trigger
-        aria-label="Show options"
+        aria-label={showOptionsLabel}
         className={cn(
           "absolute top-1/2 -translate-y-1/2 flex items-center justify-center cursor-pointer text-kumo-subtle",
           "m-0 bg-transparent p-0", // Reset Stratus global button styles
@@ -432,7 +445,15 @@ function Group(props: ComboboxBase.Group.Props) {
   );
 }
 
-function Chip(props: ComboboxBase.Chip.Props) {
+function Chip({
+  removeLabel = "Remove",
+  ...props
+}: ComboboxBase.Chip.Props & {
+  /** Accessible label for the chip remove button. Pass a translated string for i18n.
+   * @default "Remove"
+   */
+  removeLabel?: string;
+}) {
   return (
     <ComboboxBase.Chip
       {...props}
@@ -446,7 +467,7 @@ function Chip(props: ComboboxBase.Chip.Props) {
     >
       {props.children}
       <ComboboxBase.ChipRemove
-        aria-label="Remove selection"
+        aria-label={removeLabel}
         className={cn(
           "cursor-pointer rounded-md p-1 hover:bg-kumo-fill-hover",
           "bg-transparent flex",

--- a/packages/kumo/src/components/menubar/menubar.tsx
+++ b/packages/kumo/src/components/menubar/menubar.tsx
@@ -44,6 +44,7 @@ const MenuOption = ({
 }: MenuOptionProps) => {
   const button = (
     <button
+      aria-label={tooltip}
       className={cn(
         "focus:inset-ring-focus relative -ml-px flex h-full w-11 cursor-pointer items-center justify-center rounded-md border-none bg-kumo-elevated first:rounded-l-lg last:rounded-r-lg transition-colors focus:z-1 focus:outline-none focus-visible:z-1 focus-visible:inset-ring-[0.5]",
         {


### PR DESCRIPTION
## Description

- Add aria-labels to icon-only controls in `MenuBar` and `Combobox`

## Problem

Several icon-only controls were missing explicit accessible labels, so screen readers could announce them as unlabeled buttons.

Controls:
- `MenuBar` option buttons (icon-only)
- `Combobox.TriggerInput` clear button
- `Combobox.TriggerInput` dropdown trigger button
- `Combobox.ChipRemove` button in multi-select chips

## Solution

Add `aria-label` to each icon-only control:

- `MenuBar`: Uses the `tooltip` prop as the aria-label (consumer-provided)
- `Combobox.TriggerInput`: New `clearLabel` and `showOptionsLabel` props with English defaults
- `Combobox.ChipRemove`: New `removeLabel` prop with English default

All labels are customizable for i18n.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: accessibility changes require manual screen reader testing
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: screen reader testing to verify labels are announced
  - [ ] Additional testing not necessary because:
