### PR TITLE
docs(text): replace raw p tags with Text component in TextDemo

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
@@ -5,61 +5,61 @@ export function TextVariantsDemo() {
     <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="heading1">Heading 1</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-3xl (30px)</p>
+        <Text variant="mono-secondary">text-3xl (30px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="heading2">Heading 2</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-2xl (24px)</p>
+        <Text variant="mono-secondary">text-2xl (24px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="heading3">Heading 3</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-lg (16px)</p>
+        <Text variant="mono-secondary">text-lg (16px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text>Body</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-base (14px)</p>
+        <Text variant="mono-secondary">text-base (14px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text bold>Body bold</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-base (14px)</p>
+        <Text variant="mono-secondary">text-base (14px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text size="lg">Body lg</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-lg (16px)</p>
+        <Text variant="mono-secondary">text-lg (16px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text size="sm">Body sm</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-sm (13px)</p>
+        <Text variant="mono-secondary">text-sm (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text size="xs">Body xs</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-xs (12px)</p>
+        <Text variant="mono-secondary">text-xs (12px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="secondary">Body secondary</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-base (14px)</p>
+        <Text variant="mono-secondary">text-base (14px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="mono">Monospace</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-sm (13px)</p>
+        <Text variant="mono-secondary">text-sm (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="mono" size="lg">
           Monospace lg
         </Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-base (14px)</p>
+        <Text variant="mono-secondary">text-base (14px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="mono-secondary">Monospace secondary</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-sm (13px)</p>
+        <Text variant="mono-secondary">text-sm (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="success">Success</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-base (14px)</p>
+        <Text variant="mono-secondary">text-base (14px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-line bg-kumo-base p-4">
         <Text variant="error">Error</Text>
-        <p className="font-mono text-xs text-kumo-subtle">text-base (14px)</p>
+        <Text variant="mono-secondary">text-base (14px)</Text>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Replaces all `<p className="font-mono text-xs text-kumo-subtle">` label captions in `TextDemo.tsx` with `<Text variant="mono-secondary">`, using the Text component consistently in its own demo.

## Notes

`variant="mono-secondary"` renders at `sm` (13px) rather than the original `xs` (12px), as mono variants only accept `size="lg"` — there is no exact API match for `text-xs` within the Text component's type constraints.