### PR TITLE
fix: make PR description validation more flexible

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,12 +11,11 @@ The following selections do not need to be completed if this PR only contains ch
 
 - Reviews
   - [ ] bonk has reviewed the change
-  - [ ] automated review not possible because: 
+  - [ ] automated review not possible because: <!-- explain why -->
 - Tests
   - [ ] Tests included/updated
-  - [ ] Automated tests not possible - manual testing has been completed as follows:
-  - [ ] Additional testing not necessary because:
-
+  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
+  - [ ] Additional testing not necessary because: <!-- explain why -->
 
 <!--
 Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,27 @@ kumo/
 - **Pre-push hook**: Lefthook validates before push. Bypass: `git push --no-verify`
 - **AI agents NEVER**: `pnpm version`, `pnpm release`, `pnpm publish:beta`, `pnpm release:production`
 
+### Pull Request Descriptions
+
+PR descriptions are validated by CI. Include this checklist at the end of your PR body:
+
+```markdown
+- Reviews
+- [ ] bonk has reviewed the change
+- [x] automated review not possible because: <your reason here>
+- Tests
+- [ ] Tests included/updated
+- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
+- [x] Additional testing not necessary because: <your reason here>
+```
+
+Rules:
+
+- Check ONE option in each section (Reviews and Tests)
+- If providing a justification (`because:` or `as follows:`), text must follow on the same line
+- Indentation is flexible — nested under headers is fine
+- Skip validation entirely with the `skip-pr-description-validation` label
+
 ## ANTI-PATTERNS
 
 | Pattern                        | Why                                                          | Instead                                     |

