### PR TITLE
feat: allow dev server to run without building kumo first

### DIFF
--- a/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
+++ b/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
@@ -1,10 +1,11 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+// Import directly from source to avoid requiring a build step in dev mode
 import {
   THEME_CONFIG,
   AVAILABLE_THEMES,
-} from "@cloudflare/kumo/scripts/theme-generator/config";
-import type { TokenDefinition } from "@cloudflare/kumo/scripts/theme-generator/types";
+} from "../../../kumo/scripts/theme-generator/config.js";
+import type { TokenDefinition } from "../../../kumo/scripts/theme-generator/types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-hmr.ts
+++ b/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-hmr.ts
@@ -98,6 +98,14 @@ export function kumoHmrPlugin() {
         return resolve(kumoSrc, "registry/index.ts");
       }
 
+      // Code barrel
+      if (source === "@cloudflare/kumo/code") {
+        return resolve(kumoSrc, "code/index.ts");
+      }
+      if (source === "@cloudflare/kumo/code/server") {
+        return resolve(kumoSrc, "code/server.ts");
+      }
+
       // Catch-all for any other @cloudflare/kumo/styles/* CSS imports
       if (source.startsWith("@cloudflare/kumo/styles/")) {
         const styleName = source.replace("@cloudflare/kumo/styles/", "");


### PR DESCRIPTION
### Summary

  - Fix dev server startup to not require pnpm --filter @cloudflare/kumo build first
  - Add missing HMR alias for @cloudflare/kumo/code export

###  Problem

  Running pnpm dev on a fresh clone (or after rm -rf packages/kumo/dist) failed with:

  Cannot find module '@cloudflare/kumo/scripts/theme-generator/config'

  This happened because vite-plugin-kumo-colors.ts imported from the package path, which resolves via package.json exports to
  dist/scripts/theme-generator/config.js—a file that doesn't exist until the kumo package is built.

  Additionally, after fixing that, another error appeared for @cloudflare/kumo/code which was missing from the HMR plugin's alias list.

### Solution

  1. Changed vite-plugin-kumo-colors.ts to import directly from the relative source path (../../../kumo/scripts/theme-generator/config.js) instead of the
  package export. This matches the pattern already used elsewhere in the file (line 102-105 already referenced this path for file watching).
  2. Added @cloudflare/kumo/code and @cloudflare/kumo/code/server to the HMR plugin's resolve aliases.

### Test plan

  - Delete packages/kumo/dist directory
  - Run pnpm install && pnpm dev
  - Verify dev server starts without errors
  - Verify docs site loads correctly at localhost:4321