### PR TITLE
fix: hardcode themes to github-light and vesper

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/CodeHighlightedDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CodeHighlightedDemo.tsx
@@ -1,5 +1,6 @@
 import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
+import type { ReactNode } from "react";
 
 /**
  * Wrapper component that provides Shiki context for all demos.
@@ -18,7 +19,6 @@ function DemoProvider({ children }: { children: ReactNode }) {
         "css",
         "html",
       ]}
-      themes={{ light: "github-light", dark: "vesper" }}
     >
       {children}
     </ShikiProvider>
@@ -198,7 +198,6 @@ export function CodeExample({ code, language }: Props) {
     <ShikiProvider
       engine="javascript"
       languages={["tsx", "typescript", "bash", "json"]}
-      themes={{ light: "github-light", dark: "vesper" }}
     >
       <CodeHighlighted
         code={code}
@@ -210,7 +209,7 @@ export function CodeExample({ code, language }: Props) {
 }`}
         lang="tsx"
         showCopyButton
-        highlightLines={[6, 7, 8, 9, 10]}
+        highlightLines={[6, 7, 8, 9]}
       />
     </DemoProvider>
   );

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.astro
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.astro
@@ -22,7 +22,6 @@ import {
 const heroCode = `<ShikiProvider
   engine="javascript"
   languages={["tsx", "bash", "json"]}
-  themes={{ light: "github-light", dark: "vesper" }}
 >
   <CodeHighlighted code={code} lang="tsx" />
 </ShikiProvider>`;
@@ -36,7 +35,6 @@ export function App() {
     <ShikiProvider
       engine="javascript"
       languages={["tsx", "typescript", "bash", "json"]}
-      themes={{ light: "github-light", dark: "vesper" }}
     >
       {/* All CodeHighlighted components share the same Shiki instance */}
       <CodeHighlighted code="const x = 1;" lang="typescript" />
@@ -48,7 +46,6 @@ const providerPropsTable = `| Prop | Type | Required | Description |
 |------|------|----------|-------------|
 | \`engine\` | \`"javascript" \\| "wasm"\` | Yes | Highlighting engine. JavaScript is smaller (~50KB), WASM is more accurate (~180KB). |
 | \`languages\` | \`string[]\` | Yes | Languages to support. Only these will be loaded. |
-| \`themes\` | \`{ light: Theme, dark: Theme }\` | Yes | Themes for light and dark mode. |
 | \`labels\` | \`{ copy?: string, copied?: string }\` | No | Localized labels for copy button. |
 | \`children\` | \`ReactNode\` | Yes | App content. |`;
 
