### PR TITLE
fix(Dropdown): forward aria-label to checkbox in DropdownMenuCheckboxItem

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
@@ -59,18 +59,21 @@ export function DropdownCheckboxDemo() {
         <DropdownMenu.Group>
           <DropdownMenu.Label>Display</DropdownMenu.Label>
           <DropdownMenu.CheckboxItem
+            aria-label="Show sidebar"
             checked={showSidebar}
             onCheckedChange={setShowSidebar}
           >
             Show sidebar
           </DropdownMenu.CheckboxItem>
           <DropdownMenu.CheckboxItem
+            aria-label="Show line numbers"
             checked={showLineNumbers}
             onCheckedChange={setShowLineNumbers}
           >
             Show line numbers
           </DropdownMenu.CheckboxItem>
           <DropdownMenu.CheckboxItem
+            aria-label="Word wrap"
             checked={wordWrap}
             onCheckedChange={setWordWrap}
           >

--- a/packages/kumo/src/components/dropdown/dropdown.tsx
+++ b/packages/kumo/src/components/dropdown/dropdown.tsx
@@ -311,7 +311,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center text-inherit">
-      <Checkbox checked={checked} />
+      <Checkbox checked={checked} aria-label={props["aria-label"]} />
     </span>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>


### PR DESCRIPTION
## Summary

This PR improves accessibility for dropdown checkbox items by forwarding the `aria-label` prop to the underlying Checkbox component.

## Changes

- Updated `DropdownMenuCheckboxItem` to pass through `aria-label` prop to the Checkbox component
- Added example usage in the dropdown demo showing how to provide accessible labels

## Why

Currently, when using `DropdownMenuCheckboxItem`, there's no way to provide an `aria-label` directly to the checkbox element. While the children text provides context, some use cases benefit from explicit ARIA labeling for screen readers. The Checkbox component already accepts `aria-label` as a prop, so this change simply forwards it through.

This is a non-breaking, purely additive accessibility improvement.