### PR TITLE
feat(SkeletonLine): add blockHeight prop

### DIFF
--- a/.changeset/skeleton-line-block-height.md
+++ b/.changeset/skeleton-line-block-height.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+SkeletonLine: add `blockHeight` prop to set a container height and vertically center the skeleton line within it

--- a/packages/kumo-docs-astro/src/components/demos/SkeletonLineDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SkeletonLineDemo.tsx
@@ -1,4 +1,5 @@
 import { SkeletonLine } from "@cloudflare/kumo";
+import type { ReactNode } from "react";
 
 export function SkeletonLineDemo() {
   return (
@@ -27,6 +28,39 @@ export function SkeletonLineHeightDemo() {
       <SkeletonLine className="h-4" />
       <SkeletonLine className="h-6" />
       <SkeletonLine className="h-8" />
+    </div>
+  );
+}
+
+function DemoWrapper({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="relative">
+      <div className="absolute top-0 bottom-0 right-full mr-2 border-r-2 border-kumo-fill flex items-center pr-2 text-sm">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function SkeletonLineBlockHeightDemo() {
+  return (
+    <div className="flex w-64 flex-col gap-1">
+      <DemoWrapper label="32px">
+        <SkeletonLine blockHeight={32} />
+      </DemoWrapper>
+      <DemoWrapper label="48px">
+        <SkeletonLine blockHeight={48} />
+      </DemoWrapper>
+      <DemoWrapper label="64px">
+        <SkeletonLine blockHeight={64} />
+      </DemoWrapper>
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -12,6 +12,7 @@ import {
   SkeletonLineDemo,
   SkeletonLineWidthDemo,
   SkeletonLineHeightDemo,
+  SkeletonLineBlockHeightDemo,
   SkeletonLineCardDemo,
 } from "~/components/demos/SkeletonLineDemo";
 
@@ -51,10 +52,26 @@ import { SkeletonLine } from "@cloudflare/kumo";
 <ComponentSection>
   <Heading level={2}>Custom Height</Heading>
   <p class="text-kumo-strong mb-4">
-    Override the default height using Tailwind utility classes via <code>className</code>. The default height is <code>0.5rem</code>.
+    Override the default height using Tailwind utility classes via{" "}
+    <code>className</code>. The default height is <code>0.5rem</code>.
   </p>
   <ComponentExample demo="SkeletonLineHeightDemo">
     <SkeletonLineHeightDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+{/* Block Height */}
+
+<ComponentSection>
+  <Heading level={2}>Block Height</Heading>
+  <p class="text-kumo-strong mb-4">
+    Use <code>blockHeight</code> to set the height of a container that
+    vertically centers the skeleton line. Useful when replacing text of a known
+    line height. Accepts a number (treated as <code>px</code>) or any CSS string
+    value.
+  </p>
+  <ComponentExample demo="SkeletonLineBlockHeightDemo">
+    <SkeletonLineBlockHeightDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
@@ -113,6 +130,11 @@ import { SkeletonLine } from "@cloudflare/kumo";
           <td class="px-4 py-3 font-mono text-xs">maxDelay</td>
           <td class="px-4 py-3 font-mono text-xs">number</td>
           <td class="px-4 py-3 font-mono text-xs">0.5</td>
+        </tr>
+        <tr class="border-b border-kumo-line">
+          <td class="px-4 py-3 font-mono text-xs">blockHeight</td>
+          <td class="px-4 py-3 font-mono text-xs">string | number</td>
+          <td class="px-4 py-3 font-mono text-xs">-</td>
         </tr>
         <tr class="border-b border-kumo-line">
           <td class="px-4 py-3 font-mono text-xs">className</td>

--- a/packages/kumo/src/components/loader/skeleton-line.tsx
+++ b/packages/kumo/src/components/loader/skeleton-line.tsx
@@ -16,6 +16,7 @@ export const SkeletonLine = ({
   maxDuration = 1.7,
   minDelay = 0,
   maxDelay = 0.5,
+  blockHeight,
   className,
 }: {
   minWidth?: number;
@@ -24,6 +25,7 @@ export const SkeletonLine = ({
   maxDuration?: number;
   minDelay?: number;
   maxDelay?: number;
+  blockHeight?: string | number;
   className?: string;
 }) => {
   const { width, duration, delay } = useMemo(() => {
@@ -40,7 +42,19 @@ export const SkeletonLine = ({
     "--shimmer-delay": `${delay}s`,
   };
 
-  return (
+  const line = (
     <div className={cn("skeleton-line", className)} style={lineStyle}></div>
   );
+
+  if (blockHeight !== undefined) {
+    const height =
+      typeof blockHeight === "number" ? `${blockHeight}px` : blockHeight;
+    return (
+      <div className="flex items-center" style={{ height }}>
+        {line}
+      </div>
+    );
+  }
+
+  return line;
 };


### PR DESCRIPTION
## Summary

<img width="2110" height="1556" alt="CleanShot 2026-03-31 at 12 20 58@2x" src="https://github.com/user-attachments/assets/aa37151d-dc55-45df-9751-0cedcfc75af0" />

- Adds a `blockHeight` prop (`string | number`) to `SkeletonLine` that sets the height of a wrapping container and vertically centers the skeleton line within it
- Numbers are treated as `px`; strings are passed through as-is
- Useful when replacing text content of a known line height (e.g. table rows, list items)

## Docs

- Added a **Block Height** section to the `skeleton-line` docs page with a demo showing 32px, 48px, and 64px containers with a striped background to visualize the block height
- Added `blockHeight` to the API reference table

## Changeset

`minor` — additive, non-breaking new prop