### PR TITLE
fix: remove es2022 target that breaks Jest/babel-jest

### DIFF
--- a/.changeset/fix-remove-es2022-target.md
+++ b/.changeset/fix-remove-es2022-target.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Remove es2022 build target that caused Jest/babel-jest test failures in stratus

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -46,8 +46,6 @@ export default defineConfig(({ mode }) => {
       rebuildSignalPlugin(),
     ],
     build: {
-      // Runtime APIs like toSorted are guarded by tests/build/browser-compat.test.ts.
-      target: "es2022",
       lib: {
         entry: {
           // Main entry point


### PR DESCRIPTION
## Summary

Removes the `target: "es2022"` from vite.config.ts that was causing Jest test failures in stratus after upgrading kumo to 1.14.0.

## Problem

The es2022 target was added in commit 66012b7d to prevent shipping ES2023+ APIs like `toSorted()`. However, this target setting causes Vite to output ES2022 module syntax that babel-jest transforms incorrectly - specifically, `exports.F = _` appears BEFORE `function _` is defined in the transpiled output, causing `Field` to be `undefined` at runtime during tests.

This manifested as:
```
Element type is invalid: expected a string (for built-in components) or a class/function 
(for composite components) but got: undefined. Check the render method of `Input`.
```

Tests using kumo components with the `label` prop failed because `label` triggers the `Field` wrapper component, which was undefined due to the transform issue.

## Solution

Remove the `target: "es2022"` setting. The browser-compat test (`tests/build/browser-compat.test.ts`) already guards against shipping unsupported ES2023+ APIs in the built output, making the target restriction redundant.

## Verification

- Built kumo without the target and copied to stratus node_modules
- All previously failing tests now pass
- Production UI continues to work correctly (no runtime issues)