### PR TITLE
fix: replace non-semantic border-secondary token and add missing hover styles in button variants

### DIFF
--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -52,7 +52,7 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     secondary: {
       classes:
-        "bg-kumo-control !text-kumo-default ring not-disabled:hover:border-secondary! not-disabled:hover:bg-kumo-control disabled:bg-kumo-control/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-control",
+        "bg-kumo-control !text-kumo-default ring not-disabled:hover:ring-kumo-ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-control/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-control",
       description: "Default button style for most actions",
     },
     ghost: {
@@ -65,12 +65,12 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     "secondary-destructive": {
       classes:
-        "bg-kumo-control !text-kumo-danger ring not-disabled:hover:border-secondary! not-disabled:hover:bg-kumo-control disabled:bg-kumo-control/50 disabled:!text-kumo-danger/70 ring-kumo-line data-[state=open]:bg-kumo-control",
+        "bg-kumo-control !text-kumo-danger ring not-disabled:hover:ring-kumo-ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-control/50 disabled:!text-kumo-danger/70 ring-kumo-line data-[state=open]:bg-kumo-control",
       description:
         "Secondary button with destructive text for less prominent dangerous actions",
     },
     outline: {
-      classes: "bg-kumo-base text-kumo-default ring ring-kumo-line",
+      classes: "bg-kumo-base text-kumo-default ring ring-kumo-line not-disabled:hover:ring-kumo-ring not-disabled:hover:bg-kumo-tint",
       description: "Bordered button with transparent background",
     },
   },


### PR DESCRIPTION
## Summary

- Replaced `not-disabled:hover:border-secondary!` with `not-disabled:hover:ring-kumo-ring` in `secondary` and `secondary-destructive` variants — `border-secondary` is not a Kumo semantic token; `ring-kumo-ring` is the correct semantic equivalent used elsewhere (e.g. checkbox hover)
- Added `not-disabled:hover:bg-kumo-tint` to `secondary`, `secondary-destructive`, and `outline` variants to provide visible hover feedback consistent with other interactive elements
- Added `not-disabled:hover:ring-kumo-ring` to `outline` variant for ring highlight on hover

## Test plan

- [ ] Hover over `secondary` button — should show tint background and ring highlight
- [ ] Hover over `secondary-destructive` button — same hover feedback, danger text color preserved
- [ ] Hover over `outline` button — should show tint background and ring highlight
- [ ] Disabled state: no hover styles should apply (guarded by `not-disabled:`)
- [ ] Verify no `border-secondary` references remain in button component

Fixes #35