### PR TITLE
feat: tag component

### DIFF
--- a/.changeset/grumpy-turkeys-make.md
+++ b/.changeset/grumpy-turkeys-make.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+composable tag component for display + actions

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -75,6 +75,7 @@ const componentItems: NavItem[] = [
   { label: "Switch", href: "/components/switch" },
   { label: "Table", href: "/components/table" },
   { label: "Table of Contents", href: "/components/table-of-contents" },
+  { label: "Tag", href: "/components/tag" },
   { label: "Tabs", href: "/components/tabs" },
   { label: "Text", href: "/components/text" },
   { label: "Toast", href: "/components/toast" },

--- a/packages/kumo-docs-astro/src/components/demos/TagDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TagDemo.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import { DropdownMenu, Popover, Tag, Tooltip, TooltipProvider } from "@cloudflare/kumo";
+import {
+  GlobeSimpleIcon,
+  StackIcon,
+  ShieldCheckIcon,
+  DiamondIcon,
+  FunnelIcon,
+  TrashIcon,
+  ArrowSquareOutIcon,
+} from "@phosphor-icons/react";
+
+/** Basic static tags with text only. */
+export function TagBasicDemo() {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Tag>Personal Website</Tag>
+      <Tag>devportal</Tag>
+      <Tag>website-assets</Tag>
+    </div>
+  );
+}
+
+/** Tags with leading icons indicating resource type. */
+export function TagWithIconDemo() {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Tag icon={<GlobeSimpleIcon size={14} />}>Personal Website</Tag>
+      <Tag icon={<DiamondIcon size={14} />}>devportal</Tag>
+      <Tag icon={<StackIcon size={14} />}>website-assets</Tag>
+      <Tag icon={<ShieldCheckIcon size={14} />}>security-routing</Tag>
+    </div>
+  );
+}
+
+/** Tags with a dismiss button that actually removes them. */
+export function TagDismissibleDemo() {
+  const [tags, setTags] = useState([
+    { label: "Personal Website" },
+    { label: "devportal" },
+    { label: "website-assets", icon: true },
+  ]);
+
+  const remove = (label: string) => setTags((prev) => prev.filter((tag) => tag.label !== label));
+
+  if (tags.length === 0) {
+    return <p className="text-sm text-kumo-subtle">No tags!</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <Tag
+          key={tag.label}
+          icon={tag.icon ? <StackIcon size={14} /> : undefined}
+          onDismiss={() => remove(tag.label)}
+        >
+          {tag.label}
+        </Tag>
+      ))}
+    </div>
+  );
+}
+
+/** Tag composed with DropdownMenu and Tooltip. */
+export function TagClickableDemo() {
+  const [regionSelected, setRegionSelected] = useState(false);
+  const [stagingVisible, setStagingVisible] = useState(true);
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-wrap items-center gap-2">
+        <DropdownMenu>
+          <Tag.Root>
+            <DropdownMenu.Trigger render={<Tag.Main>production</Tag.Main>} />
+          </Tag.Root>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>
+              <FunnelIcon size={14} />
+              Filter by tag
+            </DropdownMenu.Item>
+            <DropdownMenu.Item>
+              <ArrowSquareOutIcon size={14} />
+              Go to tag overview
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item className="text-kumo-danger">
+              <TrashIcon size={14} />
+              Remove tag
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+        <Tooltip content="Region: US East 1" asChild>
+          <Tag
+            icon={<GlobeSimpleIcon size={14} />}
+            onClick={() => setRegionSelected((prev) => !prev)}
+          >
+            us-east-1
+          </Tag>
+        </Tooltip>
+        {regionSelected && <span className="text-sm text-kumo-subtle">Region selected</span>}
+        {stagingVisible ? (
+          <Popover>
+            <Tag.Root dismissible aria-label="staging tag">
+              <Popover.Trigger asChild>
+                <Tag.Main>staging</Tag.Main>
+              </Popover.Trigger>
+              <Tag.Dismiss
+                dismissLabel="Dismiss staging"
+                onClick={() => setStagingVisible(false)}
+              />
+            </Tag.Root>
+            <Popover.Content>
+              <Popover.Title>Tag details</Popover.Title>
+              <Popover.Description>
+                Status: staging. Use dismiss to remove this tag.
+              </Popover.Description>
+            </Popover.Content>
+          </Popover>
+        ) : (
+          <span className="text-sm text-kumo-subtle">Staging dismissed</span>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+/** Tags with a key prefix. */
+export function TagKeyDemo() {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Tag tagKey="ENV">production</Tag>
+      <Tag tagKey="REGION" icon={<GlobeSimpleIcon size={14} />}>
+        us-east-1
+      </Tag>
+      <Tag tagKey="STATUS">active</Tag>
+    </div>
+  );
+}
+
+/** Tags with a split aside section. */
+export function TagAsideDemo() {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Tag icon={<DiamondIcon size={14} />} aside="999">
+        production
+      </Tag>
+      <Tag
+        tagKey="KEY"
+        icon={<DiamondIcon size={14} />}
+        aside={
+          <>
+            <DiamondIcon size={12} /> 999
+          </>
+        }
+      >
+        All tags
+      </Tag>
+    </div>
+  );
+}
+
+/** Disabled tags. */
+export function TagDisabledDemo() {
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        <Tag disabled>Locked</Tag>
+        <Tag disabled>Cannot edit</Tag>
+        <Tag disabled>Cannot remove</Tag>
+      </div>
+    </>
+  );
+}

