### PR TITLE
Add chart theme tokens and docs

### DIFF
--- a/.changeset/chart-theme-tokens.md
+++ b/.changeset/chart-theme-tokens.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Move chart palette colors into theme-generator tokens and document the new `kumo-chart-*` tokens.

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -108,13 +108,19 @@ export function TabsRenderPropDemo() {
         {
           value: "tab2",
           label: "Link Tab",
-          render: (props) => <a {...props} href="#tab2" />,
+          render: (props) => (
+            <a {...props} href="#tab2">
+              Link Tab
+            </a>
+          ),
         },
         {
           value: "tab3",
           label: "Cloudflare",
           render: (props) => (
-            <a {...props} href="https://cloudflare.com" target="_blank" />
+            <a {...props} href="https://cloudflare.com" target="_blank">
+              Cloudflare
+            </a>
           ),
         },
       ]}

--- a/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
+++ b/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
@@ -1,10 +1,5 @@
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  THEME_CONFIG,
-  AVAILABLE_THEMES,
-} from "../../../kumo/scripts/theme-generator/config";
-import type { TokenDefinition } from "../../../kumo/scripts/theme-generator/types";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -21,23 +16,47 @@ type ColorToken = {
   tokenType: TokenType;
 };
 
+type ColorMode = {
+  light: string;
+  dark: string;
+};
+
+type TokenDefinition = {
+  theme: Record<string, ColorMode | undefined> & {
+    kumo: ColorMode;
+  };
+};
+
+type ThemeConfigModule = {
+  THEME_CONFIG: {
+    text: Record<string, TokenDefinition>;
+    color: Record<string, TokenDefinition>;
+  };
+  AVAILABLE_THEMES: readonly string[];
+};
+
+async function loadThemeConfig(configFile: string): Promise<ThemeConfigModule> {
+  const configUrl = pathToFileURL(configFile);
+  configUrl.searchParams.set("t", `${Date.now()}`);
+  return import(/* @vite-ignore */ configUrl.href) as Promise<ThemeConfigModule>;
+}
+
 /**
  * Convert theme config to ColorToken array for the virtual module.
  * Derives token data directly from config.ts (single source of truth).
  */
