### PR TITLE
fix(docs): add toast component to command palette search

### DIFF
--- a/packages/kumo-docs-astro/src/components/SearchDialog.tsx
+++ b/packages/kumo-docs-astro/src/components/SearchDialog.tsx
@@ -24,7 +24,6 @@ const COMPONENTS_WITHOUT_DOCS = new Set([
   "DateRangePicker", // Deprecated: use DatePicker with mode="range"
   "Field",
   "Icon",
-  "Toasty",
 ]);
 
 /**
@@ -34,6 +33,7 @@ const COMPONENTS_WITHOUT_DOCS = new Set([
 const SLUG_OVERRIDES: Record<string, string> = {
   CodeHighlighted: "code-highlighted",
   DropdownMenu: "dropdown",
+  Toasty: "toast",
 };
 
 /**
@@ -168,6 +168,8 @@ const COMPONENT_DESCRIPTIONS: Record<string, string> = {
   "page-header": "Combines breadcrumbs and tabs for page navigation.",
   "resource-list":
     "A layout for displaying resource lists with title and sidebar.",
+  toast:
+    "Displays brief, non-intrusive notifications that appear temporarily.",
 };
 
 interface ComponentRegistryEntry {


### PR DESCRIPTION
## Summary
- Removed `Toasty` from the `COMPONENTS_WITHOUT_DOCS` exclusion list in SearchDialog
- Added slug override (`Toasty` → `toast`) so it links to the correct docs page
- Added a description for the toast component in search results

## Test plan
- [x] Open the docs site command palette (Cmd+K) and search for "toast"
- [x] Verify the toast component appears in results with correct description
- [x] Click the result and confirm it navigates to `/components/toast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)