### PR TITLE
fix(docs): correct broken GitHub source links on multiple docs pages

### DIFF
--- a/packages/kumo-docs-astro/src/layouts/DocLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/DocLayout.astro
@@ -20,11 +20,16 @@ const baseUIUrl = baseUIComponent
   : null;
 
 // Extract the component name from the path (e.g., "components/button" -> "button")
-// and construct the direct file URL (e.g., "components/button/button.tsx")
+// and construct the direct file URL (e.g., "components/button/button.tsx").
+// If sourceFile already has a file extension, use it as-is.
 const githubSourceUrl = sourceFile
   ? (() => {
+      const base = `https://github.com/cloudflare/kumo/blob/main/packages/kumo/src/`;
+      if (/\.\w+$/.test(sourceFile)) {
+        return `${base}${sourceFile}`;
+      }
       const componentName = sourceFile.split("/").pop();
-      return `https://github.com/cloudflare/kumo/blob/main/packages/kumo/src/${sourceFile}/${componentName}.tsx`;
+      return `${base}${sourceFile}/${componentName}.tsx`;
     })()
   : null;
 ---

--- a/packages/kumo-docs-astro/src/pages/charts/custom.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/custom.astro
@@ -9,7 +9,7 @@ import Heading from "~/components/docs/Heading.astro";
 <DocLayout
   title="Custom Chart"
   description="Example charts using the Chart component."
-  sourceFile="components/chart"
+  sourceFile="components/chart/EChart.tsx"
 >
   <ComponentSection>
     <Heading level={2} class="mb-6">Custom Chart</Heading>

--- a/packages/kumo-docs-astro/src/pages/charts/index.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/index.astro
@@ -18,7 +18,7 @@ import ComponentExample from "~/components/docs/ComponentExample.astro";
 <DocLayout
   title="Charts"
   description="Charts built on ECharts."
-  sourceFile="components/chart"
+  sourceFile="components/chart/index.ts"
 >
   <ComponentSection>
     <p class="mb-4">

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.astro
@@ -17,7 +17,7 @@ import Heading from "~/components/docs/Heading.astro";
 <DocLayout
   title="Timeseries Chart"
   description="A specialized chart for displaying time-based data."
-  sourceFile="components/chart"
+  sourceFile="components/chart/TimeseriesChart.tsx"
 >
   <p class="mb-12">
     The timeseries chart is a specialized chart for displaying time-based data.

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.astro
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.astro
@@ -193,7 +193,7 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
 <DocLayout
   title="CodeHighlighted"
   description="Shiki-powered syntax highlighting with VS Code-quality highlighting, theming, and lazy loading."
-  sourceFile="code"
+  sourceFile="code/code-highlighted.tsx"
 >
   <!-- Hero Demo -->
   <ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.astro
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.astro
@@ -10,7 +10,7 @@ import { SkeletonLineDemo, SkeletonLineWidthDemo, SkeletonLineCardDemo } from ".
 <DocLayout
   title="Skeleton Line"
   description="A skeleton loading placeholder for text content."
-  sourceFile="primitives/skeleton-line"
+  sourceFile="components/loader/skeleton-line.tsx"
 >
   <ComponentSection>
     <ComponentExample code={`<div className="flex flex-col gap-3 w-64">


### PR DESCRIPTION
## Summary

- Fixes 404 GitHub source links on **5 docs pages** where components don't follow the standard `{dir}/{name}.tsx` directory convention
- Updates `DocLayout` to support explicit file paths (with extension) in the `sourceFile` prop, falling back to the existing convention for all other pages

## Problem

| Page | `sourceFile` was | Linked to (404) | Actual file |
|------|-----------------|-----------------|-------------|
| SkeletonLine | `primitives/skeleton-line` | `primitives/skeleton-line/skeleton-line.tsx` | `components/loader/skeleton-line.tsx` |
| CodeHighlighted | `code` | `code/code.tsx` | `code/code-highlighted.tsx` |
| Charts (index) | `components/chart` | `components/chart/chart.tsx` | `components/chart/index.ts` |
| Custom Chart | `components/chart` | `components/chart/chart.tsx` | `components/chart/EChart.tsx` |
| Timeseries Chart | `components/chart` | `components/chart/chart.tsx` | `components/chart/TimeseriesChart.tsx` |

## Fix

- **`DocLayout.astro`**: If `sourceFile` includes a file extension (detected via `/\.\w+$/`), use it as a direct path. Otherwise, fall back to the existing `{dir}/{name}.tsx` convention. No existing pages are affected — none of the other 38 `sourceFile` values contain a file extension.
- **5 page files updated** with explicit paths to their actual source files.