### PR TITLE
fix(code): add overflow-x-auto to CodeComponent

### DIFF
--- a/packages/kumo/src/components/code/code.tsx
+++ b/packages/kumo/src/components/code/code.tsx
@@ -100,7 +100,7 @@ export function codeVariants({
 }: KumoCodeVariantsProps = {}) {
   return cn(
     // Base styles
-    "m-0 w-auto rounded-none border-none bg-transparent p-0 font-mono text-sm leading-[20px] text-kumo-strong",
+    "m-0 w-auto rounded-none border-none bg-transparent p-0 font-mono text-sm leading-[20px] text-kumo-strong overflow-x-auto",
     // Apply lang-specific styles (currently none, but extensible)
     KUMO_CODE_VARIANTS.lang[lang].classes,
   );


### PR DESCRIPTION
When there is a long line in a CodeBlock that exceeds parent container, it just gets clipped. Adding `overflow-x: auto` to the CodeComponent to make it overflow in horizontal axis.

| Before | After |
|--|--|
| <img width="415" height="114" alt="Screenshot 2026-02-27 at 14 03 40@2x" src="https://github.com/user-attachments/assets/23fea856-8eb7-466d-b5bf-2643f8cfe291" /> | <img width="400" height="142" alt="Screenshot 2026-02-27 at 14 04 03@2x" src="https://github.com/user-attachments/assets/6597799a-bddf-4029-9f9b-7e8e10ecfc0a" /> |



