### PR TITLE
fix(docs): scope kumo-prose link rule to exclude .not-prose descendants

### DIFF
--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -89,11 +89,13 @@ html {
   content: none;
 }
 
-/* Links — underline on hover only */
-.kumo-prose :where(a) {
+/* Links — underline on hover only.
+   Mirror @tailwindcss/typography's own guard so that <a> elements inside a
+   .not-prose ancestor (e.g. ComponentExample) are excluded. */
+.kumo-prose :where(a:not(.not-prose *)) {
   text-decoration: none;
 }
-.kumo-prose :where(a):hover {
+.kumo-prose :where(a:not(.not-prose *)):hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary

- The `.kumo-prose :where(a)` rule was stripping `text-decoration` from all `<a>` elements inside prose, including Kumo `Link` components that explicitly apply the `underline` utility class
- Fixed by mirroring `@tailwindcss/typography`'s own guard: scoping the rule to `:where(a:not(.not-prose *))` so any `<a>` inside a `.not-prose` ancestor (`ComponentExample`, `CodeBlock`, `PropsTable`) is excluded automatically