### PR TITLE
fix(docs): set UTF-8 charset on served .md files

### DIFF
--- a/packages/kumo-docs-astro/public/_headers
+++ b/packages/kumo-docs-astro/public/_headers
@@ -1,0 +1,3 @@
+# Ensure .md files are served with UTF-8 charset
+/*.md
+  Content-Type: text/markdown; charset=utf-8


### PR DESCRIPTION
Fixes emoji rendering in served `.md` files (e.g., `✅` was showing as `âœ…`).

## Problem
The `.md` files generated by the markdown-pages integration contain correct UTF-8 bytes, but Cloudflare Workers serves them with `Content-Type: text/markdown` without `charset=utf-8`. Browsers fall back to Latin-1 encoding, corrupting multi-byte UTF-8 characters like emojis.

## Fix
Adds a `_headers` file to set `Content-Type: text/markdown; charset=utf-8` on all `*.md` responses. This is a Cloudflare Workers static assets feature that applies custom headers to matching responses at deploy time.

| Before | After |
|--------|--------|
|<img width="1780" height="1195" alt="Screenshot 2026-03-17 at 14 50 11" src="https://github.com/user-attachments/assets/9925b091-3c86-4014-825a-6a9691a44171" />|<img width="1780" height="1195" alt="Screenshot 2026-03-17 at 14 49 59" src="https://github.com/user-attachments/assets/875984a2-83c6-41ac-94a9-849631646bd0" />|