### PR TITLE
fix(badge): prevent crash when unknown variant is passed

### DIFF
--- a/.changeset/fix-badge-unknown-variant.md
+++ b/.changeset/fix-badge-unknown-variant.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(badge): prevent crash when unknown variant is passed
+
+Add defensive fallback to primary variant when an unrecognized variant string is provided to Badge component. This prevents "Cannot read properties of undefined (reading 'classes')" errors when consumers use a variant that doesn't exist in their installed version.

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -50,11 +50,13 @@ export interface KumoBadgeVariantsProps {
 export function badgeVariants({
   variant = KUMO_BADGE_DEFAULT_VARIANTS.variant,
 }: KumoBadgeVariantsProps = {}) {
+  const variantConfig = KUMO_BADGE_VARIANTS.variant[variant];
   return cn(
     // Base styles (exported as KUMO_BADGE_BASE_STYLES for Figma plugin)
     KUMO_BADGE_BASE_STYLES,
-    // Apply variant styles from KUMO_BADGE_VARIANTS
-    KUMO_BADGE_VARIANTS.variant[variant].classes,
+    // Apply variant styles from KUMO_BADGE_VARIANTS (fallback to primary if variant not found)
+    variantConfig?.classes ??
+      KUMO_BADGE_VARIANTS.variant[KUMO_BADGE_DEFAULT_VARIANTS.variant].classes,
   );
 }
 


### PR DESCRIPTION
## Summary

- Add defensive fallback to `primary` variant when an unrecognized variant string is passed to Badge
- Prevents `Cannot read properties of undefined (reading 'classes')` errors

## Context

When a consumer uses a variant that doesn't exist in their installed version (e.g., using `variant="success"` with 1.9.0 which doesn't have it yet), the component crashes. This adds a graceful fallback instead.