### PR TITLE
fix(ci): use two-dot diff for shallow clone compatibility

### DIFF
--- a/ci/visual-regression/run-visual-regression.ts
+++ b/ci/visual-regression/run-visual-regression.ts
@@ -73,7 +73,9 @@ function getChangedFiles(): string[] | null {
     // running untrusted PR code with secrets), so HEAD points to main. The PR's
     // head commit is fetched separately and passed via PR_HEAD_SHA.
     const head = process.env.PR_HEAD_SHA || "HEAD";
-    const output = execSync(`git diff --name-only origin/${base}...${head}`, {
+    // Use two-dot diff (A..B) instead of three-dot (A...B) because shallow
+    // clones don't have enough history to compute merge-base.
+    const output = execSync(`git diff --name-only origin/${base}..${head}`, {
       encoding: "utf-8",
     });
     return output.trim().split("\n").filter(Boolean);


### PR DESCRIPTION
The three-dot diff (A...B) requires merge-base computation, which fails with shallow clones. Two-dot diff (A..B) compares directly and works fine.

Saw the VR job fail on a recent PR with:
```
Found 39 components
fatal: origin/main...40fc9ccc8b21a6ba072d33af5124ba72b023b15b: no merge base
git diff failed, falling back to full regression: Command failed: git diff --name-only origin/main...40fc9ccc8b21a6ba072d33af5124ba72b023b15b
fatal: origin/main...40fc9ccc8b21a6ba072d33af5124ba72b023b15b: no merge base
```