### PR TITLE
fix(theme): improve info banner contrast for WCAG AA compliance

### DIFF
--- a/.changeset/fix-banner-contrast.md
+++ b/.changeset/fix-banner-contrast.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Improve info banner dark mode contrast for WCAG AA compliance. Changes `kumo-info` from `blue-700` (L=48.8%) to `blue-400` (L=70.7%), achieving 7.97:1 contrast ratio against the banner background.

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -276,7 +276,7 @@ export const THEME_CONFIG: ThemeConfig = {
       theme: {
         kumo: {
           light: "var(--color-blue-500, oklch(62.3% 0.214 259.815))",
-          dark: "var(--color-blue-700, oklch(48.8% 0.243 264.376))",
+          dark: "var(--color-blue-400, oklch(70.7% 0.165 254.624))",
         },
       },
     },

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -143,7 +143,7 @@
 
   --color-kumo-info: light-dark(
     var(--color-blue-500, oklch(62.3% 0.214 259.815)),
-    var(--color-blue-700, oklch(48.8% 0.243 264.376))
+    var(--color-blue-400, oklch(70.7% 0.165 254.624))
   );
 
   --color-kumo-info-tint: light-dark(
@@ -260,7 +260,7 @@
     --color-kumo-ring: var(--color-neutral-600, oklch(43.9% 0 0));
     --color-kumo-tip-shadow: transparent;
     --color-kumo-tip-stroke: var(--color-neutral-800, oklch(26.9% 0 0));
-    --color-kumo-info: var(--color-blue-700, oklch(48.8% 0.243 264.376));
+    --color-kumo-info: var(--color-blue-400, oklch(70.7% 0.165 254.624));
     --color-kumo-info-tint: var(--color-blue-900, oklch(37.9% 0.146 265.522));
     --color-kumo-warning: var(--color-yellow-700, oklch(55.4% 0.135 66.442));
     --color-kumo-warning-tint: var(--color-yellow-900, oklch(42.1% 0.095 57.708));


### PR DESCRIPTION
## Before

<img width="995" height="710" alt="image" src="https://github.com/user-attachments/assets/18e11cae-e9ff-4ed2-bc24-17ec0818adc6" />

## After

<img width="1029" height="710" alt="image" src="https://github.com/user-attachments/assets/35057e9b-69a4-46de-ba51-eb5186ab66f1" />

## Summary

- Changes dark mode `kumo-info` token from `blue-700` to `blue-400`
- Achieves 7.97:1 contrast ratio (passes WCAG AAA)

## Problem

The info banner in dark mode had insufficient contrast between text (`blue-700`, L=48.8%) and background tint (`blue-900` at 10% opacity), resulting in ~3-4:1 contrast ratio which fails WCAG AA for normal text.

## Solution

Updated `kumo-info` dark mode color to `blue-400` (L=70.7%), matching the pattern used by `kumo-link` in dark mode. This provides:

| Level | Requirement | Result |
|-------|-------------|--------|
| AA (normal text) | 4.5:1 | PASS |
| AA (large text) | 3:1 | PASS |
| AAA (normal text) | 7:1 | PASS |