### PR TITLE
fix(docs): normalize pathnames in SidebarNav for consistent active link highlighting

### DIFF
--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -13,6 +13,12 @@ interface NavItem {
   href: string;
 }
 
+function normalizePathname(pathname: string) {
+  if (!pathname) return "/";
+  if (pathname === "/") return "/";
+  return pathname.replace(/\/+$/, "");
+}
+
 const staticPages: NavItem[] = [
   { label: "Home", href: "/" },
   { label: "Installation", href: "/installation" },
@@ -91,6 +97,8 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [componentsOpen, setComponentsOpen] = useState(true);
   const [blocksOpen, setBlocksOpen] = useState(true);
+
+  const activePath = normalizePathname(currentPath);
 
   const [searchOpen, setSearchOpen] = useState(false);
 
@@ -181,7 +189,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
               href={item.href}
               className={cn(
                 LI_STYLE,
-                currentPath === item.href && LI_ACTIVE_STYLE,
+                activePath === normalizePathname(item.href) && LI_ACTIVE_STYLE,
               )}
             >
               {item.label}
@@ -221,7 +229,8 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
                 className={cn(
                   LI_STYLE,
                   "pl-4",
-                  currentPath === item.href && LI_ACTIVE_STYLE,
+                  activePath === normalizePathname(item.href) &&
+                    LI_ACTIVE_STYLE,
                 )}
               >
                 {item.label}
@@ -260,7 +269,8 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
                 className={cn(
                   LI_STYLE,
                   "pl-4",
-                  currentPath === item.href && LI_ACTIVE_STYLE,
+                  activePath === normalizePathname(item.href) &&
+                    LI_ACTIVE_STYLE,
                 )}
               >
                 {item.label}


### PR DESCRIPTION
## Summary

Fixes an issue where sidebar navigation links were not consistently highlighted as active due to pathname comparison inconsistencies (e.g., paths with trailing slashes vs. without).

## Changes

This PR introduces pathname normalization in the `SidebarNav` component to ensure that active link highlighting works correctly regardless of trailing slashes or other pathname variations.

The `normalizePathname()` helper function removes trailing slashes from pathnames before comparison, ensuring that paths like `/components` and `/components/` are treated as equivalent when determining which sidebar link should be highlighted as active.

## Before

<img width="1197" height="772" alt="Screenshot 2026-02-17 at 14 35 21" src="https://github.com/user-attachments/assets/8b238d58-8d40-4cec-b763-25d4ad378530" />

## After

<img width="1213" height="797" alt="Screenshot 2026-02-17 at 14 37 38" src="https://github.com/user-attachments/assets/a653786f-9e88-4511-ab9f-47609f50e54e" />


