### PR TITLE
feat(docs): add Flow test page with expandable node demo

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/FlowDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/FlowDemo.tsx
@@ -1,4 +1,36 @@
+import { forwardRef, useState } from "react";
 import { Flow } from "@cloudflare/kumo";
+import { CaretDownIcon } from "@phosphor-icons/react";
+
+const ExpandableNode = forwardRef<
+  HTMLLIElement,
+  { title: string; children: React.ReactNode }
+>(function ExpandableNode({ title, children, ...props }, ref) {
+  const [open, setOpen] = useState(false);
+  return (
+    <li
+      ref={ref}
+      {...props}
+      className="rounded-lg shadow bg-kumo-base ring ring-kumo-line overflow-hidden"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-sm font-medium text-kumo-default"
+      >
+        {title}
+        <CaretDownIcon
+          className={`size-4 text-kumo-subtle transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-kumo-line px-3 py-2 text-sm text-kumo-subtle">
+          {children}
+        </div>
+      )}
+    </li>
+  );
+});
 
 /** Basic flow diagram with sequential nodes */
 export function FlowBasicDemo() {
@@ -180,6 +212,36 @@ export function FlowParallelNestedListDemo() {
         </Flow.List>
       </Flow.Parallel>
       <Flow.Node>Destinations</Flow.Node>
+    </Flow>
+  );
+}
+
+/** Flow diagram with expandable nodes in a parallel group */
+export function FlowExpandableDemo() {
+  return (
+    <Flow>
+      <Flow.Node>Incoming Request</Flow.Node>
+      <Flow.Parallel>
+        <Flow.Node
+          render={
+            <ExpandableNode title="Auth Service">
+              <p>Validates JWT tokens and session cookies.</p>
+              <p className="mt-1">
+                Connects to identity provider via OAuth 2.0.
+              </p>
+            </ExpandableNode>
+          }
+        />
+        <Flow.Node
+          render={
+            <ExpandableNode title="Rate Limiter">
+              <p>Enforces per-IP request limits.</p>
+              <p className="mt-1">Sliding window: 100 req/min.</p>
+            </ExpandableNode>
+          }
+        />
+      </Flow.Parallel>
+      <Flow.Node>Route to Origin</Flow.Node>
     </Flow>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/tests/flow.astro
+++ b/packages/kumo-docs-astro/src/pages/tests/flow.astro
@@ -1,0 +1,129 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import {
+  FlowBasicDemo,
+  FlowParallelDemo,
+  FlowCustomContentDemo,
+  FlowComplexDemo,
+  FlowAnchorDemo,
+  FlowCenteredDemo,
+  FlowPanningDemo,
+  FlowDisabledDemo,
+  FlowParallelAlignEndDemo,
+  FlowParallelNestedListDemo,
+  FlowExpandableDemo,
+} from "../../components/demos/FlowDemo";
+---
+
+<BaseLayout title="Flow Test Page">
+  <div class="p-16 space-y-12 max-w-[1000px] mx-auto mb-64">
+    <h1 class="text-2xl font-bold text-kumo-strong">Flow Demo Components</h1>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowBasicDemo</h2>
+      <p class="text-kumo-subtle">Basic flow diagram with sequential nodes</p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowBasicDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowParallelDemo</h2>
+      <p class="text-kumo-subtle">Flow diagram with parallel branching</p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowParallelDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">
+        FlowCustomContentDemo
+      </h2>
+      <p class="text-kumo-subtle">
+        Flow diagram with custom node styling using render prop
+      </p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowCustomContentDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowComplexDemo</h2>
+      <p class="text-kumo-subtle">Complex flow diagram example</p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowComplexDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowAnchorDemo</h2>
+      <p class="text-kumo-subtle">Flow diagram with custom anchor points</p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowAnchorDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowCenteredDemo</h2>
+      <p class="text-kumo-subtle">
+        Flow diagram with vertically centered nodes
+      </p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowCenteredDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowPanningDemo</h2>
+      <p class="text-kumo-subtle">Large flow diagram demonstrating panning</p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowPanningDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">FlowDisabledDemo</h2>
+      <p class="text-kumo-subtle">Flow diagram with disabled nodes</p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowDisabledDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">
+        FlowParallelAlignEndDemo
+      </h2>
+      <p class="text-kumo-subtle">
+        Flow diagram with right-aligned parallel nodes
+      </p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowParallelAlignEndDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">
+        FlowParallelNestedListDemo
+      </h2>
+      <p class="text-kumo-subtle">
+        Flow diagram with parallel branches containing nested node sequences
+      </p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowParallelNestedListDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold text-kumo-default">
+        FlowExpandableDemo
+      </h2>
+      <p class="text-kumo-subtle">
+        Flow diagram with expandable nodes in a parallel group — click a node to
+        reveal more content
+      </p>
+      <div class="p-4 rounded-lg border border-kumo-line bg-kumo-base">
+        <FlowExpandableDemo client:visible />
+      </div>
+    </section>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
Add a new test page at /tests/flow rendering all Flow demo components. Add FlowExpandableDemo with ref-forwarded ExpandableNode that toggles content on click inside parallel Flow nodes.

<img width="2532" height="2088" alt="CleanShot 2026-02-27 at 12 35 52@2x" src="https://github.com/user-attachments/assets/14427e38-2b6d-46b6-9dbf-4416cedfb27a" />

## Context

I've been needing a page for freely testing edge cases that don't make sense as individual sections on a docs page.
