### PR TITLE
fix(docs): persist sidebar scroll position across navigation

### DIFF
--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { cn, Button } from "@cloudflare/kumo";
 import {
   CaretDownIcon,
@@ -93,6 +93,10 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
 
   const [searchOpen, setSearchOpen] = useState(false);
 
+  // Refs for scroll containers
+  const mobileScrollRef = useRef<HTMLDivElement>(null);
+  const desktopScrollRef = useRef<HTMLDivElement>(null);
+
   const toggleSidebar = () => setSidebarOpen((v) => !v);
   const toggleMobileMenu = () => setMobileMenuOpen((v) => !v);
 
@@ -111,6 +115,50 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("kumo:open-search", handleOpenSearch);
+    };
+  }, []);
+
+  // Save scroll position on scroll and navigation
+  useEffect(() => {
+    const STORAGE_KEY = "kumo-sidebar-scroll";
+
+    // Save scroll position before navigation
+    const handleBeforeUnload = () => {
+      const scrollPosition =
+        mobileScrollRef.current?.scrollTop ||
+        desktopScrollRef.current?.scrollTop ||
+        0;
+      sessionStorage.setItem(STORAGE_KEY, scrollPosition.toString());
+    };
+
+    // Save on scroll for more reliable restoration
+    const handleScroll = (e: Event) => {
+      const target = e.target as HTMLElement;
+      sessionStorage.setItem(STORAGE_KEY, target.scrollTop.toString());
+    };
+
+    // Listen for navigation events
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    // Attach scroll listeners to both containers
+    const mobileContainer = mobileScrollRef.current;
+    const desktopContainer = desktopScrollRef.current;
+
+    if (mobileContainer) {
+      mobileContainer.addEventListener("scroll", handleScroll);
+    }
+    if (desktopContainer) {
+      desktopContainer.addEventListener("scroll", handleScroll);
+    }
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      if (mobileContainer) {
+        mobileContainer.removeEventListener("scroll", handleScroll);
+      }
+      if (desktopContainer) {
+        desktopContainer.removeEventListener("scroll", handleScroll);
+      }
     };
   }, []);
 
@@ -263,7 +311,12 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
             <XIcon size={20} />
           </Button>
         </div>
-        <div className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-sm text-kumo-strong">
+        <div
+          ref={mobileScrollRef}
+          data-sidebar-scroll="mobile"
+          className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-sm text-kumo-strong"
+          style={{ scrollBehavior: "auto" }}
+        >
           {navContent}
         </div>
       </aside>
@@ -308,7 +361,11 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
       >
         <div className="h-[49px] flex-none border-b border-kumo-line" />
 
-        <div className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-sm text-kumo-strong">
+        <div
+          ref={desktopScrollRef}
+          data-sidebar-scroll="desktop"
+          className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-sm text-kumo-strong"
+        >
           {navContent}
         </div>
       </aside>

--- a/packages/kumo-docs-astro/src/layouts/MainLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/MainLayout.astro
@@ -16,6 +16,29 @@ const currentPath = Astro.url.pathname;
   <div class="isolate">
     <SidebarNav currentPath={currentPath} client:load />
 
+    <script is:inline>
+      (function () {
+        const KEY = "kumo-sidebar-scroll";
+        function restore() {
+          try {
+            const raw = sessionStorage.getItem(KEY);
+            if (!raw) return;
+            const pos = Number.parseInt(raw, 10);
+            if (!Number.isFinite(pos)) return;
+            const els = document.querySelectorAll("[data-sidebar-scroll]");
+            for (const el of els) {
+              el.scrollTop = pos;
+            }
+          } catch {
+            // no-op
+          }
+        }
+
+        restore();
+        window.addEventListener("astro:after-swap", restore);
+      })();
+    </script>
+
     <!-- Theme toggle: fixed in top right corner -->
     <div
       class="pointer-events-auto fixed top-0 right-2 z-50 flex h-[49px] items-center"
@@ -40,7 +63,7 @@ const currentPath = Astro.url.pathname;
     body:has(aside[data-sidebar-open="true"]) .main-content {
       margin-left: 304px; /* 48px rail + 256px sidebar panel */
     }
-    
+
     /* When sidebar is closed, only rail margin */
     body:has(aside[data-sidebar-open="false"]) .main-content {
       margin-left: 48px; /* w-12 = 3rem = 48px */


### PR DESCRIPTION
## Summary

- Adds sessionStorage-based scroll position persistence for the sidebar navigation
- Maintains user's scroll position when navigating between documentation pages
- Implements scroll tracking for both mobile and desktop sidebar views

## Changes

- Added refs to track mobile and desktop scroll containers in `SidebarNav.tsx`
- Implemented `useEffect` hook to save scroll position to sessionStorage on scroll and before navigation
- Added inline script in `MainLayout.astro` to restore scroll position on page load and Astro page swaps
- Applied scroll restoration to both mobile and desktop sidebar containers

## Before


https://github.com/user-attachments/assets/c38fc439-1954-43b8-8993-ac1a98cc2930



## After

https://github.com/user-attachments/assets/36577d74-7bb0-441d-941f-4582b6618fc4


## Testing

- Navigate through documentation pages and verify sidebar scroll position is maintained
- Test on both mobile and desktop viewports
- Verify scroll position persists across full page reloads (within the same session)