### PR TITLE
fix(code): add missing HCL language import to server bundle

### DIFF
--- a/.changeset/hotfix-hcl-server.md
+++ b/.changeset/hotfix-hcl-server.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add missing HCL language import to server-side Shiki bundle
+
+The HCL language was added to SupportedLanguage type and the client-side
+provider in a previous commit, but the server.tsx BUNDLED_LANGS object
+was missed. This caused typecheck failures when building.

--- a/packages/kumo/src/code/server.tsx
+++ b/packages/kumo/src/code/server.tsx
@@ -46,6 +46,7 @@ const BUNDLED_LANGS: Record<
   bash: () => import("@shikijs/langs/bash"),
   shell: () => import("@shikijs/langs/shellscript"),
   diff: () => import("@shikijs/langs/diff"),
+  hcl: () => import("@shikijs/langs/hcl"),
 };
 
 export interface HighlightCodeOptions {


### PR DESCRIPTION
## Problem

The HCL language was added to the `SupportedLanguage` type and the client-side provider in PR #283, but the `server.tsx` file's `BUNDLED_LANGS` object was missed. This is causing typecheck failures:

```
Property 'hcl' is missing in type '{ javascript: () => Promise<...>; ...; diff: () => Promise<...>; }'
but required in type 'Record<SupportedLanguage, () => Promise<{ default: unknown; }>>'.
```

## Solution

Add the missing `hcl` import to `BUNDLED_LANGS` in `server.tsx`.

## Changes

- Added `hcl: () => import("@shikijs/langs/hcl")` to the `BUNDLED_LANGS` object in `server.tsx`

## Related

- PR #283 - feat(code): add HCL as a supported syntax highlighting language