### PR TITLE
fix(ci): broken VR images on fork PRs due to missing permissions

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,6 +15,7 @@ on:
     types: [completed]
 
 permissions:
+  contents: write
   pull-requests: write
 
 concurrency:


### PR DESCRIPTION
preview-deploy.yml lacked contents: write, so uploadImageToGitHub silently failed on every API call and returned URLs to images that were never uploaded. 

Added the missing permission and response status checks so upload failures are caught instead of producing broken links.