### PR TITLE
fix(ci): restore visual regression after security hardening

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -221,6 +221,7 @@ jobs:
           GITHUB_PR_NUMBER: ${{ needs.deploy.outputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_BASE_REF: main
+          PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           BEFORE_URL: "https://kumo-ui.com"
           AFTER_URL: ${{ needs.deploy.outputs.preview_url }}
           SCREENSHOT_API_KEY: ${{ secrets.SCREENSHOT_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -246,6 +246,11 @@ jobs:
             ci/visual-regression
             .github/actions/install-dependencies
 
+      # Fetch the PR's HEAD so git diff can detect changed files.
+      # (HEAD points to main after checkout, so we need the explicit SHA)
+      - name: Fetch PR head for git diff
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
         with:
@@ -256,6 +261,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_NUMBER: ${{ needs.docs-deploy.outputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_URL: "https://kumo-ui.com"
           AFTER_URL: ${{ needs.docs-deploy.outputs.preview_url }}
           SCREENSHOT_API_KEY: ${{ secrets.SCREENSHOT_API_KEY }}

--- a/ci/visual-regression/run-visual-regression.ts
+++ b/ci/visual-regression/run-visual-regression.ts
@@ -69,7 +69,11 @@ interface ComparisonResult {
 function getChangedFiles(): string[] | null {
   try {
     const base = process.env.GITHUB_BASE_REF || "main";
-    const output = execSync(`git diff --name-only origin/${base}...HEAD`, {
+    // Use PR_HEAD_SHA when provided. CI checks out main for security (to avoid
+    // running untrusted PR code with secrets), so HEAD points to main. The PR's
+    // head commit is fetched separately and passed via PR_HEAD_SHA.
+    const head = process.env.PR_HEAD_SHA || "HEAD";
+    const output = execSync(`git diff --name-only origin/${base}...${head}`, {
       encoding: "utf-8",
     });
     return output.trim().split("\n").filter(Boolean);


### PR DESCRIPTION
## Summary

Fixes the visual regression tests that stopped working after the security hardening in #280.

## Problem

The security hardening correctly checks out the VR script from `main` to prevent untrusted PR code from running with secrets. However, this broke `git diff` detection because `HEAD` points to `main`, not the PR's head commit.

**Before:** `git diff origin/main...HEAD` → compared main to PR head  
**After security fix:** `git diff origin/main...HEAD` → compared main to main (no changes!)

This caused all PRs to skip VR with: "No visually relevant file changes detected."

## Solution

Pass the PR's head SHA explicitly via `PR_HEAD_SHA` environment variable:

1. **`preview.yml`** (internal PRs): Fetch PR head, pass `PR_HEAD_SHA`
2. **`preview-deploy.yml`** (fork PRs): Pass `PR_HEAD_SHA` via `workflow_run.head_sha`
3. **`run-visual-regression.ts`**: Use `PR_HEAD_SHA` instead of `HEAD` for diff

## Security Model Preserved

| Concern | Status | Reason |
|---------|--------|--------|
| VR script execution | ✅ Safe | Still checked out from `main`, never from PR |
| `PR_HEAD_SHA` value | ✅ Safe | GitHub-provided metadata, not user-controlled |
| `git fetch` command | ✅ Safe | Only downloads git objects, no code execution |
| PR code evaluation | ✅ Safe | Changes evaluated via deployed preview URL, not direct execution |

An attacker cannot:
- Inject shell commands (SHA is GitHub-provided)
- Modify the VR script (checked out from `main`)
- Access secrets through modified workflows (also from `main`)

## Changes

```
preview.yml:                    +6 lines (fetch + env var)
preview-deploy.yml:             +1 line (env var)
run-visual-regression.ts:       +4 lines (use PR_HEAD_SHA)
```