### PR TITLE
fix(docs): theme toggle position

### DIFF
--- a/packages/kumo-docs-astro/src/layouts/MainLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/MainLayout.astro
@@ -41,7 +41,7 @@ const currentPath = Astro.url.pathname;
 
     <!-- Theme toggle: fixed in top right corner -->
     <div
-      class="pointer-events-auto fixed top-0 right-2 z-50 flex h-[49px] items-center"
+      class="pointer-events-auto fixed top-0 right-1.5 z-50 flex h-[49px] items-center"
     >
       <ThemeToggle client:only="react" />
     </div>


### PR DESCRIPTION
Fixes the theme toggle position when in desktop mode and the main content container overflows and shows a scrollbar. It displaced the fixed theme toggle position. This PR keeps the mobile position as is, only changes position in desktop view.


| Before | After |
|--|--|
| <img width="326" height="208" alt="Screenshot 2026-02-22 at 15 09 41@2x" src="https://github.com/user-attachments/assets/9ce2ea3d-27a8-4c4c-8186-182b53434aa4" /> | <img width="411" height="251" alt="Screenshot 2026-02-22 at 15 10 13@2x" src="https://github.com/user-attachments/assets/1c34eb16-75dc-4211-9205-2841df3cccb3" /> |