--- a/packages/kumo-docs-astro/src/components/demos/TagDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TagDemo.tsx
@@ -53,6 +53,7 @@ export function TagDismissibleDemo() {
         <Tag
           key={tag.label}
           icon={tag.icon ? <StackIcon size={14} /> : undefined}
+          dismissLabel={`Dismiss ${tag.label}`}
           onDismiss={() => remove(tag.label)}
         >
           {tag.label}

--- a/packages/kumo-docs-astro/src/pages/components/tag.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tag.mdx
@@ -1,0 +1,135 @@
+---
+layout: ~/layouts/MdxDocLayout.astro
+title: "Tag"
+description: "Compact interactive token for filter chips, resource tags, multi-select tokens, and key:value displays."
+sourceFile: "components/tag"
+---
+
+import ComponentExample from "~/components/docs/ComponentExample.astro";
+import ComponentSection from "~/components/docs/ComponentSection.astro";
+import Heading from "~/components/docs/Heading.astro";
+import PropsTable from "~/components/docs/PropsTable.astro";
+import {
+  TagBasicDemo,
+  TagWithIconDemo,
+  TagDismissibleDemo,
+  TagClickableDemo,
+  TagKeyDemo,
+  TagAsideDemo,
+  TagDisabledDemo,
+} from "~/components/demos/TagDemo";
+
+{/* Hero Demo */}
+
+<ComponentSection>
+  <ComponentExample demo="TagWithIconDemo">
+    <TagWithIconDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+{/* Installation */}
+
+<ComponentSection>
+  <Heading level={2}>Installation</Heading>
+  <Heading level={3}>Barrel</Heading>
+
+```tsx
+import { Tag } from "@cloudflare/kumo";
+```
+
+<Heading level={3}>Granular</Heading>
+
+```tsx
+import { Tag } from "@cloudflare/kumo/components/tag";
+```
+
+</ComponentSection>
+
+{/* Usage */}
+
+<ComponentSection>
+  <Heading level={2}>Usage</Heading>
+
+```tsx
+import { Tag } from "@cloudflare/kumo";
+import { GlobeSimpleIcon } from "@phosphor-icons/react";
+
+export default function Example() {
+  return (
+    <div className="flex gap-2">
+      <Tag>production</Tag>
+      <Tag icon={<GlobeSimpleIcon size={14} />} onDismiss={() => remove()}>
+        us-east-1
+      </Tag>
+      <Tag tagKey="ENV" aside="3">
+        staging
+      </Tag>
+    </div>
+  );
+}
+```
+
+<p>
+  Tag sits between Badge (static label) and Button (full action). It renders the
+  visual shell and accepts interaction props — `onClick` makes it clickable,
+  `onDismiss` adds a dismiss button. All interaction logic is the consumer's
+  responsibility.
+</p>
+
+</ComponentSection>
+
+{/* Examples */}
+
+<ComponentSection>
+  <Heading level={2}>Examples</Heading>
+
+<Heading level={3}>Basic</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagBasicDemo">
+  <TagBasicDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>With icon</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagWithIconDemo">
+  <TagWithIconDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Dismissible</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagDismissibleDemo">
+  <TagDismissibleDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Composition</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagClickableDemo">
+  <TagClickableDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Key prefix</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagKeyDemo">
+  <TagKeyDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Aside section</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagAsideDemo">
+  <TagAsideDemo client:visible />
+</ComponentExample>
+
+<Heading level={3}>Disabled</Heading>
+<p>placeholder</p>
+<ComponentExample demo="TagDisabledDemo">
+  <TagDisabledDemo client:visible />
+</ComponentExample>
+
+</ComponentSection>
+
+{/* API Reference */}
+
+<ComponentSection>
+  <Heading level={2}>API Reference</Heading>
+  <PropsTable component="Tag" />
+</ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/tag.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tag.mdx
@@ -58,7 +58,11 @@ export default function Example() {
   return (
     <div className="flex gap-2">
       <Tag>production</Tag>
-      <Tag icon={<GlobeSimpleIcon size={14} />} onDismiss={() => remove()}>
+      <Tag
+        icon={<GlobeSimpleIcon size={14} />}
+        dismissLabel="Dismiss us-east-1"
+        onDismiss={() => remove()}
+      >
         us-east-1
       </Tag>
       <Tag tagKey="ENV" aside="3">

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -203,6 +203,10 @@
       "types": "./dist/src/components/table-of-contents/index.d.ts",
       "import": "./dist/components/table-of-contents.js"
     },
+    "./components/tag": {
+      "types": "./dist/src/components/tag/index.d.ts",
+      "import": "./dist/components/tag.js"
+    },
     "./utils": {
       "types": "./dist/src/utils/index.d.ts",
       "import": "./dist/utils.js"

--- a/packages/kumo/src/components/tag/index.ts
+++ b/packages/kumo/src/components/tag/index.ts
@@ -1,0 +1,11 @@
+export {
+  Tag,
+  type TagProps,
+  type TagRootProps,
+  type TagMainProps,
+  type TagLabelProps,
+  type TagDismissProps,
+  KUMO_TAG_VARIANTS,
+  KUMO_TAG_DEFAULT_VARIANTS,
+  type KumoTagVariant,
+} from "./tag";

--- a/packages/kumo/src/components/tag/tag.tsx
+++ b/packages/kumo/src/components/tag/tag.tsx
@@ -1,0 +1,308 @@
+import {
+  type KeyboardEvent,
+  type MouseEventHandler,
+  type ReactNode,
+  forwardRef,
+} from "react";
+import { XIcon } from "@phosphor-icons/react";
+import { cn } from "../../utils/cn";
+
+export const KUMO_TAG_VARIANTS = {
+  variant: {
+    default: {
+      classes: "bg-kumo-overlay ring-1 ring-kumo-line",
+      description: "Standard tag",
+    },
+  },
+} as const;
+
+export const KUMO_TAG_DEFAULT_VARIANTS = {
+  variant: "default",
+} as const;
+
+export type KumoTagVariant = keyof typeof KUMO_TAG_VARIANTS.variant;
+
+const TAG_BASE =
+  "inline-flex h-6 max-w-[320px] shrink-0 items-center gap-2.5 rounded-sm bg-kumo-overlay text-sm ring-1 ring-kumo-line";
+
+const TAG_CLICKABLE =
+  "cursor-pointer hover:bg-kumo-tint focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-kumo-brand";
+
+const MAIN_BUTTON =
+  "inline-flex min-w-0 items-center gap-1 rounded-sm bg-transparent p-0 [font:inherit] leading-4 text-kumo-default outline-none cursor-pointer disabled:cursor-not-allowed";
+
+const DISMISS_BUTTON =
+  "flex cursor-pointer items-center rounded-md bg-transparent p-1 text-kumo-subtle transition-colors hover:bg-kumo-control hover:text-kumo-default hover:outline hover:outline-1 hover:outline-kumo-line hover:[&>svg]:scale-110 focus-visible:bg-kumo-interact focus-visible:text-kumo-default focus-visible:outline focus-visible:outline-1 focus-visible:outline-kumo-brand [&>svg]:transition-transform [&>svg]:duration-150 disabled:cursor-not-allowed";
+
+const FOCUS_RING_PRIMARY =
+  "[&:has(>button:first-child:focus-visible)]:outline [&:has(>button:first-child:focus-visible)]:outline-2 [&:has(>button:first-child:focus-visible)]:outline-offset-1 [&:has(>button:first-child:focus-visible)]:outline-kumo-brand";
+
+const HOVER_PRIMARY =
+  "[&:has(>button:first-child)]:hover:bg-kumo-tint [&:has(>button:first-child:disabled)]:hover:bg-kumo-overlay";
+
+interface TagVisualProps {
+  /** Leading icon before the label. */
+  icon?: ReactNode;
+  /** Key prefix displayed before the label (e.g. "KEY: label"). */
+  tagKey?: string;
+  /** Content rendered in the aside section, separated by a divider. */
+  aside?: ReactNode;
+}
+
+const TagVisual = ({
+  icon,
+  tagKey,
+  aside,
+  children,
+}: TagVisualProps & { children?: ReactNode }) => (
+  <>
+    {icon && <span className="shrink-0">{icon}</span>}
+    {tagKey && (
+      <span className="shrink-0 font-medium text-kumo-subtle">{tagKey}:</span>
+    )}
+    <span className="truncate">{children}</span>
+    {aside && (
+      <>
+        <span aria-hidden="true" className="h-3 w-px shrink-0 bg-kumo-line" />
+        <span className="inline-flex shrink-0 items-center gap-1">{aside}</span>
+      </>
+    )}
+  </>
+);
+
+export interface TagLabelProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    TagVisualProps {
+  children?: ReactNode;
+}
+
+const TagLabel = forwardRef<HTMLSpanElement, TagLabelProps>(
+  ({ icon, tagKey, aside, children, className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn("inline-flex min-w-0 items-center gap-1", className)}
+      {...props}
+    >
+      <TagVisual icon={icon} tagKey={tagKey} aside={aside}>
+        {children}
+      </TagVisual>
+    </span>
+  ),
+);
+
+export interface TagRootProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Adds space for the dismiss button and main-focus outer ring behavior. */
+  dismissible?: boolean;
+  disabled?: boolean;
+}
+
+const TagRoot = forwardRef<HTMLSpanElement, TagRootProps>(
+  ({ dismissible = false, disabled = false, className, ...props }, ref) => (
+    <span
+      ref={ref}
+      role={dismissible ? "group" : undefined}
+      aria-disabled={disabled || undefined}
+      className={cn(
+        TAG_BASE,
+        dismissible ? "pl-2 pr-[3px]" : "pl-2 pr-2",
+        HOVER_PRIMARY,
+        FOCUS_RING_PRIMARY,
+        disabled && "opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+export interface TagMainProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    TagVisualProps {
+  children?: ReactNode;
+}
+
+const TagMain = forwardRef<HTMLButtonElement, TagMainProps>(
+  ({ type, className, icon, tagKey, aside, children, ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type ?? "button"}
+      className={cn(MAIN_BUTTON, "max-w-[284px]", className)}
+      {...props}
+    >
+      <TagVisual icon={icon} tagKey={tagKey} aside={aside}>
+        {children}
+      </TagVisual>
+    </button>
+  ),
+);
+
+export interface TagDismissProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  /** Accessible label announced by assistive technology. */
+  dismissLabel?: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+const TagDismiss = forwardRef<HTMLButtonElement, TagDismissProps>(
+  (
+    {
+      type,
+      className,
+      dismissLabel = "Dismiss",
+      onMouseDown,
+      onClick,
+      children,
+      ...props
+    },
+    ref,
+  ) => (
+    <button
+      ref={ref}
+      type={type ?? "button"}
+      aria-label={dismissLabel}
+      className={cn(DISMISS_BUTTON, className)}
+      onMouseDown={(event) => {
+        onMouseDown?.(event);
+        if (!event.defaultPrevented) {
+          event.preventDefault();
+        }
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick?.(event);
+      }}
+      {...props}
+    >
+      {children ?? <XIcon size={11} />}
+    </button>
+  ),
+);
+
+export interface TagProps {
+  children: ReactNode;
+  icon?: ReactNode;
+  tagKey?: string;
+  aside?: ReactNode;
+  onClick?: () => void;
+  onDismiss?: () => void;
+  dismissLabel?: string;
+  disabled?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const TagBase = forwardRef<HTMLElement, TagProps>(
+  (
+    {
+      children,
+      icon,
+      tagKey,
+      aside,
+      onClick,
+      onDismiss,
+      dismissLabel = "Dismiss",
+      disabled = false,
+      className,
+      "aria-label": ariaLabel,
+      ...rest
+    },
+    ref,
+  ) => {
+    const isDismissible = !!onDismiss;
+    const hasMainAction = !!onClick;
+
+    const onMainKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+      if (disabled || !onDismiss) return;
+      if (event.key === "Backspace" || event.key === "Delete") {
+        event.preventDefault();
+        onDismiss();
+      }
+    };
+
+    if (!hasMainAction && !isDismissible) {
+      return (
+        <TagRoot
+          ref={ref as React.Ref<HTMLSpanElement>}
+          disabled={disabled}
+          className={className}
+          aria-label={ariaLabel}
+          {...rest}
+        >
+          <TagLabel icon={icon} tagKey={tagKey} aside={aside}>
+            {children}
+          </TagLabel>
+        </TagRoot>
+      );
+    }
+
+    if (hasMainAction && !isDismissible) {
+      return (
+        <button
+          ref={ref as React.Ref<HTMLButtonElement>}
+          type="button"
+          disabled={disabled}
+          onClick={onClick}
+          className={cn(
+            TAG_BASE,
+            "pl-2 pr-2",
+            TAG_CLICKABLE,
+            disabled && "opacity-50",
+            className,
+          )}
+          aria-label={ariaLabel}
+          {...rest}
+        >
+          <TagLabel icon={icon} tagKey={tagKey} aside={aside}>
+            {children}
+          </TagLabel>
+        </button>
+      );
+    }
+
+    return (
+      <TagRoot
+        ref={ref as React.Ref<HTMLSpanElement>}
+        dismissible
+        disabled={disabled}
+        className={className}
+        aria-label={ariaLabel}
+        {...rest}
+      >
+        {hasMainAction ? (
+          <TagMain
+            disabled={disabled}
+            onClick={onClick}
+            onKeyDown={onMainKeyDown}
+            icon={icon}
+            tagKey={tagKey}
+            aside={aside}
+          >
+            {children}
+          </TagMain>
+        ) : (
+          <TagLabel icon={icon} tagKey={tagKey} aside={aside}>
+            {children}
+          </TagLabel>
+        )}
+        <TagDismiss
+          disabled={disabled}
+          dismissLabel={dismissLabel}
+          onClick={() => onDismiss?.()}
+        />
+      </TagRoot>
+    );
+  },
+);
+
+TagBase.displayName = "Tag";
+TagRoot.displayName = "Tag.Root";
+TagLabel.displayName = "Tag.Label";
+TagMain.displayName = "Tag.Main";
+TagDismiss.displayName = "Tag.Dismiss";
+
+export const Tag = Object.assign(TagBase, {
+  Root: TagRoot,
+  Main: TagMain,
+  Label: TagLabel,
+  Dismiss: TagDismiss,
+});

--- a/packages/kumo/src/components/tag/tag.tsx
+++ b/packages/kumo/src/components/tag/tag.tsx
@@ -32,7 +32,7 @@ const MAIN_BUTTON =
   "inline-flex min-w-0 items-center gap-1 rounded-sm bg-transparent p-0 [font:inherit] leading-4 text-kumo-default outline-none cursor-pointer disabled:cursor-not-allowed";
 
 const DISMISS_BUTTON =
-  "flex cursor-pointer items-center rounded-md bg-transparent p-1 text-kumo-subtle hover:bg-kumo-control hover:text-kumo-default focus-visible:bg-kumo-interact focus-visible:text-kumo-default focus-visible:outline focus-visible:outline-1 focus-visible:outline-kumo-brand disabled:cursor-not-allowed";
+  "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-sm bg-transparent text-kumo-subtle hover:bg-kumo-control hover:text-kumo-default focus-visible:bg-kumo-interact focus-visible:text-kumo-default focus-visible:outline focus-visible:outline-1 focus-visible:outline-kumo-brand disabled:cursor-not-allowed";
 
 const FOCUS_RING_PRIMARY =
   "[&:has(>button:first-child:focus-visible)]:outline [&:has(>button:first-child:focus-visible)]:outline-2 [&:has(>button:first-child:focus-visible)]:outline-offset-1 [&:has(>button:first-child:focus-visible)]:outline-kumo-brand";
@@ -56,7 +56,11 @@ const TagVisual = ({
   children,
 }: TagVisualProps & { children?: ReactNode }) => (
   <>
-    {icon && <span className="shrink-0">{icon}</span>}
+    {icon && (
+      <span aria-hidden="true" className="shrink-0">
+        {icon}
+      </span>
+    )}
     {tagKey && (
       <span className="shrink-0 font-medium text-kumo-subtle">{tagKey}:</span>
     )}
@@ -93,21 +97,18 @@ const TagLabel = forwardRef<HTMLSpanElement, TagLabelProps>(
 export interface TagRootProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Adds space for the dismiss button and main-focus outer ring behavior. */
   dismissible?: boolean;
-  disabled?: boolean;
 }
 
 const TagRoot = forwardRef<HTMLSpanElement, TagRootProps>(
-  ({ dismissible = false, disabled = false, className, ...props }, ref) => (
+  ({ dismissible = false, className, ...props }, ref) => (
     <span
       ref={ref}
       role={dismissible ? "group" : undefined}
-      aria-disabled={disabled || undefined}
       className={cn(
         TAG_BASE,
         dismissible ? "pl-2 pr-[3px]" : "pl-2 pr-2",
         HOVER_PRIMARY,
         FOCUS_RING_PRIMARY,
-        disabled && "opacity-50",
         className,
       )}
       {...props}
@@ -173,22 +174,31 @@ const TagDismiss = forwardRef<HTMLButtonElement, TagDismissProps>(
       }}
       {...props}
     >
-      {children ?? <XIcon size={11} />}
+      {children ?? <XIcon aria-hidden="true" size={11} />}
     </button>
   ),
 );
 
-export interface TagProps {
+export interface TagProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, "children" | "onClick"> {
   children: ReactNode;
   icon?: ReactNode;
   tagKey?: string;
   aside?: ReactNode;
-  onClick?: () => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   onDismiss?: () => void;
   dismissLabel?: string;
   disabled?: boolean;
-  className?: string;
-  "aria-label"?: string;
+}
+
+function getDefaultDismissLabel(children: ReactNode, tagKey?: string) {
+  const label =
+    typeof children === "string" || typeof children === "number"
+      ? String(children).trim()
+      : "";
+
+  if (!label) return "Dismiss";
+  return `Dismiss ${tagKey ? `${tagKey}: ` : ""}${label}`;
 }
 
 const TagBase = forwardRef<HTMLElement, TagProps>(
@@ -200,7 +210,7 @@ const TagBase = forwardRef<HTMLElement, TagProps>(
       aside,
       onClick,
       onDismiss,
-      dismissLabel = "Dismiss",
+      dismissLabel,
       disabled = false,
       className,
       "aria-label": ariaLabel,
@@ -210,6 +220,8 @@ const TagBase = forwardRef<HTMLElement, TagProps>(
   ) => {
     const isDismissible = !!onDismiss;
     const hasMainAction = !!onClick;
+    const resolvedDismissLabel =
+      dismissLabel ?? getDefaultDismissLabel(children, tagKey);
 
     const onMainKeyDown = (event: KeyboardEvent<HTMLElement>) => {
       if (disabled || !onDismiss) return;
@@ -223,8 +235,8 @@ const TagBase = forwardRef<HTMLElement, TagProps>(
       return (
         <TagRoot
           ref={ref as React.Ref<HTMLSpanElement>}
-          disabled={disabled}
-          className={className}
+          aria-disabled={disabled || undefined}
+          className={cn(disabled && "opacity-50", className)}
           aria-label={ariaLabel}
           {...rest}
         >
@@ -263,8 +275,8 @@ const TagBase = forwardRef<HTMLElement, TagProps>(
       <TagRoot
         ref={ref as React.Ref<HTMLSpanElement>}
         dismissible
-        disabled={disabled}
-        className={className}
+        aria-disabled={disabled || undefined}
+        className={cn(disabled && "opacity-50", className)}
         aria-label={ariaLabel}
         {...rest}
       >
@@ -286,7 +298,7 @@ const TagBase = forwardRef<HTMLElement, TagProps>(
         )}
         <TagDismiss
           disabled={disabled}
-          dismissLabel={dismissLabel}
+          dismissLabel={resolvedDismissLabel}
           onClick={() => onDismiss?.()}
         />
       </TagRoot>

--- a/packages/kumo/src/components/tag/tag.tsx
+++ b/packages/kumo/src/components/tag/tag.tsx
@@ -10,7 +10,7 @@ import { cn } from "../../utils/cn";
 export const KUMO_TAG_VARIANTS = {
   variant: {
     default: {
-      classes: "bg-kumo-overlay ring-1 ring-kumo-line",
+      classes: "bg-kumo-recessed ring-1 ring-kumo-line",
       description: "Standard tag",
     },
   },
@@ -23,22 +23,22 @@ export const KUMO_TAG_DEFAULT_VARIANTS = {
 export type KumoTagVariant = keyof typeof KUMO_TAG_VARIANTS.variant;
 
 const TAG_BASE =
-  "inline-flex h-6 max-w-[320px] shrink-0 items-center gap-2.5 rounded-sm bg-kumo-overlay text-sm ring-1 ring-kumo-line";
+  "inline-flex h-6 max-w-[320px] shrink-0 items-center gap-2.5 rounded-sm bg-kumo-recessed text-sm ring-1 ring-kumo-line";
 
 const TAG_CLICKABLE =
-  "cursor-pointer hover:bg-kumo-tint focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-kumo-brand";
+  "cursor-pointer hover:bg-kumo-fill-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-kumo-brand";
 
 const MAIN_BUTTON =
   "inline-flex min-w-0 items-center gap-1 rounded-sm bg-transparent p-0 [font:inherit] leading-4 text-kumo-default outline-none cursor-pointer disabled:cursor-not-allowed";
 
 const DISMISS_BUTTON =
-  "flex cursor-pointer items-center rounded-md bg-transparent p-1 text-kumo-subtle transition-colors hover:bg-kumo-control hover:text-kumo-default hover:outline hover:outline-1 hover:outline-kumo-line hover:[&>svg]:scale-110 focus-visible:bg-kumo-interact focus-visible:text-kumo-default focus-visible:outline focus-visible:outline-1 focus-visible:outline-kumo-brand [&>svg]:transition-transform [&>svg]:duration-150 disabled:cursor-not-allowed";
+  "flex cursor-pointer items-center rounded-md bg-transparent p-1 text-kumo-subtle hover:bg-kumo-control hover:text-kumo-default focus-visible:bg-kumo-interact focus-visible:text-kumo-default focus-visible:outline focus-visible:outline-1 focus-visible:outline-kumo-brand disabled:cursor-not-allowed";
 
 const FOCUS_RING_PRIMARY =
   "[&:has(>button:first-child:focus-visible)]:outline [&:has(>button:first-child:focus-visible)]:outline-2 [&:has(>button:first-child:focus-visible)]:outline-offset-1 [&:has(>button:first-child:focus-visible)]:outline-kumo-brand";
 
 const HOVER_PRIMARY =
-  "[&:has(>button:first-child)]:hover:bg-kumo-tint [&:has(>button:first-child:disabled)]:hover:bg-kumo-overlay";
+  "[&:has(>button:first-child)]:hover:bg-kumo-fill-hover [&:has(>button:first-child:disabled)]:hover:bg-kumo-recessed";
 
 interface TagVisualProps {
   /** Leading icon before the label. */

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -307,6 +307,17 @@ export {
   KUMO_TABLE_OF_CONTENTS_DEFAULT_VARIANTS,
   type KumoTableOfContentsState,
 } from "./components/table-of-contents";
+export {
+  Tag,
+  type TagProps,
+  type TagRootProps,
+  type TagMainProps,
+  type TagLabelProps,
+  type TagDismissProps,
+  KUMO_TAG_VARIANTS,
+  KUMO_TAG_DEFAULT_VARIANTS,
+  type KumoTagVariant,
+} from "./components/tag";
 // PLOP_INJECT_EXPORT
 
 // Utils

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -208,6 +208,10 @@ export default defineConfig(({ mode }) => {
             __dirname,
             "src/components/table-of-contents/index.ts",
           ),
+          "components/tag": resolve(
+            __dirname,
+            "src/components/tag/index.ts",
+          ),
           // PLOP_INJECT_COMPONENT_ENTRY
           // Utils entry point
           utils: resolve(__dirname, "src/utils/index.ts"),


### PR DESCRIPTION
## Summary

WIP 

`Tag` component.

- simple 'oneshot' element as `<Tag />`, or compound component `<Tag.Root>...` for more complex iteractions e.g. triggerable actions
- keyboard accessible for interactive elements
-  dismissable
- optional icon, key prefix, and split/aside content


### TODO: 
- variants
- tests
- 

## Demo
![tags_demo](https://github.com/user-attachments/assets/bf704b4a-e1b6-47a8-866a-99886ee4d526)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: 
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
