### PR TITLE
fix(docs): add missing success variant to Badge page

### DIFF
--- a/packages/kumo-docs-astro/src/pages/components/badge.astro
+++ b/packages/kumo-docs-astro/src/pages/components/badge.astro
@@ -10,6 +10,7 @@ import {
   BadgePrimaryDemo,
   BadgeSecondaryDemo,
   BadgeDestructiveDemo,
+  BadgeSuccessDemo,
   BadgeOutlineDemo,
   BadgeBetaDemo,
   BadgeInSentenceDemo,
@@ -27,6 +28,7 @@ import {
       code={`<Badge variant="primary">Primary</Badge>
 <Badge variant="secondary">Secondary</Badge>
 <Badge variant="destructive">Destructive</Badge>
+<Badge variant="success">Success</Badge>
 <Badge variant="outline">Outline</Badge>
 <Badge variant="beta">Beta</Badge>`}
     >
@@ -79,6 +81,13 @@ export default function Example() {
           <h4 class="mb-3 text-base font-medium">Destructive</h4>
           <ComponentExample code={`<Badge variant="destructive">Destructive</Badge>`}>
             <BadgeDestructiveDemo client:visible />
+          </ComponentExample>
+        </div>
+
+        <div>
+          <h4 class="mb-3 text-base font-medium">Success</h4>
+          <ComponentExample code={`<Badge variant="success">Success</Badge>`}>
+            <BadgeSuccessDemo client:visible />
           </ComponentExample>
         </div>
 


### PR DESCRIPTION
The Badge docs page was missing the `success` variant in two places, despite it being implemented in the component and already present in the demo file (`BadgeDemo.tsx`).

## Changes
- Added `<Badge variant="success">Success</Badge>` to the top demo code snippet
- Added the Success variant example in the Variants section (between Destructive and Outline)
- Added `BadgeSuccessDemo` import

| Before | After |
|--------|--------|
|<img width="2032" height="1161" alt="Screenshot 2026-03-17 at 13 54 33" src="https://github.com/user-attachments/assets/6a49ba66-0da1-4570-ba25-a537c3f67d18" />|<img width="2032" height="1161" alt="Screenshot 2026-03-17 at 13 53 55" src="https://github.com/user-attachments/assets/8485302b-ee43-418a-8992-72572e6497fe" />|
|<img width="2032" height="1161" alt="Screenshot 2026-03-17 at 13 54 40" src="https://github.com/user-attachments/assets/4abaf654-c251-412c-ad0f-ba46145cd3d1" />|<img width="2032" height="1161" alt="Screenshot 2026-03-17 at 13 54 09" src="https://github.com/user-attachments/assets/e373fc44-e422-4a35-b707-98fce91b8b2f" />|