### PR TITLE
fix(combobox): use fill-kumo-subtle for caret icon

### DIFF
--- a/.changeset/fix-combobox-caret.md
+++ b/.changeset/fix-combobox-caret.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix combobox caret icon visibility by using fill-kumo-subtle instead of fill-kumo-ring

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -256,7 +256,10 @@ function TriggerValue({
           iconStyles.iconRight,
         )}
       >
-        <CaretDownIcon size={iconStyles.iconSize} className="fill-kumo-ring" />
+        <CaretDownIcon
+          size={iconStyles.iconSize}
+          className="fill-kumo-subtle"
+        />
       </ComboboxBase.Icon>
     </ComboboxBase.Trigger>
   );
@@ -324,7 +327,7 @@ function TriggerInput(props: ComboboxBase.Input.Props) {
         >
           <CaretDownIcon
             size={iconStyles.iconSize}
-            className="fill-kumo-ring"
+            className="fill-kumo-subtle"
           />
         </ComboboxBase.Icon>
       </ComboboxBase.Trigger>


### PR DESCRIPTION
## Summary

Fix combobox caret icon visibility after the kumo-ring token color change in #215.

### Before
<img width="492" height="136" alt="Screenshot 2026-03-13 at 3 23 20 PM" src="https://github.com/user-attachments/assets/0dad1a25-c6ff-47d7-af98-b48dd56dcc86" />

### After
<img width="395" height="112" alt="Screenshot 2026-03-13 at 3 23 08 PM" src="https://github.com/user-attachments/assets/d2fa4de9-8099-43c0-ba10-42e77cc68486" />


## Problem

The `kumo-ring` token was changed to a very light color (93.5% lightness in light mode) for focus ring styling. However, the combobox was using `fill-kumo-ring` for its caret icon fill color, making it nearly invisible.

## Solution

Switch from `fill-kumo-ring` to `fill-kumo-subtle` for the combobox caret icons, which provides appropriate contrast for icon visibility.