### PR TITLE
feat(docs): replace Pagefind with CommandPalette for search

### DIFF
--- a/packages/kumo-docs-astro/AGENTS.md
+++ b/packages/kumo-docs-astro/AGENTS.md
@@ -88,7 +88,7 @@ Imports: `~/layouts/DocLayout.astro`, `~/components/docs/ComponentExample.astro`
 - **`dist/` is gitignored**: If `dist/demo-metadata.json` is missing, `codegen:registry` produces incomplete output
 - **SidebarNav is manual**: Adding a component page requires updating `SidebarNav.tsx` arrays
 - **HomeGrid is manual**: New components need adding to the showcase grid + `componentRoutes`
-- **Search requires build**: Pagefind index generated at `astro build` time; dev mode shows placeholder
+- **Search uses CommandPalette**: Client-side search powered by component registry API; works in dev mode without build step
 - **PropsTable error message is stale**: Says `pnpm build:ai-metadata` but correct command is `pnpm codegen:registry`
 - **BaseLayout has blocking inline script**: Reads `localStorage.theme` synchronously to prevent dark mode FOUC
 - **`global.css`**: `@custom-variant dark` overrides Tailwind dark to match `[data-mode="dark"]`

--- a/packages/kumo-docs-astro/src/components/SearchDialog.tsx
+++ b/packages/kumo-docs-astro/src/components/SearchDialog.tsx
@@ -1,40 +1,179 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-import { Dialog, cn, Loader } from "@cloudflare/kumo";
-import { MagnifyingGlassIcon, FileTextIcon } from "@phosphor-icons/react";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { matchSorter } from "match-sorter";
+import { CommandPalette, Badge, type HighlightRange } from "@cloudflare/kumo";
+import {
+  MagnifyingGlassIcon,
+  CubeIcon,
+  StackIcon,
+  SquaresFourIcon,
+  BookOpenIcon,
+} from "@phosphor-icons/react";
 
