### PR TITLE
feat: table of contents component

### DIFF
--- a/.changeset/lazy-cycles-deny.md
+++ b/.changeset/lazy-cycles-deny.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Convert Table of Contents to exported Kumo component

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -73,6 +73,7 @@ const componentItems: NavItem[] = [
   { label: "Surface", href: "/components/surface" },
   { label: "Switch", href: "/components/switch" },
   { label: "Table", href: "/components/table" },
+  { label: "Table of Contents", href: "/components/table-of-contents" },
   { label: "Tabs", href: "/components/tabs" },
   { label: "Text", href: "/components/text" },
   { label: "Toast", href: "/components/toast" },

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -30,6 +30,7 @@ import {
   Surface,
   Switch,
   Table,
+  TableOfContents,
   Tabs,
   Text,
   Toasty,
@@ -82,6 +83,7 @@ const componentRoutes: Record<string, string> = {
   surface: "/components/surface",
   switch: "/components/switch",
   table: "/components/table",
+  "table-of-contents": "/components/table-of-contents",
   tabs: "/components/tabs",
   text: "/components/text",
   toast: "/components/toast",
@@ -611,6 +613,20 @@ export function HomeGrid() {
             </Table.Row>
           </Table.Body>
         </Table>
+      ),
+    },
+    {
+      name: "TableOfContents",
+      id: "table-of-contents",
+      Component: (
+        <TableOfContents>
+          <TableOfContents.Title>On this page</TableOfContents.Title>
+          <TableOfContents.List>
+            <TableOfContents.Item active>Introduction</TableOfContents.Item>
+            <TableOfContents.Item>Installation</TableOfContents.Item>
+            <TableOfContents.Item>Usage</TableOfContents.Item>
+          </TableOfContents.List>
+        </TableOfContents>
       ),
     },
     {

--- a/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 import { TableOfContents } from "@cloudflare/kumo";
 
 const headings = [
@@ -109,5 +109,76 @@ export function TableOfContentsWithoutTitleDemo() {
         ))}
       </TableOfContents.List>
     </TableOfContents>
+  );
+}
+
+/**
+ * Demonstrates using the `render` prop to integrate with custom link components.
+ * Shows default `<a>` behavior alongside a React Router-style custom link.
+ */
+export function TableOfContentsRenderPropDemo() {
+  const [routerNavigation, setRouterNavigation] = useState<string | null>(null);
+
+  // Mock React Router Link component
+  const RouterLink = forwardRef<
+    HTMLAnchorElement,
+    React.AnchorHTMLAttributes<HTMLAnchorElement>
+  >(({ href, onClick, children, ...props }, ref) => (
+    <a
+      ref={ref}
+      href={href}
+      onClick={(e) => {
+        e.preventDefault();
+        setRouterNavigation(href ?? null);
+        onClick?.(e);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ));
+  RouterLink.displayName = "RouterLink";
+
+  return (
+    <div className="flex gap-8">
+      {/* Default: uses <a> tag */}
+      <div className="flex-1">
+        <p className="mb-2 text-xs font-medium text-kumo-subtle">
+          Default (anchor tag)
+        </p>
+        <TableOfContents>
+          <TableOfContents.List>
+            <TableOfContents.Item href="#intro" active>
+              Introduction
+            </TableOfContents.Item>
+            <TableOfContents.Item href="#install">
+              Installation
+            </TableOfContents.Item>
+          </TableOfContents.List>
+        </TableOfContents>
+      </div>
+
+      {/* With render prop: uses custom RouterLink */}
+      <div className="flex-1">
+        <p className="mb-2 text-xs font-medium text-kumo-subtle">
+          With render prop (Router)
+        </p>
+        <TableOfContents>
+          <TableOfContents.List>
+            <TableOfContents.Item render={<RouterLink />} href="/intro" active>
+              Introduction
+            </TableOfContents.Item>
+            <TableOfContents.Item render={<RouterLink />} href="/install">
+              Installation
+            </TableOfContents.Item>
+          </TableOfContents.List>
+        </TableOfContents>
+        {routerNavigation && (
+          <p className="mt-2 text-xs text-kumo-subtle">
+            Router navigated to: <code>{routerNavigation}</code>
+          </p>
+        )}
+      </div>
+    </div>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
@@ -9,22 +9,28 @@ const headings = [
   { text: "Examples" },
 ];
 
+function DemoWrapper({ children }: { children: React.ReactNode }) {
+  return <div className="min-w-48">{children}</div>;
+}
+
 export function TableOfContentsBasicDemo() {
   return (
-    <TableOfContents>
-      <TableOfContents.Title>On this page</TableOfContents.Title>
-      <TableOfContents.List>
-        {headings.map((heading) => (
-          <TableOfContents.Item
-            key={heading.text}
-            active={heading.text === "Usage"}
-            className="cursor-pointer"
-          >
-            {heading.text}
-          </TableOfContents.Item>
-        ))}
-      </TableOfContents.List>
-    </TableOfContents>
+    <DemoWrapper>
+      <TableOfContents>
+        <TableOfContents.Title>On this page</TableOfContents.Title>
+        <TableOfContents.List>
+          {headings.map((heading) => (
+            <TableOfContents.Item
+              key={heading.text}
+              active={heading.text === "Usage"}
+              className="cursor-pointer"
+            >
+              {heading.text}
+            </TableOfContents.Item>
+          ))}
+        </TableOfContents.List>
+      </TableOfContents>
+    </DemoWrapper>
   );
 }
 
@@ -32,83 +38,91 @@ export function TableOfContentsInteractiveDemo() {
   const [active, setActive] = useState("Introduction");
 
   return (
-    <TableOfContents>
-      <TableOfContents.Title>On this page</TableOfContents.Title>
-      <TableOfContents.List>
-        {headings.map((heading) => (
-          <TableOfContents.Item
-            key={heading.text}
-            active={heading.text === active}
-            onClick={() => setActive(heading.text)}
-            className="cursor-pointer"
-          >
-            {heading.text}
-          </TableOfContents.Item>
-        ))}
-      </TableOfContents.List>
-    </TableOfContents>
+    <DemoWrapper>
+      <TableOfContents>
+        <TableOfContents.Title>On this page</TableOfContents.Title>
+        <TableOfContents.List>
+          {headings.map((heading) => (
+            <TableOfContents.Item
+              key={heading.text}
+              active={heading.text === active}
+              onClick={() => setActive(heading.text)}
+              className="cursor-pointer"
+            >
+              {heading.text}
+            </TableOfContents.Item>
+          ))}
+        </TableOfContents.List>
+      </TableOfContents>
+    </DemoWrapper>
   );
 }
 
 export function TableOfContentsNoActiveDemo() {
   return (
-    <TableOfContents>
-      <TableOfContents.Title>On this page</TableOfContents.Title>
-      <TableOfContents.List>
-        {headings.map((heading) => (
-          <TableOfContents.Item key={heading.text} className="cursor-pointer">
-            {heading.text}
-          </TableOfContents.Item>
-        ))}
-      </TableOfContents.List>
-    </TableOfContents>
+    <DemoWrapper>
+      <TableOfContents>
+        <TableOfContents.Title>On this page</TableOfContents.Title>
+        <TableOfContents.List>
+          {headings.map((heading) => (
+            <TableOfContents.Item key={heading.text} className="cursor-pointer">
+              {heading.text}
+            </TableOfContents.Item>
+          ))}
+        </TableOfContents.List>
+      </TableOfContents>
+    </DemoWrapper>
   );
 }
 
 export function TableOfContentsGroupDemo() {
   return (
-    <TableOfContents>
-      <TableOfContents.Title>On this page</TableOfContents.Title>
-      <TableOfContents.List>
-        <TableOfContents.Item active className="cursor-pointer">
-          Overview
-        </TableOfContents.Item>
-        <TableOfContents.Group label="Getting Started">
-          <TableOfContents.Item className="cursor-pointer">
-            Installation
+    <DemoWrapper>
+      <TableOfContents>
+        <TableOfContents.Title>On this page</TableOfContents.Title>
+        <TableOfContents.List>
+          <TableOfContents.Item active className="cursor-pointer">
+            Overview
           </TableOfContents.Item>
-          <TableOfContents.Item className="cursor-pointer">
-            Configuration
-          </TableOfContents.Item>
-        </TableOfContents.Group>
-        <TableOfContents.Group label="API">
-          <TableOfContents.Item className="cursor-pointer">
-            Props
-          </TableOfContents.Item>
-          <TableOfContents.Item className="cursor-pointer">
-            Events
-          </TableOfContents.Item>
-        </TableOfContents.Group>
-      </TableOfContents.List>
-    </TableOfContents>
+          <TableOfContents.Group label="Getting Started">
+            <TableOfContents.Item className="cursor-pointer">
+              Installation
+            </TableOfContents.Item>
+            <TableOfContents.Item className="cursor-pointer">
+              Configuration
+            </TableOfContents.Item>
+          </TableOfContents.Group>
+          <TableOfContents.Group label="API">
+            <TableOfContents.Item className="cursor-pointer">
+              Props
+            </TableOfContents.Item>
+            <TableOfContents.Item className="cursor-pointer">
+              Events
+            </TableOfContents.Item>
+          </TableOfContents.Group>
+        </TableOfContents.List>
+      </TableOfContents>
+    </DemoWrapper>
   );
 }
 
 export function TableOfContentsWithoutTitleDemo() {
   return (
-    <TableOfContents>
-      <TableOfContents.List>
-        {headings.slice(0, 3).map((heading) => (
-          <TableOfContents.Item
-            key={heading.text}
-            active={heading.text === "Introduction"}
-            className="cursor-pointer"
-          >
-            {heading.text}
-          </TableOfContents.Item>
-        ))}
-      </TableOfContents.List>
-    </TableOfContents>
+    <DemoWrapper>
+      <TableOfContents>
+        <TableOfContents.List>
+          {headings.slice(0, 3).map((heading) => (
+            <TableOfContents.Item
+              key={heading.text}
+              active={heading.text === "Introduction"}
+              className="cursor-pointer"
+            >
+              {heading.text}
+            </TableOfContents.Item>
+          ))}
+        </TableOfContents.List>
+      </TableOfContents>
+    </DemoWrapper>
   );
 }
 
@@ -117,24 +131,26 @@ export function TableOfContentsRenderPropDemo() {
   const [clicked, setClicked] = useState<string | null>(null);
 
   return (
-    <div className="space-y-3">
-      <TableOfContents>
-        <TableOfContents.List>
-          {["Introduction", "Installation", "Usage"].map((text) => (
-            <TableOfContents.Item
-              key={text}
-              render={<button type="button" />}
-              onClick={() => setClicked(text)}
-              active={text === "Introduction"}
-            >
-              {text}
-            </TableOfContents.Item>
-          ))}
-        </TableOfContents.List>
-      </TableOfContents>
-      {clicked && (
-        <p className="text-xs text-kumo-subtle">Clicked: {clicked}</p>
-      )}
-    </div>
+    <DemoWrapper>
+      <div className="space-y-3">
+        <TableOfContents>
+          <TableOfContents.List>
+            {["Introduction", "Installation", "Usage"].map((text) => (
+              <TableOfContents.Item
+                key={text}
+                render={<button type="button" />}
+                onClick={() => setClicked(text)}
+                active={text === "Introduction"}
+              >
+                {text}
+              </TableOfContents.Item>
+            ))}
+          </TableOfContents.List>
+        </TableOfContents>
+        {clicked && (
+          <p className="text-xs text-kumo-subtle">Clicked: {clicked}</p>
+        )}
+      </div>
+    </DemoWrapper>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
@@ -74,7 +74,6 @@ export function TableOfContentsGroupDemo() {
           Overview
         </TableOfContents.Item>
         <TableOfContents.Group label="Getting Started">
-          k{" "}
           <TableOfContents.Item className="cursor-pointer">
             Installation
           </TableOfContents.Item>

--- a/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from "react";
+import { useState } from "react";
 import { TableOfContents } from "@cloudflare/kumo";
 
 const headings = [
@@ -112,73 +112,29 @@ export function TableOfContentsWithoutTitleDemo() {
   );
 }
 
-/**
- * Demonstrates using the `render` prop to integrate with custom link components.
- * Shows default `<a>` behavior alongside a React Router-style custom link.
- */
+/** Demonstrates using the `render` prop with a custom link component. */
 export function TableOfContentsRenderPropDemo() {
-  const [routerNavigation, setRouterNavigation] = useState<string | null>(null);
-
-  // Mock React Router Link component
-  const RouterLink = forwardRef<
-    HTMLAnchorElement,
-    React.AnchorHTMLAttributes<HTMLAnchorElement>
-  >(({ href, onClick, children, ...props }, ref) => (
-    <a
-      ref={ref}
-      href={href}
-      onClick={(e) => {
-        e.preventDefault();
-        setRouterNavigation(href ?? null);
-        onClick?.(e);
-      }}
-      {...props}
-    >
-      {children}
-    </a>
-  ));
-  RouterLink.displayName = "RouterLink";
+  const [clicked, setClicked] = useState<string | null>(null);
 
   return (
-    <div className="flex gap-8">
-      {/* Default: uses <a> tag */}
-      <div className="flex-1">
-        <p className="mb-2 text-xs font-medium text-kumo-subtle">
-          Default (anchor tag)
-        </p>
-        <TableOfContents>
-          <TableOfContents.List>
-            <TableOfContents.Item href="#intro" active>
-              Introduction
+    <div className="space-y-3">
+      <TableOfContents>
+        <TableOfContents.List>
+          {["Introduction", "Installation", "Usage"].map((text) => (
+            <TableOfContents.Item
+              key={text}
+              render={<button type="button" />}
+              onClick={() => setClicked(text)}
+              active={text === "Introduction"}
+            >
+              {text}
             </TableOfContents.Item>
-            <TableOfContents.Item href="#install">
-              Installation
-            </TableOfContents.Item>
-          </TableOfContents.List>
-        </TableOfContents>
-      </div>
-
-      {/* With render prop: uses custom RouterLink */}
-      <div className="flex-1">
-        <p className="mb-2 text-xs font-medium text-kumo-subtle">
-          With render prop (Router)
-        </p>
-        <TableOfContents>
-          <TableOfContents.List>
-            <TableOfContents.Item render={<RouterLink />} href="/intro" active>
-              Introduction
-            </TableOfContents.Item>
-            <TableOfContents.Item render={<RouterLink />} href="/install">
-              Installation
-            </TableOfContents.Item>
-          </TableOfContents.List>
-        </TableOfContents>
-        {routerNavigation && (
-          <p className="mt-2 text-xs text-kumo-subtle">
-            Router navigated to: <code>{routerNavigation}</code>
-          </p>
-        )}
-      </div>
+          ))}
+        </TableOfContents.List>
+      </TableOfContents>
+      {clicked && (
+        <p className="text-xs text-kumo-subtle">Clicked: {clicked}</p>
+      )}
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { TableOfContents } from "@cloudflare/kumo";
+
+const headings = [
+  { text: "Introduction" },
+  { text: "Installation" },
+  { text: "Usage" },
+  { text: "API Reference" },
+  { text: "Examples" },
+];
+
+export function TableOfContentsBasicDemo() {
+  return (
+    <TableOfContents>
+      <TableOfContents.Title>On this page</TableOfContents.Title>
+      <TableOfContents.List>
+        {headings.map((heading) => (
+          <TableOfContents.Item
+            key={heading.text}
+            active={heading.text === "Usage"}
+            className="cursor-pointer"
+          >
+            {heading.text}
+          </TableOfContents.Item>
+        ))}
+      </TableOfContents.List>
+    </TableOfContents>
+  );
+}
+
+export function TableOfContentsInteractiveDemo() {
+  const [active, setActive] = useState("Introduction");
+
+  return (
+    <TableOfContents>
+      <TableOfContents.Title>On this page</TableOfContents.Title>
+      <TableOfContents.List>
+        {headings.map((heading) => (
+          <TableOfContents.Item
+            key={heading.text}
+            active={heading.text === active}
+            onClick={() => setActive(heading.text)}
+            className="cursor-pointer"
+          >
+            {heading.text}
+          </TableOfContents.Item>
+        ))}
+      </TableOfContents.List>
+    </TableOfContents>
+  );
+}
+
+export function TableOfContentsNoActiveDemo() {
+  return (
+    <TableOfContents>
+      <TableOfContents.Title>On this page</TableOfContents.Title>
+      <TableOfContents.List>
+        {headings.map((heading) => (
+          <TableOfContents.Item key={heading.text} className="cursor-pointer">
+            {heading.text}
+          </TableOfContents.Item>
+        ))}
+      </TableOfContents.List>
+    </TableOfContents>
+  );
+}
+
+/** Items organized into labeled groups. */
+export function TableOfContentsGroupDemo() {
+  return (
+    <TableOfContents>
+      <TableOfContents.Title>On this page</TableOfContents.Title>
+      <TableOfContents.List>
+        <TableOfContents.Item active className="cursor-pointer">
+          Overview
+        </TableOfContents.Item>
+        <TableOfContents.Group label="Getting Started">
+          <TableOfContents.Item className="cursor-pointer">
+            Installation
+          </TableOfContents.Item>
+          <TableOfContents.Item className="cursor-pointer">
+            Configuration
+          </TableOfContents.Item>
+        </TableOfContents.Group>
+        <TableOfContents.Group label="API">
+          <TableOfContents.Item className="cursor-pointer">
+            Props
+          </TableOfContents.Item>
+          <TableOfContents.Item className="cursor-pointer">
+            Events
+          </TableOfContents.Item>
+        </TableOfContents.Group>
+      </TableOfContents.List>
+    </TableOfContents>
+  );
+}
+
+/** Navigation list without the title heading. */
+export function TableOfContentsWithoutTitleDemo() {
+  return (
+    <TableOfContents>
+      <TableOfContents.List>
+        {headings.slice(0, 3).map((heading) => (
+          <TableOfContents.Item
+            key={heading.text}
+            active={heading.text === "Introduction"}
+            className="cursor-pointer"
+          >
+            {heading.text}
+          </TableOfContents.Item>
+        ))}
+      </TableOfContents.List>
+    </TableOfContents>
+  );
+}

--- a/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TableOfContentsDemo.tsx
@@ -65,7 +65,6 @@ export function TableOfContentsNoActiveDemo() {
   );
 }
 
-/** Items organized into labeled groups. */
 export function TableOfContentsGroupDemo() {
   return (
     <TableOfContents>
@@ -75,6 +74,7 @@ export function TableOfContentsGroupDemo() {
           Overview
         </TableOfContents.Item>
         <TableOfContents.Group label="Getting Started">
+          k{" "}
           <TableOfContents.Item className="cursor-pointer">
             Installation
           </TableOfContents.Item>
@@ -95,7 +95,6 @@ export function TableOfContentsGroupDemo() {
   );
 }
 
-/** Navigation list without the title heading. */
 export function TableOfContentsWithoutTitleDemo() {
   return (
     <TableOfContents>

--- a/packages/kumo-docs-astro/src/components/docs/TableOfContents.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/TableOfContents.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { cn } from "@cloudflare/kumo";
-import { CaretDown } from "@phosphor-icons/react";
+import { TableOfContents as TOC } from "@cloudflare/kumo";
+import { CaretDownIcon } from "@phosphor-icons/react";
 
 export interface TocHeading {
   depth: number;
@@ -149,7 +149,7 @@ export function TableOfContents({
             </option>
           ))}
         </select>
-        <CaretDown
+        <CaretDownIcon
           size={16}
           weight="bold"
           className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-kumo-subtle"
@@ -160,43 +160,20 @@ export function TableOfContents({
 
   // Sidebar layout (default)
   return (
-    <section>
-      <p className="mb-3 text-xs font-semibold tracking-wide text-kumo-subtle uppercase">
-        On this page
-      </p>
-      <nav
-        aria-label="Table of contents"
-        className="relative space-y-1.5 before:absolute before:inset-y-0 before:left-0.5 before:w-px before:bg-kumo-hairline"
-        ref={navRef}
-      >
-        {headings.map((heading) => {
-          const isActive = activeId === heading.slug;
-          return (
-            <a
-              key={heading.slug}
-              href={`#${heading.slug}`}
-              onClick={() => handleClick(heading.slug)}
-              className={cn(
-                "group relative block truncate rounded-md py-1 pl-5 text-sm no-underline transition-all duration-500",
-                isActive
-                  ? "text-kumo-default font-medium"
-                  : "text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default hover:font-medium",
-              )}
-            >
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "absolute inset-y-0 left-0.5 w-0.5 rounded-full transition-all duration-200",
-                  isActive
-                    ? "bg-kumo-brand opacity-100"
-                    : "bg-kumo-brand opacity-0 group-hover:opacity-60",
-                )}
-              />
-              <span className="block min-w-0 leading-5">{heading.text}</span>
-            </a>
-          );
-        })}
-      </nav>
-    </section>
+    <TOC>
+      <TOC.Title>On this page</TOC.Title>
+      <TOC.List ref={navRef}>
+        {headings.map((heading) => (
+          <TOC.Item
+            key={heading.slug}
+            href={`#${heading.slug}`}
+            active={activeId === heading.slug}
+            onClick={() => handleClick(heading.slug)}
+          >
+            {heading.text}
+          </TOC.Item>
+        ))}
+      </TOC.List>
+    </TOC>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
@@ -1,0 +1,125 @@
+---
+layout: ~/layouts/MdxDocLayout.astro
+title: "Table of Contents"
+description: "Presentational compound component for section navigation with an active indicator bar."
+sourceFile: "components/table-of-contents"
+---
+
+import ComponentExample from "~/components/docs/ComponentExample.astro";
+import ComponentSection from "~/components/docs/ComponentSection.astro";
+import Heading from "~/components/docs/Heading.astro";
+import PropsTable from "~/components/docs/PropsTable.astro";
+import {
+  TableOfContentsBasicDemo,
+  TableOfContentsInteractiveDemo,
+  TableOfContentsNoActiveDemo,
+  TableOfContentsGroupDemo,
+  TableOfContentsWithoutTitleDemo,
+} from "~/components/demos/TableOfContentsDemo";
+
+{/* Hero Demo */}
+
+<ComponentSection>
+  <ComponentExample demo="TableOfContentsBasicDemo">
+    <TableOfContentsBasicDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+{/* Installation */}
+
+<ComponentSection>
+  <Heading level={2}>Installation</Heading>
+  <Heading level={3}>Barrel</Heading>
+
+```tsx
+import { TableOfContents } from "@cloudflare/kumo";
+```
+
+<Heading level={3}>Granular</Heading>
+
+```tsx
+import { TableOfContents } from "@cloudflare/kumo/components/table-of-contents";
+```
+
+</ComponentSection>
+
+{/* Usage */}
+
+<ComponentSection>
+  <Heading level={2}>Usage</Heading>
+
+```tsx
+import { TableOfContents } from "@cloudflare/kumo";
+
+export default function Example() {
+  return (
+    <TableOfContents>
+      <TableOfContents.Title>On this page</TableOfContents.Title>
+      <TableOfContents.List>
+        <TableOfContents.Item href="#intro" active>
+          Introduction
+        </TableOfContents.Item>
+        <TableOfContents.Item href="#api">API Reference</TableOfContents.Item>
+      </TableOfContents.List>
+    </TableOfContents>
+  );
+}
+```
+
+<p>
+  This component is purely presentational. All interaction logic — scroll
+  tracking, `IntersectionObserver`, active state management — is left to the
+  consumer.
+</p>
+
+</ComponentSection>
+
+{/* Examples */}
+
+<ComponentSection>
+  <Heading level={2}>Examples</Heading>
+
+<Heading level={3}>Interactive</Heading>
+<p>
+  Click an item to set it as active. The consumer controls state via `active`
+  and `onClick`.
+</p>
+<ComponentExample demo="TableOfContentsInteractiveDemo">
+  <TableOfContentsInteractiveDemo client:load />
+</ComponentExample>
+
+<Heading level={3}>No active item</Heading>
+<p>
+  When no item has `active` set, all items show the default subtle text style
+  with a hover indicator.
+</p>
+<ComponentExample demo="TableOfContentsNoActiveDemo">
+  <TableOfContentsNoActiveDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Groups</Heading>
+<p>
+  Use `TableOfContents.Group` to organize items into labeled sections with
+  indented children.
+</p>
+<ComponentExample demo="TableOfContentsGroupDemo">
+  <TableOfContentsGroupDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Without title</Heading>
+<p>
+  The title sub-component is optional — use `TableOfContents.List` directly if
+  you don't need a heading.
+</p>
+<ComponentExample demo="TableOfContentsWithoutTitleDemo">
+  <TableOfContentsWithoutTitleDemo client:visible />
+</ComponentExample>
+
+</ComponentSection>
+
+{/* API Reference */}
+
+<ComponentSection>
+  <Heading level={2}>API Reference</Heading>
+  <PropsTable component="TableOfContents" />
+</ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
@@ -116,24 +116,30 @@ export default function Example() {
   <TableOfContentsWithoutTitleDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom link component</Heading>
+<Heading level={3}>Custom element</Heading>
 <p>
-  By default, items render as standard anchor tags. Use the `render` prop to
-  integrate with framework routers like React Router or Next.js. Click the
-  Router links below to see client-side navigation.
+  Use the `render` prop to swap the default anchor for a button, router link, or
+  any element.
 </p>
 <ComponentExample demo="TableOfContentsRenderPropDemo">
   <TableOfContentsRenderPropDemo client:load />
 </ComponentExample>
 
-**With React Router**
-
 ```tsx
-import { Link } from "react-router-dom";
-
-<TableOfContents.Item render={<Link to="" />} href="/intro" active>
+// React Router
+<TableOfContents.Item render={<Link to="/intro" />} active>
   Introduction
-</TableOfContents.Item>;
+</TableOfContents.Item>
+
+// Next.js
+<TableOfContents.Item render={<Link href="/intro" />} active>
+  Introduction
+</TableOfContents.Item>
+
+// Button (no navigation)
+<TableOfContents.Item render={<button type="button" />} onClick={handleClick}>
+  Introduction
+</TableOfContents.Item>
 ```
 
 **With Next.js**
@@ -144,58 +150,6 @@ import Link from "next/link";
 <TableOfContents.Item render={<Link />} href="/intro" active>
   Introduction
 </TableOfContents.Item>;
-```
-
-**With Next.js**
-
-```tsx
-import Link from "next/link";
-
-<TableOfContents.Item render={<Link />} href="/intro" active>
-  Introduction
-</TableOfContents.Item>;
-```
-
-**With LinkProvider (app-wide)**
-
-```tsx
-import { LinkProvider } from "@cloudflare/kumo";
-import Link from "next/link";
-
-// Wrap your app once — all TableOfContents.Item components will use Link
-<LinkProvider component={Link}>
-  <App />
-</LinkProvider>;
-```
-
-**With LinkProvider (implicit)**
-
-```tsx
-import { LinkProvider } from "@cloudflare/kumo";
-import Link from "next/link";
-
-<LinkProvider component={Link}>
-  <TableOfContents>
-    <TableOfContents.List>
-      <TableOfContents.Item href="/intro">Introduction</TableOfContents.Item>
-    </TableOfContents.List>
-  </TableOfContents>
-</LinkProvider>;
-```
-
-**With LinkProvider (implicit)**
-
-```tsx
-import { LinkProvider } from "@cloudflare/kumo";
-import Link from "next/link";
-
-<LinkProvider component={Link}>
-  <TableOfContents>
-    <TableOfContents.List>
-      <TableOfContents.Item href="/intro">Introduction</TableOfContents.Item>
-    </TableOfContents.List>
-  </TableOfContents>
-</LinkProvider>;
 ```
 
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
@@ -15,6 +15,7 @@ import {
   TableOfContentsNoActiveDemo,
   TableOfContentsGroupDemo,
   TableOfContentsWithoutTitleDemo,
+  TableOfContentsRenderPropDemo,
 } from "~/components/demos/TableOfContentsDemo";
 
 {/* Hero Demo */}
@@ -114,6 +115,88 @@ export default function Example() {
 <ComponentExample demo="TableOfContentsWithoutTitleDemo">
   <TableOfContentsWithoutTitleDemo client:visible />
 </ComponentExample>
+
+<Heading level={3}>Custom link component</Heading>
+<p>
+  By default, items render as standard anchor tags. Use the `render` prop to
+  integrate with framework routers like React Router or Next.js. Click the
+  Router links below to see client-side navigation.
+</p>
+<ComponentExample demo="TableOfContentsRenderPropDemo">
+  <TableOfContentsRenderPropDemo client:load />
+</ComponentExample>
+
+**With React Router**
+
+```tsx
+import { Link } from "react-router-dom";
+
+<TableOfContents.Item render={<Link to="" />} href="/intro" active>
+  Introduction
+</TableOfContents.Item>;
+```
+
+**With Next.js**
+
+```tsx
+import Link from "next/link";
+
+<TableOfContents.Item render={<Link />} href="/intro" active>
+  Introduction
+</TableOfContents.Item>;
+```
+
+**With Next.js**
+
+```tsx
+import Link from "next/link";
+
+<TableOfContents.Item render={<Link />} href="/intro" active>
+  Introduction
+</TableOfContents.Item>;
+```
+
+**With LinkProvider (app-wide)**
+
+```tsx
+import { LinkProvider } from "@cloudflare/kumo";
+import Link from "next/link";
+
+// Wrap your app once — all TableOfContents.Item components will use Link
+<LinkProvider component={Link}>
+  <App />
+</LinkProvider>;
+```
+
+**With LinkProvider (implicit)**
+
+```tsx
+import { LinkProvider } from "@cloudflare/kumo";
+import Link from "next/link";
+
+<LinkProvider component={Link}>
+  <TableOfContents>
+    <TableOfContents.List>
+      <TableOfContents.Item href="/intro">Introduction</TableOfContents.Item>
+    </TableOfContents.List>
+  </TableOfContents>
+</LinkProvider>;
+```
+
+**With LinkProvider (implicit)**
+
+```tsx
+import { LinkProvider } from "@cloudflare/kumo";
+import Link from "next/link";
+
+<LinkProvider component={Link}>
+  <TableOfContents>
+    <TableOfContents.List>
+      <TableOfContents.Item href="/intro">Introduction</TableOfContents.Item>
+    </TableOfContents.List>
+  </TableOfContents>
+</LinkProvider>;
+```
 
 </ComponentSection>
 

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -191,6 +191,10 @@
       "types": "./dist/src/components/sidebar/index.d.ts",
       "import": "./dist/components/sidebar.js"
     },
+    "./components/table-of-contents": {
+      "types": "./dist/src/components/table-of-contents/index.d.ts",
+      "import": "./dist/components/table-of-contents.js"
+    },
     "./utils": {
       "types": "./dist/src/utils/index.d.ts",
       "import": "./dist/utils.js"

--- a/packages/kumo/src/components/table-of-contents/index.ts
+++ b/packages/kumo/src/components/table-of-contents/index.ts
@@ -1,0 +1,11 @@
+export {
+  TableOfContents,
+  type TableOfContentsProps,
+  type TableOfContentsTitleProps,
+  type TableOfContentsListProps,
+  type TableOfContentsItemProps,
+  type TableOfContentsGroupProps,
+  KUMO_TABLE_OF_CONTENTS_VARIANTS,
+  KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS,
+  type KumoTableOfContentsState,
+} from "./table-of-contents";

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.test.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import {
+  TableOfContents,
+  KUMO_TABLE_OF_CONTENTS_VARIANTS,
+  KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS,
+} from "./table-of-contents";
+
+describe("TableOfContents", () => {
+  it("should be defined", () => {
+    expect(TableOfContents).toBeDefined();
+  });
+
+  it("should have sub-components", () => {
+    expect(TableOfContents.Title).toBeDefined();
+    expect(TableOfContents.List).toBeDefined();
+    expect(TableOfContents.Item).toBeDefined();
+    expect(TableOfContents.Group).toBeDefined();
+  });
+
+  it("should render root without throwing", () => {
+    expect(() =>
+      createElement(TableOfContents, { children: "content" }),
+    ).not.toThrow();
+  });
+
+  it("should render Title without throwing", () => {
+    expect(() =>
+      createElement(TableOfContents.Title, { children: "On this page" }),
+    ).not.toThrow();
+  });
+
+  it("should render List without throwing", () => {
+    expect(() =>
+      createElement(TableOfContents.List, { children: "items" }),
+    ).not.toThrow();
+  });
+
+  it("should render Item without throwing", () => {
+    expect(() =>
+      createElement(TableOfContents.Item, {
+        href: "#section",
+        children: "Section",
+      }),
+    ).not.toThrow();
+  });
+
+  it("should render active Item without throwing", () => {
+    expect(() =>
+      createElement(TableOfContents.Item, {
+        href: "#section",
+        active: true,
+        children: "Section",
+      }),
+    ).not.toThrow();
+  });
+
+  it("should have active state variant classes", () => {
+    expect(KUMO_TABLE_OF_CONTENTS_VARIANTS.state.active.classes).toContain(
+      "text-kumo-default",
+    );
+    expect(KUMO_TABLE_OF_CONTENTS_VARIANTS.state.active.classes).toContain(
+      "font-medium",
+    );
+  });
+
+  it("should have default state variant classes", () => {
+    expect(KUMO_TABLE_OF_CONTENTS_VARIANTS.state.default.classes).toContain(
+      "text-kumo-subtle",
+    );
+  });
+
+  it("should default to inactive state", () => {
+    expect(KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS.state).toBe("default");
+  });
+
+  it("should render Group without throwing", () => {
+    expect(() =>
+      createElement(TableOfContents.Group, {
+        label: "Getting Started",
+        children: "items",
+      }),
+    ).not.toThrow();
+  });
+
+  it("should have correct displayNames", () => {
+    expect(TableOfContents.displayName).toBe("TableOfContents");
+    expect(TableOfContents.Title.displayName).toBe("TableOfContents.Title");
+    expect(TableOfContents.List.displayName).toBe("TableOfContents.List");
+    expect(TableOfContents.Item.displayName).toBe("TableOfContents.Item");
+    expect(TableOfContents.Group.displayName).toBe("TableOfContents.Group");
+  });
+});

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -24,7 +24,7 @@ export type KumoTableOfContentsState =
   keyof typeof KUMO_TABLE_OF_CONTENTS_VARIANTS.state;
 
 const ITEM_BASE =
-  "group relative block truncate rounded-md py-1 pl-5 text-sm no-underline transition-all duration-500";
+  "group relative block w-full truncate rounded-md py-1 pl-5 text-sm text-left no-underline transition-all duration-500";
 
 const INDICATOR_BASE =
   "absolute inset-y-0 left-0.5 w-0.5 rounded-full transition-all duration-200 bg-kumo-brand";

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { cloneElement, forwardRef, isValidElement } from "react";
 import { cn } from "../../utils/cn";
 
 /** TableOfContents item state variant definitions. */
@@ -74,28 +74,36 @@ const TableOfContentsList = forwardRef<
     {...props}
   />
 ));
-
-export interface TableOfContentsItemProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  /** whether this item represents the currently active section. */
+export interface TableOfContentsItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Whether this item represents the currently active section. */
   active?: boolean;
+  /**
+   * Custom element to render as the link. Use this to integrate with
+   * framework routers (e.g., Next.js `<Link>`, React Router `<NavLink>`).
+   * The element receives all anchor props including `href`, `className`, and `children`.
+   *
+   * @example
+   * ```tsx
+   * <TableOfContents.Item render={<Link />} href="/intro" active>
+   *   Introduction
+   * </TableOfContents.Item>
+   * ```
+   */
+  render?: React.ReactElement;
 }
 
 const TableOfContentsItem = forwardRef<
   HTMLAnchorElement,
   TableOfContentsItemProps
->(({ active = false, className, children, ...props }, ref) => {
+>(({ active = false, className, children, render, ...props }, ref) => {
   const stateClasses = active
     ? KUMO_TABLE_OF_CONTENTS_VARIANTS.state.active.classes
     : KUMO_TABLE_OF_CONTENTS_VARIANTS.state.default.classes;
 
-  return (
-    <a
-      ref={ref}
-      aria-current={active ? "true" : undefined}
-      className={cn(ITEM_BASE, stateClasses, className)}
-      {...props}
-    >
+  const combinedClassName = cn(ITEM_BASE, stateClasses, className);
+
+  const innerContent = (
+    <>
       <span
         aria-hidden="true"
         className={cn(
@@ -104,12 +112,30 @@ const TableOfContentsItem = forwardRef<
         )}
       />
       <span className="block min-w-0 leading-5">{children}</span>
-    </a>
+    </>
   );
+
+  const sharedProps = {
+    ref,
+    "aria-current": active ? ("true" as const) : undefined,
+    className: combinedClassName,
+    children: innerContent,
+    ...props,
+  };
+
+  // If a render prop is provided, clone it with our props
+  if (render && isValidElement(render)) {
+    return cloneElement(render, sharedProps);
+  }
+
+  // Default to anchor tag
+  return <a {...sharedProps} />;
 });
 
-export interface TableOfContentsGroupProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+export interface TableOfContentsGroupProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "title"
+> {
   /** Label displayed above the group's items. */
   label: string;
   /** URL the group label links to. */

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -5,7 +5,8 @@ import { cn } from "../../utils/cn";
 export const KUMO_TABLE_OF_CONTENTS_VARIANTS = {
   state: {
     default: {
-      classes: "text-kumo-subtle",
+      classes:
+        "text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default hover:font-medium",
       description: "Inactive section link",
     },
     active: {
@@ -19,132 +20,128 @@ export const KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS = {
   state: "default",
 } as const;
 
-export type KumoTableOfContentsState = keyof typeof KUMO_TABLE_OF_CONTENTS_VARIANTS.state;
+export type KumoTableOfContentsState =
+  keyof typeof KUMO_TABLE_OF_CONTENTS_VARIANTS.state;
 
 const ITEM_BASE =
   "group relative block truncate rounded-md py-1 pl-5 text-sm no-underline transition-all duration-500";
 
-const ITEM_HOVER = "hover:bg-kumo-tint hover:text-kumo-default hover:font-medium";
-
 const INDICATOR_BASE =
   "absolute inset-y-0 left-0.5 w-0.5 rounded-full transition-all duration-200 bg-kumo-brand";
 
-/**
- * TableOfContents root — neutral wrapper for the title and navigation list.
- *
- * @example
- * ```tsx
- * <TableOfContents>
- *   <TableOfContents.Title>On this page</TableOfContents.Title>
- *   <TableOfContents.List>
- *     <TableOfContents.Item href="#intro" active>Introduction</TableOfContents.Item>
- *     <TableOfContents.Item href="#api">API Reference</TableOfContents.Item>
- *   </TableOfContents.List>
- * </TableOfContents>
- * ```
- */
-const TableOfContentsRoot = forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
-  ({ className, ...props }, ref) => (
-    <nav ref={ref} aria-label="Table of contents" className={cn(className)} {...props} />
-  ),
-);
+export type TableOfContentsProps = React.HTMLAttributes<HTMLElement>;
 
-export type TableOfContentsTitleProps = React.HTMLAttributes<HTMLParagraphElement>;
-
-const TableOfContentsTitle = forwardRef<HTMLParagraphElement, TableOfContentsTitleProps>(
+const TableOfContentsRoot = forwardRef<HTMLElement, TableOfContentsProps>(
   ({ className, ...props }, ref) => (
-    <p
+    <nav
       ref={ref}
-      className={cn(
-        "mb-3 text-xs font-semibold tracking-wide text-kumo-subtle uppercase",
-        className,
-      )}
+      aria-label="Table of contents"
+      className={className}
       {...props}
     />
   ),
 );
+
+export type TableOfContentsTitleProps =
+  React.HTMLAttributes<HTMLParagraphElement>;
+
+const TableOfContentsTitle = forwardRef<
+  HTMLParagraphElement,
+  TableOfContentsTitleProps
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn(
+      "mb-3 text-xs font-semibold tracking-wide text-kumo-subtle uppercase",
+      className,
+    )}
+    {...props}
+  />
+));
 
 export type TableOfContentsListProps = React.HTMLAttributes<HTMLDivElement>;
 
-const TableOfContentsList = forwardRef<HTMLDivElement, TableOfContentsListProps>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "relative space-y-1.5 before:absolute before:inset-y-0 before:left-0.5 before:w-px before:bg-kumo-line",
-        className,
-      )}
-      {...props}
-    />
-  ),
-);
+const TableOfContentsList = forwardRef<
+  HTMLDivElement,
+  TableOfContentsListProps
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "relative space-y-1.5 before:absolute before:inset-y-0 before:left-0.5 before:w-px before:bg-kumo-line",
+      className,
+    )}
+    {...props}
+  />
+));
 
-export interface TableOfContentsItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface TableOfContentsItemProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** whether this item represents the currently active section. */
   active?: boolean;
 }
 
-const TableOfContentsItem = forwardRef<HTMLAnchorElement, TableOfContentsItemProps>(
-  ({ active = false, className, children, ...props }, ref) => {
-    const stateClasses = active
-      ? KUMO_TABLE_OF_CONTENTS_VARIANTS.state.active.classes
-      : cn(KUMO_TABLE_OF_CONTENTS_VARIANTS.state.default.classes, ITEM_HOVER);
+const TableOfContentsItem = forwardRef<
+  HTMLAnchorElement,
+  TableOfContentsItemProps
+>(({ active = false, className, children, ...props }, ref) => {
+  const stateClasses = active
+    ? KUMO_TABLE_OF_CONTENTS_VARIANTS.state.active.classes
+    : KUMO_TABLE_OF_CONTENTS_VARIANTS.state.default.classes;
 
-    return (
-      <a
-        ref={ref}
-        aria-current={active ? "true" : undefined}
-        className={cn(ITEM_BASE, stateClasses, className)}
-        {...props}
-      >
-        <span
-          aria-hidden="true"
-          className={cn(
-            INDICATOR_BASE,
-            active ? "opacity-100" : "opacity-0 group-hover:opacity-60",
-          )}
-        />
-        <span className="block min-w-0 leading-5">{children}</span>
-      </a>
-    );
-  },
-);
+  return (
+    <a
+      ref={ref}
+      aria-current={active ? "true" : undefined}
+      className={cn(ITEM_BASE, stateClasses, className)}
+      {...props}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          INDICATOR_BASE,
+          active ? "opacity-100" : "opacity-0 group-hover:opacity-60",
+        )}
+      />
+      <span className="block min-w-0 leading-5">{children}</span>
+    </a>
+  );
+});
 
-export interface TableOfContentsGroupProps extends Omit<
-  React.HTMLAttributes<HTMLDivElement>,
-  "title"
-> {
+export interface TableOfContentsGroupProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   /** Label displayed above the group's items. */
   label: string;
   /** URL the group label links to. */
   href?: string;
 }
 
-const TableOfContentsGroup = forwardRef<HTMLDivElement, TableOfContentsGroupProps>(
-  ({ label, href, className, children, ...props }, ref) => (
-    <div ref={ref} className={cn("mt-3", className)} {...props}>
-      {href ? (
-        <a
-          href={href}
-          className="mb-1.5 block pl-5 text-xs font-medium text-kumo-subtle no-underline hover:text-kumo-default"
-        >
-          {label}
-        </a>
-      ) : (
-        <p className="mb-1.5 pl-5 text-xs font-medium text-kumo-subtle">{label}</p>
-      )}
-      <div className="space-y-1.5 pl-3">{children}</div>
-    </div>
-  ),
-);
+const TableOfContentsGroup = forwardRef<
+  HTMLDivElement,
+  TableOfContentsGroupProps
+>(({ label, href, className, children, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-3", className)} {...props}>
+    {href ? (
+      <a
+        href={href}
+        className="mb-1.5 block pl-5 text-xs font-medium text-kumo-subtle no-underline hover:text-kumo-default"
+      >
+        {label}
+      </a>
+    ) : (
+      <p className="mb-1.5 pl-5 text-xs font-medium text-kumo-subtle">
+        {label}
+      </p>
+    )}
+    <div className="space-y-1.5 pl-3">{children}</div>
+  </div>
+));
 
 TableOfContentsRoot.displayName = "TableOfContents";
 TableOfContentsTitle.displayName = "TableOfContents.Title";
 TableOfContentsList.displayName = "TableOfContents.List";
 TableOfContentsItem.displayName = "TableOfContents.Item";
 TableOfContentsGroup.displayName = "TableOfContents.Group";
-
-export type TableOfContentsProps = React.HTMLAttributes<HTMLElement>;
 
 /**
  * TableOfContents — presentational compound component for section navigation.

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -129,6 +129,7 @@ const TableOfContentsItem = forwardRef<
   }
 
   // Default to anchor tag
+  // oxlint-disable-next-line anchor-has-content -- children are in sharedProps
   return <a {...sharedProps} />;
 });
 

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -32,13 +32,11 @@ const INDICATOR_BASE =
 export type TableOfContentsProps = React.HTMLAttributes<HTMLElement>;
 
 const TableOfContentsRoot = forwardRef<HTMLElement, TableOfContentsProps>(
-  ({ className, ...props }, ref) => (
-    <nav
-      ref={ref}
-      aria-label="Table of contents"
-      className={className}
-      {...props}
-    />
+  (
+    { className, "aria-label": ariaLabel = "Table of contents", ...props },
+    ref,
+  ) => (
+    <nav ref={ref} aria-label={ariaLabel} className={className} {...props} />
   ),
 );
 

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -1,0 +1,174 @@
+import { forwardRef } from "react";
+import { cn } from "../../utils/cn";
+
+/** TableOfContents item state variant definitions. */
+export const KUMO_TABLE_OF_CONTENTS_VARIANTS = {
+  state: {
+    default: {
+      classes: "text-kumo-subtle",
+      description: "Inactive section link",
+    },
+    active: {
+      classes: "text-kumo-default font-medium",
+      description: "Currently visible / active section",
+    },
+  },
+} as const;
+
+export const KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS = {
+  state: "default",
+} as const;
+
+export type KumoTableOfContentsState = keyof typeof KUMO_TABLE_OF_CONTENTS_VARIANTS.state;
+
+const ITEM_BASE =
+  "group relative block truncate rounded-md py-1 pl-5 text-sm no-underline transition-all duration-500";
+
+const ITEM_HOVER = "hover:bg-kumo-tint hover:text-kumo-default hover:font-medium";
+
+const INDICATOR_BASE =
+  "absolute inset-y-0 left-0.5 w-0.5 rounded-full transition-all duration-200 bg-kumo-brand";
+
+/**
+ * TableOfContents root — neutral wrapper for the title and navigation list.
+ *
+ * @example
+ * ```tsx
+ * <TableOfContents>
+ *   <TableOfContents.Title>On this page</TableOfContents.Title>
+ *   <TableOfContents.List>
+ *     <TableOfContents.Item href="#intro" active>Introduction</TableOfContents.Item>
+ *     <TableOfContents.Item href="#api">API Reference</TableOfContents.Item>
+ *   </TableOfContents.List>
+ * </TableOfContents>
+ * ```
+ */
+const TableOfContentsRoot = forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+  ({ className, ...props }, ref) => (
+    <nav ref={ref} aria-label="Table of contents" className={cn(className)} {...props} />
+  ),
+);
+
+export type TableOfContentsTitleProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+const TableOfContentsTitle = forwardRef<HTMLParagraphElement, TableOfContentsTitleProps>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn(
+        "mb-3 text-xs font-semibold tracking-wide text-kumo-subtle uppercase",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+export type TableOfContentsListProps = React.HTMLAttributes<HTMLDivElement>;
+
+const TableOfContentsList = forwardRef<HTMLDivElement, TableOfContentsListProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "relative space-y-1.5 before:absolute before:inset-y-0 before:left-0.5 before:w-px before:bg-kumo-line",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+export interface TableOfContentsItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** whether this item represents the currently active section. */
+  active?: boolean;
+}
+
+const TableOfContentsItem = forwardRef<HTMLAnchorElement, TableOfContentsItemProps>(
+  ({ active = false, className, children, ...props }, ref) => {
+    const stateClasses = active
+      ? KUMO_TABLE_OF_CONTENTS_VARIANTS.state.active.classes
+      : cn(KUMO_TABLE_OF_CONTENTS_VARIANTS.state.default.classes, ITEM_HOVER);
+
+    return (
+      <a
+        ref={ref}
+        aria-current={active ? "true" : undefined}
+        className={cn(ITEM_BASE, stateClasses, className)}
+        {...props}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            INDICATOR_BASE,
+            active ? "opacity-100" : "opacity-0 group-hover:opacity-60",
+          )}
+        />
+        <span className="block min-w-0 leading-5">{children}</span>
+      </a>
+    );
+  },
+);
+
+export interface TableOfContentsGroupProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "title"
+> {
+  /** Label displayed above the group's items. */
+  label: string;
+  /** URL the group label links to. */
+  href?: string;
+}
+
+const TableOfContentsGroup = forwardRef<HTMLDivElement, TableOfContentsGroupProps>(
+  ({ label, href, className, children, ...props }, ref) => (
+    <div ref={ref} className={cn("mt-3", className)} {...props}>
+      {href ? (
+        <a
+          href={href}
+          className="mb-1.5 block pl-5 text-xs font-medium text-kumo-subtle no-underline hover:text-kumo-default"
+        >
+          {label}
+        </a>
+      ) : (
+        <p className="mb-1.5 pl-5 text-xs font-medium text-kumo-subtle">{label}</p>
+      )}
+      <div className="space-y-1.5 pl-3">{children}</div>
+    </div>
+  ),
+);
+
+TableOfContentsRoot.displayName = "TableOfContents";
+TableOfContentsTitle.displayName = "TableOfContents.Title";
+TableOfContentsList.displayName = "TableOfContents.List";
+TableOfContentsItem.displayName = "TableOfContents.Item";
+TableOfContentsGroup.displayName = "TableOfContents.Group";
+
+export type TableOfContentsProps = React.HTMLAttributes<HTMLElement>;
+
+/**
+ * TableOfContents — presentational compound component for section navigation.
+ *
+ * Purely visual; all interaction logic (scroll tracking, active state management)
+ * is left to the consumer.
+ *
+ * @example
+ * ```tsx
+ * <TableOfContents>
+ *   <TableOfContents.Title>On this page</TableOfContents.Title>
+ *   <TableOfContents.List>
+ *     <TableOfContents.Item href="#intro" active>Introduction</TableOfContents.Item>
+ *     <TableOfContents.Group label="Getting Started">
+ *       <TableOfContents.Item href="#install">Installation</TableOfContents.Item>
+ *       <TableOfContents.Item href="#setup">Setup</TableOfContents.Item>
+ *     </TableOfContents.Group>
+ *   </TableOfContents.List>
+ * </TableOfContents>
+ * ```
+ */
+export const TableOfContents = Object.assign(TableOfContentsRoot, {
+  Title: TableOfContentsTitle,
+  List: TableOfContentsList,
+  Item: TableOfContentsItem,
+  Group: TableOfContentsGroup,
+});

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -257,6 +257,17 @@ export {
   type SidebarMenuSubButtonProps,
   type SidebarInputProps,
 } from "./components/sidebar";
+export {
+  TableOfContents,
+  type TableOfContentsProps,
+  type TableOfContentsTitleProps,
+  type TableOfContentsListProps,
+  type TableOfContentsItemProps,
+  type TableOfContentsGroupProps,
+  KUMO_TABLE_OF_CONTENTS_VARIANTS,
+  KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS,
+  type KumoTableOfContentsState,
+} from "./components/table-of-contents";
 // PLOP_INJECT_EXPORT
 
 // Utils

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -196,8 +196,11 @@ export default defineConfig(({ mode }) => {
             __dirname,
             "src/components/sidebar/index.ts",
           ),
-          'components/table-of-contents': resolve(__dirname, 'src/components/table-of-contents/index.ts'),
-        // PLOP_INJECT_COMPONENT_ENTRY
+          "components/table-of-contents": resolve(
+            __dirname,
+            "src/components/table-of-contents/index.ts",
+          ),
+          // PLOP_INJECT_COMPONENT_ENTRY
           // Utils entry point
           utils: resolve(__dirname, "src/utils/index.ts"),
           // Primitives entry point (base-ui re-exports)

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -196,7 +196,8 @@ export default defineConfig(({ mode }) => {
             __dirname,
             "src/components/sidebar/index.ts",
           ),
-          // PLOP_INJECT_COMPONENT_ENTRY
+          'components/table-of-contents': resolve(__dirname, 'src/components/table-of-contents/index.ts'),
+        // PLOP_INJECT_COMPONENT_ENTRY
           // Utils entry point
           utils: resolve(__dirname, "src/utils/index.ts"),
           // Primitives entry point (base-ui re-exports)


### PR DESCRIPTION
## Summary

Extracts the sidebar table of contents from docs into a reusable kumo component. All interaction logic stays with the consumer.

## Changes
- Add `TableOfContents` compound component with `Title`, `List`, `Item`, and `Group` sub-components
- `Item` accepts an `active` boolean and renders `aria-current="true"` for screen readers
- `Item` supports `render` prop for custom link components (React Router, Next.js, or buttons)
- `Group` accepts a `label` and optional `href` for organizing items into labeled, indented sections
- Root renders as `<nav aria-label="Table of contents">`
- Refactor the docs site `TableOfContents.tsx` to compose the new kumo primitives for the sidebar layout
- Add docs page with demos
- Add to SidebarNav and HomeGrid

## API
```tsx
<TableOfContents>
  <TableOfContents.Title>On this page</TableOfContents.Title>
  <TableOfContents.List>
    <TableOfContents.Item href="#intro" active>Introduction</TableOfContents.Item>
    <TableOfContents.Item render={<Link to="" />} href="/install">Installation</TableOfContents.Item>
    <TableOfContents.Group label="Getting Started">
      <TableOfContents.Item href="#setup">Setup</TableOfContents.Item>
    </TableOfContents.Group>
  </TableOfContents.List>
</TableOfContents>
```

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: new component, needs human review
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