@@ -60,14 +57,12 @@ const codeHighlightedPropsTable = `| Prop | Type | Required | Description |
 | \`highlightLines\` | \`number[]\` | No | Lines to emphasize (1-indexed). |
 | \`showCopyButton\` | \`boolean\` | No | Show copy-to-clipboard button. |
 | \`labels\` | \`{ copy?: string, copied?: string }\` | No | Override provider labels for this instance. |
-| \`theme\` | \`Theme\` | No | Override provider theme for this instance. |
 | \`className\` | \`string\` | No | Additional CSS classes. |`;
 
 const i18nCode = `// Set labels at the provider level for all code blocks
 <ShikiProvider
   engine="javascript"
   languages={["tsx", "bash"]}
-  themes={{ light: "github-light", dark: "vesper" }}
   labels={{ copy: "Copier", copied: "Copié!" }}
 >
   <App />
@@ -85,9 +80,7 @@ const serverUsageCode = `// Next.js RSC or Astro
 import { highlightCode } from "@cloudflare/kumo/code/server";
 
 export default async function Page() {
-  const html = await highlightCode(\`const x = 1;\`, "typescript", {
-    themes: { light: "github-light", dark: "github-dark" },
-  });
+  const html = await highlightCode(\`const x = 1;\`, "typescript");
 
   return <pre dangerouslySetInnerHTML={{ __html: html }} />;
 }`;
@@ -97,7 +90,6 @@ import { createServerHighlighter } from "@cloudflare/kumo/code/server";
 
 const highlighter = await createServerHighlighter({
   languages: ["tsx", "bash", "json"],
-  themes: ["github-light", "github-dark"],
 });
 
 const html1 = highlighter.highlight(code1, "tsx");
@@ -128,15 +120,11 @@ function CustomCodeBlock({ code, lang }) {
   return <pre dangerouslySetInnerHTML={{ __html: html }} />;
 }`;
 
-const themesCode = `// Use any Shiki/VS Code theme by name
-<ShikiProvider
-  themes={{ light: "github-light", dark: "vesper" }}
-  // ...
-/>
-
-// Other popular themes:
-// Light: "github-light", "min-light", "slack-ochin"
-// Dark: "vesper", "github-dark", "nord", "dracula"`;
+const themesCode = `// Themes are hardcoded for consistent styling:
+// - Light mode: github-light
+// - Dark mode: vesper
+//
+// No theme customization is needed or supported.`;
 
 const bundleSizeTable = `| Scenario | Languages | Engine | Lazy Load Size |
 |----------|-----------|--------|----------------|
@@ -154,7 +142,6 @@ export function Providers({ children }) {
     <ShikiProvider
       engine="javascript"
       languages={["tsx", "bash", "json"]}
-      themes={{ light: "github-light", dark: "vesper" }}
     >
       {children}
     </ShikiProvider>
@@ -179,9 +166,7 @@ const astroCode = `---
 import { highlightCode } from "@cloudflare/kumo/code/server";
 
 const { code, lang } = Astro.props;
-const html = await highlightCode(code, lang, {
-  themes: { light: "github-light", dark: "vesper" }
-});
+const html = await highlightCode(code, lang);
 ---
 
 <div class="code-block" set:html={html} />`;
@@ -197,7 +182,6 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
 <ShikiProvider
   engine="javascript"
   languages={["tsx"]}
-  themes={{ light: "github-light", dark: "vesper" }}
 >
   <App />
 </ShikiProvider>
@@ -391,9 +375,15 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
   <ComponentSection>
     <Heading level={2}>Themes</Heading>
     <p class="mb-4 text-kumo-strong">
-      Kumo ships with Cloudflare-branded themes. You can also use any Shiki/VS Code theme.
+      CodeHighlighted uses hardcoded themes for consistent styling across all Kumo applications:
     </p>
-    <CodeBlock code={themesCode} lang="tsx" />
+    <ul class="mb-4 list-disc pl-6 text-kumo-strong">
+      <li><strong>Light mode:</strong> <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">github-light</code></li>
+      <li><strong>Dark mode:</strong> <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">vesper</code></li>
+    </ul>
+    <p class="text-sm text-kumo-subtle">
+      Theme customization is not supported. This ensures visual consistency across all code blocks in your application.
+    </p>
   </ComponentSection>
 
   <!-- Server-Side Usage -->
@@ -538,12 +528,6 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
                 <td class="py-2">Languages to support (e.g., ["tsx", "bash"])</td>
               </tr>
               <tr class="border-b border-kumo-line/50">
-                <td class="py-2 pr-4"><code>themes</code></td>
-                <td class="py-2 pr-4"><code>{ light: Theme, dark: Theme }</code></td>
-                <td class="py-2 pr-4">Yes</td>
-                <td class="py-2">Themes for light and dark mode</td>
-              </tr>
-              <tr class="border-b border-kumo-line/50">
                 <td class="py-2 pr-4"><code>labels</code></td>
                 <td class="py-2 pr-4"><code>{ copy?: string, copied?: string }</code></td>
                 <td class="py-2 pr-4">No</td>
@@ -608,12 +592,6 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
                 <td class="py-2 pr-4"><code>{ copy?: string, copied?: string }</code></td>
                 <td class="py-2 pr-4">No</td>
                 <td class="py-2">Override provider labels for this instance</td>
-              </tr>
-              <tr class="border-b border-kumo-line/50">
-                <td class="py-2 pr-4"><code>theme</code></td>
-                <td class="py-2 pr-4"><code>Theme</code></td>
-                <td class="py-2 pr-4">No</td>
-                <td class="py-2">Override provider theme for this instance</td>
               </tr>
               <tr>
                 <td class="py-2 pr-4"><code>className</code></td>

--- a/packages/kumo/src/code/code-highlighted.tsx
+++ b/packages/kumo/src/code/code-highlighted.tsx
@@ -12,6 +12,8 @@ import type { CodeHighlightedProps } from "./types";
  * Must be used within a ShikiProvider. While Shiki is loading,
  * displays code as plain text (no layout shift, immediately readable).
  *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
+ *
  * @example
  * ```tsx
  * import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
@@ -19,7 +21,6 @@ import type { CodeHighlightedProps } from "./types";
  * <ShikiProvider
  *   engine="javascript"
  *   languages={['tsx', 'bash']}
- *   themes={{ light: 'github-light', dark: 'github-dark' }}
  * >
  *   <CodeHighlighted
  *     code={`const greeting = "Hello!";`}
@@ -33,7 +34,6 @@ import type { CodeHighlightedProps } from "./types";
 export function CodeHighlighted({
   code,
   lang,
-  theme,
   showLineNumbers = false,
   highlightLines,
   showCopyButton = false,
@@ -65,7 +65,7 @@ export function CodeHighlighted({
   }, [code]);
 
   // Get highlighted HTML (or null if not ready/failed)
-  const html = highlight(code, lang, theme ? { theme } : undefined);
+  const html = highlight(code, lang);
 
   // Count lines for line numbers
   const lineCount = useMemo(() => code.split("\n").length, [code]);

--- a/packages/kumo/src/code/context.ts
+++ b/packages/kumo/src/code/context.ts
@@ -1,10 +1,6 @@
 import { createContext } from "react";
 import type { Highlighter } from "shiki";
-import type {
-  ShikiThemeConfig,
-  BundledLanguage,
-  CodeHighlightedLabels,
-} from "./types";
+import type { BundledLanguage, CodeHighlightedLabels } from "./types";
 
 export interface ShikiContextValue {
   /** The initialized Shiki highlighter instance */
@@ -15,9 +11,6 @@ export interface ShikiContextValue {
 
   /** Error if initialization failed */
   error: Error | null;
-
-  /** Configured themes */
-  themes: ShikiThemeConfig;
 
   /** Configured languages */
   languages: BundledLanguage[];

--- a/packages/kumo/src/code/index.ts
+++ b/packages/kumo/src/code/index.ts
@@ -4,6 +4,8 @@
  * This module is intentionally separate from the main `@cloudflare/kumo` export
  * to avoid bundling Shiki (~65-250KB) for consumers who don't need it.
  *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
+ *
  * @example
  * ```tsx
  * import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
@@ -13,7 +15,6 @@
  *     <ShikiProvider
  *       engine="javascript"
  *       languages={['tsx', 'bash', 'json']}
- *       themes={{ light: 'github-light', dark: 'github-dark' }}
  *     >
  *       <CodeHighlighted code="const x = 1;" lang="tsx" />
  *     </ShikiProvider>
@@ -37,9 +38,5 @@ export type {
   CodeHighlightedProps,
   UseShikiHighlighterResult,
   ShikiEngine,
-  ShikiThemeConfig,
-  HighlightOptions,
   BundledLanguage,
-  BundledTheme,
-  ThemeRegistration,
 } from "./types";

--- a/packages/kumo/src/code/provider.tsx
+++ b/packages/kumo/src/code/provider.tsx
@@ -11,6 +11,8 @@ import type { ShikiProviderProps, BundledLanguage } from "./types";
  * until this provider mounts. While loading, child components can
  * render code as plain text.
  *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
+ *
  * @example
  * ```tsx
  * import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
@@ -20,7 +22,6 @@ import type { ShikiProviderProps, BundledLanguage } from "./types";
  *     <ShikiProvider
  *       engine="javascript"
  *       languages={['tsx', 'bash', 'json']}
- *       themes={{ light: 'github-light', dark: 'github-dark' }}
  *     >
  *       <CodeHighlighted code="const x = 1;" lang="tsx" />
  *     </ShikiProvider>
@@ -36,7 +37,6 @@ const DEFAULT_LABELS = {
 export function ShikiProvider({
   engine,
   languages,
-  themes,
   labels,
   children,
 }: ShikiProviderProps): ReactNode {
@@ -69,7 +69,7 @@ export function ShikiProvider({
               );
 
         const highlighter = await createHighlighter({
-          themes: [themes.light, themes.dark],
+          themes: ["github-light", "vesper"],
           langs: languages,
           engine: engineInstance,
         });
@@ -98,7 +98,7 @@ export function ShikiProvider({
     return () => {
       cancelled = true;
     };
-  }, [engine, languages, themes]);
+  }, [engine, languages]);
 
   const mergedLabels = useMemo(
     () => ({ ...DEFAULT_LABELS, ...labels }),
@@ -110,18 +110,10 @@ export function ShikiProvider({
       highlighter: state.highlighter,
       isLoading: state.isLoading,
       error: state.error,
-      themes,
       languages: languages as BundledLanguage[],
       labels: mergedLabels,
     }),
-    [
-      state.highlighter,
-      state.isLoading,
-      state.error,
-      themes,
-      languages,
-      mergedLabels,
-    ],
+    [state.highlighter, state.isLoading, state.error, languages, mergedLabels],
   );
 
   return (

--- a/packages/kumo/src/code/server.ts
+++ b/packages/kumo/src/code/server.ts
@@ -4,37 +4,27 @@
  * Use these in SSR frameworks (Next.js, Astro, Remix) or build-time scripts.
  * These functions are async and should NOT be imported in client bundles.
  *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
+ *
  * @example
  * ```tsx
  * // Next.js RSC
  * import { highlightCode } from "@cloudflare/kumo/code/server";
  *
  * export default async function Page() {
- *   const html = await highlightCode(`const x = 1;`, "tsx", {
- *     themes: { light: "github-light", dark: "github-dark" },
- *   });
+ *   const html = await highlightCode(`const x = 1;`, "tsx");
  *
  *   return <pre dangerouslySetInnerHTML={{ __html: html }} />;
  * }
  * ```
  */
 
-import type {
-  Highlighter,
-  BundledLanguage,
-  BundledTheme,
-  ThemeRegistration,
-} from "shiki";
+import type { Highlighter, BundledLanguage } from "shiki";
 import type { ShikiEngine } from "./types";
 
 export interface HighlightCodeOptions {
   /** Highlighting engine (default: "javascript") */
   engine?: ShikiEngine;
-  /** Themes for light and dark modes */
-  themes: {
-    light: BundledTheme | ThemeRegistration;
-    dark: BundledTheme | ThemeRegistration;
-  };
 }
 
 export interface CreateHighlighterOptions {
@@ -42,8 +32,6 @@ export interface CreateHighlighterOptions {
   engine?: ShikiEngine;
   /** Languages to support */
   languages: BundledLanguage[];
-  /** Themes to load */
-  themes: (BundledTheme | ThemeRegistration)[];
 }
 
 export interface ServerHighlighter {
@@ -57,19 +45,19 @@ export interface ServerHighlighter {
  * One-off highlighting for a single code snippet.
  *
  * Creates a highlighter, highlights the code, and disposes.
- * For multiple highlights, use `createHighlighter` instead.
+ * For multiple highlights, use `createServerHighlighter` instead.
+ *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
  *
  * @example
  * ```tsx
- * const html = await highlightCode(code, "tsx", {
- *   themes: { light: "cloudflare", dark: "cloudflare-dark" },
- * });
+ * const html = await highlightCode(code, "tsx");
  * ```
  */
 export async function highlightCode(
   code: string,
   lang: BundledLanguage,
-  options: HighlightCodeOptions,
+  options: HighlightCodeOptions = {},
 ): Promise<string> {
   const { createHighlighter } = await import("shiki");
 
@@ -84,7 +72,7 @@ export async function highlightCode(
         );
 
   const highlighter = await createHighlighter({
-    themes: [options.themes.light, options.themes.dark],
+    themes: ["github-light", "vesper"],
     langs: [lang],
     engine: engineInstance,
   });
@@ -92,8 +80,8 @@ export async function highlightCode(
   const html = highlighter.codeToHtml(code, {
     lang,
     themes: {
-      light: options.themes.light,
-      dark: options.themes.dark,
+      light: "github-light",
+      dark: "vesper",
     },
   });
 
@@ -108,11 +96,12 @@ export async function highlightCode(
  * More efficient than `highlightCode` when highlighting multiple snippets.
  * Remember to call `dispose()` when done.
  *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
+ *
  * @example
  * ```tsx
  * const highlighter = await createServerHighlighter({
  *   languages: ["tsx", "bash", "json"],
- *   themes: ["cloudflare", "cloudflare-dark"],
  * });
  *
  * const html1 = highlighter.highlight(code1, "tsx");
@@ -137,21 +126,18 @@ export async function createServerHighlighter(
         );
 
   const highlighter: Highlighter = await createHighlighter({
-    themes: options.themes,
+    themes: ["github-light", "vesper"],
     langs: options.languages,
     engine: engineInstance,
   });
-
-  // Get the first two themes for light/dark
-  const [lightTheme, darkTheme] = options.themes;
 
   return {
     highlight: (code: string, lang: BundledLanguage): string => {
       return highlighter.codeToHtml(code, {
         lang,
         themes: {
-          light: lightTheme,
-          dark: darkTheme,
+          light: "github-light",
+          dark: "vesper",
         },
       });
     },

--- a/packages/kumo/src/code/types.ts
+++ b/packages/kumo/src/code/types.ts
@@ -1,4 +1,4 @@
-import type { BundledLanguage, BundledTheme, ThemeRegistration } from "shiki";
+import type { BundledLanguage } from "shiki";
 
 /**
  * Shiki engine choice for syntax highlighting.
@@ -6,16 +6,6 @@ import type { BundledLanguage, BundledTheme, ThemeRegistration } from "shiki";
  * - `"wasm"` — Larger bundle (~180KB), VS Code-accurate highlighting
  */
 export type ShikiEngine = "javascript" | "wasm";
-
-/**
- * Theme configuration for light and dark modes.
- */
-export interface ShikiThemeConfig {
-  /** Theme for light mode */
-  light: BundledTheme | ThemeRegistration;
-  /** Theme for dark mode */
-  dark: BundledTheme | ThemeRegistration;
-}
 
 /**
  * Localized labels for the copy button.
@@ -45,12 +35,6 @@ export interface ShikiProviderProps {
   languages: BundledLanguage[];
 
   /**
-   * Theme configuration for light and dark modes.
-   * @example { light: 'github-light', dark: 'github-dark' }
-   */
-  themes: ShikiThemeConfig;
-
-  /**
    * Localized labels for UI elements (copy button, etc.).
    * Can be overridden at the component level.
    * @example { copy: "Copier", copied: "Copié!" }
@@ -62,14 +46,6 @@ export interface ShikiProviderProps {
 }
 
 /**
- * Options for the highlight function.
- */
-export interface HighlightOptions {
-  /** Override the theme for this specific highlight call */
-  theme?: BundledTheme | ThemeRegistration;
-}
-
-/**
  * Return value from useShikiHighlighter hook.
  */
 export interface UseShikiHighlighterResult {
@@ -78,11 +54,7 @@ export interface UseShikiHighlighterResult {
    * Returns `null` if highlighter is not ready or highlighting fails.
    * When `null` is returned, render the code as plain text.
    */
-  highlight: (
-    code: string,
-    lang: BundledLanguage,
-    options?: HighlightOptions,
-  ) => string | null;
+  highlight: (code: string, lang: BundledLanguage) => string | null;
 
   /** True while Shiki is loading */
   isLoading: boolean;
@@ -110,11 +82,6 @@ export interface CodeHighlightedProps {
    */
   lang: BundledLanguage;
 
-  /**
-   * Override provider theme for this instance.
-   */
-  theme?: BundledTheme | ThemeRegistration;
-
   /** Display line numbers */
   showLineNumbers?: boolean;
 
@@ -138,4 +105,4 @@ export interface CodeHighlightedProps {
 }
 
 // Re-export useful Shiki types for consumers
-export type { BundledLanguage, BundledTheme, ThemeRegistration } from "shiki";
+export type { BundledLanguage } from "shiki";

--- a/packages/kumo/src/code/use-shiki-highlighter.ts
+++ b/packages/kumo/src/code/use-shiki-highlighter.ts
@@ -2,16 +2,14 @@
 
 import { useContext, useCallback } from "react";
 import { ShikiContext } from "./context";
-import type {
-  UseShikiHighlighterResult,
-  BundledLanguage,
-  HighlightOptions,
-} from "./types";
+import type { UseShikiHighlighterResult, BundledLanguage } from "./types";
 
 /**
  * Hook for accessing Shiki highlighting in custom implementations.
  *
  * Must be used within a ShikiProvider.
+ *
+ * Uses hardcoded themes: `github-light` for light mode, `vesper` for dark mode.
  *
  * @example
  * ```tsx
@@ -49,14 +47,10 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
     );
   }
 
-  const { highlighter, isLoading, error, themes, languages, labels } = context;
+  const { highlighter, isLoading, error, languages, labels } = context;
 
   const highlight = useCallback(
-    (
-      code: string,
-      lang: BundledLanguage,
-      options?: HighlightOptions,
-    ): string | null => {
+    (code: string, lang: BundledLanguage): string | null => {
       if (!highlighter) {
         return null;
       }
@@ -72,12 +66,12 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
       }
 
       try {
-        // Use dual theme for light/dark mode support
+        // Use dual theme for light/dark mode support with hardcoded themes
         const html = highlighter.codeToHtml(code, {
           lang,
           themes: {
-            light: options?.theme ?? themes.light,
-            dark: options?.theme ?? themes.dark,
+            light: "github-light",
+            dark: "vesper",
           },
         });
 
@@ -90,7 +84,7 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
         return null;
       }
     },
-    [highlighter, themes, languages],
+    [highlighter, languages],
   );
 
   return {


### PR DESCRIPTION
## Summary

Hardcodes the syntax highlighting themes:
- **Light mode**: `github-light`
- **Dark mode**: `vesper`

## Changes

- Removed `themes` prop from `ShikiProvider`
- Removed `theme` prop from `CodeHighlighted`
- Removed `ShikiThemeConfig` and `HighlightOptions` types
- Updated server utilities with hardcoded themes
- Updated documentation

## Why

Simplifies the API by removing theme configuration. Users don't need to choose themes - they're automatically set based on the current color mode.