### PR TITLE
feat(docs): migrate button.mdx to auto-extract pattern and enable markdown code fences

### DIFF
--- a/packages/kumo-docs-astro/astro.config.mjs
+++ b/packages/kumo-docs-astro/astro.config.mjs
@@ -73,6 +73,15 @@ const kumoSrc = resolve(__dirname, "../kumo/src");
 export default defineConfig({
   integrations: [mdx(), react(), sitemap(), markdownPages()],
   site: "https://kumo-ui.com/",
+  markdown: {
+    shikiConfig: {
+      themes: {
+        light: "github-light",
+        dark: "vesper",
+      },
+      defaultColor: false,
+    },
+  },
   vite: {
     plugins: [
       // In dev mode, resolve @cloudflare/kumo imports to raw source files

--- a/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
@@ -100,3 +100,7 @@ export function ButtonDisabledDemo() {
     </Button>
   );
 }
+
+export function ButtonUsageDemo() {
+  return <Button variant="secondary">Click me</Button>;
+}

--- a/packages/kumo-docs-astro/src/components/docs/CodeBlock.astro
+++ b/packages/kumo-docs-astro/src/components/docs/CodeBlock.astro
@@ -10,7 +10,7 @@ const { code, lang = "tsx" } = Astro.props;
 ---
 
 <div
-  class="not-prose code-block overflow-hidden rounded-lg border border-kumo-line"
+  class="not-prose code-block"
 >
   <Code 
     code={code} 

--- a/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
@@ -60,9 +60,16 @@ const vrAttrs = vrSection
   <ComponentPreview>
     <slot />
   </ComponentPreview>
-  <div
-    class="[&>.code-block]:rounded-none [&>.code-block]:rounded-b-lg [&>.code-block]:border-t-0"
-  >
+  <div class="component-example-code">
     <CodeBlock code={resolvedCode} lang={lang} />
   </div>
 </div>
+
+<style>
+  .component-example-code :global(pre.astro-code) {
+    border-radius: 0;
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+    border-top: 0;
+  }
+</style>

--- a/packages/kumo-docs-astro/src/pages/components/button.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/button.mdx
@@ -28,12 +28,7 @@ import {
 {/* Demo */}
 
 <ComponentSection>
-  <ComponentExample
-    code={`<Button variant="secondary">Button</Button>
-<Button variant="secondary" shape="square" icon={PlusIcon} />`}
-    vrSection="basic"
-    vrTitle="Basic"
-  >
+  <ComponentExample demo="ButtonBasicDemo" vrSection="basic" vrTitle="Basic">
     <ButtonBasicDemo client:visible />
   </ComponentExample>
 </ComponentSection>
@@ -55,14 +50,15 @@ import {
 
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
-  <CodeBlock
-    code={`import { Button } from "@cloudflare/kumo";
+
+```tsx
+import { Button } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Button variant="secondary">Click me</Button>;
-}`}
-    lang="tsx"
-  />
+}
+```
+
 </ComponentSection>
 
 {/* Examples */}
@@ -76,7 +72,7 @@ export default function Example() {
 
 <h4 class="mb-3 text-base font-medium">Primary</h4>
 <ComponentExample
-  code={`<Button variant="primary">Primary</Button>`}
+  demo="ButtonPrimaryDemo"
   vrSection="variant-primary"
   vrTitle="Variant: Primary"
 >
@@ -85,7 +81,7 @@ export default function Example() {
 
 <h4 class="mb-3 text-base font-medium">Secondary</h4>
 <ComponentExample
-  code={`<Button variant="secondary">Secondary</Button>`}
+  demo="ButtonSecondaryDemo"
   vrSection="variant-secondary"
   vrTitle="Variant: Secondary"
 >
@@ -94,7 +90,7 @@ export default function Example() {
 
 <h4 class="mb-3 text-base font-medium">Ghost</h4>
 <ComponentExample
-  code={`<Button variant="ghost">Ghost</Button>`}
+  demo="ButtonGhostDemo"
   vrSection="variant-ghost"
   vrTitle="Variant: Ghost"
 >
@@ -103,7 +99,7 @@ export default function Example() {
 
 <h4 class="mb-3 text-base font-medium">Destructive</h4>
 <ComponentExample
-  code={`<Button variant="destructive">Destructive</Button>`}
+  demo="ButtonDestructiveDemo"
   vrSection="variant-destructive"
   vrTitle="Variant: Destructive"
 >
@@ -112,7 +108,7 @@ export default function Example() {
 
 <h4 class="mb-3 text-base font-medium">Outline</h4>
 <ComponentExample
-  code={`<Button variant="outline">Outline</Button>`}
+  demo="ButtonOutlineDemo"
   vrSection="variant-outline"
   vrTitle="Variant: Outline"
 >
@@ -121,7 +117,7 @@ export default function Example() {
 
 <h4 class="mb-3 text-base font-medium">Secondary Destructive</h4>
 <ComponentExample
-  code={`<Button variant="secondary-destructive">Secondary Destructive</Button>`}
+  demo="ButtonSecondaryDestructiveDemo"
   vrSection="variant-secondary-destructive"
   vrTitle="Variant: Secondary Destructive"
 >
@@ -131,14 +127,7 @@ export default function Example() {
 {/* Sizes */}
 
 <Heading level={3}>Sizes</Heading>
-<ComponentExample
-  code={`<Button size="xs" variant="secondary">Extra Small</Button>
-<Button size="sm" variant="secondary">Small</Button>
-<Button size="base" variant="secondary">Base</Button>
-<Button size="lg" variant="secondary">Large</Button>`}
-  vrSection="sizes"
-  vrTitle="Sizes"
->
+<ComponentExample demo="ButtonSizesDemo" vrSection="sizes" vrTitle="Sizes">
   <ButtonSizesDemo client:visible />
 </ComponentExample>
 
@@ -146,9 +135,7 @@ export default function Example() {
 
 <Heading level={3}>With Icon</Heading>
 <ComponentExample
-  code={`<Button variant="secondary" icon={PlusIcon}>
-  Create Worker
-</Button>`}
+  demo="ButtonWithIconDemo"
   vrSection="with-icon"
   vrTitle="With Icon"
 >
@@ -166,8 +153,7 @@ export default function Example() {
   convey the button's purpose.
 </p>
 <ComponentExample
-  code={`<Button variant="secondary" shape="square" icon={PlusIcon} aria-label="Add item" />
-<Button variant="secondary" shape="circle" icon={PlusIcon} aria-label="Add item" />`}
+  demo="ButtonIconOnlyDemo"
   vrSection="icon-only"
   vrTitle="Icon Only"
 >
@@ -178,9 +164,7 @@ export default function Example() {
 
 <Heading level={3}>Loading State</Heading>
 <ComponentExample
-  code={`<Button variant="primary" loading>
-  Loading...
-</Button>`}
+  demo="ButtonLoadingDemo"
   vrSection="loading"
   vrTitle="Loading State"
 >
@@ -191,9 +175,7 @@ export default function Example() {
 
   <Heading level={3}>Disabled State</Heading>
   <ComponentExample
-    code={`<Button variant="secondary" disabled>
-  Disabled
-</Button>`}
+    demo="ButtonDisabledDemo"
     vrSection="disabled"
     vrTitle="Disabled State"
   >

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -143,3 +143,30 @@ html {
   font-size: inherit;
   line-height: inherit;
 }
+
+/* ==========================================================================
+   Shiki code blocks — markdown code blocks use .astro-code class
+   Dual theme support: light (github-light) and dark (vesper)
+   ========================================================================== */
+
+/* Container styling for all code blocks (markdown + CodeBlock component) */
+pre.astro-code {
+  overflow: hidden;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-kumo-line);
+  margin: 0;
+}
+
+/* Light mode (default) */
+.astro-code,
+.astro-code span {
+  color: var(--shiki-light) !important;
+  background-color: var(--shiki-light-bg) !important;
+}
+
+/* Dark mode — toggle via data-mode attribute */
+[data-mode="dark"] .astro-code,
+[data-mode="dark"] .astro-code span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+}


### PR DESCRIPTION
## Summary

- Migrates `button.mdx` to use the `demo` prop pattern from #288, removing hardcoded code strings
- Enables markdown code fences (triple backticks) to render with the same styling as `CodeBlock`

## Changes

### Button docs migration
All 12 `ComponentExample` instances now use `demo="ButtonPrimaryDemo"` etc. instead of `code={\`...\`}`. The Usage section uses markdown backticks for a cleaner authoring experience.

### Markdown code fence support
- Added `shikiConfig` with `defaultColor: false` to enable dual theme CSS variable output
- Added global `pre.astro-code` styles (border, radius, theme switching via `[data-mode]`)
- Moved border/radius from CodeBlock's wrapper div to the `pre` element itself
- Added scoped style in ComponentExample to remove top border-radius when code sits flush with preview

## Why this matters

Authors can now use standard markdown code fences:

~~~mdx
```tsx
import { Button } from "@cloudflare/kumo";

export default function Example() {
  return <Button>Click me</Button>;
}
```
~~~

...and get the same styled output as `<CodeBlock code={...} />`, with proper dark mode support.