### PR TITLE
fix(combobox): add flex items-center to icon wrapper for proper vertical centering

### DIFF
--- a/.changeset/fix-combobox-icon-line-height.md
+++ b/.changeset/fix-combobox-icon-line-height.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Combobox.TriggerValue icon misalignment caused by inherited line-height
+
+The caret icon span was inheriting `line-height` from the parent button's `text-base` class, causing the span's height to exceed the icon's height (e.g., 21.5px vs 16px). The icon sits at the top of the span by default, so when the span is centered via `top-1/2 -translate-y-1/2`, the icon appears offset.
+
+Added `flex items-center` to the icon wrapper to ensure proper vertical centering regardless of inherited styles. This matches the pattern used in TriggerInput.

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -252,7 +252,7 @@ function TriggerValue({
       <ComboboxBase.Value>{props.children}</ComboboxBase.Value>
       <ComboboxBase.Icon
         className={cn(
-          "absolute top-1/2 -translate-y-1/2",
+          "absolute top-1/2 -translate-y-1/2 flex items-center",
           iconStyles.iconRight,
         )}
       >


### PR DESCRIPTION
## Summary

Fixes caret icon misalignment in `Combobox.TriggerValue` when used in environments with global line-height styles (e.g., dash).

### Screenshot (before)

<img width="391" height="55" alt="Screenshot 2026-03-09 at 8 57 21 PM" src="https://github.com/user-attachments/assets/2a5b8286-b9f6-4258-957c-3a042eed1172" />

### Screenshot (after)

<img width="396" height="57" alt="Screenshot 2026-03-09 at 8 58 22 PM" src="https://github.com/user-attachments/assets/a4aa364e-17ff-4422-a41f-866bdf8a1999" />


## Problem

The caret icon span was inheriting `line-height` from the parent button's `text-base` class. This caused:
- Span height: 21.5px (inflated by line-height)
- Icon height: 16px
- Icon sits at top of span by default (inline baseline alignment)
- When span is centered via `top-1/2 -translate-y-1/2`, the icon appears offset

**Kumo docs** (line-height: 20px, height: 16px) - works fine
**dash** (line-height: 21px, height: 21.5px) - icon misaligned

## Solution

Added `flex items-center` to the icon wrapper. This:
1. Makes the span immune to inherited line-height
2. Explicitly centers the icon within the span
3. Matches the pattern already used in `TriggerInput`

## Before/After

| Before | After |
|--------|-------|
| Icon appears ~2.75px higher than center | Icon properly centered |