### PR TITLE
fix(vr): move data-vr attrs to ComponentPreview element

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentExample.astro
@@ -74,8 +74,8 @@ const vrAttrs = resolvedVrSection
   : {};
 ---
 
-<div class="not-prose overflow-hidden rounded-lg" {...vrAttrs}>
-  <ComponentPreview>
+<div class="not-prose overflow-hidden rounded-lg">
+  <ComponentPreview {...vrAttrs}>
     <slot />
   </ComponentPreview>
   <div class="component-example-code">

--- a/packages/kumo-docs-astro/src/components/docs/ComponentPreview.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentPreview.astro
@@ -1,9 +1,14 @@
 ---
 // Container for component previews/demos
+const { class: className, ...rest } = Astro.props;
 ---
 
 <div
-  class="flex min-h-[120px] items-center justify-center rounded-t-lg border border-kumo-line bg-kumo-surface p-6"
+  class:list={[
+    "flex min-h-[120px] items-center justify-center rounded-t-lg border border-kumo-line bg-kumo-surface p-6",
+    className,
+  ]}
+  {...rest}
 >
   <slot />
 </div>


### PR DESCRIPTION
## Summary

Screenshots were capturing the entire `ComponentExample` (preview + code block). This moves the VR attributes to just the `ComponentPreview` div so screenshots capture only the rendered component.

## Root Cause Analysis

### The VR false positive saga

1. **PR #280** (security hardening) broke VR by checking out from `main`, so git diff couldn't detect changed files
2. **PR #309 & #312** fixed git diff detection (PR_HEAD_SHA + two-dot diff)
3. **PR #319** fixed the missing `data-vr-*` attributes that were dropped in PR #297's migration, and simplified the worker to use `[data-vr-demo]` elements directly

But VR still showed false positives on PR #317 - 21 screenshots with "visual changes" that were actually just font antialiasing differences in the **code blocks**.

### Why code blocks were being captured

PR #319 put the `data-vr-*` attributes on the outer `ComponentExample` container:

```html
<!-- PR #319 structure -->
<div class="not-prose overflow-hidden rounded-lg" data-vr-demo data-vr-section="..." data-vr-title="...">
  <div class="flex min-h-[120px] ...">  <!-- ComponentPreview: just the button -->
    <button>Click me</button>
  </div>
  <div class="component-example-code">   <!-- CodeBlock: syntax-highlighted code -->
    <pre>import { Button } from "@cloudflare/kumo"...</pre>
  </div>
</div>
```

The worker found `[data-vr-demo]` and screenshotted the whole thing - preview AND code block. Code blocks have syntax highlighting with lots of small text, which accumulates font antialiasing differences across environments.

### The fix

Move `data-vr-*` attributes to `ComponentPreview` only:

```html
<!-- After this PR -->
<div class="not-prose overflow-hidden rounded-lg">
  <div class="flex min-h-[120px] ..." data-vr-demo data-vr-section="..." data-vr-title="...">
    <button>Click me</button>  <!-- Only this gets screenshotted -->
  </div>
  <div class="component-example-code">
    <pre>import { Button } from "@cloudflare/kumo"...</pre>  <!-- Excluded -->
  </div>
</div>
```

## What changed

- `ComponentExample.astro`: Pass `vrAttrs` to `ComponentPreview` instead of outer div
- `ComponentPreview.astro`: Spread props onto the container div (with `class` handled separately for merging)

## Testing

After merge + worker redeploy:
1. VR screenshots should show only the rendered component (no code blocks)
2. Screenshot dimensions should be much smaller (~120px height vs full page)
3. False positives from font antialiasing should be eliminated or drastically reduced

## Related PRs

- #309: Pass PR_HEAD_SHA to fix git diff detection
- #312: Use two-dot diff for shallow clone compatibility  
- #319: Auto-derive vrSection/vrTitle + simplify worker to use `[data-vr-demo]`
- #320: This PR - move attributes to correct element