### PR TITLE
fix(checkbox, radio): remove fieldset border box and simplify group styling

### DIFF
--- a/.changeset/checkbox-radio-group-styling.md
+++ b/.changeset/checkbox-radio-group-styling.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Checkbox.Group & Radio.Group: remove fieldset border box and simplify styling
+
+- Remove `rounded-lg border border-kumo-line p-4` wrapper from both group fieldsets
+- Downsize legend from `text-lg` to `text-base` with inline-flex layout
+- Drop `font-medium` from Checkbox.Item and Radio.Item labels

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -384,7 +384,7 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
             )}
           />
         </BaseCheckbox.Root>
-        <span className="text-base font-medium text-kumo-default">{label}</span>
+        <span className="text-base text-kumo-default">{label}</span>
       </label>
     );
   },
@@ -415,13 +415,8 @@ function CheckboxGroup({
         allValues={allValues}
         disabled={disabled}
       >
-        <Fieldset.Root
-          className={cn(
-            "flex flex-col gap-4 rounded-lg border border-kumo-line p-4",
-            className,
-          )}
-        >
-          <Fieldset.Legend className="text-lg font-medium text-kumo-default">
+        <Fieldset.Root className={cn("flex flex-col gap-4", className)}>
+          <Fieldset.Legend className="text-base font-medium text-kumo-default">
             {legend}
           </Fieldset.Legend>
           <div className="flex flex-col gap-2">{children}</div>

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -318,7 +318,7 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
             <span className="h-2 w-2 rounded-full bg-kumo-base" />
           </BaseRadio.Indicator>
         </BaseRadio.Root>
-        <span className="text-base font-medium text-kumo-default">{label}</span>
+        <span className="text-base text-kumo-default">{label}</span>
       </label>
     );
   },
@@ -353,12 +353,9 @@ function RadioGroup({
       >
         <Fieldset.Root
           disabled={disabled}
-          className={cn(
-            "flex flex-col gap-4 rounded-lg border border-kumo-line p-4",
-            className,
-          )}
+          className={cn("flex flex-col gap-4", className)}
         >
-          <Fieldset.Legend className="text-lg font-medium text-kumo-default">
+          <Fieldset.Legend className="text-base font-medium text-kumo-default">
             {legend}
           </Fieldset.Legend>
           <div


### PR DESCRIPTION
## Summary

- Remove the `rounded-lg border border-kumo-line p-4` wrapper from `Checkbox.Group` and `Radio.Group` fieldsets for a lighter, more composable appearance
- Downsize group legends from `text-lg` to `text-base` with `inline-flex` layout
- Drop `font-medium` from `Checkbox.Item` and `Radio.Item` labels

Both components now follow the same simplified pattern — no opinionated border box, letting consumers control the surrounding container styling.

<img width="344" height="204" alt="Screenshot 2026-03-27 at 10 09 29 AM" src="https://github.com/user-attachments/assets/a1eaba2c-d7ea-4a32-91c9-55db847c5c3b" />

<img width="375" height="212" alt="Screenshot 2026-03-27 at 10 09 24 AM" src="https://github.com/user-attachments/assets/d456d51b-a80f-48e6-b4ba-95dcadd1f4f1" />