-export interface SearchResult {
+/**
+ * Components in the registry that don't have Astro doc pages yet.
+ * These are filtered out of search results until docs are written.
+ *
+ * To add a new component to search:
+ * 1. Create the Astro doc page (e.g., /pages/components/my-component.astro)
+ * 2. Remove it from this exclusion list
+ * 3. Add its description to COMPONENT_DESCRIPTIONS below
+ */
+const COMPONENTS_WITHOUT_DOCS = new Set([
+  "CommandPalette",
+  "DateRangePicker",
+  "Field",
+  "Icon",
+  "InputArea",
+  "Meter",
+  "Pagination",
+  "Toasty",
+]);
+
+/**
+ * Map registry component names to their doc page slugs.
+ * Only needed when the name doesn't match the standard kebab-case conversion.
+ */
+const SLUG_OVERRIDES: Record<string, string> = {
+  DropdownMenu: "dropdown",
+};
+
+/**
+ * Static pages that should be included in search.
+ * These are top-level documentation pages that aren't in the component registry.
+ */
+const STATIC_PAGES: Array<{
+  name: string;
+  description: string;
   url: string;
-  content: string;
-  excerpt: string;
-  meta: {
-    title?: string;
-  };
-  sub_results?: Array<{
-    title: string;
-    url: string;
-    excerpt: string;
-  }>;
+  category: string;
+}> = [
+  {
+    name: "Installation",
+    description: "How to install and set up Kumo in your project.",
+    url: "/installation",
+    category: "Getting Started",
+  },
+  {
+    name: "Contributing",
+    description: "Guidelines for contributing to the Kumo component library.",
+    url: "/contributing",
+    category: "Getting Started",
+  },
+  {
+    name: "Accessibility",
+    description:
+      "Accessibility standards and best practices in Kumo components.",
+    url: "/accessibility",
+    category: "Getting Started",
+  },
+  {
+    name: "Components vs Blocks",
+    description: "Understanding the difference between components and blocks.",
+    url: "/components-vs-blocks",
+    category: "Getting Started",
+  },
+  {
+    name: "Colors",
+    description: "Explore Kumo's semantic color tokens and theming system.",
+    url: "/colors",
+    category: "Guides",
+  },
+  {
+    name: "CLI",
+    description:
+      "Use the Kumo CLI to add components and blocks to your project.",
+    url: "/cli",
+    category: "Guides",
+  },
+  {
+    name: "Streaming",
+    description: "Server-side rendering and streaming support in Kumo.",
+    url: "/streaming",
+    category: "Guides",
+  },
+  {
+    name: "Figma",
+    description: "Using Kumo components in Figma with the Kumo Figma plugin.",
+    url: "/figma",
+    category: "Guides",
+  },
+  {
+    name: "Component Registry",
+    description: "Browse and explore the full Kumo component registry.",
+    url: "/registry",
+    category: "Guides",
+  },
+];
+
+/** Better descriptions from the Astro doc pages */
+const COMPONENT_DESCRIPTIONS: Record<string, string> = {
+  badge: "Displays a small label for status, categorization, or metadata.",
+  banner:
+    "Displays contextual inline messages for informational, alert, or error states.",
+  button: "Displays a button or a component that looks like a button.",
+  checkbox:
+    "A control that allows the user to toggle between checked and not checked.",
+  "clipboard-text": "A text component with a copy-to-clipboard button.",
+  code: "Syntax-highlighted code blocks with support for multiple languages.",
+  collapsible:
+    "A vertically stacked set of interactive headings that each reveal content.",
+  combobox:
+    "A searchable select component for filtering and selecting from options.",
+  dialog: "A modal window overlaid on the primary window or another dialog.",
+  dropdown: "Displays a menu of actions or functions triggered by a button.",
+  input:
+    "A text input field with built-in label, description, and error support.",
+  label: "A label component for form fields with required/optional indicators.",
+  "layer-card":
+    "A card with a layered visual effect for navigation or highlights.",
+  loader: "A loading spinner to indicate loading state.",
+  menubar: "A horizontal menu bar with icon buttons for toolbars.",
+  popover: "An accessible popup anchored to a trigger element.",
+  radio: "A control that allows selecting one option from a set.",
+  select: "Displays a list of options for the user to pick from.",
+  "sensitive-input":
+    "A masked input for sensitive values like API keys and passwords.",
+  "skeleton-line": "A skeleton loading placeholder for text content.",
+  surface: "A container component that provides a styled surface for content.",
+  switch: "A two-state toggle button that can be either on or off.",
+  table:
+    "A table component for displaying tabular data with selection support.",
+  tabs: "Layered sections of content displayed one at a time.",
+  text: "A typography component for various heading and copy styles.",
+  tooltip: "A popup that displays information on hover or focus.",
+  breadcrumbs:
+    "Shows the current page's location within a navigational hierarchy.",
+  empty:
+    "A placeholder component for empty states with illustration and actions.",
+  "page-header": "Combines breadcrumbs and tabs for page navigation.",
+  "resource-list":
+    "A layout for displaying resource lists with title and sidebar.",
+};
+
+interface ComponentRegistryEntry {
+  name: string;
+  type: "component" | "block" | "layout";
+  description: string;
+  category: string;
+  props?: Record<string, unknown>;
 }
 
-interface PagefindResult {
-  id: string;
-  score: number;
-  data: () => Promise<SearchResult>;
+interface ComponentRegistry {
+  version: string;
+  components: Record<string, ComponentRegistryEntry>;
 }
 
-interface PagefindSearchResponse {
-  results: PagefindResult[];
+interface SearchItem {
+  name: string;
+  type: "component" | "block" | "layout" | "page";
+  description: string;
+  category: string;
+  url: string;
 }
 
-interface Pagefind {
-  init: () => void;
-  options: (opts: Record<string, unknown>) => Promise<void>;
-  search: (query: string) => Promise<PagefindSearchResponse>;
-  debouncedSearch: (
-    query: string,
-    options?: Record<string, unknown>,
-    ms?: number,
-  ) => Promise<PagefindSearchResponse | null>;
+interface SearchGroup {
+  label: string;
+  items: SearchItem[];
 }
 
 interface SearchDialogProps {
@@ -42,273 +181,346 @@ interface SearchDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-/** Extract a readable title from a URL path */
-function getTitleFromUrl(url: string): string {
-  return (
-    url
-      .replace(/^\//, "")
-      .replace(/\/$/, "")
-      .split("/")
-      .pop()
-      ?.replace(/-/g, " ")
-      ?.replace(/\b\w/g, (c) => c.toUpperCase()) || url
-  );
+/** Build URL path from component type and name */
+function getComponentUrl(type: string, name: string): string {
+  const slug =
+    SLUG_OVERRIDES[name] ??
+    name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+
+  switch (type) {
+    case "block":
+      return `/blocks/${slug}`;
+    case "layout":
+      return `/layouts/${slug}`;
+    default:
+      return `/components/${slug}`;
+  }
 }
 
-/** Extract category from URL path (e.g., "components" from "/components/button") */
-function getCategoryFromUrl(url: string): string | null {
-  const parts = url.split("/").filter(Boolean);
-  return parts.length > 1 ? parts[0] : null;
+/** Get better description from mapping, falling back to registry */
+function getDescription(name: string, registryDescription: string): string {
+  const slug =
+    SLUG_OVERRIDES[name] ??
+    name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+  return COMPONENT_DESCRIPTIONS[slug] || registryDescription;
+}
+
+/** Find all matching ranges in text for a query (for highlighting) */
+function findHighlightRanges(text: string, query: string): HighlightRange[] {
+  if (!query.trim()) return [];
+
+  const ranges: HighlightRange[] = [];
+  const textLower = text.toLowerCase();
+  const queryLower = query.toLowerCase();
+
+  let startIndex = 0;
+  while (true) {
+    const index = textLower.indexOf(queryLower, startIndex);
+    if (index === -1) break;
+    // HighlightRange is [start, end] tuple (end is inclusive)
+    ranges.push([index, index + queryLower.length - 1]);
+    startIndex = index + 1;
+  }
+
+  return ranges;
+}
+
+/** Group items by category (used when browsing without a query) */
+function groupByCategory(items: SearchItem[]): SearchGroup[] {
+  const groups: Record<string, SearchItem[]> = {};
+
+  for (const item of items) {
+    const category = item.category || "Other";
+    if (!groups[category]) {
+      groups[category] = [];
+    }
+    groups[category].push(item);
+  }
+
+  // Define category order: Getting Started and Guides first, Block/Layout last
+  const categoryOrder = (cat: string): number => {
+    if (cat === "Getting Started") return 0;
+    if (cat === "Guides") return 1;
+    if (cat === "Block" || cat === "Layout") return 100;
+    return 50; // Component categories in the middle
+  };
+
+  const sortedCategories = Object.keys(groups).toSorted((a, b) => {
+    const orderDiff = categoryOrder(a) - categoryOrder(b);
+    if (orderDiff !== 0) return orderDiff;
+    return a.localeCompare(b);
+  });
+
+  return sortedCategories.map((category) => ({
+    label: category,
+    items: groups[category],
+  }));
+}
+
+/** Return items as a single "Results" group (used when searching) */
+function asSearchResults(items: SearchItem[]): SearchGroup[] {
+  if (items.length === 0) return [];
+  return [{ label: "Results", items }];
+}
+
+/** Get icon for item type */
+function getTypeIcon(type: "component" | "block" | "layout" | "page") {
+  switch (type) {
+    case "block":
+      return <StackIcon size={16} weight="duotone" />;
+    case "layout":
+      return <SquaresFourIcon size={16} weight="duotone" />;
+    case "page":
+      return <BookOpenIcon size={16} weight="duotone" />;
+    default:
+      return <CubeIcon size={16} weight="duotone" />;
+  }
+}
+
+/** Get badge for item type (only shown when searching, not when grouped by category) */
+function getTypeBadge(
+  type: "component" | "block" | "layout" | "page",
+  isSearching: boolean,
+) {
+  if (!isSearching) return null; // Don't show badge when grouped - category label is enough
+
+  switch (type) {
+    case "block":
+      return <Badge variant="secondary">Block</Badge>;
+    case "layout":
+      return <Badge variant="secondary">Layout</Badge>;
+    case "page":
+      return <Badge variant="secondary">Guide</Badge>;
+    default:
+      return null;
+  }
 }
 
 export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [pagefind, setPagefind] = useState<Pagefind | null>(null);
+  const [registry, setRegistry] = useState<ComponentRegistry | null>(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const resultsRef = useRef<HTMLDivElement>(null);
 
-  // Initialize pagefind
+  // Fetch component registry
   useEffect(() => {
-    async function initPagefind() {
+    async function fetchRegistry() {
       try {
-        const pagefindUrl = new URL(
-          "/pagefind/pagefind.js",
-          window.location.origin,
-        ).href;
-        const pf = await import(/* @vite-ignore */ pagefindUrl);
-        pf.init();
-        await pf.options({
-          basePath: "/pagefind/",
-          ranking: {
-            termFrequency: 1.0,
-            termSimilarity: 1.0,
-            pageLength: 0,
-            termSaturation: 0.5,
-          },
-        });
-        setPagefind(pf as Pagefind);
+        setLoading(true);
+        const response = await fetch("/api/component-registry");
+        if (!response.ok) {
+          throw new Error(`Failed to fetch registry: ${response.status}`);
+        }
+        const data = await response.json();
+        setRegistry(data);
         setError(null);
       } catch (err) {
-        console.warn("Pagefind not available:", err);
-        setError(
-          "Search not available. Run `pnpm build` first to enable search.",
-        );
-      }
-    }
-    initPagefind();
-  }, []);
-
-  // Search when query changes
-  useEffect(() => {
-    if (!pagefind || !query.trim()) {
-      setResults([]);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    async function doSearch() {
-      try {
-        const response = await pagefind!.debouncedSearch(query, {}, 300);
-        if (cancelled || !response) return;
-
-        const searchResults = await Promise.all(
-          response.results.slice(0, 10).map(async (result) => {
-            const data = await result.data();
-            return data;
-          }),
-        );
-
-        if (!cancelled) {
-          setResults(searchResults);
-          setSelectedIndex(0);
-        }
-      } catch (err) {
-        console.error("Search failed:", err);
+        console.error("Failed to load component registry:", err);
+        setError("Failed to load search index");
       } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        setLoading(false);
       }
     }
 
-    doSearch();
+    if (open && !registry) {
+      fetchRegistry();
+    }
+  }, [open, registry]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [query, pagefind]);
+  // Convert registry to searchable items and include static pages
+  const allItems = useMemo<SearchItem[]>(() => {
+    // Always include static pages
+    const staticItems: SearchItem[] = STATIC_PAGES.map((page) => ({
+      name: page.name,
+      type: "page" as const,
+      description: page.description,
+      category: page.category,
+      url: page.url,
+    }));
 
-  // Reset state when dialog opens/closes
+    if (!registry?.components) return staticItems;
+
+    const componentItems = Object.values(registry.components)
+      .filter((component) => !COMPONENTS_WITHOUT_DOCS.has(component.name))
+      .map((component) => ({
+        name: component.name,
+        type: component.type,
+        description: getDescription(component.name, component.description),
+        category: component.category,
+        url: getComponentUrl(component.type, component.name),
+      }));
+
+    return [...staticItems, ...componentItems];
+  }, [registry]);
+
+  // Filter and group items based on query using match-sorter
+  const filteredGroups = useMemo<SearchGroup[]>(() => {
+    if (!query.trim()) {
+      return groupByCategory(allItems);
+    }
+
+    const filtered = matchSorter(allItems, query, {
+      keys: [
+        { key: "name", threshold: matchSorter.rankings.CONTAINS },
+        { key: "description", threshold: matchSorter.rankings.CONTAINS },
+        { key: "category", threshold: matchSorter.rankings.CONTAINS },
+      ],
+    });
+
+    return asSearchResults(filtered);
+  }, [allItems, query]);
+
+  // Get flat list of all filtered items for keyboard navigation
+  const getSelectableItems = useCallback(
+    (groups: SearchGroup[]) => groups.flatMap((g) => g.items),
+    [],
+  );
+
+  // Handle item selection
+  const handleSelect = useCallback(
+    (item: SearchItem, options: { newTab: boolean }) => {
+      if (options.newTab) {
+        window.open(item.url, "_blank");
+      } else {
+        window.location.href = item.url;
+      }
+      onOpenChange(false);
+    },
+    [onOpenChange],
+  );
+
+  // Reset query when dialog closes
   useEffect(() => {
-    if (open) {
+    if (!open) {
       setQuery("");
-      setResults([]);
-      setSelectedIndex(0);
-      // Focus input after dialog animation
-      setTimeout(() => inputRef.current?.focus(), 100);
     }
   }, [open]);
 
-  // Keyboard navigation
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSelectedIndex((i) => Math.max(i - 1, 0));
-      } else if (e.key === "Enter" && results[selectedIndex]) {
-        e.preventDefault();
-        window.location.href = results[selectedIndex].url;
-        onOpenChange(false);
-      } else if (e.key === "Escape") {
-        onOpenChange(false);
-      }
-    },
-    [results, selectedIndex, onOpenChange],
+  const hasResults = filteredGroups.some((g) => g.items.length > 0);
+  const totalResults = filteredGroups.reduce(
+    (sum, g) => sum + g.items.length,
+    0,
   );
-
-  // Scroll selected item into view
-  useEffect(() => {
-    const container = resultsRef.current;
-    const selected = container?.querySelector(
-      `[data-index="${selectedIndex}"]`,
-    );
-    if (selected) {
-      selected.scrollIntoView({ block: "nearest" });
-    }
-  }, [selectedIndex]);
+  const isSearching = query.trim().length > 0;
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog
-        size="lg"
-        className="flex max-h-[80vh] flex-col overflow-hidden p-0"
-      >
-        {/* Search input */}
-        <div className="flex items-center gap-3 border-b border-kumo-line p-4">
+    <CommandPalette.Root<SearchGroup, SearchItem>
+      open={open}
+      onOpenChange={onOpenChange}
+      items={filteredGroups}
+      value={query}
+      onValueChange={setQuery}
+      itemToStringValue={(group: SearchGroup) => group.label}
+      onSelect={handleSelect}
+      getSelectableItems={getSelectableItems}
+      filter={() => true}
+    >
+      <CommandPalette.Input
+        placeholder="Search docs..."
+        leading={
           <MagnifyingGlassIcon
-            size={20}
-            className="shrink-0 text-kumo-subtle"
+            className="h-4 w-4 text-kumo-subtle"
+            weight="bold"
           />
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Search documentation..."
-            className="flex-1 bg-transparent text-base text-kumo-default outline-none placeholder:text-kumo-subtle"
-            aria-label="Search documentation"
-          />
-          {loading && <Loader size="sm" />}
-          <kbd className="hidden items-center gap-1 rounded border border-kumo-line bg-kumo-control px-2 py-1 text-xs text-kumo-subtle sm:inline-flex">
-            ESC
-          </kbd>
-        </div>
-
-        {/* Results */}
-        <div ref={resultsRef} className="min-h-[300px] flex-1 overflow-y-auto">
-          {error ? (
-            <div className="flex h-full flex-col items-center justify-center p-8 text-center text-kumo-subtle">
-              <FileTextIcon size={48} className="mb-4 opacity-50" />
-              <p>{error}</p>
-            </div>
-          ) : !query.trim() ? (
-            <div className="flex h-full flex-col items-center justify-center p-8 text-center text-kumo-subtle">
-              <FileTextIcon size={48} className="mb-4 opacity-50" />
-              <p>Type to search documentation</p>
-            </div>
-          ) : results.length === 0 && !loading ? (
-            <div className="flex h-full flex-col items-center justify-center p-8 text-center text-kumo-subtle">
-              <FileTextIcon size={48} className="mb-4 opacity-50" />
-              <p>No results found for "{query}"</p>
-            </div>
-          ) : loading && results.length === 0 ? (
-            <div className="flex h-full flex-col items-center justify-center p-8 text-center text-kumo-subtle">
-              <Loader size="base" />
-              <p className="mt-4">Searching...</p>
-            </div>
-          ) : (
-            <ul className="divide-y divide-kumo-line">
-              {results.map((result, index) => {
-                const displayTitle =
-                  result.meta?.title || getTitleFromUrl(result.url);
-                const category = getCategoryFromUrl(result.url);
-
-                return (
-                  <li key={result.url}>
-                    <a
-                      href={result.url}
-                      data-index={index}
-                      onClick={() => onOpenChange(false)}
-                      className={cn(
-                        "block px-4 py-3 transition-colors",
-                        index === selectedIndex
-                          ? "bg-kumo-tint"
-                          : "hover:bg-kumo-control",
-                      )}
-                    >
-                      <div className="mb-1 flex items-center gap-2">
-                        {category && (
-                          <span className="text-xs text-kumo-subtle capitalize">
-                            {category}
-                          </span>
-                        )}
-                        {category && (
-                          <span className="text-kumo-subtle">/</span>
-                        )}
-                        <h3 className="font-medium text-kumo-default">
-                          {displayTitle}
-                        </h3>
-                      </div>
-                      {result.excerpt && (
-                        <p
-                          className="line-clamp-2 text-sm text-kumo-strong [&_mark]:rounded-sm [&_mark]:bg-kumo-warning-tint [&_mark]:px-0.5 [&_mark]:text-kumo-default"
-                          dangerouslySetInnerHTML={{ __html: result.excerpt }}
-                        />
-                      )}
-                    </a>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-
-        {/* Footer */}
-        {results.length > 0 && (
-          <div className="flex items-center justify-between border-t border-kumo-line bg-kumo-control px-4 py-2 text-xs text-kumo-subtle">
-            <span>
-              {results.length} result{results.length === 1 ? "" : "s"}
-            </span>
-            <div className="flex items-center gap-4">
-              <span className="flex items-center gap-1">
-                <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
-                  ↑
-                </kbd>
-                <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
-                  ↓
-                </kbd>
-                <span>to navigate</span>
-              </span>
-              <span className="flex items-center gap-1">
-                <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
-                  ↵
-                </kbd>
-                <span>to select</span>
-              </span>
-            </div>
+        }
+      />
+      <CommandPalette.List>
+        {loading ? (
+          <CommandPalette.Loading />
+        ) : error ? (
+          <div className="p-8 text-center">
+            <p className="text-kumo-subtle">{error}</p>
           </div>
+        ) : !hasResults ? (
+          <CommandPalette.Empty>
+            {query.trim()
+              ? `No results found for "${query}"`
+              : "Type to search docs"}
+          </CommandPalette.Empty>
+        ) : (
+          <CommandPalette.Results>
+            {(group: SearchGroup) => (
+              <CommandPalette.Group key={group.label} items={group.items}>
+                <CommandPalette.GroupLabel>
+                  {group.label}
+                </CommandPalette.GroupLabel>
+                <CommandPalette.Items>
+                  {(item: SearchItem) => (
+                    <CommandPalette.Item<SearchItem>
+                      key={item.name}
+                      value={item}
+                      onClick={(e: React.MouseEvent) => {
+                        const newTab = e.metaKey || e.ctrlKey;
+                        handleSelect(item, { newTab });
+                      }}
+                    >
+                      <div className="flex w-full items-center gap-3">
+                        <div className="flex-shrink-0 text-kumo-subtle">
+                          {getTypeIcon(item.type)}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <CommandPalette.HighlightedText
+                              text={item.name}
+                              highlights={findHighlightRanges(item.name, query)}
+                              className="text-base font-medium text-kumo-default"
+                            />
+                            {getTypeBadge(item.type, isSearching)}
+                          </div>
+                          <CommandPalette.HighlightedText
+                            text={item.description}
+                            highlights={findHighlightRanges(
+                              item.description,
+                              query,
+                            )}
+                            className="block truncate text-sm text-kumo-subtle"
+                          />
+                        </div>
+                      </div>
+                    </CommandPalette.Item>
+                  )}
+                </CommandPalette.Items>
+              </CommandPalette.Group>
+            )}
+          </CommandPalette.Results>
         )}
-      </Dialog>
-    </Dialog.Root>
+      </CommandPalette.List>
+      <CommandPalette.Footer>
+        <span className="text-kumo-subtle">
+          {hasResults
+            ? `${totalResults} result${totalResults === 1 ? "" : "s"}`
+            : ""}
+        </span>
+        <div className="flex items-center gap-4">
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
+              ↑
+            </kbd>
+            <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
+              ↓
+            </kbd>
+            <span>navigate</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
+              ↵
+            </kbd>
+            <span>open</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
+              ⌘↵
+            </kbd>
+            <span>new tab</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-kumo-line bg-kumo-base px-1.5 py-0.5">
+              esc
+            </kbd>
+            <span>close</span>
+          </span>
+        </div>
+      </CommandPalette.Footer>
+    </CommandPalette.Root>
   );
 }


### PR DESCRIPTION
## Summary

- Replace Pagefind full-text search with CommandPalette-based search using the component registry API
- Add static doc pages (Installation, Contributing, Colors, CLI, etc.) to search results
- Use `match-sorter` for intelligent relevance ranking across name, description, and category

<img width="731" height="465" alt="Screenshot 2026-02-10 at 10 03 36 AM" src="https://github.com/user-attachments/assets/375fe8df-311f-4b9c-b27b-98bf2fa02a4c" />


## Benefits

- **Works in dev mode** - No build step required for search to function
- **Faster search** - Client-side filtering instead of loading external Pagefind index  
- **Better UX** - CommandPalette keyboard navigation (↑/↓, Enter, ⌘+Enter for new tab, Esc)
- **Consistent design** - Uses Kumo's own CommandPalette component
- **Searchable guides** - Now includes Getting Started and Guides pages, not just components

## Changes

- `SearchDialog.tsx` - Complete rewrite using `CommandPalette.Root`, `CommandPalette.HighlightedText`, etc.
- `AGENTS.md` - Updated search documentation note
- Removed all Pagefind integration code