### PR TITLE
fix(kumo): properly await dynamic imports in deep-imports test

### DIFF
--- a/.changeset/fix-deep-imports-test.md
+++ b/.changeset/fix-deep-imports-test.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix flaky vitest "Closing rpc while fetch was pending" error in deep-imports test

--- a/packages/kumo/tests/imports/deep-imports.test.ts
+++ b/packages/kumo/tests/imports/deep-imports.test.ts
@@ -8,13 +8,11 @@ describe("Deep Import Patterns", () => {
   describe("Components with configured exports", () => {
     componentsWithExports.forEach((componentName: string) => {
       it(`should import from @cloudflare/kumo/components/${componentName}`, async () => {
-        expect(async () => {
-          const module = await import(
-            `../../src/components/${componentName}/index.ts`
-          );
-          expect(module).toBeDefined();
-          expect(Object.keys(module).length).toBeGreaterThan(0);
-        }).not.toThrow();
+        const module = await import(
+          `../../src/components/${componentName}/index.ts`
+        );
+        expect(module).toBeDefined();
+        expect(Object.keys(module).length).toBeGreaterThan(0);
       });
     });
   });
@@ -43,9 +41,10 @@ describe("Deep Import Patterns", () => {
   describe("All components should have index.ts", () => {
     allComponents.forEach((componentName: string) => {
       it(`${componentName} should have an index.ts file`, async () => {
-        expect(async () => {
-          await import(`../../src/components/${componentName}/index.ts`);
-        }).not.toThrow();
+        const module = await import(
+          `../../src/components/${componentName}/index.ts`
+        );
+        expect(module).toBeDefined();
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes flaky vitest test failures with the error:
```
Error: [vitest-worker]: Closing rpc while "fetch" was pending
```

## Problem

The `deep-imports.test.ts` was wrapping async dynamic imports in `expect(async () => {...}).not.toThrow()`, which **does not actually await the promise**. This creates a race condition where:

1. Dynamic `import()` calls start executing
2. The test completes immediately (since the promise isn't awaited)
3. The vitest worker closes
4. Pending imports fail with "Closing rpc while fetch was pending"

## Impact

This flaky failure has affected:
- **PR #236** — merged with failing tests
- **PR #209** — currently blocked

## Fix

Directly await the imports and assert on the resolved module instead of using the broken `expect(async).not.toThrow()` pattern.

```diff
- expect(async () => {
-   const module = await import(`../../src/components/${componentName}/index.ts`);
-   expect(module).toBeDefined();
- }).not.toThrow();
+ const module = await import(`../../src/components/${componentName}/index.ts`);
+ expect(module).toBeDefined();
```