### PR TITLE
Restore RadioCard examples lost in MDX migration

### DIFF
--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -19,6 +19,8 @@ import {
   RadioErrorDemo,
   RadioDisabledDemo,
   RadioControlPositionDemo,
+  RadioCardDemo,
+  RadioCardHorizontalDemo,
 } from "~/components/demos/RadioDemo";
 
 {/* Demo */}
@@ -177,6 +179,77 @@ error="Please select a payment method to continue"
 </Radio.Group>`}
     >
       <RadioControlPositionDemo client:visible />
+    </ComponentExample>
+
+    <Heading level={3}>Card Appearance</Heading>
+    <p>
+      Use `appearance="card"` for a more prominent card-style layout with descriptions.
+    </p>
+    <ComponentExample
+      code={`<Radio.Group legend="Choose a plan" appearance="card" defaultValue="free">
+
+  <Radio.Item
+    label="Free"
+    description="For personal or hobby projects that aren't business-critical."
+    value="free"
+  />
+  <Radio.Item
+    label="Pro"
+    description="For professional websites that aren't business-critical."
+    value="pro"
+  />
+  <Radio.Item
+    label="Business"
+    description="For small businesses operating online."
+    value="business"
+  />
+  <Radio.Item
+    label="Contract"
+    description="For mission-critical applications that are core to your business."
+    value="contract"
+  />
+</Radio.Group>`}
+    >
+      <RadioCardDemo client:visible />
+    </ComponentExample>
+
+    <Heading level={3}>Card Appearance (Horizontal)</Heading>
+    <p>
+      Combine `appearance="card"` with `orientation="horizontal"` for a horizontal card layout.
+    </p>
+    <ComponentExample
+      code={`<Radio.Group
+
+legend="Choose a plan"
+appearance="card"
+orientation="horizontal"
+defaultValue="free"
+
+>
+
+  <Radio.Item
+    label="Free"
+    description="For personal or hobby projects that aren't business-critical."
+    value="free"
+  />
+  <Radio.Item
+    label="Pro"
+    description="For professional websites that aren't business-critical."
+    value="pro"
+  />
+  <Radio.Item
+    label="Business"
+    description="For small businesses operating online."
+    value="business"
+  />
+  <Radio.Item
+    label="Contract"
+    description="For mission-critical applications that are core to your business."
+    value="contract"
+  />
+</Radio.Group>`}
+    >
+      <RadioCardHorizontalDemo client:visible />
     </ComponentExample>
   </ComponentSection>
 


### PR DESCRIPTION
The RadioCard demos (`RadioCardDemo`, `RadioCardHorizontalDemo`) existed in `RadioDemo.tsx` but were not included when `radio.astro` was converted to `radio.mdx` in the docs MDX migration. This restores them.