### PR TITLE
fix(Pagination): use aria-label instead of label for PageSize select

### DIFF
--- a/.changeset/fix-pagination-select-label.md
+++ b/.changeset/fix-pagination-select-label.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(Pagination): use aria-label instead of label for PageSize select
+
+The Select component now shows visible labels by default. Since Pagination.PageSize
+already displays "Per page:" text next to the select, the internal Select should use
+`aria-label` for accessibility without showing a duplicate visible label.

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -101,16 +101,14 @@ function PaginationInfo({ children, className }: PaginationInfoProps) {
   const { page, perPage, totalCount, pageShowingRange } =
     usePaginationContext();
 
-  const content = children
-    ? children({ page, perPage, totalCount, pageShowingRange })
-    : totalCount && totalCount > 0
-      ? (
-          <>
-            Showing <span className="tabular-nums">{pageShowingRange}</span> of{" "}
-            <span className="tabular-nums">{totalCount}</span>
-          </>
-        )
-      : null;
+  const content = children ? (
+    children({ page, perPage, totalCount, pageShowingRange })
+  ) : totalCount && totalCount > 0 ? (
+    <>
+      Showing <span className="tabular-nums">{pageShowingRange}</span> of{" "}
+      <span className="tabular-nums">{totalCount}</span>
+    </>
+  ) : null;
 
   return (
     <div
@@ -155,7 +153,7 @@ function PaginationPageSize({
     >
       {label && <span className="text-sm text-kumo-strong">{label}</span>}
       <Select
-        label="Page size"
+        aria-label="Page size"
         value={value}
         onValueChange={(v) => onChange(v as number)}
       >


### PR DESCRIPTION
## Summary

- Fixes the PageSize select showing a duplicate "Page size" label above the dropdown
- The Select component now shows visible labels by default (matching Input behavior) since #193
- Since `Pagination.PageSize` already displays "Per page:" text next to the select, the internal Select should use `aria-label` for accessibility without showing a duplicate visible label

## Change

Changed `label="Page size"` to `aria-label="Page size"` in `Pagination.PageSize`