### PR TITLE
fix(docs): fix code block border overflow in ComponentExample

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
@@ -14,7 +14,7 @@ const { code, lang = "tsx" } = Astro.props;
   <ComponentPreview>
     <slot />
   </ComponentPreview>
-  <div class="[&_.rounded-lg]:rounded-none [&_.rounded-lg]:border-t-0">
+  <div class="[&>.code-block]:rounded-none [&>.code-block]:rounded-b-lg [&>.code-block]:border-t-0">
     <CodeBlock code={code} lang={lang} />
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Fixes visual overflow artifact in component example code snippets
- Uses more specific CSS selector targeting `.code-block` directly instead of generic `.rounded-lg`

Peep the bottom left and right corners.

**Before**
<img width="991" height="375" alt="Screenshot 2026-02-10 at 2 55 24 PM" src="https://github.com/user-attachments/assets/9ee560ee-0014-4f4a-b59b-19a448e9b6aa" />


**After**
<img width="1005" height="367" alt="Screenshot 2026-02-10 at 2 55 13 PM" src="https://github.com/user-attachments/assets/96aa6c37-1ab1-4d7d-a79d-529246af05da" />
