### PR TITLE
feat(badge): add success variant with semantic color tokens

### DIFF
--- a/.changeset/add-success-color-tokens.md
+++ b/.changeset/add-success-color-tokens.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add missing `success` background and tint semantic color tokens (`bg-kumo-success`, `bg-kumo-success-tint`) for parity with `info`, `warning`, and `danger`. Fix `text-kumo-success` dark mode contrast by using `green-400` instead of `green-500`. Add new `success` Badge variant for positive state indicators.

--- a/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
@@ -6,6 +6,7 @@ export function BadgeVariantsDemo() {
       <Badge variant="primary">Primary</Badge>
       <Badge variant="secondary">Secondary</Badge>
       <Badge variant="destructive">Destructive</Badge>
+      <Badge variant="success">Success</Badge>
       <Badge variant="outline">Outline</Badge>
       <Badge variant="beta">Beta</Badge>
     </div>
@@ -22,6 +23,10 @@ export function BadgeSecondaryDemo() {
 
 export function BadgeDestructiveDemo() {
   return <Badge variant="destructive">Destructive</Badge>;
+}
+
+export function BadgeSuccessDemo() {
+  return <Badge variant="success">Success</Badge>;
 }
 
 export function BadgeOutlineDemo() {

--- a/packages/kumo-docs-astro/src/components/demos/MeterDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/MeterDemo.tsx
@@ -25,7 +25,7 @@ export function MeterCustomStyleDemo() {
     <Meter
       label="Upload progress"
       value={80}
-      indicatorClassName="from-green-500 via-green-500 to-green-500"
+      indicatorClassName="from-kumo-success via-kumo-success to-kumo-success"
     />
   );
 }

--- a/packages/kumo-figma/src/generators/shared.ts
+++ b/packages/kumo-figma/src/generators/shared.ts
@@ -63,6 +63,8 @@ export const VAR_NAMES = {
     warningTint: "color-kumo-warning-tint",
     danger: "color-kumo-danger",
     dangerTint: "color-kumo-danger-tint",
+    success: "color-kumo-success",
+    successTint: "color-kumo-success-tint",
     // Legacy aliases (for gradual migration from old naming convention)
     // Old: "color-{name}" → New: "color-kumo-{name}"
     surface: "color-kumo-base",

--- a/packages/kumo-figma/src/parsers/tailwind-to-figma.ts
+++ b/packages/kumo-figma/src/parsers/tailwind-to-figma.ts
@@ -97,6 +97,8 @@ const COLOR_TO_VARIABLE: Record<string, string> = {
   "bg-kumo-warning-tint": "color-kumo-warning-tint",
   "bg-kumo-danger": "color-kumo-danger",
   "bg-kumo-danger-tint": "color-kumo-danger-tint",
+  "bg-kumo-success": "color-kumo-success",
+  "bg-kumo-success-tint": "color-kumo-success-tint",
   "bg-transparent": null!, // No fill
   "bg-inherit": null!, // No fill
 
@@ -124,6 +126,7 @@ const COLOR_TO_VARIABLE: Record<string, string> = {
   "border-kumo-info": "color-kumo-info",
   "border-kumo-warning": "color-kumo-warning",
   "border-kumo-danger": "color-kumo-danger",
+  "border-kumo-success": "color-kumo-success",
   "ring-kumo-line": "color-kumo-line",
   "ring-kumo-ring": "color-kumo-ring",
   "ring-kumo-danger": "color-kumo-danger",

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -89,7 +89,7 @@ export const THEME_CONFIG: ThemeConfig = {
       theme: {
         kumo: {
           light: "var(--color-green-500, oklch(72.3% 0.219 149.579))",
-          dark: "var(--color-green-500, oklch(72.3% 0.219 149.579))",
+          dark: "var(--color-green-400, oklch(79.2% 0.209 151.711))",
         },
       },
     },
@@ -322,6 +322,24 @@ export const THEME_CONFIG: ThemeConfig = {
         kumo: {
           light: "var(--color-red-300, oklch(80.8% 0.114 19.571))",
           dark: "var(--color-red-900, oklch(39.6% 0.141 25.723))",
+        },
+      },
+    },
+    "kumo-success": {
+      newName: "",
+      theme: {
+        kumo: {
+          light: "var(--color-green-500, oklch(72.3% 0.219 149.579))",
+          dark: "var(--color-green-700, oklch(52.7% 0.154 150.069))",
+        },
+      },
+    },
+    "kumo-success-tint": {
+      newName: "",
+      theme: {
+        kumo: {
+          light: "var(--color-green-300, oklch(87.1% 0.15 154.449))",
+          dark: "var(--color-green-900, oklch(39.3% 0.095 152.535))",
         },
       },
     },

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -20,12 +20,17 @@ export const KUMO_BADGE_VARIANTS = {
       classes: "bg-kumo-danger text-white",
       description: "Error or danger state indicator",
     },
+    success: {
+      classes: "bg-kumo-success text-white",
+      description: "Success or positive state indicator",
+    },
     outline: {
       classes: "border border-kumo-fill bg-transparent text-kumo-default",
       description: "Bordered badge with transparent background",
     },
     beta: {
-      classes: "border border-dashed border-kumo-brand bg-transparent text-kumo-link",
+      classes:
+        "border border-dashed border-kumo-brand bg-transparent text-kumo-link",
       description: "Indicates beta or experimental features",
     },
   },
@@ -72,6 +77,7 @@ export interface BadgeProps {
    * - `"primary"` — High-emphasis badge for important labels
    * - `"secondary"` — Subtle badge for secondary information
    * - `"destructive"` — Error or danger state indicator
+   * - `"success"` — Success or positive state indicator
    * - `"outline"` — Bordered badge with transparent background
    * - `"beta"` — Dashed-border badge for beta/experimental features
    * @default "primary"

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -45,7 +45,7 @@
 
   --text-color-kumo-success: light-dark(
     var(--color-green-500, oklch(72.3% 0.219 149.579)),
-    var(--color-green-500, oklch(72.3% 0.219 149.579))
+    var(--color-green-400, oklch(79.2% 0.209 151.711))
   );
 
   --text-color-kumo-danger: light-dark(
@@ -169,6 +169,16 @@
   --color-kumo-danger-tint: light-dark(
     var(--color-red-300, oklch(80.8% 0.114 19.571)),
     var(--color-red-900, oklch(39.6% 0.141 25.723))
+  );
+
+  --color-kumo-success: light-dark(
+    var(--color-green-500, oklch(72.3% 0.219 149.579)),
+    var(--color-green-700, oklch(52.7% 0.154 150.069))
+  );
+
+  --color-kumo-success-tint: light-dark(
+    var(--color-green-300, oklch(87.1% 0.15 154.449)),
+    var(--color-green-900, oklch(39.3% 0.095 152.535))
   );
 
 }


### PR DESCRIPTION
## Summary
- Add missing `success` background and tint semantic color tokens (`bg-kumo-success`, `bg-kumo-success-tint`) for parity with `info`, `warning`, and `danger`
- Fix `text-kumo-success` dark mode contrast by using `green-400` instead of `green-500`
- Add new `success` Badge variant for positive state indicators

## Changes
- **Theme tokens**: Added `kumo-success` and `kumo-success-tint` color tokens in theme-generator config
- **Badge component**: Added `success` variant with `bg-kumo-success text-white` styling
- **Docs**: Updated BadgeDemo with success variant examples
- **MeterDemo**: Updated to use semantic `kumo-success` token instead of raw `green-500`
- **Figma plugin**: Added success color mappings to shared.ts and tailwind-to-figma.ts parser

## Usage
\`\`\`tsx
<Badge variant="success">Success</Badge>
\`\`\`