### PR TITLE
fix(Chart): expose ECharts setOptionOpts and default notMerge to false

### DIFF
--- a/.changeset/soft-bees-reply.md
+++ b/.changeset/soft-bees-reply.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": minor
 ---
 
-Expose Chart `setOptionOpts` to control how ECharts applies option updates; `notMerge` now defaults to `false`.
+Expose Chart `optionUpdateBehavior` to control how ECharts applies option updates; `notMerge` now defaults to `false`.

--- a/packages/kumo/src/components/chart/EChart.tsx
+++ b/packages/kumo/src/components/chart/EChart.tsx
@@ -112,7 +112,7 @@ export interface ChartProps {
    * Additional options passed as the second argument to `chart.setOption()`.
    * Defaults to `{ notMerge: false, lazyUpdate: true }`.
    */
-  setOptionOpts?: SetOptionOpts;
+  optionUpdateBehavior?: SetOptionOpts;
   /** Additional CSS classes applied to the chart container `<div>` */
   className?: string;
   /**
@@ -155,7 +155,7 @@ export const Chart = forwardRef<echarts.ECharts, ChartProps>(function Chart(
   {
     echarts,
     options,
-    setOptionOpts,
+    optionUpdateBehavior,
     className,
     isDarkMode,
     height = 350,
@@ -212,9 +212,9 @@ export const Chart = forwardRef<echarts.ECharts, ChartProps>(function Chart(
     chart.setOption(options, {
       notMerge: false,
       lazyUpdate: true,
-      ...setOptionOpts,
+      ...optionUpdateBehavior,
     });
-  }, [isDarkMode, options, setOptionOpts]);
+  }, [isDarkMode, optionUpdateBehavior, options]);
 
   // Keep handlersRef in sync so wrapper closures always call the latest handler
   // without needing to re-bind listeners on every render


### PR DESCRIPTION
### Summary
Expose ECharts `setOption` update controls on `Chart` via a new `setOptionOpts` prop, and align the default update behavior to merge options by default (i.e. `notMerge: false`, which matches ECharts defaults).

### Changes
- Added `setOptionOpts?: SetOptionOpts` to `ChartProps`
- Updated `Chart` to call `chart.setOption(options, { notMerge: false, lazyUpdate: true, ...setOptionOpts })`

### Motivation
Chart previously hardcoded `notMerge: true`, which prevented consumers from using ECharts’ built-in option merging behavior. In the case of graphs with dynamic data, this meant that the axes components would be destroyed and recreated when `options` changes and does not animate. Note that `series` is an option, so this happens when new data is set. Exposing `setOptionOpts` allows users to control how updates are applied, and makes the default behavior closer to standard ECharts semantics.

https://echarts.apache.org/en/api.html#echartsInstance.setOption