### PR TITLE
fix(datepicker): remove thead background to prevent conflicts with Dashboard styles

### DIFF
--- a/packages/kumo/src/styles/kumo.css
+++ b/packages/kumo/src/styles/kumo.css
@@ -138,6 +138,10 @@
   box-sizing: border-box;
 }
 
+.rdp-root thead {
+  background: transparent;
+}
+
 /* Day cells */
 .rdp-day {
   width: var(--rdp-day-width);


### PR DESCRIPTION
## Summary

Fixes a style conflict between the DatePicker component's thead element and the Cloudflare Dashboard's default thead styles by explicitly setting the background to transparent.

## Changes

- Added `background: transparent` to `.rdp-root thead` selector in kumo.css
- This override ensures the DatePicker's calendar header doesn't inherit unwanted background styles from the Dashboard

## Why

The Dashboard has default thead styles that were conflicting with the DatePicker component, causing visual inconsistencies. This fix explicitly overrides those styles to maintain the intended DatePicker appearance.