### PR TITLE
[kumo] feat(popover): expose anchor prop on Popover.Content for virtual positioning

### DIFF
--- a/.changeset/feat-popover-anchor-prop.md
+++ b/.changeset/feat-popover-anchor-prop.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(popover): expose `anchor` prop on `Popover.Content` for virtual positioning
+
+Forwards Base UI's `anchor` prop through `Popover.Content` to the underlying `Positioner`, enabling popover positioning against custom elements, refs, or virtual points (e.g., a `DOMRect` from `getBoundingClientRect()`). This is useful when the popover trigger and the desired anchor are in different component trees, or when anchoring to a coordinate rather than a DOM element.

--- a/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
@@ -1,5 +1,6 @@
+import { useState, useRef } from "react";
 import { Popover, Button } from "@cloudflare/kumo";
-import { BellIcon } from "@phosphor-icons/react";
+import { BellIcon, DotsThree } from "@phosphor-icons/react";
 
 export function PopoverHeroDemo() {
   return (
@@ -154,5 +155,93 @@ export function PopoverOpenOnHoverDemo() {
         </div>
       </Popover.Content>
     </Popover>
+  );
+}
+
+/** Popover anchored to a virtual element instead of a trigger. */
+export function PopoverVirtualAnchorDemo() {
+  const [selectedRow, setSelectedRow] = useState<string | null>(null);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+
+  const rows = [
+    { id: "1", name: "api-gateway", status: "Active" },
+    { id: "2", name: "auth-service", status: "Active" },
+    { id: "3", name: "worker-prod", status: "Paused" },
+  ];
+
+  const handleEdit = (id: string) => {
+    const row = rowRefs.current.get(id);
+    if (row) {
+      setAnchorRect(row.getBoundingClientRect());
+      setSelectedRow(id);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <div className="overflow-hidden rounded-lg border border-kumo-hairline">
+        <table className="w-full text-sm">
+          <thead className="bg-kumo-elevated">
+            <tr>
+              <th className="px-4 py-2 text-left font-medium">Name</th>
+              <th className="px-4 py-2 text-left font-medium">Status</th>
+              <th className="w-12 px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-kumo-hairline">
+            {rows.map((row) => (
+              <tr
+                key={row.id}
+                ref={(el) => {
+                  if (el) rowRefs.current.set(row.id, el);
+                }}
+                className={
+                  selectedRow === row.id ? "bg-kumo-recessed" : "bg-kumo-base"
+                }
+              >
+                <td className="px-4 py-2 font-mono">{row.name}</td>
+                <td className="px-4 py-2 text-kumo-subtle">{row.status}</td>
+                <td className="px-4 py-2">
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    shape="square"
+                    icon={DotsThree}
+                    aria-label={`Actions for ${row.name}`}
+                    onClick={() => handleEdit(row.id)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Popover
+        open={!!selectedRow}
+        onOpenChange={(open) => !open && setSelectedRow(null)}
+      >
+        <Popover.Content
+          side="left"
+          anchor={
+            anchorRect ? { getBoundingClientRect: () => anchorRect } : undefined
+          }
+        >
+          <Popover.Title>
+            Edit {rows.find((r) => r.id === selectedRow)?.name}
+          </Popover.Title>
+          <Popover.Description>
+            The popover anchors to the selected row, not the icon button.
+          </Popover.Description>
+          <div className="mt-3">
+            <Popover.Close asChild>
+              <Button size="sm" variant="secondary">
+                Close
+              </Button>
+            </Popover.Close>
+          </div>
+        </Popover.Content>
+      </Popover>
+    </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -17,6 +17,7 @@ import {
   PopoverPositionDemo,
   PopoverCustomContentDemo,
   PopoverOpenOnHoverDemo,
+  PopoverVirtualAnchorDemo,
 } from "~/components/demos/PopoverDemo";
 
 {/* Hero Demo */}
@@ -190,44 +191,9 @@ export default function Example() {
   from `getBoundingClientRect()`). This is useful when the trigger and the
   desired anchor are in different component trees.
 </p>
-
-```tsx
-import { Popover } from "@cloudflare/kumo";
-import { useState, useRef } from "react";
-
-function VirtualAnchorExample() {
-  const [open, setOpen] = useState(false);
-  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  return (
-    <>
-      <button
-        ref={buttonRef}
-        onClick={() => {
-          setAnchorRect(buttonRef.current?.getBoundingClientRect() ?? null);
-          setOpen((prev) => !prev);
-        }}
-      >
-        Open popover
-      </button>
-      <Popover open={open} onOpenChange={setOpen}>
-        <Popover.Content
-          side="bottom"
-          anchor={
-            anchorRect ? { getBoundingClientRect: () => anchorRect } : undefined
-          }
-        >
-          <Popover.Title>Virtual Anchor</Popover.Title>
-          <Popover.Description>
-            This popover is anchored to a DOMRect.
-          </Popover.Description>
-        </Popover.Content>
-      </Popover>
-    </>
-  );
-}
-```
+<ComponentExample demo="PopoverVirtualAnchorDemo">
+  <PopoverVirtualAnchorDemo client:load />
+</ComponentExample>
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -183,6 +183,52 @@ export default function Example() {
   <PopoverOpenOnHoverDemo client:load />
 </ComponentExample>
 
+<Heading level={3}>Virtual Anchor</Heading>
+<p>
+  Use the `anchor` prop on `Popover.Content` to position the popover against an
+  element other than the trigger, or against a virtual point (e.g., a `DOMRect`
+  from `getBoundingClientRect()`). This is useful when the trigger and the
+  desired anchor are in different component trees.
+</p>
+
+```tsx
+import { Popover } from "@cloudflare/kumo";
+import { useState, useRef } from "react";
+
+function VirtualAnchorExample() {
+  const [open, setOpen] = useState(false);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        onClick={() => {
+          setAnchorRect(buttonRef.current?.getBoundingClientRect() ?? null);
+          setOpen((prev) => !prev);
+        }}
+      >
+        Open popover
+      </button>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Popover.Content
+          side="bottom"
+          anchor={
+            anchorRect ? { getBoundingClientRect: () => anchorRect } : undefined
+          }
+        >
+          <Popover.Title>Virtual Anchor</Popover.Title>
+          <Popover.Description>
+            This popover is anchored to a DOMRect.
+          </Popover.Description>
+        </Popover.Content>
+      </Popover>
+    </>
+  );
+}
+```
+
 </ComponentSection>
 
 {/* API Reference */}
@@ -204,9 +250,10 @@ export default function Example() {
 <Heading level={3}>Popover.Content</Heading>
 <p>
   The container for popover content. Controls positioning via `side`, `align`,
-  `sideOffset`, and `alignOffset` props. Use `positionMethod="fixed"` (the
-  default) when the popover needs to escape stacking contexts, such as when
-  inside sticky headers.
+  `sideOffset`, and `alignOffset` props. Use the `anchor` prop to position
+  against a custom element or virtual point instead of the trigger. Use
+  `positionMethod="fixed"` when the popover needs to escape stacking contexts,
+  such as when inside sticky headers.
 </p>
 <PropsTable component="Popover.Content" />
 

--- a/packages/kumo/src/components/popover/popover.tsx
+++ b/packages/kumo/src/components/popover/popover.tsx
@@ -102,6 +102,10 @@ PopoverTrigger.displayName = "Popover.Trigger";
 /** Alignment options for popover positioning */
 type PopoverAlign = "start" | "center" | "end";
 
+type BasePopoverPositionerProps = ComponentPropsWithoutRef<
+  typeof PopoverBase.Positioner
+>;
+
 /**
  * Popover content panel props.
  *
@@ -113,6 +117,28 @@ type PopoverAlign = "start" | "center" | "end";
  * ```
  */
 export type PopoverContentProps = KumoPopoverVariantsProps & {
+  /**
+   * An element to position the popup against.
+   * By default, the popup will be positioned against the trigger.
+   *
+   * Accepts a DOM element, a ref to a DOM element, a virtual element
+   * (object with a `getBoundingClientRect` method), or a function
+   * returning any of these.
+   *
+   * This is useful when the popover trigger and the desired anchor point
+   * are in different component trees, or when positioning against a
+   * coordinate (e.g., a `DOMRect` from `getBoundingClientRect()`).
+   *
+   * @example Virtual element (e.g., anchoring to a DOMRect)
+   * ```tsx
+   * <Popover open={open} onOpenChange={setOpen}>
+   *   <Popover.Content anchor={{ getBoundingClientRect: () => anchorRect }}>
+   *     <p>Anchored content</p>
+   *   </Popover.Content>
+   * </Popover>
+   * ```
+   */
+  anchor?: BasePopoverPositionerProps["anchor"];
   /**
    * How to align the popover relative to the trigger.
    * @default "center"
@@ -153,6 +179,7 @@ function PopoverContent({
   sideOffset = 8,
   alignOffset = 0,
   positionMethod = "absolute",
+  anchor,
   className,
   container: containerProp,
 }: PopoverContentProps) {
@@ -162,6 +189,7 @@ function PopoverContent({
   return (
     <PopoverBase.Portal container={container}>
       <PopoverBase.Positioner
+        anchor={anchor}
         align={align}
         alignOffset={alignOffset}
         side={side}


### PR DESCRIPTION
Fixes #N/A (feature request — no existing issue).

## Summary

Exposes Base UI's `anchor` prop on `Popover.Content`, enabling popover positioning against custom elements, refs, or virtual points (e.g., a `DOMRect` from `getBoundingClientRect()`).

This is a **one-prop passthrough** — the prop already exists on the underlying `PopoverBase.Positioner` from `@base-ui/react`, but Kumo's styled wrapper did not surface it.

## Motivation

Internal Cloudflare tools (including ProvUI) have **7+ hand-rolled anchored popovers** that each reimplement ~50 lines of manual viewport collision detection, arrow positioning, click-outside handling, and portal rendering — all because Kumo's Popover doesn't support positioning against a virtual anchor.

The common pattern is a speech-bubble popover anchored to a button inside a table row or sidebar card, where the trigger element and the popover are in different component trees. Without the `anchor` prop, consumers must bypass Kumo's `Popover` entirely and either use `createPortal` with manual positioning or import the raw Base UI primitive.

With this change, all of those hand-rolled popovers can be replaced with:

```tsx
<Popover open={open} onOpenChange={setOpen}>
  <Popover.Content
    side="left"
    anchor={{ getBoundingClientRect: () => anchorRect }}
  >
    {/* content */}
  </Popover.Content>
</Popover>
```

## Changes

- **`packages/kumo/src/components/popover/popover.tsx`**: Added `anchor` prop to `PopoverContentProps` (type extracted from `PopoverBase.Positioner` props to stay in sync with Base UI). Passed through to `<PopoverBase.Positioner anchor={anchor}>`. JSDoc with usage example.
- **`packages/kumo-docs-astro/src/pages/components/popover.mdx`**: Added "Virtual Anchor" example section with code sample. Updated `Popover.Content` API reference description.
- **`.changeset/feat-popover-anchor-prop.md`**: Minor version bump changeset.

## Type safety

The `anchor` prop type is derived directly from Base UI's `PopoverPositioner` props using `ComponentPropsWithoutRef<typeof PopoverBase.Positioner>["anchor"]`, so it automatically stays in sync with future Base UI updates.

---

- Reviews
- [x] bonk has reviewed the change
- [x] automated review not possible because: pure prop passthrough with no new logic to review — type is derived from Base UI
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [x] Additional testing not necessary because: This is a pure prop passthrough — no new logic. The prop is forwarded unchanged to Base UI's `Positioner`, which already has its own test coverage. TypeScript compilation confirms the type is correct.