### PR TITLE
feat(docs): add custom color example to Loader page

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/LoaderDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LoaderDemo.tsx
@@ -17,3 +17,8 @@ export function LoaderSizesDemo() {
 export function LoaderCustomSizeDemo() {
   return <Loader size={24} />;
 }
+
+/** Shows how to change the loader color using className */
+export function LoaderCustomColorDemo() {
+  return <Loader className="text-kumo-subtle" />;
+}

--- a/packages/kumo-docs-astro/src/pages/components/loader.astro
+++ b/packages/kumo-docs-astro/src/pages/components/loader.astro
@@ -9,6 +9,7 @@ import {
   LoaderBasicDemo,
   LoaderSizesDemo,
   LoaderCustomSizeDemo,
+  LoaderCustomColorDemo,
 } from "../../components/demos/LoaderDemo";
 ---
 
@@ -65,6 +66,13 @@ export default function Example() {
         <Heading level={3}>Custom Size</Heading>
         <ComponentExample code={`<Loader size={24} />`}>
           <LoaderCustomSizeDemo client:visible />
+        </ComponentExample>
+      </div>
+
+      <div>
+        <Heading level={3}>Custom Color</Heading>
+        <ComponentExample code={`<Loader className="text-kumo-subtle" />`}>
+          <LoaderCustomColorDemo client:visible />
         </ComponentExample>
       </div>
     </div>


### PR DESCRIPTION
Adds a "Custom Color" example to the Loader docs page showing how to change the spinner color via `className="text-kumo-subtle"`. The Loader SVG uses `currentColor`, so any text color utility controls the spinner color.

## Changes
- `LoaderDemo.tsx`: Added `LoaderCustomColorDemo`
- `loader.astro`: Added "Custom Color" section after "Custom Size"

<img width="1780" height="1195" alt="Screenshot 2026-03-17 at 14 27 51" src="https://github.com/user-attachments/assets/7dbc83e8-e33c-41b6-96f1-2c0d1646868b" />