--- a/tools/deployments/validate-pr-description.test.ts
+++ b/tools/deployments/validate-pr-description.test.ts
@@ -1,0 +1,336 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { validateDescription } from "./validate-pr-description.ts";
+
+const NO_LABELS = "[]";
+const NO_FILES = "[]";
+const WITH_CHANGESET = '[".changeset/some-change.md"]';
+
+describe("validateDescription", () => {
+  describe("Reviews section", () => {
+    it("passes when bonk has reviewed", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("passes when automated review is not possible with justification", () => {
+      const body = `
+- Reviews
+- [x] automated review not possible because: simple prop change
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("fails when automated review justification is empty", () => {
+      const body = `
+- Reviews
+- [x] automated review not possible because:
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.ok(
+        errors.includes(
+          "Your PR must have bonk review, or provide justification for why automated review is not possible",
+        ),
+      );
+    });
+
+    it("fails when automated review justification is only whitespace", () => {
+      const body = `
+- Reviews
+- [x] automated review not possible because:    
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.ok(
+        errors.includes(
+          "Your PR must have bonk review, or provide justification for why automated review is not possible",
+        ),
+      );
+    });
+
+    it("fails when no review checkbox is checked", () => {
+      const body = `
+- Reviews
+- [ ] bonk has reviewed the change
+- [ ] automated review not possible because:
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.ok(
+        errors.includes(
+          "Your PR must have bonk review, or provide justification for why automated review is not possible",
+        ),
+      );
+    });
+
+    it("allows indented checkboxes", () => {
+      const body = `
+- Reviews
+  - [x] bonk has reviewed the change
+- Tests
+  - [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("allows extra whitespace around checkbox", () => {
+      const body = `
+- Reviews
+-  [x]  bonk has reviewed the change
+- Tests
+-  [x]  Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+  });
+
+  describe("Tests section", () => {
+    it("passes when tests are included", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("passes when manual testing is described", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Automated tests not possible - manual testing has been completed as follows: tested in browser
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("passes when testing is not necessary with justification", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Additional testing not necessary because: docs only change
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("fails when manual testing description is empty", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Automated tests not possible - manual testing has been completed as follows:
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.ok(
+        errors.includes(
+          "Your PR must include tests, or provide justification for why no tests are required",
+        ),
+      );
+    });
+
+    it("fails when testing not necessary justification is empty", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Additional testing not necessary because:
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.ok(
+        errors.includes(
+          "Your PR must include tests, or provide justification for why no tests are required",
+        ),
+      );
+    });
+
+    it("fails when no test checkbox is checked", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [ ] Tests included/updated
+- [ ] Automated tests not possible - manual testing has been completed as follows:
+- [ ] Additional testing not necessary because:
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.ok(
+        errors.includes(
+          "Your PR must include tests, or provide justification for why no tests are required",
+        ),
+      );
+    });
+  });
+
+  describe("Changesets", () => {
+    it("passes when changeset is included", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("fails when changeset is missing", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Tests included/updated
+      `;
+      const errors = validateDescription("Test PR", body, NO_LABELS, NO_FILES);
+      assert.ok(errors.some((e) => e.includes("changeset")));
+    });
+
+    it("passes when no-changeset-required label is applied", () => {
+      const body = `
+- Reviews
+- [x] bonk has reviewed the change
+- Tests
+- [x] Tests included/updated
+      `;
+      const labels = '["no-changeset-required"]';
+      const errors = validateDescription("Test PR", body, labels, NO_FILES);
+      assert.deepStrictEqual(errors, []);
+    });
+  });
+
+  describe("skip-pr-description-validation label", () => {
+    it("skips all validation when label is applied", () => {
+      const body = "This PR has no checklist at all";
+      const labels = '["skip-pr-description-validation"]';
+      const errors = validateDescription("Test PR", body, labels, NO_FILES);
+      assert.deepStrictEqual(errors, []);
+    });
+  });
+
+  describe("real-world PR bodies", () => {
+    it("handles GitHub-style nested checkboxes", () => {
+      const body = `
+## Summary
+Some changes here.
+
+---
+
+- Reviews
+  - [ ] bonk has reviewed the change
+  - [x] automated review not possible because: simple prop type change
+- Tests
+  - [ ] Tests included/updated
+  - [ ] Automated tests not possible - manual testing has been completed as follows:
+  - [x] Additional testing not necessary because: this is a type-only change
+      `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("handles Windows line endings", () => {
+      const body =
+        "- Reviews\r\n- [x] bonk has reviewed the change\r\n- Tests\r\n- [x] Tests included/updated";
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+  });
+});

--- a/tools/deployments/validate-pr-description.test.ts
+++ b/tools/deployments/validate-pr-description.test.ts
@@ -54,8 +54,8 @@ describe("validateDescription", () => {
         WITH_CHANGESET,
       );
       assert.ok(
-        errors.includes(
-          "Your PR must have bonk review, or provide justification for why automated review is not possible",
+        errors.some(
+          (e) => e.includes("bonk review") && e.includes("same line"),
         ),
       );
     });
@@ -74,8 +74,8 @@ describe("validateDescription", () => {
         WITH_CHANGESET,
       );
       assert.ok(
-        errors.includes(
-          "Your PR must have bonk review, or provide justification for why automated review is not possible",
+        errors.some(
+          (e) => e.includes("bonk review") && e.includes("same line"),
         ),
       );
     });
@@ -94,11 +94,7 @@ describe("validateDescription", () => {
         NO_LABELS,
         WITH_CHANGESET,
       );
-      assert.ok(
-        errors.includes(
-          "Your PR must have bonk review, or provide justification for why automated review is not possible",
-        ),
-      );
+      assert.ok(errors.some((e) => e.includes("bonk review")));
     });
 
     it("allows indented checkboxes", () => {
@@ -124,6 +120,18 @@ describe("validateDescription", () => {
 - Tests
 -  [x]  Tests included/updated
       `;
+      const errors = validateDescription(
+        "Test PR",
+        body,
+        NO_LABELS,
+        WITH_CHANGESET,
+      );
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it("allows tabs in indentation", () => {
+      const body =
+        "- Reviews\n\t- [x] bonk has reviewed the change\n- Tests\n\t- [x] Tests included/updated";
       const errors = validateDescription(
         "Test PR",
         body,
@@ -197,9 +205,7 @@ describe("validateDescription", () => {
         WITH_CHANGESET,
       );
       assert.ok(
-        errors.includes(
-          "Your PR must include tests, or provide justification for why no tests are required",
-        ),
+        errors.some((e) => e.includes("tests") && e.includes("same line")),
       );
     });
 
@@ -217,9 +223,7 @@ describe("validateDescription", () => {
         WITH_CHANGESET,
       );
       assert.ok(
-        errors.includes(
-          "Your PR must include tests, or provide justification for why no tests are required",
-        ),
+        errors.some((e) => e.includes("tests") && e.includes("same line")),
       );
     });
 
@@ -238,11 +242,7 @@ describe("validateDescription", () => {
         NO_LABELS,
         WITH_CHANGESET,
       );
-      assert.ok(
-        errors.includes(
-          "Your PR must include tests, or provide justification for why no tests are required",
-        ),
-      );
+      assert.ok(errors.some((e) => e.includes("tests")));
     });
   });
 

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -44,10 +44,14 @@ export function validateDescription(
   }
 
   // Validate bonk review
+  // Flexible: allows optional leading whitespace/indentation
+  // Uses [ \t]* (space/tab only) after colon to require justification on same line
   if (
     !(
-      /- \[x\] bonk has reviewed the change/i.test(body) ||
-      /- \[x\] automated review not possible because:\s*.+/i.test(body)
+      /^\s*-\s*\[x\]\s*bonk has reviewed the change/im.test(body) ||
+      /^\s*-\s*\[x\]\s*automated review not possible because:[ \t]*\S/im.test(
+        body,
+      )
     )
   ) {
     errors.push(
@@ -56,13 +60,17 @@ export function validateDescription(
   }
 
   // Validate tests
+  // Flexible: allows optional leading whitespace/indentation
+  // Uses [ \t]* (space/tab only) after colon to require justification on same line
   if (
     !(
-      /- \[x\] Tests included\/updated/i.test(body) ||
-      /- \[x\] Automated tests not possible - manual testing has been completed as follows:\s*.+/i.test(
+      /^\s*-\s*\[x\]\s*Tests included\/updated/im.test(body) ||
+      /^\s*-\s*\[x\]\s*Automated tests not possible - manual testing has been completed as follows:[ \t]*\S/im.test(
         body,
       ) ||
-      /- \[x\] Additional testing not necessary because:\s*.+/i.test(body)
+      /^\s*-\s*\[x\]\s*Additional testing not necessary because:[ \t]*\S/im.test(
+        body,
+      )
     )
   ) {
     errors.push(

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -55,7 +55,8 @@ export function validateDescription(
     )
   ) {
     errors.push(
-      "Your PR must have bonk review, or provide justification for why automated review is not possible",
+      "Your PR must have bonk review, or provide justification for why automated review is not possible. " +
+        "If providing a justification, it must be on the same line as the checkbox (e.g., '- [x] automated review not possible because: reason here').",
     );
   }
 
@@ -74,7 +75,8 @@ export function validateDescription(
     )
   ) {
     errors.push(
-      "Your PR must include tests, or provide justification for why no tests are required",
+      "Your PR must include tests, or provide justification for why no tests are required. " +
+        "If providing a justification, it must be on the same line as the checkbox.",
     );
   }
 


### PR DESCRIPTION
Fixes the frustrating PR description validation failures caused by whitespace/indentation mismatches.

## Problem

The validation regex was too strict about formatting:
- Required checkboxes at exact start of line, but GitHub's PR template uses indented checkboxes
- Used `\s*` after `because:` which accidentally matched across newlines, letting empty justifications pass

## Changes

- Allow indented checkboxes (`  - [x]` now works)
- Allow flexible whitespace around checkbox markers
- Require justifications on same line with `[ \t]*\S` instead of `\s*.+`
- Add placeholder hints to PR template (`<!-- explain why -->`)
- Document format in AGENTS.md for AI tooling
- Add 19 unit tests covering edge cases

## Backwards Compatibility

Strictly more permissive for valid PRs. Only breaks PRs that were incorrectly passing with empty justifications.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: regex changes are straightforward, tests cover the behavior
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because: