### PR TITLE
feat(Pagination): prevent password managers autofilling Pagination input

### DIFF
--- a/.changeset/seven-ducks-cut.md
+++ b/.changeset/seven-ducks-cut.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Prevent password managers autofilling Pagination input field

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -234,6 +234,11 @@ function PaginationControls({
                 setPage(number);
                 setEditingPage(number);
               }}
+              // Prevent password managers from auto-filling
+              autoComplete="off"
+              data-1p-ignore
+              data-lpignore="true"
+              data-form-type="other"
             />
           )}
           <InputGroup.Button


### PR DESCRIPTION
### Summary 
- Update `Pagination` component to prevent password managers from auto-filling the page selector `<input>` 

### Screenshots 
| Before | After |
|--------|--------|
| <img  alt="image" src="https://github.com/user-attachments/assets/8ce13383-b002-4910-87fa-04ddb98f9bd7" /> | <img  alt="image" src="https://github.com/user-attachments/assets/335110a5-cad6-457a-a3c0-21f42a789166" /> |