### PR TITLE
Fix sidebar collapsible close animation

### DIFF
--- a/.changeset/fix-sidebar-collapsible-close-animation.md
+++ b/.changeset/fix-sidebar-collapsible-close-animation.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix sidebar collapsible content snapping shut instead of animating smoothly when closing.

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -1,3 +1,4 @@
+import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import {
   Sidebar,
@@ -111,5 +112,22 @@ describe("Sidebar", () => {
 
   it("should throw when useSidebar is called outside provider", () => {
     expect(() => useSidebar()).toThrow();
+  });
+
+  it("should preserve measured height on closed sidebar collapsible content until exit transition runs", () => {
+    render(
+      <SidebarCollapsible>
+        <SidebarCollapsibleContent data-testid="sidebar-collapsible-content">
+          Content
+        </SidebarCollapsibleContent>
+      </SidebarCollapsible>,
+    );
+
+    const panel = screen.getByTestId("sidebar-collapsible-content");
+
+    expect(panel.className).toContain("h-[var(--collapsible-panel-height)]");
+    expect(panel.className).toContain("data-[starting-style]:h-0");
+    expect(panel.className).toContain("data-[ending-style]:h-0");
+    expect(panel.className).not.toContain("data-[closed]:h-0");
   });
 });

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1679,8 +1679,8 @@ const SidebarCollapsibleTrigger = CollapsibleBase.Trigger;
  *
  * Animation flow:
  * - **Opening**: `data-starting-style` (h=0) → `data-open` (h=measured) — transition up
- * - **Closing**: `data-open` removed + `data-ending-style` (h=0) — transition down
- * - **Closed**: `data-closed` (h=0) — stays collapsed while mounted
+ * - **Closing**: `data-open` removed, measured height retained until `data-ending-style` (h=0) — transition down
+ * - **Closed**: `data-closed` while hidden/mounted; no extra height override needed
  */
 const SidebarCollapsibleContent = forwardRef<
   HTMLDivElement,
@@ -1691,13 +1691,17 @@ const SidebarCollapsibleContent = forwardRef<
     keepMounted={keepMounted}
     className={cn(
       "overflow-hidden",
-      // Default: show at measured height (when data-open, no override matches)
+      // Default: keep the measured height that Base UI writes to --collapsible-panel-height.
+      // This must also remain true during the initial close frame so the exit transition has
+      // a real starting height before data-ending-style flips it to 0.
       "h-[var(--collapsible-panel-height)]",
       // Transition height — matches production NavGroup easing
       "transition-[height] duration-250 ease-[cubic-bezier(0.77,0,0.175,1)]",
       "motion-reduce:transition-none",
-      // Closed / animating in / animating out: height 0
-      "data-[closed]:h-0 data-[starting-style]:h-0 data-[ending-style]:h-0",
+      // Only force height 0 during the active enter/exit transition phases.
+      // Applying h-0 for data-closed snaps the panel shut before Base UI adds
+      // data-ending-style, skipping the collapse animation.
+      "data-[starting-style]:h-0 data-[ending-style]:h-0",
       className,
     )}
     {...props}


### PR DESCRIPTION

Fix the sidebar collapsible close animation so nested items ease smoothly when collapsing instead of snapping shut. The panel now preserves its measured height until Base UI applies `data-ending-style`, and a regression test covers the sidebar collapsible panel classes.

---

- Reviews
  - [x] automated review not possible because: this is a small transition-state fix and I do not have bonk review for this PR yet.
- Tests
  - [x] Tests included/updated
