### PR TITLE
feat(link): introduce `useClientRouting` hook to for router integration

### DIFF
--- a/.changeset/calm-rivers-share.md
+++ b/.changeset/calm-rivers-share.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(link): add router-agnostic client routing events
+
+- Emit `kumo:navigate` and `kumo:prefetch` from eligible internal links
+- Add `useClientRouting()` to integrate Link events with application routers

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -287,8 +287,12 @@ export default function Example() {
       <h3 class="mb-2 font-semibold">Framework Integration</h3>
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>
-          Use the `render` prop with React Router, Next.js, or other framework
-          links
+          Use the `useClientRouting()` hook to integrate Kumo with a client-side
+          router
+        </li>
+        <li>
+          You may also use the `render` prop with React Router, Next.js, or
+          other framework links
         </li>
         <li>Pass your framework's Link component as the render prop value</li>
         <li>

--- a/packages/kumo/src/components/link/client-routing.ts
+++ b/packages/kumo/src/components/link/client-routing.ts
@@ -1,0 +1,169 @@
+import { useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+
+export const KUMO_NAVIGATE_EVENT = "kumo:navigate";
+export const KUMO_PREFETCH_EVENT = "kumo:prefetch";
+
+export type KumoLinkEventSource = "click" | "hover" | "focus";
+
+export type KumoLinkEventDetail = {
+  href: string;
+  anchor: HTMLAnchorElement;
+  nativeEvent: Event;
+  source: KumoLinkEventSource;
+};
+
+export class KumoNavigateEvent extends CustomEvent<KumoLinkEventDetail> {
+  constructor(detail: KumoLinkEventDetail) {
+    super(KUMO_NAVIGATE_EVENT, {
+      bubbles: true,
+      cancelable: true,
+      detail,
+    });
+  }
+}
+
+export class KumoPrefetchEvent extends CustomEvent<KumoLinkEventDetail> {
+  constructor(detail: KumoLinkEventDetail) {
+    super(KUMO_PREFETCH_EVENT, {
+      bubbles: true,
+      cancelable: false,
+      detail,
+    });
+  }
+}
+
+export type UseClientRoutingHandlers = {
+  onNavigate?: (href: string, event: KumoNavigateEvent) => void;
+  onPrefetch?: (href: string, event: KumoPrefetchEvent) => void;
+};
+
+export type UseClientRoutingOptions = {
+  target?: EventTarget | null;
+};
+
+export function shouldUseClientRouter(
+  anchor: HTMLAnchorElement,
+  event?: Pick<
+    MouseEvent | ReactMouseEvent<HTMLAnchorElement>,
+    | "defaultPrevented"
+    | "metaKey"
+    | "ctrlKey"
+    | "shiftKey"
+    | "altKey"
+    | "button"
+  >,
+): boolean {
+  if (!anchor.href) return false;
+  if (anchor.hasAttribute("download")) return false;
+
+  const target = anchor.getAttribute("target");
+  if (target && target !== "_self") return false;
+
+  const rawHref = anchor.getAttribute("href");
+  if (!rawHref || rawHref.startsWith("#")) return false;
+
+  let url: URL;
+  try {
+    url = new URL(anchor.href, window.location.href);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  if (url.origin !== window.location.origin) return false;
+
+  if (!event) return true;
+  if (event.defaultPrevented) return false;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return false;
+  }
+  if (event.button !== 0) return false;
+
+  return true;
+}
+
+/**
+ * Bridge Kumo link events to an application router.
+ *
+ * Listens for `kumo:navigate` and `kumo:prefetch` on `options.target ?? window`.
+ * Call `event.preventDefault()` inside `onNavigate` to accept the router
+ * handoff and suppress native anchor navigation. If `onNavigate` does not
+ * cancel the custom event, the browser handles the link normally.
+ *
+ * @example
+ * useClientRouting({
+ *   onNavigate(href, event) {
+ *     if (!router.canHandle(href)) {
+ *       return;
+ *     }
+ *     event.preventDefault();
+ *     router.navigate(href);
+ *   },
+ *   onPrefetch(href) {
+ *     router.prefetch?.(href);
+ *   },
+ * });
+ */
+export function useClientRouting(
+  handlers: UseClientRoutingHandlers,
+  options: UseClientRoutingOptions = {},
+): void {
+  const onNavigateRef = useRef(handlers.onNavigate);
+  const onPrefetchRef = useRef(handlers.onPrefetch);
+
+  onNavigateRef.current = handlers.onNavigate;
+  onPrefetchRef.current = handlers.onPrefetch;
+
+  useEffect(() => {
+    const target =
+      options.target === null
+        ? null
+        : (options.target ?? (typeof window !== "undefined" ? window : null));
+
+    if (!target) {
+      return;
+    }
+
+    function handlePrefetch(nativeEvent: Event) {
+      const event = nativeEvent as KumoPrefetchEvent;
+      const href = event.detail?.href;
+
+      if (!href) return;
+
+      onPrefetchRef.current?.(href, event);
+    }
+
+    function handleNavigate(nativeEvent: Event) {
+      const event = nativeEvent as KumoNavigateEvent;
+      const href = event.detail?.href;
+
+      if (!href) return;
+
+      onNavigateRef.current?.(href, event);
+
+      if (event.defaultPrevented) {
+        event.stopImmediatePropagation();
+      }
+    }
+
+    target.addEventListener(
+      KUMO_PREFETCH_EVENT,
+      handlePrefetch as EventListener,
+    );
+    target.addEventListener(
+      KUMO_NAVIGATE_EVENT,
+      handleNavigate as EventListener,
+    );
+
+    return () => {
+      target.removeEventListener(
+        KUMO_PREFETCH_EVENT,
+        handlePrefetch as EventListener,
+      );
+      target.removeEventListener(
+        KUMO_NAVIGATE_EVENT,
+        handleNavigate as EventListener,
+      );
+    };
+  }, [options.target]);
+}

--- a/packages/kumo/src/components/link/index.ts
+++ b/packages/kumo/src/components/link/index.ts
@@ -1,1 +1,14 @@
 export * from "./link";
+export {
+  KUMO_NAVIGATE_EVENT,
+  KUMO_PREFETCH_EVENT,
+  KumoNavigateEvent,
+  KumoPrefetchEvent,
+  useClientRouting,
+} from "./client-routing";
+export type {
+  KumoLinkEventDetail,
+  KumoLinkEventSource,
+  UseClientRoutingHandlers,
+  UseClientRoutingOptions,
+} from "./client-routing";

--- a/packages/kumo/src/components/link/link.test.tsx
+++ b/packages/kumo/src/components/link/link.test.tsx
@@ -1,6 +1,50 @@
-import { describe, it, expect } from "vitest";
-import { createElement } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { createElement, type MouseEvent as ReactMouseEvent } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Link, KUMO_LINK_VARIANTS, linkVariants } from "./link";
+import {
+  KUMO_NAVIGATE_EVENT,
+  KUMO_PREFETCH_EVENT,
+  KumoNavigateEvent,
+  useClientRouting,
+  type KumoPrefetchEvent,
+} from "./client-routing";
+
+function RouterBridge({
+  onNavigate,
+  onPrefetch,
+  target,
+}: {
+  onNavigate?: (href: string, event: KumoNavigateEvent) => void;
+  onPrefetch?: (href: string, event: KumoPrefetchEvent) => void;
+  target?: EventTarget | null;
+}) {
+  useClientRouting({ onNavigate, onPrefetch }, { target });
+  return null;
+}
+
+function listenForEvent<T extends Event>(type: string) {
+  const spy = vi.fn();
+  const listener: EventListener = (event) => spy(event as T);
+
+  window.addEventListener(type, listener);
+
+  return {
+    spy,
+    dispose() {
+      window.removeEventListener(type, listener);
+    },
+  };
+}
+
+function createClickEvent(init: MouseEventInit = {}): MouseEvent {
+  return new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...init,
+  });
+}
 
 describe("Link", () => {
   it("should be defined", () => {
@@ -112,5 +156,314 @@ describe("Link", () => {
       children: "Dashboard",
     };
     expect(() => createElement(Link, props)).not.toThrow();
+  });
+
+  it("dispatches kumo:navigate for eligible internal clicks and prevents the real click when handled", () => {
+    const onNavigate = vi.fn((_href: string, event: KumoNavigateEvent) => {
+      event.preventDefault();
+    });
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(
+      <>
+        <RouterBridge onNavigate={onNavigate} />
+        <Link href="/docs">Learn more</Link>
+      </>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Learn more" });
+    const clickEvent = createClickEvent();
+    const dispatchResult = anchor.dispatchEvent(clickEvent);
+
+    expect(dispatchResult).toBe(false);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(navigateEvents.spy).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith(
+      new URL("/docs", window.location.href).href,
+      expect.objectContaining({
+        type: KUMO_NAVIGATE_EVENT,
+        detail: expect.objectContaining({
+          href: new URL("/docs", window.location.href).href,
+          anchor,
+          source: "click",
+        }),
+      }),
+    );
+
+    navigateEvents.dispose();
+  });
+
+  it("allows normal browser navigation when onNavigate does not prevent the custom event", () => {
+    const onNavigate = vi.fn();
+
+    render(
+      <>
+        <RouterBridge onNavigate={onNavigate} />
+        <Link href="/docs">Learn more</Link>
+      </>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Learn more" });
+    const clickEvent = createClickEvent();
+    const dispatchResult = anchor.dispatchEvent(clickEvent);
+
+    expect(dispatchResult).toBe(true);
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(onNavigate).toHaveBeenCalledWith(
+      new URL("/docs", window.location.href).href,
+      expect.objectContaining({ type: KUMO_NAVIGATE_EVENT }),
+    );
+  });
+
+  it("stops later navigate listeners after one handler accepts the handoff", () => {
+    const firstNavigate = vi.fn((_href: string, event: KumoNavigateEvent) => {
+      event.preventDefault();
+    });
+    const secondNavigate = vi.fn();
+
+    render(
+      <>
+        <RouterBridge onNavigate={firstNavigate} />
+        <RouterBridge onNavigate={secondNavigate} />
+        <Link href="/docs">Learn more</Link>
+      </>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Learn more" });
+    const clickEvent = createClickEvent();
+    const dispatchResult = anchor.dispatchEvent(clickEvent);
+
+    expect(dispatchResult).toBe(false);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(firstNavigate).toHaveBeenCalledTimes(1);
+    expect(secondNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch kumo:navigate for external links", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(<Link href="https://example.com/docs">External</Link>);
+
+    const anchor = screen.getByRole("link", { name: "External" });
+    anchor.dispatchEvent(createClickEvent());
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for target=_blank links", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(
+      <Link href="/docs" target="_blank">
+        New tab
+      </Link>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "New tab" });
+    anchor.dispatchEvent(createClickEvent());
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for named targets", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(
+      <Link href="/docs" target="report-frame">
+        Report
+      </Link>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Report" });
+    anchor.dispatchEvent(createClickEvent());
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for download links", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(
+      <Link href="/report.csv" download>
+        Download
+      </Link>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Download" });
+    anchor.dispatchEvent(createClickEvent());
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for disabled links", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(
+      <Link href="/docs" disabled>
+        Disabled
+      </Link>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Disabled" });
+    anchor.dispatchEvent(createClickEvent());
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for modified clicks", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(<Link href="/docs">Modified</Link>);
+
+    const anchor = screen.getByRole("link", { name: "Modified" });
+    anchor.dispatchEvent(createClickEvent({ metaKey: true }));
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for middle clicks", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(<Link href="/docs">Middle</Link>);
+
+    const anchor = screen.getByRole("link", { name: "Middle" });
+    anchor.dispatchEvent(createClickEvent({ button: 1 }));
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("does not dispatch kumo:navigate for fragment-only links", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+
+    render(<Link href="#section">Jump</Link>);
+
+    const anchor = screen.getByRole("link", { name: "Jump" });
+    anchor.dispatchEvent(createClickEvent());
+
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("dispatches kumo:prefetch on hover for eligible internal links", () => {
+    const onPrefetch = vi.fn();
+    const prefetchEvents =
+      listenForEvent<KumoPrefetchEvent>(KUMO_PREFETCH_EVENT);
+
+    render(
+      <>
+        <RouterBridge onPrefetch={onPrefetch} />
+        <Link href="/docs">Hover me</Link>
+      </>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Hover me" });
+    fireEvent.mouseEnter(anchor);
+
+    expect(prefetchEvents.spy).toHaveBeenCalledTimes(1);
+    expect(onPrefetch).toHaveBeenCalledWith(
+      new URL("/docs", window.location.href).href,
+      expect.objectContaining({
+        type: KUMO_PREFETCH_EVENT,
+        detail: expect.objectContaining({
+          href: new URL("/docs", window.location.href).href,
+          anchor,
+          source: "hover",
+        }),
+      }),
+    );
+
+    prefetchEvents.dispose();
+  });
+
+  it("dispatches kumo:prefetch on focus for eligible internal links", () => {
+    const onPrefetch = vi.fn();
+
+    render(
+      <>
+        <RouterBridge onPrefetch={onPrefetch} />
+        <Link href="/docs">Focus me</Link>
+      </>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Focus me" });
+    fireEvent.focus(anchor);
+
+    expect(onPrefetch).toHaveBeenCalledWith(
+      new URL("/docs", window.location.href).href,
+      expect.objectContaining({
+        type: KUMO_PREFETCH_EVENT,
+        detail: expect.objectContaining({ source: "focus" }),
+      }),
+    );
+  });
+
+  it("does not dispatch kumo:navigate when the consumer prevents the click", () => {
+    const navigateEvents =
+      listenForEvent<KumoNavigateEvent>(KUMO_NAVIGATE_EVENT);
+    const onClick = vi.fn((event: ReactMouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <Link href="/docs" onClick={onClick}>
+        Consumer handled
+      </Link>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Consumer handled" });
+    const clickEvent = createClickEvent();
+    anchor.dispatchEvent(clickEvent);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(navigateEvents.spy).not.toHaveBeenCalled();
+
+    navigateEvents.dispose();
+  });
+
+  it("detaches useClientRouting listeners on unmount", () => {
+    const onNavigate = vi.fn();
+
+    const { unmount } = render(<RouterBridge onNavigate={onNavigate} />);
+    unmount();
+
+    const anchor = document.createElement("a");
+    anchor.href = "/docs";
+
+    window.dispatchEvent(
+      new KumoNavigateEvent({
+        href: anchor.href,
+        anchor,
+        nativeEvent: new Event("click"),
+        source: "click",
+      }),
+    );
+
+    expect(onNavigate).not.toHaveBeenCalled();
   });
 });

--- a/packages/kumo/src/components/link/link.tsx
+++ b/packages/kumo/src/components/link/link.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, type SVGProps } from "react";
+import {
+  forwardRef,
+  type FocusEvent,
+  type MouseEvent,
+  type SVGProps,
+} from "react";
 import { useRender } from "@base-ui/react/use-render";
 import { mergeProps } from "@base-ui/react/merge-props";
 import { cn } from "../../utils/cn";
@@ -6,6 +11,12 @@ import {
   useLinkComponent,
   type LinkComponentProps,
 } from "../../utils/link-provider";
+import {
+  KumoNavigateEvent,
+  KumoPrefetchEvent,
+  shouldUseClientRouter,
+  type KumoLinkEventSource,
+} from "./client-routing";
 
 /**
  * ExternalIcon - Visual indicator for links that open in a new tab/window.
@@ -97,7 +108,13 @@ export function linkVariants({
  */
 export type LinkProps = useRender.ComponentProps<"a"> &
   LinkComponentProps &
-  KumoLinkVariantsProps;
+  KumoLinkVariantsProps & {
+    disabled?: boolean;
+  };
+
+function getAnchorFromEventTarget(target: EventTarget | null) {
+  return target instanceof HTMLAnchorElement ? target : null;
+}
 
 /**
  * Link component for consistent inline text links.
@@ -105,6 +122,10 @@ export type LinkProps = useRender.ComponentProps<"a"> &
  * Supports composition via `render` prop for framework-specific routing:
  * - Without render: renders via LinkProvider (default anchor or configured component)
  * - With render: merges props onto the provided element with proper ref/event handling
+ *
+ * When the link is eligible for client-side navigation, custom navigation events are
+ * dispatched on interaction, which can be handled with the `useClientRouting` hook
+ * to integrate with the application's client-side router.
  *
  * @example Basic usage
  * ```tsx
@@ -126,7 +147,16 @@ export type LinkProps = useRender.ComponentProps<"a"> &
  * ```
  */
 const LinkBase = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
-  { className, variant = "inline", render, ...props },
+  {
+    className,
+    disabled = false,
+    onClick,
+    onFocus,
+    onMouseEnter,
+    variant = "inline",
+    render,
+    ...props
+  },
   ref,
 ) {
   const LinkComponent = useLinkComponent();
@@ -138,10 +168,89 @@ const LinkBase = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     ),
   };
 
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+
+    const anchor = getAnchorFromEventTarget(event.currentTarget);
+    if (!anchor) {
+      return;
+    }
+
+    if (!shouldUseClientRouter(anchor, event)) {
+      return;
+    }
+
+    const handledByClientRouting =
+      anchor.dispatchEvent(
+        new KumoNavigateEvent({
+          href: anchor.href,
+          anchor,
+          nativeEvent: event.nativeEvent,
+          source: "click",
+        }),
+      ) === false;
+
+    if (handledByClientRouting) {
+      event.preventDefault();
+    }
+  };
+
+  const handlePrefetch = (
+    event: MouseEvent<HTMLAnchorElement> | FocusEvent<HTMLAnchorElement>,
+    source: Extract<KumoLinkEventSource, "hover" | "focus">,
+  ) => {
+    if (event.defaultPrevented || disabled) {
+      return;
+    }
+
+    const anchor = getAnchorFromEventTarget(event.currentTarget);
+    if (!anchor) {
+      return;
+    }
+
+    if (!shouldUseClientRouter(anchor)) {
+      return;
+    }
+
+    anchor.dispatchEvent(
+      new KumoPrefetchEvent({
+        href: anchor.href,
+        anchor,
+        nativeEvent: event.nativeEvent,
+        source,
+      }),
+    );
+  };
+
+  const handleMouseEnter = (event: MouseEvent<HTMLAnchorElement>) => {
+    onMouseEnter?.(event);
+    handlePrefetch(event, "hover");
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLAnchorElement>) => {
+    onFocus?.(event);
+    handlePrefetch(event, "focus");
+  };
+
   const element = useRender({
     render: render ?? <LinkComponent />,
     ref,
-    props: mergeProps<"a">(defaultProps, props, { className }),
+    props: mergeProps<"a">(defaultProps, props, {
+      "aria-disabled": disabled || undefined,
+      className,
+      onClick: handleClick,
+      onMouseEnter: handleMouseEnter,
+      onFocus: handleFocus,
+    }),
   });
 
   return element;

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -161,11 +161,19 @@ export {
 export {
   Link,
   linkVariants,
+  KUMO_NAVIGATE_EVENT,
+  KUMO_PREFETCH_EVENT,
+  KumoNavigateEvent,
+  KumoPrefetchEvent,
   KUMO_LINK_VARIANTS,
   KUMO_LINK_DEFAULT_VARIANTS,
+  useClientRouting,
   type LinkProps,
+  type KumoLinkEventDetail,
   type KumoLinkVariant,
   type KumoLinkVariantsProps,
+  type UseClientRoutingHandlers,
+  type UseClientRoutingOptions,
 } from "./components/link";
 export { Breadcrumbs, type BreadcrumbsProps } from "./components/breadcrumbs";
 export { Empty, type EmptyProps } from "./components/empty";


### PR DESCRIPTION
This PR introduces a new `useClientRouting({onNavigate, onPrefetch})` hook to allow Kumo to integrate with client-side routers by listening for `kumo:navigate` and `kumo:prefetch` custom events dispatched from `Link` (on `click` and `mouseenter`/`focus` respectively).

```tsx
import { useNavigate } from "react-router";
import { useClientRouting } from "@cloudflare/kumo";

function App() {
  const navigate = useNavigate();

  useClientRouting({
    onNavigate: (href, event) => {
      if (URL.canParse(href)) {
        event.preventDefault(); // cancel the native browser navigation!

        const { pathname, search, hash } = URL.parse(href);
        const anchor = event.detail.anchor;

        navigate(
          { pathname, search, hash },
          { replace: anchor.dataset.method === "replace" }
        );
      }
    }
  });
}
```

The custom events are dispatched only for links to internal hrefs (i.e. same origin, doesn't have a non-`_self` target, no `download` attribute), and only when they are activated normally (i.e. no modifier keys were held, no middle-click / right-click activation).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: 
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
