### PR TITLE
fix(Select): improve label API to match Input component pattern

### DIFF
--- a/.changeset/fix-select-label-api.md
+++ b/.changeset/fix-select-label-api.md
@@ -1,0 +1,25 @@
+---
+"@cloudflare/kumo": minor
+---
+
+**Select: Improved label API to match Input component pattern**
+
+- `hideLabel` is now deprecated. When `label` is provided, the label is **visible by default** (previously hidden by default).
+  - For visible labels: `<Select label="Country" />` (no changes needed if you were using `hideLabel={false}`)
+  - For hidden labels: Use `<Select aria-label="Select a country" />` instead of `<Select label="Country" hideLabel={true} />`
+
+- **Bug fix**: Placeholder text now displays correctly when using object map `items` format (e.g., `items={{ a: "Option A" }}`). Previously, placeholders only worked with array format items.
+
+**Backward compatibility**: `hideLabel={true}` still works but shows a deprecation warning in development. Existing code using `hideLabel={false}` requires no changes.
+
+**Migration guide:**
+
+```tsx
+// Before (label hidden by default)
+<Select label="Country" />                    // label was sr-only
+<Select label="Country" hideLabel={false} />  // label was visible
+
+// After (label visible by default, matching Input)
+<Select label="Country" />                    // label is now visible
+<Select aria-label="Country" />               // use aria-label for hidden labels
+```

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -141,6 +141,7 @@ export function HomeGrid() {
       id: "select",
       Component: (
         <Select
+          aria-label="Select version"
           className="w-[200px]"
           renderValue={(v) => {
             const labels: Record<string, string> = {

--- a/packages/kumo-docs-astro/src/components/demos/LabelDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LabelDemo.tsx
@@ -51,7 +51,7 @@ export function LabelFormMixedDemo() {
         type="email"
       />
       <Input label="Company" required={false} placeholder="Acme Inc." />
-      <Select label="Country" hideLabel={false} placeholder="Select a country">
+      <Select label="Country" placeholder="Select a country">
         <Select.Option value="us">United States</Select.Option>
         <Select.Option value="uk">United Kingdom</Select.Option>
         <Select.Option value="ca">Canada</Select.Option>

--- a/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
@@ -1,40 +1,48 @@
 import { useState, useEffect } from "react";
 import { Select, Text } from "@cloudflare/kumo";
 
+/** Basic Select with visible label - the recommended pattern. */
 export function SelectBasicDemo() {
   const [value, setValue] = useState("apple");
 
   return (
-    <div className="flex gap-2">
-      <Select
-        className="w-[200px]"
-        value={value}
-        onValueChange={(v) => setValue(v ?? "apple")}
-        items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
-      />
-
-      <Select
-        value={value}
-        className="w-[200px]"
-        onValueChange={(v) => setValue(v ?? "apple")}
-        items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
-      >
-        <Select.Option value="apple">Apple</Select.Option>
-        <Select.Option value="banana">Banana</Select.Option>
-        <Select.Option value="cherry">Cherry</Select.Option>
-      </Select>
-    </div>
+    <Select
+      label="Favorite Fruit"
+      className="w-[200px]"
+      value={value}
+      onValueChange={(v) => setValue(v ?? "apple")}
+      items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
+    />
   );
 }
 
-export function SelectLabelValueDemo() {
-  const [value, setValue] = useState("bug");
+/** Select without visible label - use aria-label for accessibility. */
+export function SelectWithoutLabelDemo() {
+  const [value, setValue] = useState("apple");
 
   return (
     <Select
+      aria-label="Select a fruit"
       className="w-[200px]"
       value={value}
-      onValueChange={(v) => setValue(v as string)}
+      onValueChange={(v) => setValue(v ?? "apple")}
+      items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
+    />
+  );
+}
+
+/** Select with label, description, and error handling. */
+export function SelectWithFieldDemo() {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <Select
+      label="Issue Type"
+      description="Choose the category that best describes your issue"
+      error={!value ? "Please select an issue type" : undefined}
+      className="w-[280px]"
+      value={value}
+      onValueChange={(v) => setValue(v as string | null)}
       items={{
         bug: "Bug",
         documentation: "Documentation",
@@ -44,38 +52,44 @@ export function SelectLabelValueDemo() {
   );
 }
 
+/** Select with placeholder text when no value is selected. */
 export function SelectPlaceholderDemo() {
   const [value, setValue] = useState<string | null>(null);
 
   return (
     <Select
+      label="Category"
+      placeholder="Choose a category..."
       className="w-[200px]"
       value={value}
       onValueChange={(v) => setValue(v as string | null)}
-      items={[
-        { value: null, label: "Please select" },
-        { value: "bug", label: "Bug" },
-        { value: "documentation", label: "Documentation" },
-        { value: "feature", label: "Feature" },
-      ]}
+      items={{
+        bug: "Bug",
+        documentation: "Documentation",
+        feature: "Feature",
+      }}
     />
   );
 }
 
-export function SelectPlaceholderUsingPropDemo() {
+/** Select with label tooltip for additional context. */
+export function SelectWithTooltipDemo() {
   const [value, setValue] = useState<string | null>(null);
 
   return (
     <Select
+      label="Priority"
+      labelTooltip="Higher priority issues are addressed first"
+      placeholder="Select priority"
       className="w-[200px]"
       value={value}
-      placeholder="Please select"
       onValueChange={(v) => setValue(v as string | null)}
-      items={[
-        { value: "bug", label: "Bug" },
-        { value: "documentation", label: "Documentation" },
-        { value: "feature", label: "Feature" },
-      ]}
+      items={{
+        low: "Low",
+        medium: "Medium",
+        high: "High",
+        critical: "Critical",
+      }}
     />
   );
 }
@@ -89,11 +103,13 @@ const languages = [
   { value: "pt", label: "Portuguese", emoji: "🇵🇹" },
 ];
 
+/** Select with custom rendering for complex option display. */
 export function SelectCustomRenderingDemo() {
   const [value, setValue] = useState(languages[0]);
 
   return (
     <Select
+      label="Language"
       className="w-[200px]"
       renderValue={(v) => (
         <span>
@@ -112,10 +128,12 @@ export function SelectCustomRenderingDemo() {
   );
 }
 
+/** Select in loading state. */
 export function SelectLoadingDemo() {
-  return <Select className="w-[200px]" loading />;
+  return <Select aria-label="Loading select" className="w-[200px]" loading />;
 }
 
+/** Select that loads data asynchronously. */
 export function SelectLoadingDataDemo() {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<undefined | string[]>();
@@ -140,28 +158,31 @@ export function SelectLoadingDataDemo() {
 
   return (
     <Select
+      label="Assignee"
       className="w-[200px]"
       loading={loading}
       value={value}
       onValueChange={(v) => setValue(v as string | null)}
-      placeholder="Please select"
+      placeholder="Select assignee"
       items={items}
     />
   );
 }
 
+/** Multi-select for choosing multiple values. */
 export function SelectMultipleDemo() {
   const [value, setValue] = useState<string[]>(["Name", "Location", "Size"]);
 
   return (
     <Select
+      label="Visible Columns"
       className="w-[250px]"
       multiple
       renderValue={(value) => {
         if (value.length > 3) {
           return (
             <span className="line-clamp-1">
-              {value.slice(2).join(", ") + ` and ${value.length - 2} more`}
+              {value.slice(0, 2).join(", ") + ` and ${value.length - 2} more`}
             </span>
           );
         }
@@ -190,17 +211,20 @@ const authors = [
   { id: 7, name: "Laura Kim", title: "Technical Writer" },
 ];
 
+/** Select with complex object values and custom option rendering. */
 export function SelectComplexDemo() {
   const [value, setValue] = useState<(typeof authors)[0] | null>(null);
 
   return (
     <Select
+      label="Author"
+      description="Select the primary author for this document"
       className="w-[200px]"
       onValueChange={(v) => setValue(v as (typeof authors)[0] | null)}
       value={value}
       isItemEqualToValue={(item, value) => item?.id === value?.id}
       renderValue={(author) => {
-        return author?.name ?? "Please select author";
+        return author?.name ?? "Select an author";
       }}
     >
       {authors.map((author) => (

--- a/packages/kumo-docs-astro/src/pages/components/select.astro
+++ b/packages/kumo-docs-astro/src/pages/components/select.astro
@@ -7,14 +7,15 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 import PropsTable from "../../components/docs/PropsTable.astro";
 import {
   SelectBasicDemo,
-  SelectLabelValueDemo,
+  SelectWithoutLabelDemo,
+  SelectWithFieldDemo,
   SelectPlaceholderDemo,
+  SelectWithTooltipDemo,
   SelectCustomRenderingDemo,
   SelectLoadingDemo,
   SelectLoadingDataDemo,
   SelectMultipleDemo,
   SelectComplexDemo,
-  SelectPlaceholderUsingPropDemo,
 } from "../../components/demos/SelectDemo";
 ---
 
@@ -24,87 +25,92 @@ import {
   sourceFile="components/select"
   baseUIComponent="select"
 >
-  <!-- Basic Usage -->
+  <!-- Basic Usage with Label -->
   <ComponentSection>
     <Heading level={3}>Basic Usage</Heading>
     <p class="mb-4 flex flex-col gap-4">
       <span class="text-kumo-strong">
-        A simple select component. Use the <code
-          class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code
-        > prop to provide options — when <code
-          class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code
-        > is provided without children, the select automatically renders options.
-        This also controls what text appears in the trigger when an option is selected.
-        For custom option rendering, you can still provide manual
-        <code class="rounded bg-kumo-control px-1 py-0.5 text-sm"
-          >Select.Option</code
-        > children.
+        A select with a visible label. When you provide the <code
+          class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code
+        > prop, the select automatically renders inside a Field wrapper with the label displayed above it.
       </span>
     </p>
 
     <ComponentExample
       code={`import { Select } from "@cloudflare/kumo";
 
-// Option 1
 function App() {
   const [value, setValue] = useState("apple");
 
   return (
     <Select
+      label="Favorite Fruit"
       className="w-[200px]"
       value={value}
       onValueChange={(v) => setValue(v ?? "apple")}
       items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
     />
   )
-}
-
-// Option 2
-function App() {
-  const [value, setValue] = useState("apple");
-
-  return (
-    <Select
-      value={value}
-      className="w-[200px]"
-      onValueChange={(v) => setValue(v ?? "apple")}
-      items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
-    >
-      <Select.Option value="apple">Apple</Select.Option>
-      <Select.Option value="banana">Banana</Select.Option>
-      <Select.Option value="cherry">Cherry</Select.Option>
-    </Select>
-  )
-}
-`}
+}`}
     >
       <SelectBasicDemo client:load />
     </ComponentExample>
   </ComponentSection>
 
-  <!-- Basic Label and Value -->
+  <!-- Without Visible Label -->
   <ComponentSection>
-    <Heading level={3}>Basic Label and Value</Heading>
+    <Heading level={3}>Without Visible Label</Heading>
     <p class="mb-4 flex flex-col gap-4">
       <span class="text-kumo-strong">
-        A select component where the internal value differs from the displayed
-        text. Useful when you need to store identifiers while showing
-        user-friendly labels.
+        When a visible label isn't needed (e.g., in compact UIs or when context is clear),
+        use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">aria-label</code> for accessibility.
       </span>
     </p>
 
     <ComponentExample
       code={`import { Select } from "@cloudflare/kumo";
 
-// Option 1: Using object map
 function App() {
-  const [value, setValue] = useState("bug");
+  const [value, setValue] = useState("apple");
 
   return (
     <Select
+      aria-label="Select a fruit"
       className="w-[200px]"
       value={value}
-      onValueChange={(v) => setValue(v ?? "bug")}
+      onValueChange={(v) => setValue(v ?? "apple")}
+      items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
+    />
+  )
+}`}
+    >
+      <SelectWithoutLabelDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- With Description and Error -->
+  <ComponentSection>
+    <Heading level={3}>With Description and Error</Heading>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-kumo-strong">
+        Select integrates with the Field wrapper to show description text and validation errors.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`import { Select } from "@cloudflare/kumo";
+
+function App() {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <Select
+      label="Issue Type"
+      description="Choose the category that best describes your issue"
+      error={!value ? "Please select an issue type" : undefined}
+      className="w-[280px]"
+      value={value}
+      onValueChange={(v) => setValue(v as string | null)}
       items={{
         bug: "Bug",
         documentation: "Documentation",
@@ -112,27 +118,9 @@ function App() {
       }}
     />
   )
-}
-  
-// Option 2: Using array of objects
-function App() {
-  const [value, setValue] = useState("bug");
-
-  return (
-    <Select
-      className="w-[200px]"
-      value={value}
-      onValueChange={(v) => setValue(v as any)}
-      items={[
-        {value: "bug", label: "Bug"},
-        {value: "documentation", label: "Documentation"},
-        {value: "feature", label: "Feature"},
-      ]}
-    />
-  )
 }`}
     >
-      <SelectLabelValueDemo client:load />
+      <SelectWithFieldDemo client:load />
     </ComponentExample>
   </ComponentSection>
 
@@ -141,59 +129,72 @@ function App() {
     <Heading level={3}>Placeholder</Heading>
     <p class="mb-4 flex flex-col gap-4">
       <span class="text-kumo-strong">
-        A select component with a placeholder option. The empty value must be <strong
-          >null</strong
-        >, not an empty string or undefined. Using undefined will cause the
-        component to behave as uncontrolled.
+        Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> prop
+        to show text when no value is selected.
       </span>
     </p>
 
     <ComponentExample
       code={`import { Select } from "@cloudflare/kumo";
 
-// Option 1: Manual placeholder using a null-value item
 function App() {
   const [value, setValue] = useState<string | null>(null);
 
   return (
     <Select
+      label="Category"
+      placeholder="Choose a category..."
       className="w-[200px]"
       value={value}
-      onValueChange={(v) => setValue(v as any)}
-      items={[
-        { value: null, label: "Please select" },
-        { value: "bug", label: "Bug" },
-        { value: "documentation", label: "Documentation" },
-        { value: "feature", label: "Feature" },
-      ]}
+      onValueChange={(v) => setValue(v as string | null)}
+      items={{
+        bug: "Bug",
+        documentation: "Documentation",
+        feature: "Feature",
+      }}
     />
   )
-}
-
-// Option 2: Using the placeholder prop
-function App() {
-  const [value, setValue] = useState<string | null>(null);
-
-  return (
-    <Select
-      placeholder="Please select"
-      className="w-[200px]"
-      value={value}
-      onValueChange={(v) => setValue(v as any)}
-      items={[
-        { value: "bug", label: "Bug" },
-        { value: "documentation", label: "Documentation" },
-        { value: "feature", label: "Feature" },
-      ]}
-    />
-  )
-}
-`}
+}`}
     >
-      <div class="flex gap-2">
-        <SelectPlaceholderDemo client:load />
-        <SelectPlaceholderUsingPropDemo client:load />
-      </div>
+      <SelectPlaceholderDemo client:load />
+    </ComponentExample>
+  </ComponentSection>
+
+  <!-- Label Tooltip -->
+  <ComponentSection>
+    <Heading level={3}>Label with Tooltip</Heading>
+    <p class="mb-4 flex flex-col gap-4">
+      <span class="text-kumo-strong">
+        Add a tooltip icon next to the label for additional context using <code
+          class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
+      </span>
+    </p>
+
+    <ComponentExample
+      code={`import { Select } from "@cloudflare/kumo";
+
+function App() {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <Select
+      label="Priority"
+      labelTooltip="Higher priority issues are addressed first"
+      placeholder="Select priority"
+      className="w-[200px]"
+      value={value}
+      onValueChange={(v) => setValue(v as string | null)}
+      items={{
+        low: "Low",
+        medium: "Medium",
+        high: "High",
+        critical: "Critical",
+      }}
+    />
+  )
+}`}
+    >
+      <SelectWithTooltipDemo client:load />
     </ComponentExample>
   </ComponentSection>
 

--- a/packages/kumo/src/components/select/select.test.tsx
+++ b/packages/kumo/src/components/select/select.test.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { Select } from "./select";
 
 describe("Select", () => {
-  describe("description with hideLabel", () => {
-    it("renders description when hideLabel is true (default)", () => {
+  describe("label visibility (new behavior)", () => {
+    it("shows visible label by default when label prop is provided", () => {
       render(
         <Select label="Database" description="Select your preferred database">
           <Select.Option value="postgres">PostgreSQL</Select.Option>
@@ -13,10 +13,12 @@ describe("Select", () => {
         </Select>,
       );
 
+      // Label should be visible (in Field wrapper)
+      expect(screen.getByText("Database")).toBeTruthy();
       expect(screen.getByText("Select your preferred database")).toBeTruthy();
     });
 
-    it("renders description when hideLabel is explicitly true", () => {
+    it("hides label when hideLabel={true} (backward compatibility)", () => {
       render(
         <Select
           label="Database"
@@ -27,49 +29,42 @@ describe("Select", () => {
         </Select>,
       );
 
+      // Label should exist but be visually hidden (sr-only class)
+      const srOnlyLabel = document.querySelector(".sr-only");
+      expect(srOnlyLabel).toBeTruthy();
+      expect(srOnlyLabel?.textContent).toBe("Database");
       expect(
         screen.getByText("Helper text for database selection"),
       ).toBeTruthy();
     });
 
-    it("renders description when hideLabel is false", () => {
+    it("uses aria-label for accessibility when no visible label needed", () => {
       render(
-        <Select
-          label="Database"
-          hideLabel={false}
-          description="Visible label with description"
-        >
+        <Select aria-label="Select a database">
+          <Select.Option value="postgres">PostgreSQL</Select.Option>
+        </Select>,
+      );
+
+      const trigger = document.querySelector('[role="combobox"]');
+      expect(trigger?.getAttribute("aria-label")).toBe("Select a database");
+    });
+  });
+
+  describe("description and error", () => {
+    it("renders description with visible label", () => {
+      render(
+        <Select label="Database" description="Visible label with description">
           <Select.Option value="postgres">PostgreSQL</Select.Option>
         </Select>,
       );
 
       expect(screen.getByText("Visible label with description")).toBeTruthy();
-      // Label should also be visible
       expect(screen.getByText("Database")).toBeTruthy();
     });
 
-    it("keeps label accessible via sr-only when hideLabel is true", () => {
+    it("renders error message", () => {
       render(
-        <Select label="Database" hideLabel={true} description="Helper text">
-          <Select.Option value="postgres">PostgreSQL</Select.Option>
-        </Select>,
-      );
-
-      // Label should exist but be visually hidden (sr-only class)
-      const srOnlyLabel = document.querySelector(".sr-only");
-      expect(srOnlyLabel).toBeTruthy();
-      expect(srOnlyLabel?.textContent).toBe("Database");
-    });
-  });
-
-  describe("error with hideLabel", () => {
-    it("renders error message when hideLabel is true", () => {
-      render(
-        <Select
-          label="Database"
-          hideLabel={true}
-          error="Please select a database"
-        >
+        <Select label="Database" error="Please select a database">
           <Select.Option value="postgres">PostgreSQL</Select.Option>
         </Select>,
       );
@@ -77,11 +72,10 @@ describe("Select", () => {
       expect(screen.getByText("Please select a database")).toBeTruthy();
     });
 
-    it("renders error object when hideLabel is true", () => {
+    it("renders error object", () => {
       render(
         <Select
           label="Database"
-          hideLabel={true}
           error={{ message: "Database is required", match: true }}
         >
           <Select.Option value="postgres">PostgreSQL</Select.Option>
@@ -95,7 +89,6 @@ describe("Select", () => {
       render(
         <Select
           label="Database"
-          hideLabel={true}
           description="Select your preferred database"
           error="Please select a database"
         >
@@ -251,12 +244,24 @@ describe("Select", () => {
         />,
       );
 
-      // Since there's no item with value=null, Base UI falls back to placeholder
-      // However, Base UI treats the object map differently - it doesn't find a match
-      // for null value, but also doesn't show the placeholder text in the span
-      const trigger = document.querySelector('[role="combobox"]');
-      expect(trigger).toBeTruthy();
-      expect(trigger?.getAttribute("aria-label")).toBe("Choose one");
+      // Placeholder should be visible in the trigger
+      expect(screen.getByText("Choose one")).toBeTruthy();
+    });
+
+    it("shows placeholder with object map items format", () => {
+      // Object map format should work the same as array format for placeholders
+      render(
+        <Select
+          placeholder="Select a fruit"
+          value={null}
+          items={{
+            apple: "Apple",
+            banana: "Banana",
+          }}
+        />,
+      );
+
+      expect(screen.getByText("Select a fruit")).toBeTruthy();
     });
 
     it("works with items as array format", () => {

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -64,6 +64,26 @@ export function selectVariants(_props: KumoSelectVariantsProps = {}) {
 }
 
 /**
+ * Normalizes items to array format for Base UI.
+ * Object maps are converted to array format so Base UI can properly
+ * handle value matching and placeholder display.
+ */
+function normalizeItems<T>(
+  items:
+    | Record<string, ReactNode>
+    | ReadonlyArray<{ label: ReactNode; value: T }>,
+): ReadonlyArray<{ label: ReactNode; value: T }> {
+  if (Array.isArray(items)) {
+    return items;
+  }
+  // Convert object map to array format
+  return Object.entries(items).map(([key, label]) => ({
+    value: key as T,
+    label,
+  }));
+}
+
+/**
  * Auto-generates Select.Option elements from items prop.
  * Only used when children are not explicitly provided.
  * Filters out null values (typically used for placeholders).
@@ -73,17 +93,10 @@ function renderOptionsFromItems<T>(
     | Record<string, ReactNode>
     | ReadonlyArray<{ label: ReactNode; value: T }>,
 ): ReactNode {
-  // Handle object map format: { key: "Label" }
-  if (!Array.isArray(items)) {
-    return Object.entries(items).map(([key, label]) => (
-      <Option key={key} value={key as T}>
-        {label}
-      </Option>
-    ));
-  }
+  const normalizedItems = normalizeItems(items);
 
-  // Handle array format: [{ value, label }] - filter out null values
-  return items
+  // Filter out null values and render options
+  return normalizedItems
     .filter((item) => item.value !== null)
     .map((item, index) => (
       <Option
@@ -103,9 +116,17 @@ type SelectPropsGeneric<
     multiple?: Multiple;
     renderValue?: (value: Multiple extends true ? T[] : T) => ReactNode;
     className?: string;
-    /** Label content for the select (enables Field wrapper) - can be a string or any React node */
+    /**
+     * Label content for the select.
+     * When provided, enables the Field wrapper with a visible label.
+     * For accessibility without a visible label, use `aria-label` instead.
+     */
     label?: ReactNode;
-    /** Visually hide the label (sr-only). Set to `false` for a visible label. @default true */
+    /**
+     * @deprecated Use `aria-label` for hidden labels instead of `label` + `hideLabel={true}`.
+     * When `label` is provided without `hideLabel`, the label is now visible by default (matching Input behavior).
+     * This prop will be removed in a future version.
+     */
     hideLabel?: boolean;
     placeholder?: string;
     loading?: boolean;
@@ -120,23 +141,38 @@ type SelectPropsGeneric<
 /**
  * Select component props.
  *
+ * **Accessible Name Required:** Select should have one of:
+ * 1. `label` prop (recommended) - enables Field wrapper with visible label
+ * 2. `aria-label` - for selects without visible label (accessibility-only)
+ * 3. `aria-labelledby` - for custom label association
+ *
  * @example
  * ```tsx
+ * // With visible label (recommended)
  * <Select label="Country" onValueChange={setValue}>
  *   <Select.Option value="us">United States</Select.Option>
  *   <Select.Option value="uk">United Kingdom</Select.Option>
+ * </Select>
+ *
+ * // Without visible label (use aria-label for accessibility)
+ * <Select aria-label="Select a country" onValueChange={setValue}>
+ *   <Select.Option value="us">United States</Select.Option>
  * </Select>
  * ```
  */
 export interface SelectProps {
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
-  /** Label content for the select (enables Field wrapper) — can be a string or any React node. */
+  /**
+   * Label content for the select.
+   * When provided, enables the Field wrapper with a visible label above the select.
+   * For accessibility without a visible label, use `aria-label` instead.
+   */
   label?: ReactNode;
   /**
-   * Visually hide the label while keeping it accessible to screen readers.
-   * Set to `false` to show a visible label above the select via the Field wrapper.
-   * @default true
+   * @deprecated Use `aria-label` for hidden labels instead of `label` + `hideLabel={true}`.
+   * When `label` is provided without `hideLabel`, the label is now visible by default (matching Input behavior).
+   * This prop will be removed in a future version.
    */
   hideLabel?: boolean;
   /** Placeholder text shown when no value is selected. */
@@ -182,7 +218,7 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   className,
   renderValue,
   label,
-  hideLabel = true,
+  hideLabel,
   placeholder,
   loading,
   labelTooltip,
@@ -198,13 +234,28 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   // For aria-label, use string label or placeholder (ReactNode labels can't be used for aria-label)
   const fallbackLabel = typeof label === "string" ? label : placeholder;
 
-  // Use Field wrapper when label is provided and not hidden
-  const useFieldWrapper = label && !hideLabel;
+  // Deprecation warning for hideLabel
+  if (process.env.NODE_ENV !== "production" && hideLabel !== undefined) {
+    console.warn(
+      "[Kumo Select]: `hideLabel` is deprecated. For hidden labels, use `aria-label` instead of `label` + `hideLabel={true}`.\n" +
+        "  Migration:\n" +
+        '  - For visible labels: <Select label="Country" /> (hideLabel no longer needed)\n' +
+        '  - For hidden labels: <Select aria-label="Select a country" /> (remove label and hideLabel)',
+    );
+  }
+
+  // New behavior: label presence determines Field wrapper visibility (like Input)
+  // hideLabel is only respected for backward compatibility when explicitly set to true
+  const useFieldWrapper = label && hideLabel !== true;
   const triggerLabelledBy = useFieldWrapper
     ? undefined
     : (ariaLabelledby ?? (label ? labelId : undefined));
   const triggerAriaLabel =
     ariaLabel ?? (!triggerLabelledBy ? fallbackLabel : undefined);
+
+  // Normalize items to array format for Base UI compatibility
+  // This fixes placeholder not showing with object map items
+  const normalizedItems = props.items ? normalizeItems(props.items) : undefined;
 
   // Auto-render children from items if children not provided
   const renderedChildren =
@@ -213,7 +264,7 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   const selectControl = (
     <SelectBase.Root
       {...props}
-      items={props.items}
+      items={normalizedItems}
       disabled={loading || props.disabled}
     >
       <SelectBase.Trigger


### PR DESCRIPTION
## Summary

Fixes the confusing `hideLabel` API in the Select component by aligning it with the Input component pattern.

### Changes

- **Label visible by default**: When `label` prop is provided, the label is now visible (matching Input behavior). Previously it was hidden by default, which was counterintuitive.
- **Deprecate `hideLabel`**: Added deprecation warning in development. Users should migrate to `aria-label` for accessibility-only labels.
- **Fix placeholder bug**: Placeholder text now displays correctly when using object map `items` format (e.g., `items={{ a: "Option A" }}`).
- **Updated docs**: Better examples showing the recommended patterns.

### Migration

```tsx
// Before (label hidden by default - confusing!)
<Select label="Country" />                    // label was sr-only
<Select label="Country" hideLabel={false} />  // label was visible

// After (label visible by default - intuitive!)
<Select label="Country" />                    // label is now visible
<Select aria-label="Country" />               // use aria-label for hidden labels
```

### Why this change?

The `hideLabel` API was confusing for several reasons:
1. It defaulted to `true`, hiding labels by default (opposite of user expectations)
2. Double-negative naming: "I want to show the label, so I set `hideLabel={false}`"
3. Inconsistent with the Input component which shows labels when `label` is provided

This change makes the API intuitive: provide a `label` to show it, use `aria-label` when you don't want a visible label.

### Backward Compatibility

- `hideLabel={true}` still works (with deprecation warning)
- Existing code using `hideLabel={false}` will work unchanged (label was already visible)
- Existing code relying on hidden labels by default will need to migrate to `aria-label`