-function getColorsFromConfig(): ColorToken[] {
+async function getColorsFromConfig(configFile: string): Promise<ColorToken[]> {
+  const { THEME_CONFIG, AVAILABLE_THEMES } = await loadThemeConfig(configFile);
   const colors: ColorToken[] = [];
 
   // Process text color tokens
   for (const [tokenName, def] of Object.entries(THEME_CONFIG.text)) {
-    const typedDef = def as TokenDefinition;
-
     // Base kumo theme (semantic tokens)
-    if (typedDef.theme.kumo) {
+    if (def.theme.kumo) {
       colors.push({
         name: `--text-color-${tokenName}`,
-        light: typedDef.theme.kumo.light,
-        dark: typedDef.theme.kumo.dark,
+        light: def.theme.kumo.light,
+        dark: def.theme.kumo.dark,
         theme: "kumo",
         tokenType: "semantic",
       });
@@ -45,8 +64,8 @@ function getColorsFromConfig(): ColorToken[] {
 
     // Theme overrides
     for (const themeName of AVAILABLE_THEMES) {
-      if (themeName !== "kumo" && typedDef.theme[themeName]) {
-        const themeColors = typedDef.theme[themeName]!;
+      if (themeName !== "kumo" && def.theme[themeName]) {
+        const themeColors = def.theme[themeName]!;
         colors.push({
           name: `--text-color-${tokenName}`,
           light: themeColors.light,
@@ -60,14 +79,12 @@ function getColorsFromConfig(): ColorToken[] {
 
   // Process color tokens (bg, border, ring, etc.)
   for (const [tokenName, def] of Object.entries(THEME_CONFIG.color)) {
-    const typedDef = def as TokenDefinition;
-
     // Base kumo theme (semantic tokens)
-    if (typedDef.theme.kumo) {
+    if (def.theme.kumo) {
       colors.push({
         name: `--color-${tokenName}`,
-        light: typedDef.theme.kumo.light,
-        dark: typedDef.theme.kumo.dark,
+        light: def.theme.kumo.light,
+        dark: def.theme.kumo.dark,
         theme: "kumo",
         tokenType: "semantic",
       });
@@ -75,8 +92,8 @@ function getColorsFromConfig(): ColorToken[] {
 
     // Theme overrides
     for (const themeName of AVAILABLE_THEMES) {
-      if (themeName !== "kumo" && typedDef.theme[themeName]) {
-        const themeColors = typedDef.theme[themeName]!;
+      if (themeName !== "kumo" && def.theme[themeName]) {
+        const themeColors = def.theme[themeName]!;
         colors.push({
           name: `--color-${tokenName}`,
           light: themeColors.light,
@@ -113,9 +130,9 @@ export function kumoColorsPlugin() {
       }
     },
 
-    load(id: string) {
+    async load(id: string) {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-        const colors = getColorsFromConfig();
+        const colors = await getColorsFromConfig(configFile);
 
         return `
 export const kumoColors = ${JSON.stringify(colors, null, 2)};

--- a/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
+++ b/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
@@ -1,5 +1,10 @@
 import { dirname, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import {
+  THEME_CONFIG,
+  AVAILABLE_THEMES,
+} from "../../../kumo/scripts/theme-generator/config";
+import type { TokenDefinition } from "../../../kumo/scripts/theme-generator/types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -16,47 +21,23 @@ type ColorToken = {
   tokenType: TokenType;
 };
 
-type ColorMode = {
-  light: string;
-  dark: string;
-};
-
-type TokenDefinition = {
-  theme: Record<string, ColorMode | undefined> & {
-    kumo: ColorMode;
-  };
-};
-
-type ThemeConfigModule = {
-  THEME_CONFIG: {
-    text: Record<string, TokenDefinition>;
-    color: Record<string, TokenDefinition>;
-  };
-  AVAILABLE_THEMES: readonly string[];
-};
-
-async function loadThemeConfig(configFile: string): Promise<ThemeConfigModule> {
-  const configUrl = pathToFileURL(configFile);
-  configUrl.searchParams.set("t", `${Date.now()}`);
-  return import(/* @vite-ignore */ configUrl.href) as Promise<ThemeConfigModule>;
-}
-
 /**
  * Convert theme config to ColorToken array for the virtual module.
  * Derives token data directly from config.ts (single source of truth).
  */
-async function getColorsFromConfig(configFile: string): Promise<ColorToken[]> {
-  const { THEME_CONFIG, AVAILABLE_THEMES } = await loadThemeConfig(configFile);
+function getColorsFromConfig(): ColorToken[] {
   const colors: ColorToken[] = [];
 
   // Process text color tokens
   for (const [tokenName, def] of Object.entries(THEME_CONFIG.text)) {
+    const typedDef = def as TokenDefinition;
+
     // Base kumo theme (semantic tokens)
-    if (def.theme.kumo) {
+    if (typedDef.theme.kumo) {
       colors.push({
         name: `--text-color-${tokenName}`,
-        light: def.theme.kumo.light,
-        dark: def.theme.kumo.dark,
+        light: typedDef.theme.kumo.light,
+        dark: typedDef.theme.kumo.dark,
         theme: "kumo",
         tokenType: "semantic",
       });
@@ -64,8 +45,8 @@ async function getColorsFromConfig(configFile: string): Promise<ColorToken[]> {
 
     // Theme overrides
     for (const themeName of AVAILABLE_THEMES) {
-      if (themeName !== "kumo" && def.theme[themeName]) {
-        const themeColors = def.theme[themeName]!;
+      if (themeName !== "kumo" && typedDef.theme[themeName]) {
+        const themeColors = typedDef.theme[themeName]!;
         colors.push({
           name: `--text-color-${tokenName}`,
           light: themeColors.light,
@@ -79,12 +60,14 @@ async function getColorsFromConfig(configFile: string): Promise<ColorToken[]> {
 
   // Process color tokens (bg, border, ring, etc.)
   for (const [tokenName, def] of Object.entries(THEME_CONFIG.color)) {
+    const typedDef = def as TokenDefinition;
+
     // Base kumo theme (semantic tokens)
-    if (def.theme.kumo) {
+    if (typedDef.theme.kumo) {
       colors.push({
         name: `--color-${tokenName}`,
-        light: def.theme.kumo.light,
-        dark: def.theme.kumo.dark,
+        light: typedDef.theme.kumo.light,
+        dark: typedDef.theme.kumo.dark,
         theme: "kumo",
         tokenType: "semantic",
       });
@@ -92,8 +75,8 @@ async function getColorsFromConfig(configFile: string): Promise<ColorToken[]> {
 
     // Theme overrides
     for (const themeName of AVAILABLE_THEMES) {
-      if (themeName !== "kumo" && def.theme[themeName]) {
-        const themeColors = def.theme[themeName]!;
+      if (themeName !== "kumo" && typedDef.theme[themeName]) {
+        const themeColors = typedDef.theme[themeName]!;
         colors.push({
           name: `--color-${tokenName}`,
           light: themeColors.light,
@@ -130,9 +113,9 @@ export function kumoColorsPlugin() {
       }
     },
 
-    async load(id: string) {
+    load(id: string) {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-        const colors = await getColorsFromConfig(configFile);
+        const colors = getColorsFromConfig();
 
         return `
 export const kumoColors = ${JSON.stringify(colors, null, 2)};

--- a/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
+++ b/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
@@ -1,10 +1,7 @@
+import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  THEME_CONFIG,
-  AVAILABLE_THEMES,
-} from "../../../kumo/scripts/theme-generator/config";
-import type { TokenDefinition } from "../../../kumo/scripts/theme-generator/types";
+import * as ts from "typescript";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -21,23 +18,63 @@ type ColorToken = {
   tokenType: TokenType;
 };
 
+type ColorMode = {
+  light: string;
+  dark: string;
+};
+
+type TokenDefinition = {
+  theme: Record<string, ColorMode | undefined> & {
+    kumo: ColorMode;
+  };
+};
+
+type ThemeConfigModule = {
+  THEME_CONFIG: {
+    text: Record<string, TokenDefinition>;
+    color: Record<string, TokenDefinition>;
+  };
+  AVAILABLE_THEMES: readonly string[];
+};
+
+async function loadThemeConfig(configFile: string): Promise<ThemeConfigModule> {
+  const source = await readFile(configFile, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: configFile,
+  });
+
+  const exportsObject: Record<string, unknown> = {};
+  const moduleObject = { exports: exportsObject };
+  const evaluator = new Function(
+    "exports",
+    "module",
+    outputText,
+  ) as (exports: Record<string, unknown>, module: { exports: Record<string, unknown> }) => void;
+
+  evaluator(exportsObject, moduleObject);
+  return moduleObject.exports as ThemeConfigModule;
+}
+
 /**
  * Convert theme config to ColorToken array for the virtual module.
  * Derives token data directly from config.ts (single source of truth).
  */
-function getColorsFromConfig(): ColorToken[] {
+async function getColorsFromConfig(configFile: string): Promise<ColorToken[]> {
+  const { THEME_CONFIG, AVAILABLE_THEMES } = await loadThemeConfig(configFile);
   const colors: ColorToken[] = [];
 
   // Process text color tokens
   for (const [tokenName, def] of Object.entries(THEME_CONFIG.text)) {
-    const typedDef = def as TokenDefinition;
-
     // Base kumo theme (semantic tokens)
-    if (typedDef.theme.kumo) {
+    if (def.theme.kumo) {
       colors.push({
         name: `--text-color-${tokenName}`,
-        light: typedDef.theme.kumo.light,
-        dark: typedDef.theme.kumo.dark,
+        light: def.theme.kumo.light,
+        dark: def.theme.kumo.dark,
         theme: "kumo",
         tokenType: "semantic",
       });
@@ -45,8 +82,8 @@ function getColorsFromConfig(): ColorToken[] {
 
     // Theme overrides
     for (const themeName of AVAILABLE_THEMES) {
-      if (themeName !== "kumo" && typedDef.theme[themeName]) {
-        const themeColors = typedDef.theme[themeName]!;
+      if (themeName !== "kumo" && def.theme[themeName]) {
+        const themeColors = def.theme[themeName]!;
         colors.push({
           name: `--text-color-${tokenName}`,
           light: themeColors.light,
@@ -60,14 +97,12 @@ function getColorsFromConfig(): ColorToken[] {
 
   // Process color tokens (bg, border, ring, etc.)
   for (const [tokenName, def] of Object.entries(THEME_CONFIG.color)) {
-    const typedDef = def as TokenDefinition;
-
     // Base kumo theme (semantic tokens)
-    if (typedDef.theme.kumo) {
+    if (def.theme.kumo) {
       colors.push({
         name: `--color-${tokenName}`,
-        light: typedDef.theme.kumo.light,
-        dark: typedDef.theme.kumo.dark,
+        light: def.theme.kumo.light,
+        dark: def.theme.kumo.dark,
         theme: "kumo",
         tokenType: "semantic",
       });
@@ -75,8 +110,8 @@ function getColorsFromConfig(): ColorToken[] {
 
     // Theme overrides
     for (const themeName of AVAILABLE_THEMES) {
-      if (themeName !== "kumo" && typedDef.theme[themeName]) {
-        const themeColors = typedDef.theme[themeName]!;
+      if (themeName !== "kumo" && def.theme[themeName]) {
+        const themeColors = def.theme[themeName]!;
         colors.push({
           name: `--color-${tokenName}`,
           light: themeColors.light,
@@ -113,9 +148,9 @@ export function kumoColorsPlugin() {
       }
     },
 
-    load(id: string) {
+    async load(id: string) {
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-        const colors = getColorsFromConfig();
+        const colors = await getColorsFromConfig(configFile);
 
         return `
 export const kumoColors = ${JSON.stringify(colors, null, 2)};

--- a/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
+++ b/packages/kumo-docs-astro/src/lib/vite-plugin-kumo-colors.ts
@@ -3,8 +3,8 @@ import { fileURLToPath } from "node:url";
 import {
   THEME_CONFIG,
   AVAILABLE_THEMES,
-} from "@cloudflare/kumo/scripts/theme-generator/config";
-import type { TokenDefinition } from "@cloudflare/kumo/scripts/theme-generator/types";
+} from "../../../kumo/scripts/theme-generator/config";
+import type { TokenDefinition } from "../../../kumo/scripts/theme-generator/types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/kumo-docs-astro/src/pages/colors.astro
+++ b/packages/kumo-docs-astro/src/pages/colors.astro
@@ -149,6 +149,27 @@ export const AVAILABLE_THEMES = ["kumo", "fedramp", "myTheme"] as const;`}
   </ComponentSection>
 
   <ComponentSection>
+    <h2 class="mb-4 text-2xl font-bold">Chart Tokens</h2>
+    <p class="mb-4 text-kumo-strong">
+      Chart components use dedicated semantic tokens from <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">packages/kumo/scripts/theme-generator/config.ts</code>
+      so chart palettes stay centralized with the rest of the theme system.
+    </p>
+    <p class="mb-4 text-kumo-strong">
+      Look for tokens prefixed with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">kumo-chart-</code>, including categorical series colors like
+      <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">kumo-chart-series-blue</code> and semantic colors like
+      <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">kumo-chart-attention</code>.
+      These also cover chart UI details such as brush selection and loading states.
+    </p>
+    <CodeBlock
+      code={`import { ChartPalette } from "@cloudflare/kumo";
+
+const requests = ChartPalette.color(0, isDarkMode);
+const errors = ChartPalette.semantic("Attention", isDarkMode);`}
+      lang="tsx"
+    />
+  </ComponentSection>
+
+  <ComponentSection>
     <h2 class="mb-4 text-2xl font-bold">Token Reference</h2>
     <p class="mb-4 text-kumo-strong">
       Toggle the theme in the header to see how tokens adapt. Tokens marked as "global" 

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -369,6 +369,196 @@ export const THEME_CONFIG: ThemeConfig = {
         },
       },
     },
+    "kumo-chart-series-blue": {
+      newName: "",
+      description: "Primary categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#086FFF",
+          dark: "#086FFFE6",
+        },
+      },
+    },
+    "kumo-chart-series-violet": {
+      newName: "",
+      description: "Secondary categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#CF7EE9",
+          dark: "#CF7EE9E6",
+        },
+      },
+    },
+    "kumo-chart-series-cyan": {
+      newName: "",
+      description: "Categorical chart series color for tertiary datasets.",
+      theme: {
+        kumo: {
+          light: "#73CEE6",
+          dark: "#73CEE6E6",
+        },
+      },
+    },
+    "kumo-chart-series-indigo": {
+      newName: "",
+      description: "Categorical chart series color for additional datasets.",
+      theme: {
+        kumo: {
+          light: "#5B5FEF",
+          dark: "#5B5FEFE6",
+        },
+      },
+    },
+    "kumo-chart-series-light-blue": {
+      newName: "",
+      description: "Light blue categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#82B6FF",
+          dark: "#82B6FFE6",
+        },
+      },
+    },
+    "kumo-chart-series-pink": {
+      newName: "",
+      description: "Pink categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#F5609F",
+          dark: "#F5609FE6",
+        },
+      },
+    },
+    "kumo-chart-series-indigo-soft": {
+      newName: "",
+      description: "Soft indigo categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#C2BDF3",
+          dark: "#C2BDF3E6",
+        },
+      },
+    },
+    "kumo-chart-series-violet-strong": {
+      newName: "",
+      description: "Strong violet categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#8D1EB1",
+          dark: "#8D1EB1E6",
+        },
+      },
+    },
+    "kumo-chart-series-violet-soft": {
+      newName: "",
+      description: "Soft violet categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#EBCAF6",
+          dark: "#EBCAF6E6",
+        },
+      },
+    },
+    "kumo-chart-series-indigo-muted": {
+      newName: "",
+      description: "Muted indigo categorical chart series color.",
+      theme: {
+        kumo: {
+          light: "#7366E4",
+          dark: "#7366E4E6",
+        },
+      },
+    },
+    "kumo-chart-attention": {
+      newName: "",
+      description: "Semantic chart color for attention or error states.",
+      theme: {
+        kumo: {
+          light: "#FC574A",
+          dark: "#FC574AE6",
+        },
+      },
+    },
+    "kumo-chart-warning": {
+      newName: "",
+      description: "Semantic chart color for warning states.",
+      theme: {
+        kumo: {
+          light: "#F8A054",
+          dark: "#F8A054E6",
+        },
+      },
+    },
+    "kumo-chart-neutral": {
+      newName: "",
+      description: "Semantic chart color for neutral highlighted series.",
+      theme: {
+        kumo: {
+          light: "#82B6FF",
+          dark: "#82B6FFE6",
+        },
+      },
+    },
+    "kumo-chart-neutral-light": {
+      newName: "",
+      description: "Lighter semantic chart color for neutral comparison series.",
+      theme: {
+        kumo: {
+          light: "#B9D6FF",
+          dark: "#B9D6FFE6",
+        },
+      },
+    },
+    "kumo-chart-disabled": {
+      newName: "",
+      description: "Semantic chart color for disabled or de-emphasized series.",
+      theme: {
+        kumo: {
+          light: "#B6B6B6",
+          dark: "#B6B6B6E6",
+        },
+      },
+    },
+    "kumo-chart-disabled-light": {
+      newName: "",
+      description: "Lighter disabled chart color for secondary de-emphasis.",
+      theme: {
+        kumo: {
+          light: "#D9D9D9",
+          dark: "#D9D9D9E6",
+        },
+      },
+    },
+    "kumo-chart-brush-fill": {
+      newName: "",
+      description: "Brush selection fill color used in timeseries charts.",
+      theme: {
+        kumo: {
+          light: "rgba(120,140,180,0.3)",
+          dark: "rgba(120,140,180,0.3)",
+        },
+      },
+    },
+    "kumo-chart-brush-stroke": {
+      newName: "",
+      description: "Brush selection border color used in timeseries charts.",
+      theme: {
+        kumo: {
+          light: "rgba(120,140,180,0.8)",
+          dark: "rgba(120,140,180,0.8)",
+        },
+      },
+    },
+    "kumo-chart-loader-stroke": {
+      newName: "",
+      description: "Loading skeleton stroke color used in timeseries charts.",
+      theme: {
+        kumo: {
+          light: "rgba(0,0,0,0.2)",
+          dark: "rgba(255,255,255,0.5)",
+        },
+      },
+    },
   },
 
   /**

--- a/packages/kumo/src/components/chart/Color.ts
+++ b/packages/kumo/src/components/chart/Color.ts
@@ -1,124 +1,83 @@
-/**
- * Categorical colors for light mode — used when assigning colors to data series
- * by index (e.g. the first series gets Blue, the second gets Violet, etc.).
- */
-enum ChartCategoricalLightColors {
-  Blue = "#086FFF",
-  Violet = "#CF7EE9",
-  Cyan = "#73CEE6",
-  Indigo = "#5B5FEF",
-  LightBlue = "#82B6FF",
-  Pink = "#F5609F",
-  Indigo3 = "#C2BDF3",
-  Violet2 = "#8D1EB1",
-  Violet3 = "#EBCAF6",
-  Indigo2 = "#7366E4",
-}
+import { THEME_CONFIG } from "../../../scripts/theme-generator/config";
 
-/**
- * Categorical colors for dark mode — same hues as the light palette but with
- * `E6` alpha (90% opacity) appended to soften contrast on dark backgrounds.
- */
-enum ChartCategoricalDarkColors {
-  Blue = "#086FFFE6",
-  Violet = "#CF7EE9E6",
-  Cyan = "#73CEE6E6",
-  Indigo = "#5B5FEFE6",
-  LightBlue = "#82B6FFE6",
-  Pink = "#F5609FE6",
-  Indigo3 = "#C2BDF3E6",
-  Violet2 = "#8D1EB1E6",
-  Violet3 = "#EBCAF6E6",
-  Indigo2 = "#7366E4E6",
-}
+const CHART_CATEGORICAL_COLOR_TOKENS = [
+  "kumo-chart-series-blue",
+  "kumo-chart-series-violet",
+  "kumo-chart-series-cyan",
+  "kumo-chart-series-indigo",
+  "kumo-chart-series-light-blue",
+  "kumo-chart-series-pink",
+  "kumo-chart-series-indigo-soft",
+  "kumo-chart-series-violet-strong",
+  "kumo-chart-series-violet-soft",
+  "kumo-chart-series-indigo-muted",
+] as const;
 
-/**
- * Semantic colors for light mode — used to convey meaning (status, severity)
- * rather than just distinguishing series. Use via `ChartPalette.semantic()`.
- */
-enum ChartSemanticLightColors {
-  Attention = "#FC574A",
-  Warning = "#F8A054",
-  Neutral = "#82B6FF",
-  NeutralLight = "#B9D6FF",
-  Disabled = "#B6B6B6",
-  DisabledLight = "#D9D9D9",
-}
+type ChartSemanticName =
+  | "Attention"
+  | "Warning"
+  | "Neutral"
+  | "NeutralLight"
+  | "Disabled"
+  | "DisabledLight";
 
-/**
- * Semantic colors for dark mode — same meanings as the light palette but with
- * `E6` alpha (90% opacity) for dark backgrounds.
- */
-enum ChartSemanticDarkColors {
-  Attention = "#FC574AE6",
-  Warning = "#F8A054E6",
-  Neutral = "#82B6FFE6",
-  NeutralLight = "#B9D6FFE6",
-  Disabled = "#B6B6B6E6",
-  DisabledLight = "#D9D9D9E6",
+type ChartColorTokenName = keyof typeof THEME_CONFIG.color;
+
+const CHART_SEMANTIC_COLOR_TOKENS: Record<ChartSemanticName, ChartColorTokenName> =
+  {
+    Attention: "kumo-chart-attention",
+    Warning: "kumo-chart-warning",
+    Neutral: "kumo-chart-neutral",
+    NeutralLight: "kumo-chart-neutral-light",
+    Disabled: "kumo-chart-disabled",
+    DisabledLight: "kumo-chart-disabled-light",
+  };
+
+function getChartColorToken(
+  tokenName: ChartColorTokenName,
+  isDarkMode = false,
+): string {
+  const token = THEME_CONFIG.color[tokenName];
+
+  if (!token) {
+    throw new Error(`Unknown chart color token: ${tokenName}`);
+  }
+
+  return isDarkMode ? token.theme.kumo.dark : token.theme.kumo.light;
 }
 
 /**
  * Ordered list of categorical colors for light mode, indexed by series position.
  * Used as the default ECharts color palette when `isDarkMode` is `false`.
  */
-export const CHART_LIGHT_COLORS = [
-  ChartCategoricalLightColors.Blue,
-  ChartCategoricalLightColors.Violet,
-  ChartCategoricalLightColors.Cyan,
-  ChartCategoricalLightColors.Indigo,
-  ChartCategoricalLightColors.LightBlue,
-  ChartCategoricalLightColors.Pink,
-  ChartCategoricalLightColors.Indigo3,
-  ChartCategoricalLightColors.Violet2,
-  ChartCategoricalLightColors.Violet3,
-  ChartCategoricalLightColors.Indigo2,
-];
+export const CHART_LIGHT_COLORS = CHART_CATEGORICAL_COLOR_TOKENS.map(
+  (tokenName) => getChartColorToken(tokenName),
+);
 
 /**
  * Ordered list of categorical colors for dark mode, indexed by series position.
  * Used as the default ECharts color palette when `isDarkMode` is `true`.
  */
-export const CHART_DARK_COLORS = [
-  ChartCategoricalDarkColors.Blue,
-  ChartCategoricalDarkColors.Violet,
-  ChartCategoricalDarkColors.Cyan,
-  ChartCategoricalDarkColors.Indigo,
-  ChartCategoricalDarkColors.LightBlue,
-  ChartCategoricalDarkColors.Pink,
-  ChartCategoricalDarkColors.Indigo3,
-  ChartCategoricalDarkColors.Violet2,
-  ChartCategoricalDarkColors.Violet3,
-  ChartCategoricalDarkColors.Indigo2,
-];
+export const CHART_DARK_COLORS = CHART_CATEGORICAL_COLOR_TOKENS.map(
+  (tokenName) => getChartColorToken(tokenName, true),
+);
 
 /**
  * Utilities for resolving Kumo chart colors by semantic name or series index.
- * Both functions accept an `isDarkMode` flag and return the appropriate hex color.
+ * Both functions accept an `isDarkMode` flag and return the appropriate color.
  */
 export namespace ChartPalette {
   /**
-   * Returns the hex color for a named semantic value (status, severity, etc.).
+   * Returns the color for a named semantic value (status, severity, etc.).
    *
    * @example
    * ```ts
-   * ChartPalette.semantic("Attention")           // "#FC574A" (light)
-   * ChartPalette.semantic("Warning", true)       // "#F8A054E6" (dark)
+   * ChartPalette.semantic("Attention")           // kumo chart attention color (light)
+   * ChartPalette.semantic("Warning", true)       // kumo chart warning color (dark)
    * ```
    */
-  export function semantic(
-    name:
-      | "Attention"
-      | "Warning"
-      | "Neutral"
-      | "NeutralLight"
-      | "Disabled"
-      | "DisabledLight",
-    isDarkMode = false,
-  ) {
-    return isDarkMode
-      ? ChartSemanticDarkColors[name]
-      : ChartSemanticLightColors[name];
+  export function semantic(name: ChartSemanticName, isDarkMode = false) {
+    return getChartColorToken(CHART_SEMANTIC_COLOR_TOKENS[name], isDarkMode);
   }
 
   /**
@@ -127,9 +86,9 @@ export namespace ChartPalette {
    *
    * @example
    * ```ts
-   * ChartPalette.color(0)        // Blue (light)
-   * ChartPalette.color(0, true)  // Blue with E6 alpha (dark)
-   * ChartPalette.color(10)       // wraps back to Blue
+   * ChartPalette.color(0)        // first categorical color (light)
+   * ChartPalette.color(0, true)  // first categorical color (dark)
+   * ChartPalette.color(10)       // wraps back to the first color
    * ```
    */
   export function color(index: number, isDarkMode = false) {
@@ -137,4 +96,11 @@ export namespace ChartPalette {
       ? CHART_DARK_COLORS[index % CHART_DARK_COLORS.length]
       : CHART_LIGHT_COLORS[index % CHART_LIGHT_COLORS.length];
   }
+}
+
+export function getChartThemeColor(
+  tokenName: ChartColorTokenName,
+  isDarkMode = false,
+) {
+  return getChartColorToken(tokenName, isDarkMode);
 }

--- a/packages/kumo/src/components/chart/Legend.tsx
+++ b/packages/kumo/src/components/chart/Legend.tsx
@@ -84,8 +84,18 @@ function SmallItem({ color, value, name, inactive }: LegendItemProps) {
  *
  * @example
  * ```tsx
- * <ChartLegend.SmallItem name="Requests" color="#086FFF" value="1,234" />
- * <ChartLegend.LargeItem name="Latency" color="#CF7EE9" value="42" unit="ms" inactive />
+ * <ChartLegend.SmallItem
+ *   name="Requests"
+ *   color={ChartPalette.color(0, isDarkMode)}
+ *   value="1,234"
+ * />
+ * <ChartLegend.LargeItem
+ *   name="Latency"
+ *   color={ChartPalette.semantic("Warning", isDarkMode)}
+ *   value="42"
+ *   unit="ms"
+ *   inactive
+ * />
  * ```
  */
 export const ChartLegend = {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -3,6 +3,7 @@ import type { LineSeriesOption, BarSeriesOption } from "echarts/charts";
 import type { EChartsOption } from "echarts";
 import { useEffect, useMemo, useRef } from "react";
 import { Chart, ChartEvents } from "./EChart";
+import { getChartThemeColor } from "./Color";
 
 /** A single data series rendered on a `TimeseriesChart` */
 export interface TimeseriesData {
@@ -99,7 +100,13 @@ export interface TimeseriesChartProps {
  *
  * <TimeseriesChart
  *   echarts={echarts}
- *   data={[{ name: "Requests", data: [[Date.now(), 42]], color: "#086FFF" }]}
+ *   data={[
+ *     {
+ *       name: "Requests",
+ *       data: [[Date.now(), 42]],
+ *       color: ChartPalette.color(0, isDarkMode),
+ *     },
+ *   ]}
  *   xAxisName="Time"
  *   xAxisTickFormat={(ts) => new Date(ts).toLocaleTimeString()}
  *   yAxisName="Count"
@@ -216,8 +223,8 @@ export function TimeseriesChart({
         },
         brushStyle: {
           borderWidth: 1,
-          color: "rgba(120,140,180,0.3)",
-          borderColor: "rgba(120,140,180,0.8)",
+          color: getChartThemeColor("kumo-chart-brush-fill", isDarkMode),
+          borderColor: getChartThemeColor("kumo-chart-brush-stroke", isDarkMode),
         },
       },
       tooltip: {
@@ -399,7 +406,10 @@ function ChartWaveLoader({
   }
   const d = points.join(" ");
 
-  const strokeColor = isDarkMode ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.2)";
+  const strokeColor = getChartThemeColor(
+    "kumo-chart-loader-stroke",
+    isDarkMode,
+  );
 
   return (
     <div

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -191,6 +191,101 @@
     var(--color-green-900, oklch(39.3% 0.095 152.535))
   );
 
+  --color-kumo-chart-series-blue: light-dark(
+    #086FFF,
+    #086FFFE6
+  );
+
+  --color-kumo-chart-series-violet: light-dark(
+    #CF7EE9,
+    #CF7EE9E6
+  );
+
+  --color-kumo-chart-series-cyan: light-dark(
+    #73CEE6,
+    #73CEE6E6
+  );
+
+  --color-kumo-chart-series-indigo: light-dark(
+    #5B5FEF,
+    #5B5FEFE6
+  );
+
+  --color-kumo-chart-series-light-blue: light-dark(
+    #82B6FF,
+    #82B6FFE6
+  );
+
+  --color-kumo-chart-series-pink: light-dark(
+    #F5609F,
+    #F5609FE6
+  );
+
+  --color-kumo-chart-series-indigo-soft: light-dark(
+    #C2BDF3,
+    #C2BDF3E6
+  );
+
+  --color-kumo-chart-series-violet-strong: light-dark(
+    #8D1EB1,
+    #8D1EB1E6
+  );
+
+  --color-kumo-chart-series-violet-soft: light-dark(
+    #EBCAF6,
+    #EBCAF6E6
+  );
+
+  --color-kumo-chart-series-indigo-muted: light-dark(
+    #7366E4,
+    #7366E4E6
+  );
+
+  --color-kumo-chart-attention: light-dark(
+    #FC574A,
+    #FC574AE6
+  );
+
+  --color-kumo-chart-warning: light-dark(
+    #F8A054,
+    #F8A054E6
+  );
+
+  --color-kumo-chart-neutral: light-dark(
+    #82B6FF,
+    #82B6FFE6
+  );
+
+  --color-kumo-chart-neutral-light: light-dark(
+    #B9D6FF,
+    #B9D6FFE6
+  );
+
+  --color-kumo-chart-disabled: light-dark(
+    #B6B6B6,
+    #B6B6B6E6
+  );
+
+  --color-kumo-chart-disabled-light: light-dark(
+    #D9D9D9,
+    #D9D9D9E6
+  );
+
+  --color-kumo-chart-brush-fill: light-dark(
+    rgba(120,140,180,0.3),
+    rgba(120,140,180,0.3)
+  );
+
+  --color-kumo-chart-brush-stroke: light-dark(
+    rgba(120,140,180,0.8),
+    rgba(120,140,180,0.8)
+  );
+
+  --color-kumo-chart-loader-stroke: light-dark(
+    rgba(0,0,0,0.2),
+    rgba(255,255,255,0.5)
+  );
+
 }
 
 @theme {
@@ -243,6 +338,25 @@
     --color-kumo-danger-tint: var(--color-red-300, oklch(80.8% 0.114 19.571));
     --color-kumo-success: var(--color-green-500, oklch(72.3% 0.219 149.579));
     --color-kumo-success-tint: var(--color-green-300, oklch(87.1% 0.15 154.449));
+    --color-kumo-chart-series-blue: #086FFF;
+    --color-kumo-chart-series-violet: #CF7EE9;
+    --color-kumo-chart-series-cyan: #73CEE6;
+    --color-kumo-chart-series-indigo: #5B5FEF;
+    --color-kumo-chart-series-light-blue: #82B6FF;
+    --color-kumo-chart-series-pink: #F5609F;
+    --color-kumo-chart-series-indigo-soft: #C2BDF3;
+    --color-kumo-chart-series-violet-strong: #8D1EB1;
+    --color-kumo-chart-series-violet-soft: #EBCAF6;
+    --color-kumo-chart-series-indigo-muted: #7366E4;
+    --color-kumo-chart-attention: #FC574A;
+    --color-kumo-chart-warning: #F8A054;
+    --color-kumo-chart-neutral: #82B6FF;
+    --color-kumo-chart-neutral-light: #B9D6FF;
+    --color-kumo-chart-disabled: #B6B6B6;
+    --color-kumo-chart-disabled-light: #D9D9D9;
+    --color-kumo-chart-brush-fill: rgba(120,140,180,0.3);
+    --color-kumo-chart-brush-stroke: rgba(120,140,180,0.8);
+    --color-kumo-chart-loader-stroke: rgba(0,0,0,0.2);
   }
   
   :root[data-mode="dark"], [data-mode="dark"]:not([data-theme]), [data-mode="dark"] [data-theme="kumo"], [data-theme="kumo"][data-mode="dark"], [data-theme="kumo"] [data-mode="dark"] {
@@ -282,5 +396,24 @@
     --color-kumo-danger-tint: var(--color-red-900, oklch(39.6% 0.141 25.723));
     --color-kumo-success: var(--color-green-700, oklch(52.7% 0.154 150.069));
     --color-kumo-success-tint: var(--color-green-900, oklch(39.3% 0.095 152.535));
+    --color-kumo-chart-series-blue: #086FFFE6;
+    --color-kumo-chart-series-violet: #CF7EE9E6;
+    --color-kumo-chart-series-cyan: #73CEE6E6;
+    --color-kumo-chart-series-indigo: #5B5FEFE6;
+    --color-kumo-chart-series-light-blue: #82B6FFE6;
+    --color-kumo-chart-series-pink: #F5609FE6;
+    --color-kumo-chart-series-indigo-soft: #C2BDF3E6;
+    --color-kumo-chart-series-violet-strong: #8D1EB1E6;
+    --color-kumo-chart-series-violet-soft: #EBCAF6E6;
+    --color-kumo-chart-series-indigo-muted: #7366E4E6;
+    --color-kumo-chart-attention: #FC574AE6;
+    --color-kumo-chart-warning: #F8A054E6;
+    --color-kumo-chart-neutral: #82B6FFE6;
+    --color-kumo-chart-neutral-light: #B9D6FFE6;
+    --color-kumo-chart-disabled: #B6B6B6E6;
+    --color-kumo-chart-disabled-light: #D9D9D9E6;
+    --color-kumo-chart-brush-fill: rgba(120,140,180,0.3);
+    --color-kumo-chart-brush-stroke: rgba(120,140,180,0.8);
+    --color-kumo-chart-loader-stroke: rgba(255,255,255,0.5);
   }
 }


### PR DESCRIPTION
## Summary
- add `kumo-chart-*` theme tokens for chart palettes and chart UI colors
- update chart components to consume theme-config-backed colors instead of hardcoded literals
- document the new chart tokens on `/colors`
- fix docs token sourcing in dev so the Colors token reference reflects the source config
- fix the Tabs demo anchor accessibility lint issue

## Testing
- `pnpm --filter @cloudflare/kumo codegen:themes`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo-docs-astro lint` *(branch-specific oxlint errors fixed; remaining astro color-template failures are pre-existing elsewhere in the docs package)*
- verified `http://localhost:4321/colors` renders the new chart token docs and CSS vars locally

## Notes
- includes a changeset for `@cloudflare/kumo`

<img width="497" height="681" alt="Screenshot 2026-03-17 at 10 06 46 PM" src="https://github.com/user-attachments/assets/90c21dcd-7c3a-4446-9b68-6f2b4af2d995" />

