### PR TITLE
feat(docs): auto-extract code snippets from demo source files

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
@@ -13,30 +13,34 @@ const demoSources = import.meta.glob("~/components/demos/*.tsx", {
 interface Props {
   /** Raw code string (legacy) */
   code?: string;
-  /** Name of the demo function to extract, e.g. "InputBasicDemo" */
+  /** Name of the demo function to extract, e.g. "InputBasicDemo". Auto-discovers the file. */
   demo?: string;
-  /** Name of the demo file (without .tsx), e.g. "InputDemo" */
-  file?: string;
   lang?: "tsx" | "ts" | "jsx" | "js" | "bash" | "css";
   vrSection?: string;
   vrTitle?: string;
 }
 
-const { code, demo, file, lang = "tsx", vrSection, vrTitle } = Astro.props;
+const { code, demo, lang = "tsx", vrSection, vrTitle } = Astro.props;
 
 // Resolve the code snippet: either from the `code` prop (legacy) or auto-extracted from demo source
 let resolvedCode = code ?? "";
 
-if (demo && file) {
-  // Find the matching source file
-  const sourceKey = Object.keys(demoSources).find((key) =>
-    key.endsWith(`/${file}.tsx`),
-  );
-  if (sourceKey) {
-    resolvedCode = extractDemoSnippet(demoSources[sourceKey], demo);
-  } else {
-    resolvedCode = `// Could not find demo file "${file}.tsx"`;
+if (demo) {
+  // Scan all loaded sources for the function name
+  let found = false;
+  for (const [, source] of Object.entries(demoSources)) {
+    if (source.includes(`function ${demo}`)) {
+      resolvedCode = extractDemoSnippet(source, demo);
+      found = true;
+      break;
+    }
   }
+  if (!found) {
+    resolvedCode = `// Could not find demo "${demo}" in any demo file`;
+    console.warn(`[ComponentExample] Could not find demo "${demo}" in any demo file`);
+  }
+} else if (!code) {
+  console.warn(`[ComponentExample] Missing both "code" and "demo" props`);
 }
 
 const vrAttrs = vrSection

--- a/packages/kumo-docs-astro/src/lib/extract-demo-snippet.ts
+++ b/packages/kumo-docs-astro/src/lib/extract-demo-snippet.ts
@@ -71,8 +71,13 @@ export function extractDemoSnippet(
   }
 
   // Only include imports whose names appear in the function body
+  // Use word boundary regex to avoid false positives (e.g., "Input" matching "InputBasicDemo")
   const usedImports = imports
-    .filter((imp) => imp.names.some((name) => targetFunction!.includes(name)))
+    .filter((imp) =>
+      imp.names.some((name) =>
+        new RegExp(`\\b${name}\\b`).test(targetFunction!),
+      ),
+    )
     .map((imp) => imp.text);
 
   const importBlock = usedImports.join("\n");

--- a/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
@@ -19,7 +19,7 @@ import {
 } from "~/components/demos/BreadcrumbsDemo";
 
 <ComponentSection>
-  <ComponentExample demo="BreadcrumbsWithIconsDemo" file="BreadcrumbsDemo">
+  <ComponentExample demo="BreadcrumbsWithIconsDemo">
     <BreadcrumbsWithIconsDemo client:visible />
   </ComponentExample>
 </ComponentSection>
@@ -34,7 +34,7 @@ import {
 
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
-  <ComponentExample demo="BreadcrumbsDemo" file="BreadcrumbsDemo">
+  <ComponentExample demo="BreadcrumbsDemo">
     <BreadcrumbsDemo client:visible />
   </ComponentExample>
 </ComponentSection>
@@ -43,28 +43,28 @@ import {
   <Heading level={2}>Examples</Heading>
 
   <Heading level={3}>Basic</Heading>
-  <ComponentExample demo="BreadcrumbsDemo" file="BreadcrumbsDemo">
+  <ComponentExample demo="BreadcrumbsDemo">
     <BreadcrumbsDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
   <Heading level={3}>Loading</Heading>
-  <ComponentExample demo="BreadcrumbsLoadingDemo" file="BreadcrumbsDemo">
+  <ComponentExample demo="BreadcrumbsLoadingDemo">
     <BreadcrumbsLoadingDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
   <Heading level={3}>Root</Heading>
-  <ComponentExample demo="BreadcrumbsRootDemo" file="BreadcrumbsDemo">
+  <ComponentExample demo="BreadcrumbsRootDemo">
     <BreadcrumbsRootDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
   <Heading level={3}>Clipboard</Heading>
-  <ComponentExample demo="BreadcrumbsWithClipboardDemo" file="BreadcrumbsDemo">
+  <ComponentExample demo="BreadcrumbsWithClipboardDemo">
     <BreadcrumbsWithClipboardDemo client:visible />
   </ComponentExample>
 </ComponentSection>


### PR DESCRIPTION
## Problem

Since migrating to MDX, code snippets in component examples have been broken. MDX strips leading whitespace from multi-line template literals in JSX props ([mdx-js/mdx#2574](https://github.com/mdx-js/mdx/issues/2574)), causing all indentation to be lost.

On top of that, the current pattern duplicates every code example as a hardcoded string alongside the actual demo component, leading to drift between what's shown and what's rendered:

```jsx
// Before: duplicated, fragile, broken by MDX whitespace stripping
<ComponentExample
  code={`<Breadcrumbs>
  <Breadcrumbs.Link href="#">Home</Breadcrumbs.Link>
</Breadcrumbs>`}
>
  <BreadcrumbsDemo client:visible />
</ComponentExample>
```

## Solution

Extract code snippets directly from demo source files at build time. Single source of truth — the demo IS the snippet.

```jsx
// After: no duplication, no MDX whitespace issues
<ComponentExample demo="BreadcrumbsWithIconsDemo" file="BreadcrumbsDemo">
  <BreadcrumbsWithIconsDemo client:visible />
</ComponentExample>
```

<img width="1010" height="569" alt="Screenshot 2026-03-23 at 3 33 50 PM" src="https://github.com/user-attachments/assets/69c1baf7-e04e-4854-a65d-deeedec3e77b" />

### How it works

1. `ComponentExample.astro` uses `import.meta.glob("?raw")` to load all demo source files as raw strings at build time
2. `extract-demo-snippet.ts` uses the **TypeScript compiler API** to parse the source and extract:
   - The named export function (e.g., `BreadcrumbsWithIconsDemo`)
   - Only the import statements that function actually uses (tree-shaken imports)
3. The extracted code is passed to `CodeBlock` for syntax highlighting

### Smart import filtering

If a demo file has `import { House } from "@phosphor-icons/react"` but the specific function doesn't use `House`, that import is excluded from the snippet.

## Scope

This PR converts **only `breadcrumbs.mdx`** as a proof of concept. The remaining ~35 component pages can be migrated incrementally. The legacy `code` prop still works, so there's no breaking change.

## Changes

- **New**: `src/lib/extract-demo-snippet.ts` — TypeScript AST-based snippet extraction
- **Modified**: `src/components/docs/ComponentExample.astro` — added `demo` and `file` props alongside legacy `code`
- **Modified**: `src/pages/components/breadcrumbs.mdx` — converted all examples to new pattern