### PR TITLE
chore: add minimumReleaseAge to prevent installing compromised packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,11 @@
 packages:
   - packages/*
 
+# Security: reject packages published less than 3 days ago to reduce
+# the risk of installing compromised/malicious releases.
+# See https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 4320
+
 catalog:
   "@cloudflare/vite-plugin": ^1.15.3
   "@cloudflare/workers-types": ^4.20240909.0


### PR DESCRIPTION
## Problem

Supply chain attacks via compromised npm packages are a real and growing threat. Most malicious releases are discovered and removed from the registry within hours, but by then they may have already been installed.

## Solution

Add `minimumReleaseAge: 4320` (3 days) to `pnpm-workspace.yaml`. This tells pnpm to reject any package version published less than 3 days ago — including transitive dependencies — giving the community time to discover and flag malicious releases before they enter our dependency tree.

This is a built-in pnpm feature (added in v10.16.0, we're on v10.22.0). See [pnpm docs](https://pnpm.io/settings#minimumreleaseage).

## Notes

- No impact on existing installs — all current lockfile versions are well past the 3-day threshold
- If a brand-new release needs to be installed urgently, specific packages can be exempted via `minimumReleaseAgeExclude`
- No changeset needed — this is a workspace config change, not a library change