### PR TITLE
feat(tooltip, popover): deprecate asChild in favor of render prop

### DIFF
--- a/.changeset/deprecate-aschild-add-render.md
+++ b/.changeset/deprecate-aschild-add-render.md
@@ -1,0 +1,32 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(tooltip, popover): deprecate `asChild` in favor of `render` prop
+
+Unifies composition patterns across the library by adopting Base UI's `render` prop pattern. The `asChild` prop is now deprecated on:
+
+- `Tooltip`
+- `Popover.Trigger`
+- `Popover.Close`
+
+**Migration:**
+
+```diff
+- <Tooltip content="Save" asChild>
+-   <Button>Save</Button>
+- </Tooltip>
++ <Tooltip content="Save" render={<Button>Save</Button>} />
+
+- <Popover.Trigger asChild>
+-   <Button>Open</Button>
+- </Popover.Trigger>
++ <Popover.Trigger render={<Button>Open</Button>} />
+
+- <Popover.Close asChild>
+-   <Button>Close</Button>
+- </Popover.Close>
++ <Popover.Close render={<Button>Close</Button>} />
+```
+
+The `asChild` prop remains functional for backward compatibility but will be removed in a future major version.

--- a/packages/kumo-docs-astro/src/components/demos/DatePickerDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DatePickerDemo.tsx
@@ -104,12 +104,10 @@ export function DatePickerPopoverDemo() {
   return (
     <Popover>
       <Popover.Trigger
-        render={
-          <Button variant="outline" icon={CalendarDotsIcon}>
-            {date ? date.toLocaleDateString() : "Pick a date"}
-          </Button>
-        }
-      />
+        render={<Button variant="outline" icon={CalendarDotsIcon} />}
+      >
+        {date ? date.toLocaleDateString() : "Pick a date"}
+      </Popover.Trigger>
       <Popover.Content className="p-3">
         <DatePicker mode="single" selected={date} onChange={setDate} />
       </Popover.Content>
@@ -132,12 +130,10 @@ export function DatePickerRangePopoverDemo() {
   return (
     <Popover>
       <Popover.Trigger
-        render={
-          <Button variant="outline" icon={CalendarDotsIcon}>
-            {formatRange()}
-          </Button>
-        }
-      />
+        render={<Button variant="outline" icon={CalendarDotsIcon} />}
+      >
+        {formatRange()}
+      </Popover.Trigger>
       <Popover.Content className="p-3">
         <DatePicker
           mode="range"
@@ -228,12 +224,10 @@ export function DatePickerRangeWithPresetsDemo() {
   return (
     <Popover>
       <Popover.Trigger
-        render={
-          <Button variant="outline" icon={CalendarDotsIcon}>
-            {formatRange()}
-          </Button>
-        }
-      />
+        render={<Button variant="outline" icon={CalendarDotsIcon} />}
+      >
+        {formatRange()}
+      </Popover.Trigger>
       <Popover.Content className="p-0">
         <div className="flex">
           <div className="flex flex-col gap-1 border-r border-kumo-hairline p-2 text-sm">

--- a/packages/kumo-docs-astro/src/components/demos/DatePickerDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DatePickerDemo.tsx
@@ -12,11 +12,15 @@ export function DatePickerSingleDemo() {
 
   return (
     <div className="flex flex-col gap-4">
-      <DatePicker mode="single" selected={date} onChange={d => {
-        if (d) {
-          setDate(d);
-        }
-      }} />
+      <DatePicker
+        mode="single"
+        selected={date}
+        onChange={(d) => {
+          if (d) {
+            setDate(d);
+          }
+        }}
+      />
       <p className="text-sm text-kumo-subtle">
         Selected: {date ? date.toLocaleDateString() : "None"}
       </p>
@@ -99,11 +103,13 @@ export function DatePickerPopoverDemo() {
 
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button variant="outline" icon={CalendarDotsIcon}>
-          {date ? date.toLocaleDateString() : "Pick a date"}
-        </Button>
-      </Popover.Trigger>
+      <Popover.Trigger
+        render={
+          <Button variant="outline" icon={CalendarDotsIcon}>
+            {date ? date.toLocaleDateString() : "Pick a date"}
+          </Button>
+        }
+      />
       <Popover.Content className="p-3">
         <DatePicker mode="single" selected={date} onChange={setDate} />
       </Popover.Content>
@@ -125,11 +131,13 @@ export function DatePickerRangePopoverDemo() {
 
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button variant="outline" icon={CalendarDotsIcon}>
-          {formatRange()}
-        </Button>
-      </Popover.Trigger>
+      <Popover.Trigger
+        render={
+          <Button variant="outline" icon={CalendarDotsIcon}>
+            {formatRange()}
+          </Button>
+        }
+      />
       <Popover.Content className="p-3">
         <DatePicker
           mode="range"
@@ -219,11 +227,13 @@ export function DatePickerRangeWithPresetsDemo() {
 
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button variant="outline" icon={CalendarDotsIcon}>
-          {formatRange()}
-        </Button>
-      </Popover.Trigger>
+      <Popover.Trigger
+        render={
+          <Button variant="outline" icon={CalendarDotsIcon}>
+            {formatRange()}
+          </Button>
+        }
+      />
       <Popover.Content className="p-0">
         <div className="flex">
           <div className="flex flex-col gap-1 border-r border-kumo-hairline p-2 text-sm">
@@ -234,10 +244,11 @@ export function DatePickerRangeWithPresetsDemo() {
                   key={preset.label}
                   type="button"
                   onClick={() => handlePresetClick(preset)}
-                  className={`rounded-md px-3 py-1.5 text-left whitespace-nowrap ${isActive
-                    ? "bg-kumo-bg-inverse text-kumo-text-inverse"
-                    : "text-kumo-strong hover:bg-kumo-control"
-                    }`}
+                  className={`rounded-md px-3 py-1.5 text-left whitespace-nowrap ${
+                    isActive
+                      ? "bg-kumo-bg-inverse text-kumo-text-inverse"
+                      : "text-kumo-strong hover:bg-kumo-control"
+                  }`}
                 >
                   {preset.label}
                 </button>

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -562,7 +562,7 @@ export function HomeGrid() {
       id: "popover",
       Component: (
         <Popover>
-          <Popover.Trigger render={<Button>Open Popover</Button>} />
+          <Popover.Trigger render={<Button />}>Open Popover</Popover.Trigger>
           <Popover.Content>
             <Popover.Title>Popover Title</Popover.Title>
             <Popover.Description>This is a popover.</Popover.Description>

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -242,16 +242,23 @@ export function HomeGrid() {
       Component: (
         <TooltipProvider>
           <div className="flex gap-2">
-            <Tooltip content="Add" asChild open>
-              <Button shape="square" icon={PlusIcon} aria-label="Add" />
-            </Tooltip>
-            <Tooltip content="Change language" asChild>
-              <Button
-                shape="square"
-                icon={TranslateIcon}
-                aria-label="Change language"
-              />
-            </Tooltip>
+            <Tooltip
+              content="Add"
+              open
+              render={
+                <Button shape="square" icon={PlusIcon} aria-label="Add" />
+              }
+            />
+            <Tooltip
+              content="Change language"
+              render={
+                <Button
+                  shape="square"
+                  icon={TranslateIcon}
+                  aria-label="Change language"
+                />
+              }
+            />
           </div>
         </TooltipProvider>
       ),

--- a/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
@@ -5,9 +5,11 @@ import { BellIcon, DotsThree } from "@phosphor-icons/react";
 export function PopoverHeroDemo() {
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button shape="square" icon={BellIcon} aria-label="Notifications" />
-      </Popover.Trigger>
+      <Popover.Trigger
+        render={
+          <Button shape="square" icon={BellIcon} aria-label="Notifications" />
+        }
+      />
       <Popover.Content>
         <Popover.Title>Notifications</Popover.Title>
         <Popover.Description>
@@ -21,9 +23,7 @@ export function PopoverHeroDemo() {
 export function PopoverBasicDemo() {
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button>Open Popover</Button>
-      </Popover.Trigger>
+      <Popover.Trigger render={<Button>Open Popover</Button>} />
       <Popover.Content>
         <Popover.Title>Popover Title</Popover.Title>
         <Popover.Description>
@@ -37,20 +37,20 @@ export function PopoverBasicDemo() {
 export function PopoverWithCloseDemo() {
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button>Open Settings</Button>
-      </Popover.Trigger>
+      <Popover.Trigger render={<Button>Open Settings</Button>} />
       <Popover.Content>
         <Popover.Title>Settings</Popover.Title>
         <Popover.Description>
           Configure your preferences below.
         </Popover.Description>
         <div className="mt-3">
-          <Popover.Close asChild>
-            <Button variant="secondary" size="sm">
-              Close
-            </Button>
-          </Popover.Close>
+          <Popover.Close
+            render={
+              <Button variant="secondary" size="sm">
+                Close
+              </Button>
+            }
+          />
         </div>
       </Popover.Content>
     </Popover>
@@ -61,9 +61,7 @@ export function PopoverPositionDemo() {
   return (
     <div className="flex flex-wrap gap-4">
       <Popover>
-        <Popover.Trigger asChild>
-          <Button variant="secondary">Bottom</Button>
-        </Popover.Trigger>
+        <Popover.Trigger render={<Button variant="secondary">Bottom</Button>} />
         <Popover.Content side="bottom">
           <Popover.Title>Bottom</Popover.Title>
           <Popover.Description>
@@ -73,9 +71,7 @@ export function PopoverPositionDemo() {
       </Popover>
 
       <Popover>
-        <Popover.Trigger asChild>
-          <Button variant="secondary">Top</Button>
-        </Popover.Trigger>
+        <Popover.Trigger render={<Button variant="secondary">Top</Button>} />
         <Popover.Content side="top">
           <Popover.Title>Top</Popover.Title>
           <Popover.Description>Popover on top.</Popover.Description>
@@ -83,9 +79,7 @@ export function PopoverPositionDemo() {
       </Popover>
 
       <Popover>
-        <Popover.Trigger asChild>
-          <Button variant="secondary">Left</Button>
-        </Popover.Trigger>
+        <Popover.Trigger render={<Button variant="secondary">Left</Button>} />
         <Popover.Content side="left">
           <Popover.Title>Left</Popover.Title>
           <Popover.Description>Popover on left.</Popover.Description>
@@ -93,9 +87,7 @@ export function PopoverPositionDemo() {
       </Popover>
 
       <Popover>
-        <Popover.Trigger asChild>
-          <Button variant="secondary">Right</Button>
-        </Popover.Trigger>
+        <Popover.Trigger render={<Button variant="secondary">Right</Button>} />
         <Popover.Content side="right">
           <Popover.Title>Right</Popover.Title>
           <Popover.Description>Popover on right.</Popover.Description>
@@ -108,9 +100,7 @@ export function PopoverPositionDemo() {
 export function PopoverCustomContentDemo() {
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button>User Profile</Button>
-      </Popover.Trigger>
+      <Popover.Trigger render={<Button>User Profile</Button>} />
       <Popover.Content className="w-64">
         <div className="flex items-center gap-3">
           <div className="size-10 rounded-full bg-kumo-recessed" />
@@ -123,11 +113,13 @@ export function PopoverCustomContentDemo() {
           <Button variant="secondary" size="sm" className="flex-1">
             Profile
           </Button>
-          <Popover.Close asChild>
-            <Button variant="ghost" size="sm" className="flex-1">
-              Sign Out
-            </Button>
-          </Popover.Close>
+          <Popover.Close
+            render={
+              <Button variant="ghost" size="sm" className="flex-1">
+                Sign Out
+              </Button>
+            }
+          />
         </div>
       </Popover.Content>
     </Popover>
@@ -137,9 +129,11 @@ export function PopoverCustomContentDemo() {
 export function PopoverOpenOnHoverDemo() {
   return (
     <Popover>
-      <Popover.Trigger openOnHover delay={200} asChild>
-        <Button variant="secondary">Hover Me</Button>
-      </Popover.Trigger>
+      <Popover.Trigger
+        openOnHover
+        delay={200}
+        render={<Button variant="secondary">Hover Me</Button>}
+      />
       <Popover.Content>
         <Popover.Title>Hover Triggered</Popover.Title>
         <Popover.Description>
@@ -147,11 +141,13 @@ export function PopoverOpenOnHoverDemo() {
           interactive content like buttons and links.
         </Popover.Description>
         <div className="mt-3">
-          <Popover.Close asChild>
-            <Button variant="secondary" size="sm">
-              Got it
-            </Button>
-          </Popover.Close>
+          <Popover.Close
+            render={
+              <Button variant="secondary" size="sm">
+                Got it
+              </Button>
+            }
+          />
         </div>
       </Popover.Content>
     </Popover>
@@ -234,11 +230,13 @@ export function PopoverVirtualAnchorDemo() {
             The popover anchors to the selected row, not the icon button.
           </Popover.Description>
           <div className="mt-3">
-            <Popover.Close asChild>
-              <Button size="sm" variant="secondary">
-                Close
-              </Button>
-            </Popover.Close>
+            <Popover.Close
+              render={
+                <Button size="sm" variant="secondary">
+                  Close
+                </Button>
+              }
+            />
           </div>
         </Popover.Content>
       </Popover>

--- a/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
@@ -23,7 +23,7 @@ export function PopoverHeroDemo() {
 export function PopoverBasicDemo() {
   return (
     <Popover>
-      <Popover.Trigger render={<Button>Open Popover</Button>} />
+      <Popover.Trigger render={<Button />}>Open Popover</Popover.Trigger>
       <Popover.Content>
         <Popover.Title>Popover Title</Popover.Title>
         <Popover.Description>
@@ -37,20 +37,16 @@ export function PopoverBasicDemo() {
 export function PopoverWithCloseDemo() {
   return (
     <Popover>
-      <Popover.Trigger render={<Button>Open Settings</Button>} />
+      <Popover.Trigger render={<Button />}>Open Settings</Popover.Trigger>
       <Popover.Content>
         <Popover.Title>Settings</Popover.Title>
         <Popover.Description>
           Configure your preferences below.
         </Popover.Description>
         <div className="mt-3">
-          <Popover.Close
-            render={
-              <Button variant="secondary" size="sm">
-                Close
-              </Button>
-            }
-          />
+          <Popover.Close render={<Button variant="secondary" size="sm" />}>
+            Close
+          </Popover.Close>
         </div>
       </Popover.Content>
     </Popover>
@@ -61,7 +57,9 @@ export function PopoverPositionDemo() {
   return (
     <div className="flex flex-wrap gap-4">
       <Popover>
-        <Popover.Trigger render={<Button variant="secondary">Bottom</Button>} />
+        <Popover.Trigger render={<Button variant="secondary" />}>
+          Bottom
+        </Popover.Trigger>
         <Popover.Content side="bottom">
           <Popover.Title>Bottom</Popover.Title>
           <Popover.Description>
@@ -71,7 +69,9 @@ export function PopoverPositionDemo() {
       </Popover>
 
       <Popover>
-        <Popover.Trigger render={<Button variant="secondary">Top</Button>} />
+        <Popover.Trigger render={<Button variant="secondary" />}>
+          Top
+        </Popover.Trigger>
         <Popover.Content side="top">
           <Popover.Title>Top</Popover.Title>
           <Popover.Description>Popover on top.</Popover.Description>
@@ -79,7 +79,9 @@ export function PopoverPositionDemo() {
       </Popover>
 
       <Popover>
-        <Popover.Trigger render={<Button variant="secondary">Left</Button>} />
+        <Popover.Trigger render={<Button variant="secondary" />}>
+          Left
+        </Popover.Trigger>
         <Popover.Content side="left">
           <Popover.Title>Left</Popover.Title>
           <Popover.Description>Popover on left.</Popover.Description>
@@ -87,7 +89,9 @@ export function PopoverPositionDemo() {
       </Popover>
 
       <Popover>
-        <Popover.Trigger render={<Button variant="secondary">Right</Button>} />
+        <Popover.Trigger render={<Button variant="secondary" />}>
+          Right
+        </Popover.Trigger>
         <Popover.Content side="right">
           <Popover.Title>Right</Popover.Title>
           <Popover.Description>Popover on right.</Popover.Description>
@@ -100,7 +104,7 @@ export function PopoverPositionDemo() {
 export function PopoverCustomContentDemo() {
   return (
     <Popover>
-      <Popover.Trigger render={<Button>User Profile</Button>} />
+      <Popover.Trigger render={<Button />}>User Profile</Popover.Trigger>
       <Popover.Content className="w-64">
         <div className="flex items-center gap-3">
           <div className="size-10 rounded-full bg-kumo-recessed" />
@@ -114,12 +118,10 @@ export function PopoverCustomContentDemo() {
             Profile
           </Button>
           <Popover.Close
-            render={
-              <Button variant="ghost" size="sm" className="flex-1">
-                Sign Out
-              </Button>
-            }
-          />
+            render={<Button variant="ghost" size="sm" className="flex-1" />}
+          >
+            Sign Out
+          </Popover.Close>
         </div>
       </Popover.Content>
     </Popover>
@@ -132,8 +134,10 @@ export function PopoverOpenOnHoverDemo() {
       <Popover.Trigger
         openOnHover
         delay={200}
-        render={<Button variant="secondary">Hover Me</Button>}
-      />
+        render={<Button variant="secondary" />}
+      >
+        Hover Me
+      </Popover.Trigger>
       <Popover.Content>
         <Popover.Title>Hover Triggered</Popover.Title>
         <Popover.Description>
@@ -141,13 +145,9 @@ export function PopoverOpenOnHoverDemo() {
           interactive content like buttons and links.
         </Popover.Description>
         <div className="mt-3">
-          <Popover.Close
-            render={
-              <Button variant="secondary" size="sm">
-                Got it
-              </Button>
-            }
-          />
+          <Popover.Close render={<Button variant="secondary" size="sm" />}>
+            Got it
+          </Popover.Close>
         </div>
       </Popover.Content>
     </Popover>
@@ -230,13 +230,9 @@ export function PopoverVirtualAnchorDemo() {
             The popover anchors to the selected row, not the icon button.
           </Popover.Description>
           <div className="mt-3">
-            <Popover.Close
-              render={
-                <Button size="sm" variant="secondary">
-                  Close
-                </Button>
-              }
-            />
+            <Popover.Close render={<Button size="sm" variant="secondary" />}>
+              Close
+            </Popover.Close>
           </div>
         </Popover.Content>
       </Popover>

--- a/packages/kumo-docs-astro/src/components/demos/TooltipDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TooltipDemo.tsx
@@ -78,19 +78,25 @@ export function TooltipDelayDemo() {
         <Tooltip
           content="Opens after 1 second"
           delay={1000}
-          render={<Button variant="secondary">1s open delay</Button>}
-        />
+          render={<Button variant="secondary" />}
+        >
+          1s open delay
+        </Tooltip>
         <Tooltip
           content="Stays open 500ms after leaving"
           closeDelay={500}
-          render={<Button variant="secondary">500ms close delay</Button>}
-        />
+          render={<Button variant="secondary" />}
+        >
+          500ms close delay
+        </Tooltip>
         <Tooltip
           content="Instant open, stays 1s"
           delay={0}
           closeDelay={1000}
-          render={<Button variant="secondary">Instant + 1s close</Button>}
-        />
+          render={<Button variant="secondary" />}
+        >
+          Instant + 1s close
+        </Tooltip>
       </div>
     </TooltipProvider>
   );

--- a/packages/kumo-docs-astro/src/components/demos/TooltipDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TooltipDemo.tsx
@@ -4,9 +4,12 @@ import { Info, PlusIcon, TranslateIcon } from "@phosphor-icons/react";
 export function TooltipHeroDemo() {
   return (
     <TooltipProvider>
-      <Tooltip content="Add new item" asChild>
-        <Button shape="square" icon={PlusIcon} aria-label="Add new item" />
-      </Tooltip>
+      <Tooltip
+        content="Add new item"
+        render={
+          <Button shape="square" icon={PlusIcon} aria-label="Add new item" />
+        }
+      />
     </TooltipProvider>
   );
 }
@@ -14,9 +17,10 @@ export function TooltipHeroDemo() {
 export function TooltipBasicDemo() {
   return (
     <TooltipProvider>
-      <Tooltip content="Add" asChild>
-        <Button shape="square" icon={PlusIcon} aria-label="Add" />
-      </Tooltip>
+      <Tooltip
+        content="Add"
+        render={<Button shape="square" icon={PlusIcon} aria-label="Add" />}
+      />
     </TooltipProvider>
   );
 }
@@ -25,23 +29,27 @@ export function TooltipMultipleDemo() {
   return (
     <TooltipProvider>
       <div className="flex gap-2">
-        <Tooltip content="Add" asChild>
-          <Button shape="square" icon={PlusIcon} aria-label="Add" />
-        </Tooltip>
-        <Tooltip content="Change language" asChild>
-          <Button
-            shape="square"
-            icon={TranslateIcon}
-            aria-label="Change language"
-          />
-        </Tooltip>
+        <Tooltip
+          content="Add"
+          render={<Button shape="square" icon={PlusIcon} aria-label="Add" />}
+        />
+        <Tooltip
+          content="Change language"
+          render={
+            <Button
+              shape="square"
+              icon={TranslateIcon}
+              aria-label="Change language"
+            />
+          }
+        />
       </div>
     </TooltipProvider>
   );
 }
 
 /**
- * Without `asChild`, Tooltip wraps children in an internal button element.
+ * Without `render`, Tooltip wraps children in an internal button element.
  * Defensive styles are applied by default, but you can fully customize
  * the trigger by passing className - your styles override the defaults.
  */
@@ -67,24 +75,22 @@ export function TooltipDelayDemo() {
   return (
     <TooltipProvider>
       <div className="flex gap-4">
-        <Tooltip content="Opens after 1 second" delay={1000} asChild>
-          <Button variant="secondary">1s open delay</Button>
-        </Tooltip>
+        <Tooltip
+          content="Opens after 1 second"
+          delay={1000}
+          render={<Button variant="secondary">1s open delay</Button>}
+        />
         <Tooltip
           content="Stays open 500ms after leaving"
           closeDelay={500}
-          asChild
-        >
-          <Button variant="secondary">500ms close delay</Button>
-        </Tooltip>
+          render={<Button variant="secondary">500ms close delay</Button>}
+        />
         <Tooltip
           content="Instant open, stays 1s"
           delay={0}
           closeDelay={1000}
-          asChild
-        >
-          <Button variant="secondary">Instant + 1s close</Button>
-        </Tooltip>
+          render={<Button variant="secondary">Instant + 1s close</Button>}
+        />
       </div>
     </TooltipProvider>
   );

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -158,10 +158,10 @@ export function DatePickerDropdown() {
 
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button variant="outline" icon={CalendarDotsIcon}>
-          {date ? date.toLocaleDateString() : "Pick a date"}
-        </Button>
+      <Popover.Trigger
+        render={<Button variant="outline" icon={CalendarDotsIcon} />}
+      >
+        {date ? date.toLocaleDateString() : "Pick a date"}
       </Popover.Trigger>
       <Popover.Content className="p-3">
         <DatePicker

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -57,7 +57,7 @@ import { Popover, Button } from "@cloudflare/kumo";
 export default function Example() {
   return (
     <Popover>
-      <Popover.Trigger render={<Button>Open</Button>} />
+      <Popover.Trigger render={<Button />}>Open</Popover.Trigger>
       <Popover.Content>
         <Popover.Title>Popover Title</Popover.Title>
         <Popover.Description>Popover content goes here.</Popover.Description>

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -57,9 +57,7 @@ import { Popover, Button } from "@cloudflare/kumo";
 export default function Example() {
   return (
     <Popover>
-      <Popover.Trigger asChild>
-        <Button>Open</Button>
-      </Popover.Trigger>
+      <Popover.Trigger render={<Button>Open</Button>} />
       <Popover.Content>
         <Popover.Title>Popover Title</Popover.Title>
         <Popover.Description>Popover content goes here.</Popover.Description>
@@ -208,7 +206,7 @@ export default function Example() {
 
 <Heading level={3}>Popover.Trigger</Heading>
 <p>
-  A button that opens the popover when clicked. Use `asChild` to render your own
+  A button that opens the popover when clicked. Use `render` to render your own
   element.
 </p>
 <PropsTable component="Popover.Trigger" />
@@ -233,8 +231,8 @@ export default function Example() {
 
 <Heading level={3}>Popover.Close</Heading>
 <p>
-  A button that closes the popover when clicked. Use `asChild` to render your
-  own element.
+  A button that closes the popover when clicked. Use `render` to render your own
+  element.
 </p>
 <PropsTable component="Popover.Close" />
 

--- a/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
@@ -52,7 +52,11 @@ import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";
 import { Tooltip, Button } from "@cloudflare/kumo";
 
 export default function Example() {
-  return <Tooltip content="Tooltip text" render={<Button>Hover me</Button>} />;
+  return (
+    <Tooltip content="Tooltip text" render={<Button />}>
+      Hover me
+    </Tooltip>
+  );
 }
 ```
 

--- a/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
@@ -52,11 +52,7 @@ import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";
 import { Tooltip, Button } from "@cloudflare/kumo";
 
 export default function Example() {
-  return (
-    <Tooltip content="Tooltip text" asChild>
-      <Button>Hover me</Button>
-    </Tooltip>
-  );
+  return <Tooltip content="Tooltip text" render={<Button>Hover me</Button>} />;
 }
 ```
 
@@ -108,9 +104,7 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
 </TooltipProvider>
 
 // Then use Tooltip anywhere inside
-<Tooltip content="Add" asChild>
-  <Button shape="square" icon={PlusIcon} />
-</Tooltip>
+<Tooltip content="Add" render={<Button shape="square" icon={PlusIcon} />} />
 ```
 
 </ComponentSection>

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -260,11 +260,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     );
 
     if (title) {
-      return (
-        <Tooltip content={title} asChild>
-          {button}
-        </Tooltip>
-      );
+      return <Tooltip content={title} render={button} />;
     }
 
     return button;

--- a/packages/kumo/src/components/label/label.tsx
+++ b/packages/kumo/src/components/label/label.tsx
@@ -99,16 +99,19 @@ export function Label({
         <span className="font-normal text-kumo-strong">(optional)</span>
       )}
       {tooltip && (
-        <Tooltip content={tooltip} asChild>
-          <Button
-            variant="ghost"
-            size="xs"
-            shape="square"
-            aria-label="More information"
-          >
-            <Info className="size-4" />
-          </Button>
-        </Tooltip>
+        <Tooltip
+          content={tooltip}
+          render={
+            <Button
+              variant="ghost"
+              size="xs"
+              shape="square"
+              aria-label="More information"
+            >
+              <Info className="size-4" />
+            </Button>
+          }
+        />
       )}
     </>
   );

--- a/packages/kumo/src/components/menubar/menubar.tsx
+++ b/packages/kumo/src/components/menubar/menubar.tsx
@@ -42,23 +42,24 @@ const MenuOption = ({
   onClick,
   tooltip,
 }: MenuOptionProps) => {
-  return (
-    <Tooltip content={tooltip} asChild>
-      <button
-        className={cn(
-          "focus:inset-ring-focus relative -ml-px flex h-full w-11 cursor-pointer items-center justify-center rounded-md border-none bg-kumo-elevated first:rounded-l-lg last:rounded-r-lg transition-colors focus:z-1 focus:outline-none focus-visible:z-1 focus-visible:inset-ring-[0.5]",
-          {
-            "z-2 bg-kumo-base shadow-xs transition-colors ring ring-kumo-line/40": isActive === id,
-          },
-        )}
-        onClick={onClick}
-      >
-        <IconContext.Provider value={{ size: 18 }} {...({} as any)}>
-          {icon}
-        </IconContext.Provider>
-      </button>
-    </Tooltip>
+  const button = (
+    <button
+      className={cn(
+        "focus:inset-ring-focus relative -ml-px flex h-full w-11 cursor-pointer items-center justify-center rounded-md border-none bg-kumo-elevated first:rounded-l-lg last:rounded-r-lg transition-colors focus:z-1 focus:outline-none focus-visible:z-1 focus-visible:inset-ring-[0.5]",
+        {
+          "z-2 bg-kumo-base shadow-xs transition-colors ring ring-kumo-line/40":
+            isActive === id,
+        },
+      )}
+      onClick={onClick}
+    >
+      <IconContext.Provider value={{ size: 18 }} {...({} as any)}>
+        {icon}
+      </IconContext.Provider>
+    </button>
   );
+
+  return <Tooltip content={tooltip} render={button} />;
 };
 
 /**

--- a/packages/kumo/src/components/popover/popover.tsx
+++ b/packages/kumo/src/components/popover/popover.tsx
@@ -70,7 +70,10 @@ type BasePopoverTriggerProps = ComponentPropsWithoutRef<
 >;
 
 export type PopoverTriggerProps = BasePopoverTriggerProps & {
-  /** When true, the trigger element will be the child element */
+  /**
+   * @deprecated Use the `render` prop instead.
+   * @example `<Popover.Trigger render={<Button />}>` instead of `<Popover.Trigger asChild><Button /></Popover.Trigger>`
+   */
   asChild?: boolean;
 };
 
@@ -78,17 +81,21 @@ function PopoverTrigger({
   children,
   className,
   asChild,
+  render,
   ...props
 }: PopoverTriggerProps) {
+  // Support both render prop (preferred) and deprecated asChild pattern
+  const resolvedRender =
+    render ??
+    (asChild ? (children as BasePopoverTriggerProps["render"]) : undefined);
+
   return (
     <PopoverBase.Trigger
       className={className}
-      render={
-        asChild ? (children as BasePopoverTriggerProps["render"]) : undefined
-      }
+      render={resolvedRender}
       {...props}
     >
-      {asChild ? undefined : children}
+      {resolvedRender ? undefined : children}
     </PopoverBase.Trigger>
   );
 }
@@ -275,7 +282,10 @@ PopoverDescription.displayName = "Popover.Description";
 type BasePopoverCloseProps = ComponentPropsWithoutRef<typeof PopoverBase.Close>;
 
 export type PopoverCloseProps = BasePopoverCloseProps & {
-  /** When true, the close element will be the child element */
+  /**
+   * @deprecated Use the `render` prop instead.
+   * @example `<Popover.Close render={<Button />}>` instead of `<Popover.Close asChild><Button /></Popover.Close>`
+   */
   asChild?: boolean;
 };
 
@@ -283,17 +293,17 @@ function PopoverClose({
   children,
   className,
   asChild,
+  render,
   ...props
 }: PopoverCloseProps) {
+  // Support both render prop (preferred) and deprecated asChild pattern
+  const resolvedRender =
+    render ??
+    (asChild ? (children as BasePopoverCloseProps["render"]) : undefined);
+
   return (
-    <PopoverBase.Close
-      className={className}
-      render={
-        asChild ? (children as BasePopoverCloseProps["render"]) : undefined
-      }
-      {...props}
-    >
-      {asChild ? undefined : children}
+    <PopoverBase.Close className={className} render={resolvedRender} {...props}>
+      {resolvedRender ? undefined : children}
     </PopoverBase.Close>
   );
 }
@@ -348,9 +358,7 @@ function ArrowSvg(props: React.ComponentProps<"svg">) {
  * @example
  * ```tsx
  * <Popover>
- *   <Popover.Trigger asChild>
- *     <Button>Open</Button>
- *   </Popover.Trigger>
+ *   <Popover.Trigger render={<Button>Open</Button>} />
  *   <Popover.Content>
  *     <Popover.Title>Notifications</Popover.Title>
  *     <Popover.Description>You are all caught up!</Popover.Description>

--- a/packages/kumo/src/components/popover/popover.tsx
+++ b/packages/kumo/src/components/popover/popover.tsx
@@ -72,7 +72,7 @@ type BasePopoverTriggerProps = ComponentPropsWithoutRef<
 export type PopoverTriggerProps = BasePopoverTriggerProps & {
   /**
    * @deprecated Use the `render` prop instead.
-   * @example `<Popover.Trigger render={<Button />}>` instead of `<Popover.Trigger asChild><Button /></Popover.Trigger>`
+   * @example `<Popover.Trigger render={<Button />}>Open</Popover.Trigger>` instead of `<Popover.Trigger asChild><Button>Open</Button></Popover.Trigger>`
    */
   asChild?: boolean;
 };
@@ -85,6 +85,7 @@ function PopoverTrigger({
   ...props
 }: PopoverTriggerProps) {
   // Support both render prop (preferred) and deprecated asChild pattern
+  // When using asChild, children IS the render element, so don't pass it as children
   const resolvedRender =
     render ??
     (asChild ? (children as BasePopoverTriggerProps["render"]) : undefined);
@@ -95,7 +96,7 @@ function PopoverTrigger({
       render={resolvedRender}
       {...props}
     >
-      {resolvedRender ? undefined : children}
+      {asChild ? undefined : children}
     </PopoverBase.Trigger>
   );
 }
@@ -284,7 +285,7 @@ type BasePopoverCloseProps = ComponentPropsWithoutRef<typeof PopoverBase.Close>;
 export type PopoverCloseProps = BasePopoverCloseProps & {
   /**
    * @deprecated Use the `render` prop instead.
-   * @example `<Popover.Close render={<Button />}>` instead of `<Popover.Close asChild><Button /></Popover.Close>`
+   * @example `<Popover.Close render={<Button />}>Close</Popover.Close>` instead of `<Popover.Close asChild><Button>Close</Button></Popover.Close>`
    */
   asChild?: boolean;
 };
@@ -297,13 +298,14 @@ function PopoverClose({
   ...props
 }: PopoverCloseProps) {
   // Support both render prop (preferred) and deprecated asChild pattern
+  // When using asChild, children IS the render element, so don't pass it as children
   const resolvedRender =
     render ??
     (asChild ? (children as BasePopoverCloseProps["render"]) : undefined);
 
   return (
     <PopoverBase.Close className={className} render={resolvedRender} {...props}>
-      {resolvedRender ? undefined : children}
+      {asChild ? undefined : children}
     </PopoverBase.Close>
   );
 }

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -953,11 +953,10 @@ SidebarMenuItem.displayName = "Sidebar.MenuItem";
 
 export type SidebarMenuButtonSize = "base" | "sm";
 
-export interface SidebarMenuButtonProps
-  extends Omit<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    "className" | "children"
-  > {
+export interface SidebarMenuButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "className" | "children"
+> {
   icon?: React.ComponentType<{ className?: string }> | React.ReactNode;
   active?: boolean;
   /**
@@ -1104,14 +1103,10 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
     }
 
     // Wrap in Tooltip when collapsed and tooltip text is provided.
-    // Use asChild so TooltipTrigger merges onto the button/link via render prop
+    // Use render prop so Tooltip merges onto the button/link
     // instead of wrapping it in another <button> (which would cause invalid nesting).
     if (state === "collapsed" && tooltip) {
-      button = (
-        <Tooltip content={tooltip} side="right" asChild>
-          {button}
-        </Tooltip>
-      );
+      button = <Tooltip content={tooltip} side="right" render={button} />;
     }
 
     // Auto-wrap in <li> when not already inside a MenuItem
@@ -1264,8 +1259,7 @@ SidebarMenuSubItem.displayName = "Sidebar.MenuSubItem";
 // Sidebar MenuSubButton
 // ============================================================================
 
-export interface SidebarMenuSubButtonProps
-  extends ComponentPropsWithoutRef<"button"> {
+export interface SidebarMenuSubButtonProps extends ComponentPropsWithoutRef<"button"> {
   /** Marks this sub-item as currently active/selected. @default false */
   active?: boolean;
   /** Navigation URL. When set, renders as a link via LinkProvider. */
@@ -1525,15 +1519,8 @@ const SidebarResizeHandle = forwardRef<
   HTMLDivElement,
   ComponentPropsWithoutRef<"div">
 >(({ className, ...props }, ref) => {
-  const {
-    side,
-    resizable,
-    setIsResizing,
-    setWidth,
-    setOpen,
-    open,
-    minWidth,
-  } = useSidebar();
+  const { side, resizable, setIsResizing, setWidth, setOpen, open, minWidth } =
+    useSidebar();
   const startX = useRef(0);
   const startWidth = useRef(0);
   const wasCollapsed = useRef(false);

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -77,7 +77,9 @@ type TooltipAlign = "start" | "center" | "end";
  *
  * @example
  * ```tsx
- * <Tooltip content="Add new item" render={<Button shape="square" icon={PlusIcon} />} />
+ * <Tooltip content="Add new item" render={<Button shape="square" icon={PlusIcon} />}>
+ *   Add
+ * </Tooltip>
  * ```
  */
 export type TooltipProps = BaseTooltipProps &
@@ -91,7 +93,7 @@ export type TooltipProps = BaseTooltipProps &
     align?: TooltipAlign;
     /**
      * @deprecated Use the `render` prop instead.
-     * @example `<Tooltip render={<Button />}>` instead of `<Tooltip asChild><Button /></Tooltip>`
+     * @example `<Tooltip render={<Button />}>Label</Tooltip>` instead of `<Tooltip asChild><Button>Label</Button></Tooltip>`
      */
     asChild?: boolean;
     /** Additional CSS classes merged via `cn()`. */
@@ -115,8 +117,8 @@ export type TooltipProps = BaseTooltipProps &
      */
     delay?: number;
     /**
-     * Element to render as the tooltip trigger. Props are merged onto this element.
-     * @example `<Tooltip content="Save" render={<Button>Save</Button>} />`
+     * Element to render as the tooltip trigger. Children are passed to this element.
+     * @example `<Tooltip content="Save" render={<Button />}>Save</Tooltip>`
      */
     render?: TriggerProps["render"];
   };
@@ -127,7 +129,9 @@ export type TooltipProps = BaseTooltipProps &
  *
  * @example
  * ```tsx
- * <Tooltip content="Save changes" render={<Button variant="primary">Save</Button>} />
+ * <Tooltip content="Save changes" render={<Button variant="primary" />}>
+ *   Save
+ * </Tooltip>
  * ```
  */
 export function Tooltip({
@@ -147,6 +151,7 @@ export function Tooltip({
   const container = containerProp ?? contextContainer ?? undefined;
 
   // Support both render prop (preferred) and deprecated asChild pattern
+  // When using asChild, children IS the render element, so don't pass it as children
   const resolvedRender =
     render ?? (asChild ? (children as TriggerProps["render"]) : undefined);
   const shouldUseRender = resolvedRender !== undefined;
@@ -166,7 +171,7 @@ export function Tooltip({
         )}
         render={resolvedRender}
       >
-        {shouldUseRender ? undefined : (children as ReactNode)}
+        {asChild ? undefined : (children as ReactNode)}
       </TooltipBase.Trigger>
       <TooltipBase.Portal container={container}>
         <TooltipBase.Positioner align={align} side={side} sideOffset={10}>

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -77,9 +77,7 @@ type TooltipAlign = "start" | "center" | "end";
  *
  * @example
  * ```tsx
- * <Tooltip content="Add new item" asChild>
- *   <Button shape="square" icon={PlusIcon} />
- * </Tooltip>
+ * <Tooltip content="Add new item" render={<Button shape="square" icon={PlusIcon} />} />
  * ```
  */
 export type TooltipProps = BaseTooltipProps &
@@ -91,7 +89,10 @@ export type TooltipProps = BaseTooltipProps &
      * - `"end"` — Align to the end edge
      */
     align?: TooltipAlign;
-    /** When `true`, the trigger wraps the child element instead of adding a wrapper. */
+    /**
+     * @deprecated Use the `render` prop instead.
+     * @example `<Tooltip render={<Button />}>` instead of `<Tooltip asChild><Button /></Tooltip>`
+     */
     asChild?: boolean;
     /** Additional CSS classes merged via `cn()`. */
     className?: string;
@@ -113,6 +114,11 @@ export type TooltipProps = BaseTooltipProps &
      * @default 600
      */
     delay?: number;
+    /**
+     * Element to render as the tooltip trigger. Props are merged onto this element.
+     * @example `<Tooltip content="Save" render={<Button>Save</Button>} />`
+     */
+    render?: TriggerProps["render"];
   };
 
 /**
@@ -121,9 +127,7 @@ export type TooltipProps = BaseTooltipProps &
  *
  * @example
  * ```tsx
- * <Tooltip content="Save changes" asChild>
- *   <Button variant="primary">Save</Button>
- * </Tooltip>
+ * <Tooltip content="Save changes" render={<Button variant="primary">Save</Button>} />
  * ```
  */
 export function Tooltip({
@@ -131,6 +135,7 @@ export function Tooltip({
   children,
   align,
   asChild,
+  render,
   side,
   className,
   container: containerProp,
@@ -141,22 +146,27 @@ export function Tooltip({
   const contextContainer = usePortalContainer();
   const container = containerProp ?? contextContainer ?? undefined;
 
+  // Support both render prop (preferred) and deprecated asChild pattern
+  const resolvedRender =
+    render ?? (asChild ? (children as TriggerProps["render"]) : undefined);
+  const shouldUseRender = resolvedRender !== undefined;
+
   return (
     <TooltipBase.Root {...props}>
       <TooltipBase.Trigger
         closeDelay={closeDelay}
         delay={delay}
         className={cn(
-          // Defensive resets when rendering as button wrapper (not asChild)
+          // Defensive resets when rendering as button wrapper (not render/asChild)
           // These prevent global button styles from polluting the trigger
           // Consumer styles passed via className will override these (tailwind-merge)
-          !asChild &&
+          !shouldUseRender &&
             "inline-flex items-center bg-transparent border-none shadow-none p-0 m-0 h-auto min-h-0 leading-[0]",
           className,
         )}
-        render={asChild ? (children as TriggerProps["render"]) : undefined}
+        render={resolvedRender}
       >
-        {asChild ? undefined : (children as ReactNode)}
+        {shouldUseRender ? undefined : (children as ReactNode)}
       </TooltipBase.Trigger>
       <TooltipBase.Portal container={container}>
         <TooltipBase.Positioner align={align} side={side} sideOffset={10}>


### PR DESCRIPTION
## Summary

Unifies composition patterns across the library by adopting Base UI's `render` prop pattern. This deprecates the `asChild` prop on Tooltip, Popover.Trigger, and Popover.Close.

**Changes:**
- Add `render` prop to `Tooltip`, `Popover.Trigger`, `Popover.Close`
- Mark `asChild` as `@deprecated` (still functional for backward compatibility)
- Update all internal usages (Button, Sidebar, MenuBar, Label) to use `render`
- Update all demo files and documentation examples

## Migration

```diff
- <Tooltip content="Save" asChild>
-   <Button>Save</Button>
- </Tooltip>
+ <Tooltip content="Save" render={<Button />}>
+   Save
+ </Tooltip>

- <Popover.Trigger asChild>
-   <Button>Open</Button>
- </Popover.Trigger>
+ <Popover.Trigger render={<Button />}>Open</Popover.Trigger>

- <Popover.Close asChild>
-   <Button>Close</Button>
- </Popover.Close>
+ <Popover.Close render={<Button />}>Close</Popover.Close>
```

## Why

The `render` prop is the modern pattern used by Base UI. It provides:
- Cleaner separation of element type/props from content
- Better type inference
- Consistency with other Base UI components

The `Text` component's `as` prop is intentionally preserved as it serves a different purpose (semantic HTML element selection).

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: deprecation and API pattern change requires human review of migration path and backward compatibility
- Tests
  - [x] Additional testing not necessary because: existing demos serve as integration tests, no new runtime behavior added (render prop is passed through to Base UI)