### PR TITLE
fix(dropdown): pass children through when render prop is provided

### DIFF
--- a/.changeset/fix-dropdown-trigger-children.md
+++ b/.changeset/fix-dropdown-trigger-children.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(dropdown): pass children through when render prop is provided on DropdownMenu.Trigger

--- a/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
@@ -144,6 +144,33 @@ export function DropdownNestedDemo() {
 }
 
 /**
+ * Demonstrates using the render prop with children to compose a custom trigger
+ * that contains other elements. The render prop provides the trigger element,
+ * while children are rendered inside it.
+ */
+export function DropdownAvatarTriggerDemo() {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger
+        render={<button type="button" className="rounded-full" />}
+      >
+        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-kumo-brand text-sm font-medium text-white">
+          MR
+        </span>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item icon={UserIcon}>Profile</DropdownMenu.Item>
+        <DropdownMenu.Item icon={GearIcon}>Settings</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item icon={SignOutIcon} variant="danger">
+          Log out
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+/**
  * Demonstrates the new LinkItem component for navigation links.
  * Use LinkItem instead of Item with href for cleaner, more semantic links.
  */

--- a/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
@@ -14,6 +14,7 @@ import {
   DropdownBasicDemo,
   DropdownCheckboxDemo,
   DropdownNestedDemo,
+  DropdownAvatarTriggerDemo,
   DropdownLinkItemDemo,
 } from "~/components/demos/DropdownDemo";
 
@@ -94,6 +95,16 @@ export default function Example() {
 </p>
 <ComponentExample demo="DropdownNestedDemo">
   <DropdownNestedDemo client:load />
+</ComponentExample>
+
+<Heading level={3}>Custom Trigger with Avatar</Heading>
+<p>
+  Use the `render` prop to customize the trigger element while passing children
+  to render inside it. This is useful when you need a non-button trigger (like
+  an avatar) wrapped in an accessible button element.
+</p>
+<ComponentExample demo="DropdownAvatarTriggerDemo">
+  <DropdownAvatarTriggerDemo client:load />
 </ComponentExample>
 
 <Heading level={3}>Navigation Links</Heading>

--- a/packages/kumo/src/components/dropdown/dropdown.tsx
+++ b/packages/kumo/src/components/dropdown/dropdown.tsx
@@ -425,25 +425,34 @@ DropdownMenuRadioItemIndicator.displayName = "DropdownMenuRadioItemIndicator";
 /**
  * Custom Trigger that converts a single child element to the `render` prop
  * to avoid nested button issues with base-ui's Menu.Trigger.
+ *
+ * When an explicit `render` prop is provided, children are passed through
+ * to the rendered element.
  */
 const DropdownMenuTrigger = React.forwardRef<
   HTMLButtonElement,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
 >(({ children, render, ...props }, ref) => {
-  // If render prop is provided, use it directly
-  // Otherwise, convert single child element to render prop
+  // If render prop is explicitly provided, use it and pass children through
+  if (render) {
+    return (
+      <DropdownMenuPrimitive.Trigger ref={ref} {...props} render={render}>
+        {children}
+      </DropdownMenuPrimitive.Trigger>
+    );
+  }
+
+  // Otherwise, auto-promote single child element to render prop
   const childElement = React.isValidElement(children) ? children : null;
-  const effectiveRender = render ?? childElement;
 
   return (
     <DropdownMenuPrimitive.Trigger
       ref={ref}
       {...props}
-      {...(effectiveRender && {
-        render: effectiveRender as React.ReactElement<Record<string, unknown>>,
+      {...(childElement && {
+        render: childElement as React.ReactElement<Record<string, unknown>>,
       })}
     >
-      {/* Only pass children if not using as render prop */}
       {childElement ? undefined : children}
     </DropdownMenuPrimitive.Trigger>
   );


### PR DESCRIPTION
Fixes #367

## Summary

`DropdownMenu.Trigger` now correctly passes children through to the rendered element when an explicit `render` prop is provided.

## The Problem

`DropdownMenu.Trigger` has a convenience behavior that auto-promotes a single React element child to Base UI's `render` prop. This replaces the default `<button>` with that element, which is useful when you want a custom button as your trigger:

```tsx
// This works - Button becomes the trigger element
<DropdownMenu.Trigger>
  <Button>Open Menu</Button>
</DropdownMenu.Trigger>
```

However, there was a bug: **when an explicit `render` prop was provided alongside children, the children were silently dropped.**

### Before (broken)

```tsx
// Intent: render a <button> containing an avatar
<DropdownMenu.Trigger
  render={<button type="button" className="rounded-full" />}
>
  <Avatar><AvatarFallback>MR</AvatarFallback></Avatar>
</DropdownMenu.Trigger>
```

**Expected:** A `<button>` wrapping the Avatar.  
**Actual:** An empty `<button>` - the Avatar children were dropped.

### Root Cause

The original implementation:

```tsx
const childElement = React.isValidElement(children) ? children : null;
const effectiveRender = render ?? childElement;

return (
  <DropdownMenuPrimitive.Trigger
    {...(effectiveRender && { render: effectiveRender })}
  >
    {childElement ? undefined : children}  // ← BUG: drops children when childElement is truthy
  </DropdownMenuPrimitive.Trigger>
);
```

The condition `childElement ? undefined : children` was meant to prevent passing children when they were auto-promoted to `render`. But it also dropped children when an explicit `render` prop was provided, because `childElement` would still be truthy.

## The Fix

Now we handle the explicit `render` prop case separately:

```tsx
// If render prop is explicitly provided, use it and pass children through
if (render) {
  return (
    <DropdownMenuPrimitive.Trigger render={render}>
      {children}  // ← Children are preserved
    </DropdownMenuPrimitive.Trigger>
  );
}

// Otherwise, auto-promote single child element to render prop (existing behavior)
const childElement = React.isValidElement(children) ? children : null;
// ...
```

## Why This Is Non-Breaking

1. **Existing auto-promotion behavior is unchanged** - Single React element children still get promoted to `render` prop automatically
2. **Explicit `render` prop now works correctly** - Children are passed through as expected
3. **No API changes** - Same props, same types, same usage patterns

## New Documentation

Added a "Custom Trigger with Avatar" example showing the `render` prop with children pattern:

```tsx
<DropdownMenu.Trigger
  render={<button type="button" className="rounded-full" />}
>
  <span className="avatar">MR</span>
</DropdownMenu.Trigger>
```

## Bonk

- [x] bonk has reviewed the change

## Tests

- [x] Additional testing not necessary because: Bug fix with new docs example that exercises the fixed behavior. The example would have rendered an empty button before this fix.