### PR TITLE
fix(field): add leading-snug to error message for consistent line height

### DIFF
--- a/.changeset/field-error-line-height.md
+++ b/.changeset/field-error-line-height.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Field error message line height by adding `leading-snug` for consistent text spacing

--- a/packages/kumo/src/components/field/field.tsx
+++ b/packages/kumo/src/components/field/field.tsx
@@ -132,7 +132,7 @@ export function Field({
       {error ? (
         <FieldBase.Error
           className={cn(
-            "text-sm text-kumo-danger",
+            "text-sm leading-snug text-kumo-danger",
             // Span full width in horizontal layout
             "col-span-full",
           )}


### PR DESCRIPTION
## Summary

- Adds `leading-snug` to Field error message styling for consistent text line height
- Aligns error message styling with the description text which already uses `leading-snug`