### PR TITLE
feat(breadcrumbs): add items-based API with overflow support

### DIFF
--- a/.changeset/breadcrumbs-overflow.md
+++ b/.changeset/breadcrumbs-overflow.md
@@ -1,0 +1,13 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add items-based API with overflow support to Breadcrumbs component
+
+- New `items` prop accepts an array of `BreadcrumbItem` objects for declarative breadcrumb definition
+- New `currentItem` prop for the current page item
+- Automatic overflow detection collapses items that don't fit into a dropdown menu
+- Tree visualization in overflow menu shows breadcrumb hierarchy with L-shaped SVG connectors
+- Support for custom router links via `render` prop on items
+- Loading state support on current item
+- Fully backward compatible - existing compound component API continues to work

--- a/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
@@ -113,9 +113,9 @@ function TreeMenu({ items }: { items: BreadcrumbItem[] }) {
 
   // Keep these in sync with the Menu.Item layout below.
   const ROW_H = 32; // `h-8`
-  const BASE_X = 6; // root spine x (keep left of root label)
-  const INDENT = 14; // per-level indent (relaxed depth)
-  const BRANCH = 6; // horizontal branch into label (shorter)
+  const BASE_X = 12; // root spine x (give room for shifted L starts)
+  const INDENT = 14; // per-level indent
+  const BRANCH = 2; // horizontal branch into label
   const TEXT_GAP = 10; // space between branch and text
 
   const totalHeight = items.length * ROW_H;
@@ -138,7 +138,8 @@ function TreeMenu({ items }: { items: BreadcrumbItem[] }) {
         {items.map((_, i) => {
           if (i === 0) return null;
 
-          const x1 = xLevel(i - 1);
+          // Shift the vertical line left so L appears to start from middle of parent's base
+          const x1 = xLevel(i - 1) - 6;
           const x2 = xLevel(i) + BRANCH;
           const y2 = yCenter(i);
           // Avoid drawing through the root label: start below row 0 for the first connector.

--- a/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
@@ -1,5 +1,12 @@
-import { Breadcrumbs } from "@cloudflare/kumo";
-import { House } from "@phosphor-icons/react";
+import { useRef, useState, useEffect, type ReactNode } from "react";
+import { Breadcrumbs, Button } from "@cloudflare/kumo";
+import { Menu } from "@cloudflare/kumo/primitives/menu";
+import {
+  HouseIcon,
+  DotsThreeIcon,
+  CaretRightIcon,
+  DatabaseIcon,
+} from "@phosphor-icons/react";
 
 export function BreadcrumbsDemo() {
   return (
@@ -16,7 +23,7 @@ export function BreadcrumbsDemo() {
 export function BreadcrumbsWithIconsDemo() {
   return (
     <Breadcrumbs>
-      <Breadcrumbs.Link href="#" icon={<House size={16} />}>
+      <Breadcrumbs.Link href="#" icon={<HouseIcon size={16} />}>
         Home
       </Breadcrumbs.Link>
       <Breadcrumbs.Separator />
@@ -30,7 +37,7 @@ export function BreadcrumbsWithIconsDemo() {
 export function BreadcrumbsLoadingDemo() {
   return (
     <Breadcrumbs>
-      <Breadcrumbs.Link href="#" icon={<House size={16} />}>
+      <Breadcrumbs.Link href="#" icon={<HouseIcon size={16} />}>
         Home
       </Breadcrumbs.Link>
       <Breadcrumbs.Separator />
@@ -44,7 +51,7 @@ export function BreadcrumbsLoadingDemo() {
 export function BreadcrumbsRootDemo() {
   return (
     <Breadcrumbs>
-      <Breadcrumbs.Current icon={<House size={16} />}>
+      <Breadcrumbs.Current icon={<HouseIcon size={16} />}>
         Worker Analytics
       </Breadcrumbs.Current>
     </Breadcrumbs>
@@ -59,5 +66,334 @@ export function BreadcrumbsWithClipboardDemo() {
       <Breadcrumbs.Current>Breadcrumbs</Breadcrumbs.Current>
       <Breadcrumbs.Clipboard text="#" />
     </Breadcrumbs>
+  );
+}
+
+// ============================================================================
+// PROTOTYPE: Overflow Breadcrumbs
+// ============================================================================
+
+type BreadcrumbItem = {
+  label: string;
+  href: string;
+  icon?: ReactNode;
+};
+
+/**
+ * Prototype: Data-driven breadcrumbs with overflow collapse.
+ * Items that don't fit collapse into a dropdown menu.
+ *
+ * API inspired by Blueprint JS:
+ * - `items`: Array of breadcrumb data
+ * - `collapseFrom`: "start" (default) or "end"
+ * - `minVisibleItems`: Minimum items to always show
+ */
+function OverflowBreadcrumbs({
+  items,
+  currentItem,
+  collapseFrom = "start",
+  minVisibleItems = 1,
+  className,
+}: {
+  items: BreadcrumbItem[];
+  currentItem: BreadcrumbItem;
+  collapseFrom?: "start" | "end";
+  minVisibleItems?: number;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [overflowCount, setOverflowCount] = useState(0);
+  const [itemWidths, setItemWidths] = useState<number[]>([]);
+  const [currentItemWidth, setCurrentItemWidth] = useState(0);
+  const [measured, setMeasured] = useState(false);
+
+  // Measure all items once on mount
+  useEffect(() => {
+    if (!measureRef.current) return;
+
+    const measureContainer = measureRef.current;
+    const itemEls = measureContainer.querySelectorAll("[data-measure-item]");
+    const currentEl = measureContainer.querySelector("[data-measure-current]");
+
+    const widths = Array.from(itemEls).map(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const currentWidth = currentEl?.getBoundingClientRect().width ?? 100;
+
+    setItemWidths(widths);
+    setCurrentItemWidth(currentWidth);
+    setMeasured(true);
+  }, [items, currentItem]);
+
+  // Compute overflow based on cached widths
+  useEffect(() => {
+    if (!measured || !containerRef.current) return;
+
+    const computeOverflow = () => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const containerWidth = container.offsetWidth;
+      const overflowButtonWidth = 36;
+      const separatorWidth = 20;
+
+      // Start with space needed for current item only
+      let usedWidth = currentItemWidth;
+      let visibleCount = 0;
+
+      // Measure from the end (items closest to current) to preserve parent context
+      for (let i = items.length - 1; i >= 0; i--) {
+        const itemWidth = itemWidths[i] ?? 80;
+        // Each visible item needs: separator before it + the item itself
+        const neededWidth = separatorWidth + itemWidth;
+
+        // If we have overflow, we need space for the overflow button + its separator
+        const itemsBeforeThis = i;
+        const willHaveOverflow = itemsBeforeThis > 0;
+        const overflowSpace = willHaveOverflow
+          ? overflowButtonWidth + separatorWidth
+          : 0;
+
+        // Check if adding this item (plus overflow button if needed) fits
+        if (usedWidth + neededWidth + overflowSpace <= containerWidth) {
+          usedWidth += neededWidth;
+          visibleCount++;
+        } else {
+          // Can't fit this item - check if we need overflow button space
+          // All remaining items go to overflow
+          break;
+        }
+      }
+
+      // Don't enforce minVisibleItems if it would cause overflow/truncation
+      // Only apply it if there's actually room
+      const overflowNeeded = items.length - visibleCount;
+      if (overflowNeeded > 0 && overflowNeeded < items.length) {
+        // We have some overflow - check if minVisibleItems fits
+        const minVisible = Math.min(minVisibleItems, items.length);
+        if (visibleCount < minVisible) {
+          // Check if forcing minVisibleItems would actually fit
+          let testWidth =
+            currentItemWidth + overflowButtonWidth + separatorWidth;
+          for (let i = items.length - minVisible; i < items.length; i++) {
+            testWidth += separatorWidth + (itemWidths[i] ?? 80);
+          }
+          if (testWidth <= containerWidth) {
+            visibleCount = minVisible;
+          }
+        }
+      }
+
+      setOverflowCount(items.length - visibleCount);
+    };
+
+    computeOverflow();
+
+    const observer = new ResizeObserver(computeOverflow);
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [measured, items.length, itemWidths, currentItemWidth, minVisibleItems]);
+
+  // Split items into overflow and visible
+  const overflowItems =
+    collapseFrom === "start"
+      ? items.slice(0, overflowCount)
+      : items.slice(items.length - overflowCount);
+
+  const visibleItems =
+    collapseFrom === "start"
+      ? items.slice(overflowCount)
+      : items.slice(0, items.length - overflowCount);
+
+  return (
+    <>
+      {/* Hidden measurement container - renders all items to measure their natural width */}
+      <div
+        ref={measureRef}
+        className="pointer-events-none absolute flex items-center gap-1 text-sm opacity-0"
+        aria-hidden
+      >
+        {items.map((item, index) => (
+          <span
+            key={index}
+            data-measure-item
+            className="flex shrink-0 items-center gap-1 whitespace-nowrap"
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </span>
+        ))}
+        <span
+          data-measure-current
+          className="flex shrink-0 items-center gap-1 font-medium whitespace-nowrap"
+        >
+          {currentItem.icon}
+          <span>{currentItem.label}</span>
+        </span>
+      </div>
+
+      <nav
+        ref={containerRef}
+        className={`flex items-center gap-1 overflow-hidden text-sm ${className ?? ""}`}
+        aria-label="Breadcrumb"
+      >
+        {/* Overflow dropdown */}
+        {overflowItems.length > 0 && (
+          <>
+            <Menu.Root>
+              <Menu.Trigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    shape="square"
+                    aria-label="Show collapsed breadcrumbs"
+                    className="shrink-0"
+                  >
+                    <DotsThreeIcon weight="bold" size={16} />
+                  </Button>
+                }
+              />
+              <Menu.Portal>
+                <Menu.Positioner className="z-50">
+                  <Menu.Popup className="bg-kumo-elevated border border-kumo-line rounded-lg shadow-lg py-3 px-4 min-w-48">
+                    {(collapseFrom === "start"
+                      ? overflowItems
+                      : [...overflowItems].reverse()
+                    ).map((item, i, arr) => {
+                      const isLast = i === arr.length - 1;
+                      const indent = i * 20;
+
+                      return (
+                        <div key={i} className="relative flex items-center">
+                          {/* Vertical line - runs full height except stops at middle on last item */}
+                          {i > 0 && (
+                            <div
+                              className="absolute left-[9px] w-px bg-kumo-line"
+                              style={{
+                                top: 0,
+                                height: isLast ? "50%" : "100%",
+                              }}
+                            />
+                          )}
+                          {/* Horizontal branch */}
+                          {i > 0 && (
+                            <div
+                              className="absolute top-1/2 h-px bg-kumo-line"
+                              style={{
+                                left: 9,
+                                width: indent - 9 + 6,
+                              }}
+                            />
+                          )}
+                          <Menu.Item
+                            render={<a href={item.href} />}
+                            className="py-2 px-2 text-sm text-kumo-default hover:text-kumo-brand rounded cursor-pointer outline-none"
+                            style={{ marginLeft: indent }}
+                          >
+                            {item.label}
+                          </Menu.Item>
+                        </div>
+                      );
+                    })}
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+            <Separator />
+          </>
+        )}
+
+        {/* Visible items */}
+        {visibleItems.map((item, index) => (
+          <span key={index} className="contents">
+            <a
+              href={item.href}
+              className="flex shrink-0 items-center gap-1 text-kumo-subtle hover:text-kumo-default whitespace-nowrap"
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </a>
+            <Separator />
+          </span>
+        ))}
+
+        {/* Current item (never collapses) */}
+        <span className="flex shrink-0 items-center gap-1 font-medium whitespace-nowrap">
+          {currentItem.icon}
+          <span>{currentItem.label}</span>
+        </span>
+      </nav>
+    </>
+  );
+}
+
+function Separator() {
+  return (
+    <CaretRightIcon
+      size={16}
+      className="shrink-0 text-kumo-inactive"
+      aria-hidden
+    />
+  );
+}
+
+/**
+ * Interactive demo showing breadcrumbs with overflow behavior.
+ * Drag the slider to resize and watch items collapse into a dropdown.
+ */
+export function BreadcrumbsOverflowDemo() {
+  const [width, setWidth] = useState(500);
+
+  // Realistic Cloudflare dashboard route: D1 database settings
+  const items: BreadcrumbItem[] = [
+    {
+      label: "Acme Corp",
+      href: "#",
+      icon: <HouseIcon size={16} className="shrink-0" />,
+    },
+    { label: "Workers & Pages", href: "#" },
+    { label: "D1 SQL Databases", href: "#" },
+    { label: "production-db", href: "#" },
+  ];
+
+  const currentItem: BreadcrumbItem = {
+    label: "Settings",
+    href: "#",
+    icon: <DatabaseIcon size={16} className="shrink-0" />,
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <label className="text-sm text-kumo-subtle whitespace-nowrap">
+          Container width:
+        </label>
+        <input
+          type="range"
+          min={200}
+          max={600}
+          value={width}
+          onChange={(e) => setWidth(Number(e.target.value))}
+          className="flex-1 max-w-48"
+        />
+        <span className="text-sm text-kumo-subtle tabular-nums w-14">
+          {width}px
+        </span>
+      </div>
+
+      <div
+        className="border border-kumo-line rounded-lg p-3 bg-kumo-base"
+        style={{ width }}
+      >
+        <OverflowBreadcrumbs
+          items={items}
+          currentItem={currentItem}
+          collapseFrom="start"
+          minVisibleItems={1}
+        />
+      </div>
+    </div>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
@@ -69,15 +69,134 @@ export function BreadcrumbsWithClipboardDemo() {
   );
 }
 
+function ArrowSvg(props: React.ComponentProps<"svg">) {
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className="fill-kumo-base"
+      />
+      <path
+        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
+        className="fill-kumo-tip-shadow"
+      />
+      <path
+        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+        className="fill-kumo-tip-stroke"
+      />
+    </svg>
+  );
+}
+
 // ============================================================================
 // PROTOTYPE: Overflow Breadcrumbs
 // ============================================================================
 
 type BreadcrumbItem = {
   label: string;
-  href: string;
+  /** Anchor navigation (renders a real `<a>` via `Menu.LinkItem`). */
+  href?: string;
+  /** Override the underlying element (e.g. router `Link`). */
+  render?: React.ReactElement;
   icon?: ReactNode;
 };
+
+/**
+ * Overflow menu list that visually shows a breadcrumb path as an indented tree.
+ *
+ * Uses Base UI `Menu.Item` for keyboard navigation, with a single SVG overlay
+ * to draw the connector lines. This keeps the semantics and interaction intact
+ * while letting us fully control the visual.
+ */
+function TreeMenu({ items }: { items: BreadcrumbItem[] }) {
+  if (items.length === 0) return null;
+
+  // Keep these in sync with the Menu.Item layout below.
+  const ROW_H = 32; // `h-8`
+  const BASE_X = 6; // root spine x (keep left of root label)
+  const INDENT = 14; // per-level indent (relaxed depth)
+  const BRANCH = 6; // horizontal branch into label (shorter)
+  const TEXT_GAP = 10; // space between branch and text
+
+  const totalHeight = items.length * ROW_H;
+  const yCenter = (index: number) => index * ROW_H + ROW_H / 2;
+  const xLevel = (level: number) => BASE_X + level * INDENT;
+  const xText = (level: number) => xLevel(level) + BRANCH + TEXT_GAP;
+
+  return (
+    <div className="relative" style={{ height: totalHeight }}>
+      <svg
+        className="pointer-events-none absolute inset-0"
+        aria-hidden
+        focusable="false"
+      >
+        {/*
+          One full L-connector per item.
+          This avoids overlapping stroke caps at joints (which can darken pixels
+          when using opacity) and keeps the connectors crisp.
+        */}
+        {items.map((_, i) => {
+          if (i === 0) return null;
+
+          const x1 = xLevel(i - 1);
+          const x2 = xLevel(i) + BRANCH;
+          const y2 = yCenter(i);
+          // Avoid drawing through the root label: start below row 0 for the first connector.
+          const y1 = i === 1 ? yCenter(0) + ROW_H / 2 : yCenter(i - 1);
+
+          return (
+            <path
+              key={`l-${i}`}
+              d={`M ${x1} ${y1} V ${y2} H ${x2}`}
+              stroke="var(--color-kumo-line)"
+              strokeWidth="1"
+              strokeLinecap="butt"
+              strokeLinejoin="miter"
+              fill="none"
+            />
+          );
+        })}
+      </svg>
+
+      <div className="relative flex flex-col">
+        {items.map((item, i) =>
+          item.render ? (
+            <Menu.Item
+              key={i}
+              render={item.render}
+              label={item.label}
+              closeOnClick
+              className={
+                // Keep layout deterministic for the SVG overlay (avoid margins).
+                // Match Select/Combobox interaction styling (highlight-driven).
+                "flex h-8 min-w-0 cursor-pointer items-center rounded px-2 text-sm text-kumo-default outline-none select-none " +
+                // Use a little alpha so connector lines stay visible when highlighted.
+                "data-highlighted:bg-kumo-tint/60"
+              }
+              style={{ paddingLeft: i === 0 ? 8 : xText(i) }}
+            >
+              <span className="min-w-0 truncate">{item.label}</span>
+            </Menu.Item>
+          ) : (
+            <Menu.LinkItem
+              key={i}
+              href={item.href ?? "#"}
+              label={item.label}
+              closeOnClick
+              className={
+                "flex h-8 min-w-0 cursor-pointer items-center rounded px-2 text-sm text-kumo-default outline-none select-none " +
+                "data-highlighted:bg-kumo-tint/60"
+              }
+              style={{ paddingLeft: i === 0 ? 8 : xText(i) }}
+            >
+              <span className="min-w-0 truncate">{item.label}</span>
+            </Menu.LinkItem>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
 
 /**
  * Prototype: Data-driven breadcrumbs with overflow collapse.
@@ -235,7 +354,7 @@ function OverflowBreadcrumbs({
 
       <nav
         ref={containerRef}
-        className={`flex items-center gap-1 overflow-hidden text-sm ${className ?? ""}`}
+        className={`flex items-center gap-1 text-sm ${className ?? ""}`}
         aria-label="Breadcrumb"
       >
         {/* Overflow dropdown */}
@@ -245,58 +364,30 @@ function OverflowBreadcrumbs({
               <Menu.Trigger
                 render={
                   <Button
-                    variant="ghost"
+                    variant="outline"
                     size="sm"
-                    shape="square"
                     aria-label="Show collapsed breadcrumbs"
+                    icon={<DotsThreeIcon weight="bold" size={16} />}
                     className="shrink-0"
-                  >
-                    <DotsThreeIcon weight="bold" size={16} />
-                  </Button>
+                  ></Button>
                 }
               />
               <Menu.Portal>
-                <Menu.Positioner className="z-50">
-                  <Menu.Popup className="bg-kumo-elevated border border-kumo-line rounded-lg shadow-lg py-3 px-4 min-w-48">
-                    {(collapseFrom === "start"
-                      ? overflowItems
-                      : [...overflowItems].reverse()
-                    ).map((item, i, arr) => {
-                      const isLast = i === arr.length - 1;
-                      const indent = i * 20;
-
-                      return (
-                        <div key={i} className="relative flex items-center">
-                          {/* Vertical line - runs full height except stops at middle on last item */}
-                          {i > 0 && (
-                            <div
-                              className="absolute left-[9px] w-px bg-kumo-line"
-                              style={{
-                                top: 0,
-                                height: isLast ? "50%" : "100%",
-                              }}
-                            />
-                          )}
-                          {/* Horizontal branch */}
-                          {i > 0 && (
-                            <div
-                              className="absolute top-1/2 h-px bg-kumo-line"
-                              style={{
-                                left: 9,
-                                width: indent - 9 + 6,
-                              }}
-                            />
-                          )}
-                          <Menu.Item
-                            render={<a href={item.href} />}
-                            className="py-2 px-2 text-sm text-kumo-default hover:text-kumo-brand rounded cursor-pointer outline-none"
-                            style={{ marginLeft: indent }}
-                          >
-                            {item.label}
-                          </Menu.Item>
-                        </div>
-                      );
-                    })}
+                <Menu.Positioner sideOffset={8} align="start">
+                  <Menu.Popup
+                    className={
+                      "min-w-48 rounded-lg p-2 " +
+                      // Match Kumo DropdownMenu styling (no arrow).
+                      "bg-kumo-control text-kumo-default shadow-lg ring ring-kumo-line"
+                    }
+                  >
+                    <TreeMenu
+                      items={
+                        collapseFrom === "start"
+                          ? overflowItems
+                          : [...overflowItems].reverse()
+                      }
+                    />
                   </Menu.Popup>
                 </Menu.Positioner>
               </Menu.Portal>
@@ -384,7 +475,7 @@ export function BreadcrumbsOverflowDemo() {
       </div>
 
       <div
-        className="border border-kumo-line rounded-lg p-3 bg-kumo-base"
+        className="border border-kumo-line rounded-lg p-5 bg-kumo-base"
         style={{ width }}
       >
         <OverflowBreadcrumbs

--- a/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
@@ -1,12 +1,6 @@
-import { useRef, useState, useEffect, type ReactNode } from "react";
-import { Breadcrumbs, Button } from "@cloudflare/kumo";
-import { Menu } from "@cloudflare/kumo/primitives/menu";
-import {
-  HouseIcon,
-  DotsThreeIcon,
-  CaretRightIcon,
-  DatabaseIcon,
-} from "@phosphor-icons/react";
+import { useState } from "react";
+import { Breadcrumbs, type BreadcrumbItem } from "@cloudflare/kumo";
+import { HouseIcon, DatabaseIcon } from "@phosphor-icons/react";
 
 export function BreadcrumbsDemo() {
   return (
@@ -69,403 +63,134 @@ export function BreadcrumbsWithClipboardDemo() {
   );
 }
 
-function ArrowSvg(props: React.ComponentProps<"svg">) {
-  return (
-    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
-      <path
-        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
-        className="fill-kumo-base"
-      />
-      <path
-        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
-        className="fill-kumo-tip-shadow"
-      />
-      <path
-        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
-        className="fill-kumo-tip-stroke"
-      />
-    </svg>
-  );
+/**
+ * Items-based API: basic usage with href for navigation.
+ */
+export function BreadcrumbsItemsDemo() {
+  const items: BreadcrumbItem[] = [
+    { label: "Home", href: "/", icon: <HouseIcon size={16} /> },
+    { label: "Projects", href: "/projects" },
+  ];
+
+  return <Breadcrumbs items={items} currentItem={{ label: "My Project" }} />;
 }
 
-// ============================================================================
-// PROTOTYPE: Overflow Breadcrumbs
-// ============================================================================
-
-type BreadcrumbItem = {
-  label: string;
-  /** Anchor navigation (renders a real `<a>` via `Menu.LinkItem`). */
-  href?: string;
-  /** Override the underlying element (e.g. router `Link`). */
-  render?: React.ReactElement;
-  icon?: ReactNode;
-};
-
 /**
- * Overflow menu list that visually shows a breadcrumb path as an indented tree.
- *
- * Uses Base UI `Menu.Item` for keyboard navigation, with a single SVG overlay
- * to draw the connector lines. This keeps the semantics and interaction intact
- * while letting us fully control the visual.
+ * Items-based API with loading state on current item.
  */
-function TreeMenu({ items }: { items: BreadcrumbItem[] }) {
-  if (items.length === 0) return null;
-
-  // Keep these in sync with the Menu.Item layout below.
-  const ROW_H = 32; // `h-8`
-  const BASE_X = 12; // root spine x (give room for shifted L starts)
-  const INDENT = 14; // per-level indent
-  const BRANCH = 2; // horizontal branch into label
-  const TEXT_GAP = 10; // space between branch and text
-
-  const totalHeight = items.length * ROW_H;
-  const yCenter = (index: number) => index * ROW_H + ROW_H / 2;
-  const xLevel = (level: number) => BASE_X + level * INDENT;
-  const xText = (level: number) => xLevel(level) + BRANCH + TEXT_GAP;
+export function BreadcrumbsItemsLoadingDemo() {
+  const items: BreadcrumbItem[] = [
+    { label: "Home", href: "#", icon: <HouseIcon size={16} /> },
+    { label: "Projects", href: "#" },
+  ];
 
   return (
-    <div className="relative" style={{ height: totalHeight }}>
-      <svg
-        className="pointer-events-none absolute inset-0"
-        aria-hidden
-        focusable="false"
-      >
-        {/*
-          One full L-connector per item.
-          This avoids overlapping stroke caps at joints (which can darken pixels
-          when using opacity) and keeps the connectors crisp.
-        */}
-        {items.map((_, i) => {
-          if (i === 0) return null;
-
-          // Shift the vertical line left so L appears to start from middle of parent's base
-          const x1 = xLevel(i - 1) - 6;
-          const x2 = xLevel(i) + BRANCH;
-          const y2 = yCenter(i);
-          // Avoid drawing through the root label: start below row 0 for the first connector.
-          const y1 = i === 1 ? yCenter(0) + ROW_H / 2 : yCenter(i - 1);
-
-          return (
-            <path
-              key={`l-${i}`}
-              d={`M ${x1} ${y1} V ${y2} H ${x2}`}
-              stroke="var(--color-kumo-line)"
-              strokeWidth="1"
-              strokeLinecap="butt"
-              strokeLinejoin="miter"
-              fill="none"
-            />
-          );
-        })}
-      </svg>
-
-      <div className="relative flex flex-col">
-        {items.map((item, i) =>
-          item.render ? (
-            <Menu.Item
-              key={i}
-              render={item.render}
-              label={item.label}
-              closeOnClick
-              className={
-                // Keep layout deterministic for the SVG overlay (avoid margins).
-                // Match Select/Combobox interaction styling (highlight-driven).
-                "flex h-8 min-w-0 cursor-pointer items-center rounded px-2 text-sm text-kumo-default outline-none select-none " +
-                // Use a little alpha so connector lines stay visible when highlighted.
-                "data-highlighted:bg-kumo-tint/60"
-              }
-              style={{ paddingLeft: i === 0 ? 8 : xText(i) }}
-            >
-              <span className="min-w-0 truncate">{item.label}</span>
-            </Menu.Item>
-          ) : (
-            <Menu.LinkItem
-              key={i}
-              href={item.href ?? "#"}
-              label={item.label}
-              closeOnClick
-              className={
-                "flex h-8 min-w-0 cursor-pointer items-center rounded px-2 text-sm text-kumo-default outline-none select-none " +
-                "data-highlighted:bg-kumo-tint/60"
-              }
-              style={{ paddingLeft: i === 0 ? 8 : xText(i) }}
-            >
-              <span className="min-w-0 truncate">{item.label}</span>
-            </Menu.LinkItem>
-          ),
-        )}
-      </div>
-    </div>
+    <Breadcrumbs items={items} currentItem={{ label: "", loading: true }} />
   );
 }
 
 /**
- * Prototype: Data-driven breadcrumbs with overflow collapse.
- * Items that don't fit collapse into a dropdown menu.
- *
- * API inspired by Blueprint JS:
- * - `items`: Array of breadcrumb data
- * - `collapseFrom`: "start" (default) or "end"
- * - `minVisibleItems`: Minimum items to always show
+ * Items-based API with custom render prop for router integration.
+ * Use the `render` prop to provide your own link component (e.g., Next.js Link, React Router Link).
+ * The component will clone your element and inject the label + icon as children.
  */
-function OverflowBreadcrumbs({
-  items,
-  currentItem,
-  collapseFrom = "start",
-  minVisibleItems = 1,
-  className,
-}: {
-  items: BreadcrumbItem[];
-  currentItem: BreadcrumbItem;
-  collapseFrom?: "start" | "end";
-  minVisibleItems?: number;
-  className?: string;
-}) {
-  const containerRef = useRef<HTMLElement>(null);
-  const measureRef = useRef<HTMLDivElement>(null);
-  const [overflowCount, setOverflowCount] = useState(0);
-  const [itemWidths, setItemWidths] = useState<number[]>([]);
-  const [currentItemWidth, setCurrentItemWidth] = useState(0);
-  const [measured, setMeasured] = useState(false);
-
-  // Measure all items once on mount
-  useEffect(() => {
-    if (!measureRef.current) return;
-
-    const measureContainer = measureRef.current;
-    const itemEls = measureContainer.querySelectorAll("[data-measure-item]");
-    const currentEl = measureContainer.querySelector("[data-measure-current]");
-
-    const widths = Array.from(itemEls).map(
-      (el) => el.getBoundingClientRect().width,
-    );
-    const currentWidth = currentEl?.getBoundingClientRect().width ?? 100;
-
-    setItemWidths(widths);
-    setCurrentItemWidth(currentWidth);
-    setMeasured(true);
-  }, [items, currentItem]);
-
-  // Compute overflow based on cached widths
-  useEffect(() => {
-    if (!measured || !containerRef.current) return;
-
-    const computeOverflow = () => {
-      const container = containerRef.current;
-      if (!container) return;
-
-      const containerWidth = container.offsetWidth;
-      const overflowButtonWidth = 36;
-      const separatorWidth = 20;
-
-      // Start with space needed for current item only
-      let usedWidth = currentItemWidth;
-      let visibleCount = 0;
-
-      // Measure from the end (items closest to current) to preserve parent context
-      for (let i = items.length - 1; i >= 0; i--) {
-        const itemWidth = itemWidths[i] ?? 80;
-        // Each visible item needs: separator before it + the item itself
-        const neededWidth = separatorWidth + itemWidth;
-
-        // If we have overflow, we need space for the overflow button + its separator
-        const itemsBeforeThis = i;
-        const willHaveOverflow = itemsBeforeThis > 0;
-        const overflowSpace = willHaveOverflow
-          ? overflowButtonWidth + separatorWidth
-          : 0;
-
-        // Check if adding this item (plus overflow button if needed) fits
-        if (usedWidth + neededWidth + overflowSpace <= containerWidth) {
-          usedWidth += neededWidth;
-          visibleCount++;
-        } else {
-          // Can't fit this item - check if we need overflow button space
-          // All remaining items go to overflow
-          break;
-        }
-      }
-
-      // Don't enforce minVisibleItems if it would cause overflow/truncation
-      // Only apply it if there's actually room
-      const overflowNeeded = items.length - visibleCount;
-      if (overflowNeeded > 0 && overflowNeeded < items.length) {
-        // We have some overflow - check if minVisibleItems fits
-        const minVisible = Math.min(minVisibleItems, items.length);
-        if (visibleCount < minVisible) {
-          // Check if forcing minVisibleItems would actually fit
-          let testWidth =
-            currentItemWidth + overflowButtonWidth + separatorWidth;
-          for (let i = items.length - minVisible; i < items.length; i++) {
-            testWidth += separatorWidth + (itemWidths[i] ?? 80);
-          }
-          if (testWidth <= containerWidth) {
-            visibleCount = minVisible;
-          }
-        }
-      }
-
-      setOverflowCount(items.length - visibleCount);
-    };
-
-    computeOverflow();
-
-    const observer = new ResizeObserver(computeOverflow);
-    observer.observe(containerRef.current);
-    return () => observer.disconnect();
-  }, [measured, items.length, itemWidths, currentItemWidth, minVisibleItems]);
-
-  // Split items into overflow and visible
-  const overflowItems =
-    collapseFrom === "start"
-      ? items.slice(0, overflowCount)
-      : items.slice(items.length - overflowCount);
-
-  const visibleItems =
-    collapseFrom === "start"
-      ? items.slice(overflowCount)
-      : items.slice(0, items.length - overflowCount);
-
-  return (
-    <>
-      {/* Hidden measurement container - renders all items to measure their natural width */}
-      <div
-        ref={measureRef}
-        className="pointer-events-none absolute flex items-center gap-1 text-sm opacity-0"
-        aria-hidden
-      >
-        {items.map((item, index) => (
-          <span
-            key={index}
-            data-measure-item
-            className="flex shrink-0 items-center gap-1 whitespace-nowrap"
-          >
-            {item.icon}
-            <span>{item.label}</span>
-          </span>
-        ))}
-        <span
-          data-measure-current
-          className="flex shrink-0 items-center gap-1 font-medium whitespace-nowrap"
-        >
-          {currentItem.icon}
-          <span>{currentItem.label}</span>
-        </span>
-      </div>
-
-      <nav
-        ref={containerRef}
-        className={`flex items-center gap-1 text-sm ${className ?? ""}`}
-        aria-label="Breadcrumb"
-      >
-        {/* Overflow dropdown */}
-        {overflowItems.length > 0 && (
-          <>
-            <Menu.Root>
-              <Menu.Trigger
-                render={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    aria-label="Show collapsed breadcrumbs"
-                    icon={<DotsThreeIcon weight="bold" size={16} />}
-                    className="shrink-0"
-                  ></Button>
-                }
-              />
-              <Menu.Portal>
-                <Menu.Positioner sideOffset={8} align="start">
-                  <Menu.Popup
-                    className={
-                      "min-w-48 rounded-lg p-2 " +
-                      // Match Kumo DropdownMenu styling (no arrow).
-                      "bg-kumo-control text-kumo-default shadow-lg ring ring-kumo-line"
-                    }
-                  >
-                    <TreeMenu
-                      items={
-                        collapseFrom === "start"
-                          ? overflowItems
-                          : [...overflowItems].reverse()
-                      }
-                    />
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
-            <Separator />
-          </>
-        )}
-
-        {/* Visible items */}
-        {visibleItems.map((item, index) => (
-          <span key={index} className="contents">
-            <a
-              href={item.href}
-              className="flex shrink-0 items-center gap-1 text-kumo-subtle hover:text-kumo-default whitespace-nowrap"
-            >
-              {item.icon}
-              <span>{item.label}</span>
-            </a>
-            <Separator />
-          </span>
-        ))}
-
-        {/* Current item (never collapses) */}
-        <span className="flex shrink-0 items-center gap-1 font-medium whitespace-nowrap">
-          {currentItem.icon}
-          <span>{currentItem.label}</span>
-        </span>
-      </nav>
-    </>
+export function BreadcrumbsItemsCustomRenderDemo() {
+  // Simulating a router Link component
+  const RouterLink = ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children?: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
   );
-}
 
-function Separator() {
+  const items: BreadcrumbItem[] = [
+    {
+      label: "Home",
+      icon: <HouseIcon size={16} />,
+      // Use render prop for custom link component
+      render: <RouterLink to="/" />,
+    },
+    {
+      label: "Projects",
+      render: <RouterLink to="/projects" />,
+    },
+    {
+      label: "Settings",
+      render: <RouterLink to="/projects/settings" />,
+    },
+  ];
+
   return (
-    <CaretRightIcon
-      size={16}
-      className="shrink-0 text-kumo-inactive"
-      aria-hidden
+    <Breadcrumbs
+      items={items}
+      currentItem={{ label: "General", icon: <DatabaseIcon size={16} /> }}
     />
   );
 }
 
 /**
- * Interactive demo showing breadcrumbs with overflow behavior.
+ * Interactive demo showing the items-based API with automatic overflow.
  * Drag the slider to resize and watch items collapse into a dropdown.
+ *
+ * This demo showcases:
+ * - Automatic overflow with tree visualization in dropdown
+ * - Icons on breadcrumb items
+ * - Custom render prop for router integration (simulated)
+ * - Loading state toggle
  */
 export function BreadcrumbsOverflowDemo() {
-  const [width, setWidth] = useState(500);
+  const [width, setWidth] = useState(600);
+  const [isLoading, setIsLoading] = useState(false);
 
-  // Realistic Cloudflare dashboard route: D1 database settings
+  // Simulated router Link component
+  const RouterLink = ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children?: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  );
+
   const items: BreadcrumbItem[] = [
     {
       label: "Acme Corp",
-      href: "#",
       icon: <HouseIcon size={16} className="shrink-0" />,
+      // Using render prop for custom link component (e.g., Next.js Link)
+      render: <RouterLink to="#" />,
     },
     { label: "Workers & Pages", href: "#" },
-    { label: "D1 SQL Databases", href: "#" },
     { label: "production-db", href: "#" },
   ];
 
   const currentItem: BreadcrumbItem = {
     label: "Settings",
-    href: "#",
     icon: <DatabaseIcon size={16} className="shrink-0" />,
+    loading: isLoading,
   };
 
   return (
     <div className="flex w-full flex-col gap-4">
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <label className="text-sm text-kumo-subtle whitespace-nowrap">
           Container width:
         </label>
         <input
           type="range"
           min={200}
-          max={600}
+          max={700}
           value={width}
           onChange={(e) => setWidth(Number(e.target.value))}
           className="flex-1 max-w-48"
@@ -473,13 +198,21 @@ export function BreadcrumbsOverflowDemo() {
         <span className="text-sm text-kumo-subtle tabular-nums w-14">
           {width}px
         </span>
+        <label className="flex items-center gap-2 text-sm text-kumo-subtle">
+          <input
+            type="checkbox"
+            checked={isLoading}
+            onChange={(e) => setIsLoading(e.target.checked)}
+          />
+          Loading
+        </label>
       </div>
 
       <div
         className="border border-kumo-line rounded-lg p-5 bg-kumo-base"
         style={{ width }}
       >
-        <OverflowBreadcrumbs
+        <Breadcrumbs
           items={items}
           currentItem={currentItem}
           collapseFrom="start"

--- a/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
@@ -74,14 +74,7 @@ import {
   <Heading level={3}>Overflow (Prototype)</Heading>
   <p>
     When breadcrumbs overflow their container, items collapse into a dropdown
-    menu. Drag the slider to resize and watch items collapse. API inspired by{" "}
-    <a
-      href="https://blueprintjs.com/docs/#core/components/breadcrumbs"
-      className="text-kumo-link"
-    >
-      Blueprint JS
-    </a>
-    .
+    menu. Drag the slider to resize and watch items collapse.
   </p>
   <ComponentExample demo="BreadcrumbsOverflowDemo">
     <BreadcrumbsOverflowDemo client:load />

--- a/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
@@ -16,6 +16,7 @@ import {
   BreadcrumbsWithClipboardDemo,
   BreadcrumbsLoadingDemo,
   BreadcrumbsRootDemo,
+  BreadcrumbsOverflowDemo,
 } from "~/components/demos/BreadcrumbsDemo";
 
 <ComponentSection>
@@ -66,6 +67,24 @@ import {
   <Heading level={3}>Clipboard</Heading>
   <ComponentExample demo="BreadcrumbsWithClipboardDemo">
     <BreadcrumbsWithClipboardDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+  <Heading level={3}>Overflow (Prototype)</Heading>
+  <p>
+    When breadcrumbs overflow their container, items collapse into a dropdown
+    menu. Drag the slider to resize and watch items collapse. API inspired by{" "}
+    <a
+      href="https://blueprintjs.com/docs/#core/components/breadcrumbs"
+      className="text-kumo-link"
+    >
+      Blueprint JS
+    </a>
+    .
+  </p>
+  <ComponentExample demo="BreadcrumbsOverflowDemo">
+    <BreadcrumbsOverflowDemo client:load />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Breadcrumb as Breadcrumbs, type BreadcrumbItem } from "./breadcrumbs";
+
+describe("Breadcrumbs", () => {
+  describe("Compound Component API (legacy)", () => {
+    it("renders breadcrumb links and current item", () => {
+      render(
+        <Breadcrumbs>
+          <Breadcrumbs.Link href="/home">Home</Breadcrumbs.Link>
+          <Breadcrumbs.Separator />
+          <Breadcrumbs.Link href="/docs">Docs</Breadcrumbs.Link>
+          <Breadcrumbs.Separator />
+          <Breadcrumbs.Current>Current Page</Breadcrumbs.Current>
+        </Breadcrumbs>,
+      );
+
+      // Component renders both mobile and desktop views, so use getAllBy
+      expect(screen.getAllByText("Home").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Docs").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Current Page").length).toBeGreaterThan(0);
+    });
+
+    it("renders current item with aria-current", () => {
+      render(
+        <Breadcrumbs>
+          <Breadcrumbs.Current>Current Page</Breadcrumbs.Current>
+        </Breadcrumbs>,
+      );
+
+      // Component renders both mobile and desktop views, so find within nav
+      const nav = document.querySelector('nav[aria-label="breadcrumb"]');
+      const current = nav?.querySelector("[aria-current='page']");
+      expect(current).toBeTruthy();
+      expect(current?.textContent).toContain("Current Page");
+    });
+
+    it("renders with icons", () => {
+      render(
+        <Breadcrumbs>
+          <Breadcrumbs.Link
+            href="/home"
+            icon={<span data-testid="home-icon" />}
+          >
+            Home
+          </Breadcrumbs.Link>
+          <Breadcrumbs.Separator />
+          <Breadcrumbs.Current icon={<span data-testid="current-icon" />}>
+            Current
+          </Breadcrumbs.Current>
+        </Breadcrumbs>,
+      );
+
+      // Icons appear in both mobile and desktop views
+      expect(screen.getAllByTestId("home-icon").length).toBeGreaterThan(0);
+      expect(screen.getAllByTestId("current-icon").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Items API", () => {
+    it("renders items-based breadcrumbs", () => {
+      const items: BreadcrumbItem[] = [
+        { label: "Home", href: "/" },
+        { label: "Projects", href: "/projects" },
+      ];
+
+      render(<Breadcrumbs items={items} currentItem={{ label: "Settings" }} />);
+
+      // Items appear in both measurement container and nav, so use getAllByText
+      expect(screen.getAllByText("Home").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Projects").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Settings").length).toBeGreaterThan(0);
+    });
+
+    it("renders nav with aria-label", () => {
+      render(
+        <Breadcrumbs
+          items={[{ label: "Home", href: "/" }]}
+          currentItem={{ label: "Settings" }}
+        />,
+      );
+
+      const nav = document.querySelector('nav[aria-label="Breadcrumb"]');
+      expect(nav).toBeTruthy();
+    });
+
+    it("renders current item with aria-current", () => {
+      render(
+        <Breadcrumbs
+          items={[{ label: "Home", href: "/" }]}
+          currentItem={{ label: "Current" }}
+        />,
+      );
+
+      const nav = document.querySelector('nav[aria-label="Breadcrumb"]');
+      const current = nav?.querySelector("[aria-current='page']");
+      expect(current).toBeTruthy();
+      expect(current?.textContent).toContain("Current");
+    });
+
+    it("renders items with icons", () => {
+      const items: BreadcrumbItem[] = [
+        { label: "Home", href: "/", icon: <span data-testid="home-icon" /> },
+      ];
+
+      render(
+        <Breadcrumbs
+          items={items}
+          currentItem={{
+            label: "Settings",
+            icon: <span data-testid="settings-icon" />,
+          }}
+        />,
+      );
+
+      // Icons appear in measurement container too, so check for multiple
+      expect(screen.getAllByTestId("home-icon").length).toBeGreaterThan(0);
+      expect(screen.getAllByTestId("settings-icon").length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -306,88 +306,65 @@ export interface BreadcrumbsItemsProps extends KumoBreadcrumbsVariantsProps {
 }
 
 // Layout constants for TreeMenu (pixels)
-const TREE_ROW_HEIGHT = 32;
-const TREE_BASE_X = 12;
-const TREE_INDENT = 14;
-const TREE_BRANCH = 2;
-const TREE_TEXT_GAP = 10;
-
-function treeXLevel(level: number): number {
-  return TREE_BASE_X + level * TREE_INDENT;
-}
-
-function treeXText(level: number): number {
-  return treeXLevel(level) + TREE_BRANCH + TREE_TEXT_GAP;
-}
-
-function treeYCenter(index: number): number {
-  return index * TREE_ROW_HEIGHT + TREE_ROW_HEIGHT / 2;
-}
+const TREE_INDENT = 8;
 
 const TREE_MENU_ITEM_CLASS =
-  "flex h-8 min-w-0 cursor-pointer items-center rounded px-2 text-sm text-kumo-default outline-none select-none data-highlighted:bg-kumo-tint/60";
+  "flex h-9 min-w-0 cursor-pointer items-center gap-2 rounded px-3 text-sm text-kumo-default outline-none select-none data-highlighted:bg-kumo-tint/60";
 
 /**
- * Renders overflow breadcrumb items as an indented tree structure.
+ * L-shaped connector icon for tree hierarchy visualization.
+ */
+function TreeConnector() {
+  return (
+    <svg
+      width="16"
+      height="20"
+      viewBox="0 0 16 20"
+      fill="none"
+      className="shrink-0 text-kumo-line"
+      aria-hidden
+    >
+      <path
+        d="M1 0 V12 H15"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Renders overflow breadcrumb items as an indented tree structure
+ * with disconnected L-shaped connectors showing hierarchy.
  */
 function TreeMenu({ items }: { items: BreadcrumbItem[] }) {
   if (items.length === 0) return null;
 
-  const totalHeight = items.length * TREE_ROW_HEIGHT;
-
   return (
-    <div className="relative" style={{ height: totalHeight }}>
-      <svg
-        className="pointer-events-none absolute inset-0"
-        width="100%"
-        height={totalHeight}
-        aria-hidden
-        focusable="false"
-      >
-        {items.map((_, i) => {
-          if (i === 0) return null;
+    <div className="flex flex-col py-1">
+      {items.map((item, i) => {
+        const paddingLeft = i === 0 ? 12 : 12 + i * TREE_INDENT;
 
-          const x1 = treeXLevel(i - 1) - 6;
-          const x2 = treeXLevel(i) + TREE_BRANCH;
-          const y2 = treeYCenter(i);
-          const y1 =
-            i === 1 ? treeYCenter(0) + TREE_ROW_HEIGHT / 2 : treeYCenter(i - 1);
-
-          return (
-            <path
-              key={i}
-              d={`M ${x1} ${y1} V ${y2} H ${x2}`}
-              stroke="var(--color-kumo-line)"
-              strokeWidth="1"
-              strokeLinecap="butt"
-              strokeLinejoin="miter"
-              fill="none"
-            />
-          );
-        })}
-      </svg>
-
-      <div className="relative flex flex-col">
-        {items.map((item, i) => {
-          const paddingLeft = i === 0 ? 8 : treeXText(i);
-
-          return (
-            <Menu.Item
-              key={i}
-              render={
-                item.render ?? (
-                  <a href={item.href ?? "#"} aria-label={item.label} />
-                )
-              }
-              closeOnClick
-              className={TREE_MENU_ITEM_CLASS}
-              style={{ paddingLeft }}
-            >
-              <span className="min-w-0 truncate">{item.label}</span>
-            </Menu.Item>
-          );
-        })}
-      </div>
+        return (
+          <Menu.Item
+            key={i}
+            render={
+              item.render ?? (
+                <a href={item.href ?? "#"} aria-label={item.label} />
+              )
+            }
+            closeOnClick
+            className={TREE_MENU_ITEM_CLASS}
+            style={{ paddingLeft }}
+          >
+            {i > 0 && <TreeConnector />}
+            <span className="min-w-0 truncate">{item.label}</span>
+          </Menu.Item>
+        );
+      })}
     </div>
   );
 }

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -321,12 +321,12 @@ function TreeConnector() {
       height="20"
       viewBox="0 0 16 20"
       fill="none"
-      className="shrink-0 text-kumo-subtle"
+      className="shrink-0"
       aria-hidden
     >
       <path
         d="M1 0 V12 H15"
-        stroke="currentColor"
+        className="stroke-kumo-hairline"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -321,7 +321,7 @@ function TreeConnector() {
       height="20"
       viewBox="0 0 16 20"
       fill="none"
-      className="shrink-0 text-kumo-line"
+      className="shrink-0 text-kumo-subtle"
       aria-hidden
     >
       <path

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -684,6 +684,7 @@ export function Breadcrumb(props: BreadcrumbsCombinedProps) {
   return <CompoundBreadcrumbs {...props} />;
 }
 
+Breadcrumb.displayName = "Breadcrumbs";
 Breadcrumb.Link = Link;
 Breadcrumb.Current = Current;
 Breadcrumb.Separator = Separator;

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -3,16 +3,22 @@ import {
   cloneElement,
   isValidElement,
   useEffect,
+  useRef,
   useState,
   type PropsWithChildren,
   type ReactElement,
   type ReactNode,
 } from "react";
-import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
+import { CheckIcon, CopyIcon, DotsThree } from "@phosphor-icons/react";
+import { Menu } from "@base-ui/react/menu";
 import { Button } from "../../components/button";
 import { SkeletonLine } from "../../components/loader/skeleton-line";
 import { useLinkComponent } from "../../utils/link-provider";
 import { cn } from "../../utils/cn";
+
+// ============================================================================
+// Variant Definitions
+// ============================================================================
 
 /** Breadcrumbs size variant definitions. */
 export const KUMO_BREADCRUMBS_VARIANTS = {
@@ -52,6 +58,33 @@ export function breadcrumbsVariants({
     KUMO_BREADCRUMBS_VARIANTS.size[size].classes,
   );
 }
+
+// ============================================================================
+// Shared Components
+// ============================================================================
+
+function Separator() {
+  return (
+    <span
+      className="flex shrink-0 items-center text-kumo-inactive"
+      aria-hidden="true"
+    >
+      <svg width="24" height="24" fill="none" viewBox="0 0 24 24">
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M10.75 8.75L14.25 12L10.75 15.25"
+        />
+      </svg>
+    </span>
+  );
+}
+
+// ============================================================================
+// Compound Component API (Legacy)
+// ============================================================================
 
 export interface BreadcrumbsItemProps {
   href: string;
@@ -106,25 +139,6 @@ function Current({
   );
 }
 
-function Separator() {
-  return (
-    <span
-      className="flex shrink-0 items-center text-kumo-inactive"
-      aria-hidden="true"
-    >
-      <svg width="24" height="24" fill="none" viewBox="0 0 24 24">
-        <path
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.5"
-          d="M10.75 8.75L14.25 12L10.75 15.25"
-        />
-      </svg>
-    </span>
-  );
-}
-
 function MobileEllipsis() {
   return (
     <span className="flex shrink-0 items-center text-kumo-subtle" aria-hidden>
@@ -173,59 +187,6 @@ function Clipboard({ text }: { text: string }) {
   );
 }
 
-/**
- * Breadcrumbs component props.
- *
- * @example
- * ```tsx
- * <Breadcrumbs>
- *   <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
- *   <Breadcrumbs.Separator />
- *   <Breadcrumbs.Link href="/docs">Docs</Breadcrumbs.Link>
- *   <Breadcrumbs.Separator />
- *   <Breadcrumbs.Current>Current Page</Breadcrumbs.Current>
- * </Breadcrumbs>
- * ```
- */
-export interface BreadcrumbsProps
-  extends PropsWithChildren,
-    KumoBreadcrumbsVariantsProps {
-  /** Additional CSS classes merged via `cn()`. */
-  className?: string;
-}
-
-/**
- * Navigation breadcrumb trail showing the current page's location in a hierarchy.
- * Compound component with `Breadcrumbs.Link`, `Breadcrumbs.Current`, `Breadcrumbs.Separator`, and `Breadcrumbs.Clipboard`.
- *
- * @example
- * ```tsx
- * <Breadcrumbs>
- *   <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
- *   <Breadcrumbs.Separator />
- *   <Breadcrumbs.Current>Dashboard</Breadcrumbs.Current>
- * </Breadcrumbs>
- * ```
- */
-export function Breadcrumb({
-  children,
-  size = "base",
-  className,
-}: BreadcrumbsProps) {
-  const childArray = Children.toArray(children);
-  const mobileChildren = getMobileBreadcrumbChildren(childArray);
-
-  return (
-    <nav
-      className={cn(breadcrumbsVariants({ size }), className)}
-      aria-label="breadcrumb"
-    >
-      <div className="contents sm:hidden">{mobileChildren}</div>
-      <div className="hidden sm:contents">{childArray}</div>
-    </nav>
-  );
-}
-
 function isComponentElement(
   child: ReactNode,
   component: unknown,
@@ -260,6 +221,467 @@ function getMobileBreadcrumbChildren(children: ReactNode[]): ReactNode[] {
   );
 
   return [...trailingItems, ...extras];
+}
+
+/**
+ * Breadcrumbs component props for compound component API.
+ *
+ * @example
+ * ```tsx
+ * <Breadcrumbs>
+ *   <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
+ *   <Breadcrumbs.Separator />
+ *   <Breadcrumbs.Link href="/docs">Docs</Breadcrumbs.Link>
+ *   <Breadcrumbs.Separator />
+ *   <Breadcrumbs.Current>Current Page</Breadcrumbs.Current>
+ * </Breadcrumbs>
+ * ```
+ */
+export interface BreadcrumbsProps
+  extends PropsWithChildren, KumoBreadcrumbsVariantsProps {
+  /** Additional CSS classes merged via `cn()`. */
+  className?: string;
+}
+
+function CompoundBreadcrumbs({
+  children,
+  size = "base",
+  className,
+}: BreadcrumbsProps) {
+  const childArray = Children.toArray(children);
+  const mobileChildren = getMobileBreadcrumbChildren(childArray);
+
+  return (
+    <nav
+      className={cn(breadcrumbsVariants({ size }), className)}
+      aria-label="breadcrumb"
+    >
+      <div className="contents sm:hidden">{mobileChildren}</div>
+      <div className="hidden sm:contents">{childArray}</div>
+    </nav>
+  );
+}
+
+// ============================================================================
+// Items-based API with Overflow Support
+// ============================================================================
+
+/**
+ * A single breadcrumb item in the items-based API.
+ */
+export interface BreadcrumbItem {
+  /** Display text for the breadcrumb. */
+  label: string;
+  /** URL for anchor navigation (renders `<a>` element). */
+  href?: string;
+  /** Custom element to render (e.g., router Link). Takes precedence over `href`. */
+  render?: ReactElement;
+  /** Optional icon displayed before the label. */
+  icon?: ReactNode;
+  /** Show loading skeleton instead of label (only applies to currentItem). */
+  loading?: boolean;
+}
+
+/**
+ * Props for items-based Breadcrumbs API with automatic overflow handling.
+ */
+export interface BreadcrumbsItemsProps extends KumoBreadcrumbsVariantsProps {
+  /** Array of breadcrumb items (ancestors of current page). */
+  items: BreadcrumbItem[];
+  /** The current page item (never collapses into overflow). */
+  currentItem: BreadcrumbItem;
+  /**
+   * Which end to collapse items from when space is limited.
+   * @default "start"
+   */
+  collapseFrom?: "start" | "end";
+  /**
+   * Minimum number of ancestor items to keep visible (excluding current).
+   * Only applied if there's room; won't cause truncation.
+   * @default 1
+   */
+  minVisibleItems?: number;
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+// Layout constants for TreeMenu (pixels)
+const TREE_ROW_HEIGHT = 32;
+const TREE_BASE_X = 12;
+const TREE_INDENT = 14;
+const TREE_BRANCH = 2;
+const TREE_TEXT_GAP = 10;
+
+function treeXLevel(level: number): number {
+  return TREE_BASE_X + level * TREE_INDENT;
+}
+
+function treeXText(level: number): number {
+  return treeXLevel(level) + TREE_BRANCH + TREE_TEXT_GAP;
+}
+
+function treeYCenter(index: number): number {
+  return index * TREE_ROW_HEIGHT + TREE_ROW_HEIGHT / 2;
+}
+
+const TREE_MENU_ITEM_CLASS =
+  "flex h-8 min-w-0 cursor-pointer items-center rounded px-2 text-sm text-kumo-default outline-none select-none data-highlighted:bg-kumo-tint/60";
+
+/**
+ * Renders overflow breadcrumb items as an indented tree structure.
+ */
+function TreeMenu({ items }: { items: BreadcrumbItem[] }) {
+  if (items.length === 0) return null;
+
+  const totalHeight = items.length * TREE_ROW_HEIGHT;
+
+  return (
+    <div className="relative" style={{ height: totalHeight }}>
+      <svg
+        className="pointer-events-none absolute inset-0"
+        width="100%"
+        height={totalHeight}
+        aria-hidden
+        focusable="false"
+      >
+        {items.map((_, i) => {
+          if (i === 0) return null;
+
+          const x1 = treeXLevel(i - 1) - 6;
+          const x2 = treeXLevel(i) + TREE_BRANCH;
+          const y2 = treeYCenter(i);
+          const y1 =
+            i === 1 ? treeYCenter(0) + TREE_ROW_HEIGHT / 2 : treeYCenter(i - 1);
+
+          return (
+            <path
+              key={i}
+              d={`M ${x1} ${y1} V ${y2} H ${x2}`}
+              stroke="var(--color-kumo-line)"
+              strokeWidth="1"
+              strokeLinecap="butt"
+              strokeLinejoin="miter"
+              fill="none"
+            />
+          );
+        })}
+      </svg>
+
+      <div className="relative flex flex-col">
+        {items.map((item, i) => {
+          const paddingLeft = i === 0 ? 8 : treeXText(i);
+
+          return (
+            <Menu.Item
+              key={i}
+              render={
+                item.render ?? (
+                  <a href={item.href ?? "#"} aria-label={item.label} />
+                )
+              }
+              closeOnClick
+              className={TREE_MENU_ITEM_CLASS}
+              style={{ paddingLeft }}
+            >
+              <span className="min-w-0 truncate">{item.label}</span>
+            </Menu.Item>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Items-based breadcrumbs with automatic overflow handling.
+ * Measures items and collapses them into a dropdown when they don't fit.
+ */
+function ItemsBreadcrumbs({
+  items,
+  currentItem,
+  collapseFrom = "start",
+  minVisibleItems = 0,
+  size = "base",
+  className,
+}: BreadcrumbsItemsProps) {
+  const containerRef = useRef<HTMLElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [overflowCount, setOverflowCount] = useState(0);
+  const [itemWidths, setItemWidths] = useState<number[]>([]);
+  const [currentItemWidth, setCurrentItemWidth] = useState(0);
+  const [measured, setMeasured] = useState(false);
+  const LinkComponent = useLinkComponent();
+
+  // Measure all items once on mount/change
+  useEffect(() => {
+    if (!measureRef.current) return;
+
+    const measureContainer = measureRef.current;
+    const itemEls = measureContainer.querySelectorAll("[data-measure-item]");
+    const currentEl = measureContainer.querySelector("[data-measure-current]");
+
+    const widths = Array.from(itemEls).map(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const currentWidth = currentEl?.getBoundingClientRect().width ?? 100;
+
+    setItemWidths(widths);
+    setCurrentItemWidth(currentWidth);
+    setMeasured(true);
+  }, [items, currentItem]);
+
+  // Compute overflow based on cached widths
+  useEffect(() => {
+    if (!measured || !containerRef.current) return;
+
+    const computeOverflow = () => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      // Be conservative - subtract buffer for measurement inaccuracies
+      const containerWidth = container.offsetWidth - 16;
+      const overflowButtonWidth = 48; // button + ring + padding
+      const separatorWidth = 32; // separator + gaps (24px icon + gaps)
+
+      // Start with current item width + its preceding separator
+      let usedWidth = currentItemWidth + separatorWidth;
+      let visibleCount = 0;
+
+      // Measure from end to preserve parent context
+      for (let i = items.length - 1; i >= 0; i--) {
+        const itemWidth = itemWidths[i] ?? 80;
+        const neededWidth = separatorWidth + itemWidth;
+
+        const willHaveOverflow = i > 0;
+        const overflowSpace = willHaveOverflow
+          ? overflowButtonWidth + separatorWidth
+          : 0;
+
+        if (usedWidth + neededWidth + overflowSpace <= containerWidth) {
+          usedWidth += neededWidth;
+          visibleCount++;
+        } else {
+          break;
+        }
+      }
+
+      // Honor minVisibleItems if it fits
+      const overflowNeeded = items.length - visibleCount;
+      if (overflowNeeded > 0 && overflowNeeded < items.length) {
+        const minVisible = Math.min(minVisibleItems, items.length);
+        if (visibleCount < minVisible) {
+          let testWidth =
+            currentItemWidth + overflowButtonWidth + separatorWidth;
+          for (let i = items.length - minVisible; i < items.length; i++) {
+            testWidth += separatorWidth + (itemWidths[i] ?? 80);
+          }
+          if (testWidth <= containerWidth) {
+            visibleCount = minVisible;
+          }
+        }
+      }
+
+      setOverflowCount(items.length - visibleCount);
+    };
+
+    computeOverflow();
+
+    const observer = new ResizeObserver(computeOverflow);
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [measured, items.length, itemWidths, currentItemWidth, minVisibleItems]);
+
+  // Split items
+  const overflowItems =
+    collapseFrom === "start"
+      ? items.slice(0, overflowCount)
+      : items.slice(items.length - overflowCount);
+
+  const visibleItems =
+    collapseFrom === "start"
+      ? items.slice(overflowCount)
+      : items.slice(0, items.length - overflowCount);
+
+  return (
+    <>
+      {/* Hidden measurement container */}
+      <div
+        ref={measureRef}
+        className="pointer-events-none absolute flex items-center gap-1 text-sm opacity-0"
+        aria-hidden
+      >
+        {items.map((item, index) => (
+          <span
+            key={index}
+            data-measure-item
+            className="flex shrink-0 items-center gap-1 whitespace-nowrap"
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </span>
+        ))}
+        <span
+          data-measure-current
+          className="flex shrink-0 items-center gap-1 font-medium whitespace-nowrap"
+        >
+          {currentItem.icon}
+          <span>{currentItem.label}</span>
+        </span>
+      </div>
+
+      <nav
+        ref={containerRef}
+        className={cn(
+          "group flex min-w-0 max-w-full items-center",
+          KUMO_BREADCRUMBS_VARIANTS.size[size].classes,
+          className,
+        )}
+        aria-label="Breadcrumb"
+      >
+        {/* Overflow menu */}
+        {overflowItems.length > 0 && (
+          <>
+            <Menu.Root>
+              <Menu.Trigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    aria-label="Show collapsed breadcrumbs"
+                    icon={<DotsThree weight="bold" size={16} />}
+                    className="shrink-0"
+                  />
+                }
+              />
+              <Menu.Portal>
+                <Menu.Positioner sideOffset={8} align="start">
+                  <Menu.Popup className="min-w-48 rounded-lg bg-kumo-control p-2 text-kumo-default shadow-lg ring ring-kumo-line">
+                    <TreeMenu
+                      items={
+                        collapseFrom === "start"
+                          ? overflowItems
+                          : [...overflowItems].reverse()
+                      }
+                    />
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.Root>
+            <Separator />
+          </>
+        )}
+
+        {/* Visible items */}
+        {visibleItems.map((item, i) => {
+          const renderProps = item.render?.props as
+            | { className?: string }
+            | undefined;
+
+          return (
+            <span key={i} className="contents">
+              {item.render ? (
+                cloneElement(
+                  item.render,
+                  {
+                    className: cn(
+                      "flex shrink-0 items-center gap-1 text-kumo-subtle hover:text-kumo-default whitespace-nowrap no-underline",
+                      renderProps?.className,
+                    ),
+                  } as React.HTMLAttributes<HTMLElement>,
+                  item.icon,
+                  <span>{item.label}</span>,
+                )
+              ) : (
+                <LinkComponent
+                  to={item.href ?? "#"}
+                  className="flex shrink-0 items-center gap-1 text-kumo-subtle hover:text-kumo-default whitespace-nowrap no-underline"
+                >
+                  {item.icon}
+                  <span>{item.label}</span>
+                </LinkComponent>
+              )}
+              <Separator />
+            </span>
+          );
+        })}
+
+        {/* Current item */}
+        {currentItem.loading ? (
+          <div className="flex w-[125px] min-w-0 items-center gap-1">
+            {currentItem.icon && (
+              <span className="flex shrink-0 items-center">
+                {currentItem.icon}
+              </span>
+            )}
+            <SkeletonLine />
+          </div>
+        ) : (
+          <span
+            className="flex shrink-0 items-center gap-1 font-medium whitespace-nowrap"
+            aria-current="page"
+          >
+            {currentItem.icon && (
+              <span className="flex shrink-0 items-center">
+                {currentItem.icon}
+              </span>
+            )}
+            <span>{currentItem.label}</span>
+          </span>
+        )}
+      </nav>
+    </>
+  );
+}
+
+// ============================================================================
+// Unified Breadcrumb Component
+// ============================================================================
+
+/**
+ * Combined props type supporting both APIs.
+ * When `items` is provided, uses items-based API with overflow.
+ * Otherwise, uses compound component API with children.
+ */
+export type BreadcrumbsCombinedProps =
+  | BreadcrumbsProps
+  | (BreadcrumbsItemsProps & { children?: never });
+
+function hasItemsProps(
+  props: BreadcrumbsCombinedProps,
+): props is BreadcrumbsItemsProps {
+  return "items" in props && Array.isArray(props.items);
+}
+
+/**
+ * Navigation breadcrumb trail showing the current page's location in a hierarchy.
+ *
+ * Supports two APIs:
+ *
+ * **Compound Component API** (legacy):
+ * ```tsx
+ * <Breadcrumbs>
+ *   <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
+ *   <Breadcrumbs.Separator />
+ *   <Breadcrumbs.Current>Dashboard</Breadcrumbs.Current>
+ * </Breadcrumbs>
+ * ```
+ *
+ * **Items API** (with automatic overflow):
+ * ```tsx
+ * <Breadcrumbs
+ *   items={[
+ *     { label: "Home", href: "/" },
+ *     { label: "Projects", href: "/projects" },
+ *   ]}
+ *   currentItem={{ label: "Settings" }}
+ * />
+ * ```
+ */
+export function Breadcrumb(props: BreadcrumbsCombinedProps) {
+  if (hasItemsProps(props)) {
+    return <ItemsBreadcrumbs {...props} />;
+  }
+  return <CompoundBreadcrumbs {...props} />;
 }
 
 Breadcrumb.Link = Link;

--- a/packages/kumo/src/components/breadcrumbs/index.ts
+++ b/packages/kumo/src/components/breadcrumbs/index.ts
@@ -3,7 +3,10 @@ export {
   breadcrumbsVariants,
   KUMO_BREADCRUMBS_VARIANTS,
   KUMO_BREADCRUMBS_DEFAULT_VARIANTS,
+  type BreadcrumbItem,
   type BreadcrumbsProps,
+  type BreadcrumbsItemsProps,
+  type BreadcrumbsCombinedProps,
   type KumoBreadcrumbsSize,
   type KumoBreadcrumbsVariantsProps,
 } from "./breadcrumbs";

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -167,7 +167,13 @@ export {
   type KumoLinkVariant,
   type KumoLinkVariantsProps,
 } from "./components/link";
-export { Breadcrumbs, type BreadcrumbsProps } from "./components/breadcrumbs";
+export {
+  Breadcrumbs,
+  type BreadcrumbItem,
+  type BreadcrumbsProps,
+  type BreadcrumbsItemsProps,
+  type BreadcrumbsCombinedProps,
+} from "./components/breadcrumbs";
 export { Empty, type EmptyProps } from "./components/empty";
 export {
   Grid,


### PR DESCRIPTION
## Summary

Adds a new items-based API to the Breadcrumbs component with automatic overflow support:

- New `items` prop accepts an array of `BreadcrumbItem` objects for declarative breadcrumb definition
- New `currentItem` prop for the current page item
- Automatic overflow detection collapses items that don't fit into a dropdown menu
- Tree visualization in overflow menu shows breadcrumb hierarchy with L-shaped SVG connectors
- Support for custom router links via `render` prop on items
- Loading state support on current item
- Exported new types: `BreadcrumbItem`, `BreadcrumbsItemsProps`, `BreadcrumbsCombinedProps`


https://github.com/user-attachments/assets/758d9dcd-6077-4bdc-868c-6a59388b21cf



## Usage

```tsx
import { Breadcrumbs, type BreadcrumbItem } from "@cloudflare/kumo";

const items: BreadcrumbItem[] = [
  { label: "Home", href: "/" },
  { label: "Projects", href: "/projects" },
  { label: "Settings", href: "/projects/settings" },
];

<Breadcrumbs 
  items={items} 
  currentItem={{ label: "General" }} 
/>
```

## Backward Compatibility

The existing compound component API continues to work unchanged:

```tsx
<Breadcrumbs>
  <Breadcrumbs.Link href="/">Home</Breadcrumbs.Link>
  <Breadcrumbs.Separator />
  <Breadcrumbs.Current>Current Page</Breadcrumbs.Current>
</Breadcrumbs>
```

## Demo

The demo page includes an interactive example with a width slider to test overflow behavior.

## Checklist

- [x] Tests included/updated
- [x] bonk has reviewed the change