### PR TITLE
Add missing components to HomeGrid and improve tile layout

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -10,12 +10,14 @@ import {
   DatePicker,
   Dialog,
   DropdownMenu,
+  Flow,
   Grid,
   GridItem,
   Input,
   InputArea,
   Label,
   LayerCard,
+  Link,
   Loader,
   MenuBar,
   Meter,
@@ -61,13 +63,15 @@ const componentRoutes: Record<string, string> = {
   dialog: "/components/dialog",
   dropdown: "/components/dropdown",
   empty: "/components/empty",
+  flow: "/components/flow",
   grid: "/components/grid",
   input: "/components/input",
   "input-area": "/components/input-area",
   label: "/components/label",
   "layer-card": "/components/layer-card",
+  link: "/components/link",
   loader: "/components/loader",
-  menubar: "/components/menu-bar",
+  "menu-bar": "/components/menu-bar",
   meter: "/components/meter",
   pagination: "/components/pagination",
   popover: "/components/popover",
@@ -330,16 +334,14 @@ export function HomeGrid() {
       name: "CodeHighlighted",
       id: "code-highlighted",
       Component: (
-        <div className="w-full px-4">
-          <ShikiProvider engine="javascript" languages={["typescript"]}>
-            <CodeHighlighted
-              lang="typescript"
-              code={`const sum = (a: number, b: number) => {
+        <ShikiProvider engine="javascript" languages={["typescript"]}>
+          <CodeHighlighted
+            lang="typescript"
+            code={`const sum = (a: number, b: number) => {
   return a + b;
 };`}
-            />
-          </ShikiProvider>
-        </div>
+          />
+        </ShikiProvider>
       ),
     },
     {
@@ -405,7 +407,10 @@ export function HomeGrid() {
           perPage={10}
           totalCount={100}
           setPage={setPaginationPage}
-        />
+          className="w-auto"
+        >
+          <Pagination.Controls />
+        </Pagination>
       ),
     },
     {
@@ -417,14 +422,12 @@ export function HomeGrid() {
       name: "Meter",
       id: "meter",
       Component: (
-        <div className="w-full px-4">
-          <Meter value={75} label="My meter" customValue="100 / 5,000" />
-        </div>
+        <Meter value={75} label="My meter" customValue="100 / 5,000" />
       ),
     },
     {
       name: "MenuBar",
-      id: "menubar",
+      id: "menu-bar",
       Component: (
         <MenuBar
           isActive={menuBarActive}
@@ -449,7 +452,7 @@ export function HomeGrid() {
       name: "DatePicker",
       id: "date-picker",
       Component: (
-        <div className="scale-90">
+        <div className="-m-4 scale-85">
           <DatePicker mode="single" />
         </div>
       ),
@@ -477,6 +480,31 @@ export function HomeGrid() {
       id: "command-palette",
       Component: (
         <Button icon={MagnifyingGlassIcon}>Open Command Palette</Button>
+      ),
+    },
+    {
+      name: "Flow",
+      id: "flow",
+      Component: (
+        <Flow>
+          <Flow.Node>Step 1</Flow.Node>
+          <Flow.Node>Step 2</Flow.Node>
+        </Flow>
+      ),
+    },
+    {
+      name: "Link",
+      id: "link",
+      Component: (
+        <div className="flex flex-col gap-2 text-sm">
+          <Link href="#">Default link</Link>
+          <Link href="#" variant="current">
+            Current color link
+          </Link>
+          <Link href="#" variant="plain">
+            Plain link
+          </Link>
+        </div>
       ),
     },
     {
@@ -616,9 +644,11 @@ export function HomeGrid() {
                 {c.name}
               </span>
             )}
-            {c.Component ?? (
-              <p className="text-base font-medium text-kumo-subtle">TBD</p>
-            )}
+            <div className="flex w-full items-center justify-center p-8">
+              {c.Component ?? (
+                <p className="text-base font-medium text-kumo-subtle">TBD</p>
+              )}
+            </div>
           </li>
         );
       })}

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -89,11 +89,11 @@ html {
   content: none;
 }
 
-/* Links — underline on hover only */
-.kumo-prose :where(a) {
+/* Links — underline on hover only (skip .not-prose where components control their own styles) */
+.kumo-prose :where(a):not(:where(.not-prose, .not-prose *)) {
   text-decoration: none;
 }
-.kumo-prose :where(a):hover {
+.kumo-prose :where(a):not(:where(.not-prose, .not-prose *)):hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
Improve the HomeGrid component showcase and fix a CSS issue where `.kumo-prose` was overriding component link styles inside `.not-prose` demo sections.

## Changes

### HomeGrid
- Add Flow and Link tiles — were in sidebar navigation but missing from the grid
- Fix menubar route key — `menubar` → `menu-bar` to match slug convention
- Consistent tile padding — add `p-8` wrapper around all tile content, remove redundant per-tile padding wrappers
- Simplify Pagination tile — show controls only (hide "Showing 1-10 of 100" text)
- Shrink DatePicker — `scale-85` to reduce row height

### CSS fix
- Fix prose link override — `.kumo-prose :where(a)` now excludes `.not-prose` descendants so Kumo components (Link, Breadcrumbs) render their own `text-decoration` styles correctly in demos

| Before | After |
|--------|--------|
|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 35 31" src="https://github.com/user-attachments/assets/a7569577-2d83-4a27-b3e1-53dbb264464b" />|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 35 33" src="https://github.com/user-attachments/assets/b02bb0f7-c0cc-470b-ab4e-ab3f8103bedf" />|
|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 35 46" src="https://github.com/user-attachments/assets/83c2158a-9a46-467a-a966-64a6d7097652" />|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 35 48" src="https://github.com/user-attachments/assets/1034563e-72e3-4ef2-9fe4-f96ec06a7641" />|
|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 36 31" src="https://github.com/user-attachments/assets/2e45be90-ada3-4db8-9f66-cd5b5a263380" />|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 36 34" src="https://github.com/user-attachments/assets/ec3eb9d0-f173-40ec-ad62-e5d5e2fc130b" />|
|<img width="2032" height="1161" alt="Screenshot 2026-03-19 at 19 36 36" src="https://github.com/user-attachments/assets/9ba2b562-68e1-4c6a-bd74-b6ef8ec1e747" />||