### PR TITLE
fix(page header): prevent tab overflow and fix spacing

### DIFF
--- a/.changeset/page-header-tab-overflow.md
+++ b/.changeset/page-header-tab-overflow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix tab overflow in page header block and add overflow scroll handling to tabs component.

--- a/packages/kumo-docs-astro/src/components/kumo/page-header/page-header.tsx
+++ b/packages/kumo-docs-astro/src/components/kumo/page-header/page-header.tsx
@@ -82,7 +82,7 @@ export function PageHeader({
       )}
 
       {tabs && (
-        <div className="flex w-full items-center justify-between border-b border-kumo-line pt-1 pb-3 pl-3">
+        <div className="flex w-full items-center justify-between gap-3 border-b border-kumo-line pt-1 pb-3 overflow-hidden">
           <Tabs
             tabs={tabs}
             selectedValue={defaultTab}
@@ -92,7 +92,7 @@ export function PageHeader({
             }}
           />
 
-          <div className="flex items-center gap-2">{children}</div>
+          <div className="ml-auto flex shrink-0 items-center gap-2">{children}</div>
         </div>
       )}
     </div>

--- a/packages/kumo/src/blocks/page-header/page-header.tsx
+++ b/packages/kumo/src/blocks/page-header/page-header.tsx
@@ -81,7 +81,7 @@ export function PageHeader({
       )}
 
       {tabs && (
-        <div className="flex w-full items-center justify-between border-b border-kumo-line pt-1 pb-3 pl-3">
+        <div className="flex w-full items-center justify-between gap-3 border-b border-kumo-line pt-1 pb-3 overflow-hidden">
           <Tabs
             tabs={tabs}
             selectedValue={defaultTab}
@@ -91,7 +91,7 @@ export function PageHeader({
             }}
           />
 
-          <div className="flex items-center gap-2">{children}</div>
+          <div className="ml-auto flex shrink-0 items-center gap-2">{children}</div>
         </div>
       )}
     </div>

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -156,7 +156,7 @@ export function Tabs({
       <TabsPrimitive.List
         activateOnFocus={activateOnFocus}
         className={cn(
-          "scrollbar-hide relative flex min-w-0 shrink items-stretch",
+          "scrollbar-hide relative flex min-w-0 shrink items-stretch overflow-x-auto overflow-y-hidden",
           isSegmented && "h-9 rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-line/70",
           isUnderline && "h-7 gap-4 border-b border-kumo-ring pb-2",
           listClassName,

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -156,7 +156,7 @@ export function Tabs({
       <TabsPrimitive.List
         activateOnFocus={activateOnFocus}
         className={cn(
-          "scrollbar-hide relative flex min-w-0 shrink items-stretch overflow-x-auto overflow-y-hidden",
+          "no-scrollbar relative flex min-w-0 shrink items-stretch overflow-x-auto overflow-y-hidden",
           isSegmented && "h-9 rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-line/70",
           isUnderline && "h-7 gap-4 border-b border-kumo-ring pb-2",
           listClassName,


### PR DESCRIPTION
 The page header tabs overflow the container when there are many tabs alongside action buttons.

This PR fixes the overflow by adding scroll handling to the tab list and adjusting spacing in the page header block. Also replaces `scrollbar-hide` with `no-scrollbar` utility class .

Before:
<img width="786" height="195" alt="image" src="https://github.com/user-attachments/assets/857998a2-97cf-4d72-96af-1449048dc2a1" />

After:
<img width="775" height="186" alt="image" src="https://github.com/user-attachments/assets/c7631731-8ba6-4e63-8574-5de1923ee9a4" />

### Open question
 Currently the scrollbar is fully hidden. Would a thin overlay scrollbar be preferable to hint at scrollable content? Or a overflow fade?

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->


- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: 
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CSS-only class changes


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
