### PR TITLE
fix(layer-card): update Secondary header background to bg-kumo-surface (neutral-25)

### DIFF
--- a/.changeset/layer-card-header-background.md
+++ b/.changeset/layer-card-header-background.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update LayerCard.Secondary header to use fixed height and adjusted padding

--- a/packages/kumo-docs-astro/src/components/demos/LayerCardDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerCardDemo.tsx
@@ -4,7 +4,7 @@ import { ArrowRightIcon } from "@phosphor-icons/react";
 export function LayerCardDemo() {
   return (
     <LayerCard>
-      <LayerCard.Secondary className="flex items-center justify-between">
+      <LayerCard.Secondary className="justify-between pr-2.5">
         <div>Next Steps</div>
         <Button
           variant="ghost"

--- a/packages/kumo/src/components/layer-card/layer-card.tsx
+++ b/packages/kumo/src/components/layer-card/layer-card.tsx
@@ -55,7 +55,7 @@ function LayerCardSecondary({ children, className }: LayerCardProps) {
   return (
     <div
       className={cn(
-        "flex items-center gap-2 p-4 text-base font-medium text-kumo-strong -my-2 bg-kumo-recessed",
+        "flex items-center gap-2 h-12 px-4 pb-2 text-base font-medium text-kumo-strong -mb-2 bg-kumo-recessed",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

- Updates `LayerCard.Secondary` header background from `bg-kumo-recessed` (neutral-50) to `bg-kumo-surface` (neutral-25)
- Minor demo adjustment to `LayerCardDemo` layout classes

## Changes

The `LayerCard.Secondary` component previously used `bg-kumo-recessed` as its background, which ends up looking too dark when used commonly throughout the page:

<img width="2432" height="1920" alt="CleanShot 2026-03-30 at 08 51 21@2x" src="https://github.com/user-attachments/assets/2903a672-2341-43f8-a592-e2c187b99874" />

This PR updates it to the lighter `bg-kumo-surface`, making the titles less distracting:

<img width="2960" height="1916" alt="CleanShot 2026-03-30 at 08 51 57@2x" src="https://github.com/user-attachments/assets/8c8444e5-9ea5-4a40-a325-00696c5fc783" />