### PR TITLE
Add copy to clipboard to all code blocks

### DIFF
--- a/.changeset/add-copy-button.md
+++ b/.changeset/add-copy-button.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Add copy to clipboard button to all code blocks

--- a/packages/kumo-docs-astro/src/components/docs/CodeBlock.astro
+++ b/packages/kumo-docs-astro/src/components/docs/CodeBlock.astro
@@ -1,5 +1,6 @@
 ---
 import { Code } from "astro:components";
+import { CopyCodeButton } from "./CopyCodeButton";
 
 interface Props {
   code: string;
@@ -9,12 +10,12 @@ interface Props {
 const { code, lang = "tsx" } = Astro.props;
 ---
 
-<div
-  class="not-prose code-block"
->
-  <Code 
-    code={code} 
-    lang={lang} 
+<div class="not-prose code-block relative">
+  <CopyCodeButton client:load code={code} />
+
+  <Code
+    code={code}
+    lang={lang}
     themes={{
       light: "github-light",
       dark: "vesper"
@@ -37,7 +38,7 @@ const { code, lang = "tsx" } = Astro.props;
     color: var(--shiki-light) !important;
     background-color: var(--shiki-light-bg) !important;
   }
-  
+
   /* Dark mode - use dark theme colors */
   [data-mode="dark"] .code-block .astro-code,
   [data-mode="dark"] .code-block .astro-code span {

--- a/packages/kumo-docs-astro/src/components/docs/CopyCodeButton.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/CopyCodeButton.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
+import { Button, cn, Tooltip } from "@cloudflare/kumo";
+
+const slideAnimations = {
+  initial:
+    "pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 translate-y-full",
+  animate: "translate-y-0 opacity-100",
+  end: "pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 -translate-y-full",
+} as const;
+
+interface CopyCodeButtonProps {
+  code: string;
+}
+
+export function CopyCodeButton({ code }: CopyCodeButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      return;
+    }
+
+    setCopied(true);
+
+    // Clear previous timeout to handle rapid clicks
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setCopied(false);
+      timeoutRef.current = null;
+    }, 1500);
+  }, [code]);
+
+  return (
+    <div className="absolute top-4 right-4">
+      <Tooltip content={copied ? "Copied" : "Copy"} asChild>
+        <Button
+          aria-label={copied ? "Copied" : "Copy code to clipboard"}
+          className="relative overflow-hidden bg-kumo-base text-kumo-subtle"
+          onClick={handleCopy}
+          shape="square"
+          size="sm"
+          variant="ghost"
+        >
+          <span
+            className={cn(
+              "flex items-center justify-center transition-all duration-200",
+              copied ? slideAnimations.animate : slideAnimations.initial,
+            )}
+          >
+            <CheckIcon size={16} />
+          </span>
+          <span
+            className={cn(
+              "flex items-center justify-center transition-all duration-200",
+              copied ? slideAnimations.end : slideAnimations.animate,
+            )}
+          >
+            <CopyIcon size={16} />
+          </span>
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/blocks/delete-resource.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/delete-resource.mdx
@@ -10,6 +10,7 @@ import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import {
   DeleteResourceBasicDemo,
   DeleteResourceErrorDemo,
@@ -37,27 +38,24 @@ import {
     <div>
       <p>**1. Initialize Kumo config (first time only)**</p>
 
-```bash
-npx @cloudflare/kumo init
-```
+<CodeBlock code={`npx @cloudflare/kumo init`} lang="bash" />
 
 </div>
 <div>
 <p>**2. Install the block**</p>
 
-```bash
-npx @cloudflare/kumo add DeleteResource
-```
+<CodeBlock code={`npx @cloudflare/kumo add DeleteResource`} lang="bash" />
 
 </div>
 <div>
 <p>**3. Import from your local path**</p>
 
-```tsx
-// The path depends on your kumo.json blocksDir setting
+<CodeBlock
+  code={`// The path depends on your kumo.json blocksDir setting
 // Default: src/components/kumo/
-import { DeleteResource } from "./components/kumo/delete-resource/delete-resource";
-```
+import { DeleteResource } from "./components/kumo/delete-resource/delete-resource";`}
+  lang="tsx"
+/>
 
     </div>
 
@@ -74,8 +72,7 @@ import { DeleteResource } from "./components/kumo/delete-resource/delete-resourc
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { useState } from "react";
+<CodeBlock code={`import { useState } from "react";
 import { DeleteResource } from "./components/kumo/delete-resource/delete-resource";
 import { Button } from "@cloudflare/kumo";
 
@@ -108,8 +105,7 @@ export default function Example() {
       />
     </>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
@@ -9,6 +9,7 @@ import Heading from "~/components/docs/Heading.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import {
   PageHeaderHeroDemo,
   PageHeaderBasicDemo,
@@ -41,27 +42,24 @@ import {
     <div>
       <p>**1. Initialize Kumo config (first time only)**</p>
 
-```bash
-npx @cloudflare/kumo init
-```
+<CodeBlock code={`npx @cloudflare/kumo init`} lang="bash" />
 
 </div>
 <div>
 <p>**2. Install the block**</p>
 
-```bash
-npx @cloudflare/kumo add PageHeader
-```
+<CodeBlock code={`npx @cloudflare/kumo add PageHeader`} lang="bash" />
 
 </div>
 <div>
 <p>**3. Import from your local path**</p>
 
-```tsx
-// The path depends on your kumo.json blocksDir setting
+<CodeBlock
+  code={`// The path depends on your kumo.json blocksDir setting
 // Default: src/components/kumo/
-import { PageHeader } from "./components/kumo/page-header/page-header";
-```
+import { PageHeader } from "./components/kumo/page-header/page-header";`}
+  lang="tsx"
+/>
 
     </div>
 
@@ -73,8 +71,7 @@ import { PageHeader } from "./components/kumo/page-header/page-header";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { PageHeader } from "./components/kumo/page-header/page-header";
+<CodeBlock code={`import { PageHeader } from "./components/kumo/page-header/page-header";
 import { Breadcrumbs } from "@cloudflare/kumo";
 
 export default function Example() {
@@ -99,8 +96,7 @@ export default function Example() {
       }}
     />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
@@ -9,6 +9,7 @@ import Heading from "~/components/docs/Heading.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import {
   ResourceListBasicDemo,
   ResourceListWithUsageDemo,
@@ -36,27 +37,24 @@ import {
     <div>
       <p>**1. Initialize Kumo config (first time only)**</p>
 
-```bash
-npx @cloudflare/kumo init
-```
+<CodeBlock code={`npx @cloudflare/kumo init`} lang="bash" />
 
 </div>
 <div>
 <p>**2. Install the block**</p>
 
-```bash
-npx @cloudflare/kumo add ResourceListPage
-```
+<CodeBlock code={`npx @cloudflare/kumo add ResourceListPage`} lang="bash" />
 
 </div>
 <div>
 <p>**3. Import from your local path**</p>
 
-```tsx
-// The path depends on your kumo.json blocksDir setting
+<CodeBlock
+  code={`// The path depends on your kumo.json blocksDir setting
 // Default: src/components/kumo/
-import { ResourceListPage } from "./components/kumo/resource-list/resource-list";
-```
+import { ResourceListPage } from "./components/kumo/resource-list/resource-list";`}
+  lang="tsx"
+/>
 
     </div>
 
@@ -73,8 +71,7 @@ import { ResourceListPage } from "./components/kumo/resource-list/resource-list"
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { ResourceListPage } from "./components/kumo/resource-list/resource-list";
+<CodeBlock code={`import { ResourceListPage } from "./components/kumo/resource-list/resource-list";
 import { Surface } from "@cloudflare/kumo";
 import { DatabaseIcon } from "@phosphor-icons/react";
 
@@ -88,8 +85,7 @@ export default function DatabasesPage() {
       <Surface className="p-6">{/* Your resource list content */}</Surface>
     </ResourceListPage>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/charts/index.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/index.mdx
@@ -6,6 +6,7 @@ sourceFile: "components/chart"
 ---
 
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import {
   PieChartPreviewDemo,
   TimeseriesChartPreviewDemo,
@@ -23,17 +24,14 @@ import ComponentExample from "~/components/docs/ComponentExample.astro";
     Chart components are built on ECharts. Install it as a dependency:
   </p>
 
-```bash
-npm install echarts
-```
+<CodeBlock code={`npm install echarts`} lang="bash" />
 
 <p class="my-4">
   For optimal bundle size, import only the ECharts components you need. The
   examples below show the minimum required imports for our use cases.
 </p>
 
-```tsx
-import * as echarts from "echarts/core";
+<CodeBlock code={`import * as echarts from "echarts/core";
 import { BarChart, LineChart, PieChart } from "echarts/charts";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -55,8 +53,7 @@ echarts.use([
   TooltipComponent,
   CanvasRenderer,
   AriaComponent,
-]);
-```
+]);`} lang="tsx" />
 
 </ComponentSection>
 
@@ -92,12 +89,10 @@ echarts.use([
       colors for differentiating arbitrary series.
     </p>
 
-```tsx
-import { ChartPalette } from "@cloudflare/kumo";
+<CodeBlock code={`import { ChartPalette } from "@cloudflare/kumo";
 
 const attention = ChartPalette.semantic("Attention", isDarkMode);
-const series0 = ChartPalette.color(0, isDarkMode);
-```
+const series0 = ChartPalette.color(0, isDarkMode);`} lang="tsx" />
 
     <ColorDemo />
 

--- a/packages/kumo-docs-astro/src/pages/cli.mdx
+++ b/packages/kumo-docs-astro/src/pages/cli.mdx
@@ -5,14 +5,13 @@ description: "Access component documentation and install blocks from your termin
 ---
 
 import { CLITerminal } from "~/components/demos/CLIDemo";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 
 ## Installation
 
 The Kumo CLI is available via npx. No installation required.
 
-```bash
-npx @cloudflare/kumo help
-```
+<CodeBlock code={`npx @cloudflare/kumo help`} lang="bash" />
 
 ## Commands
 
@@ -20,31 +19,31 @@ npx @cloudflare/kumo help
 
 Install copy-paste blocks into your project for full customization.
 
-```bash
-# Initialize kumo.json configuration
+<CodeBlock code={`# Initialize kumo.json configuration
 npx @cloudflare/kumo init
 
 # List all available blocks
+
 npx @cloudflare/kumo blocks
 
 # Install a block to your project
-npx @cloudflare/kumo add PageHeader
-```
+
+npx @cloudflare/kumo add PageHeader`} lang="bash" />
 
 ### Component Registry
 
 Access component documentation directly from your terminal.
 
-```bash
-# List all Kumo components with categories
+<CodeBlock code={`# List all Kumo components with categories
 npx @cloudflare/kumo ls
 
 # Get detailed documentation for a component
+
 npx @cloudflare/kumo doc Button
 
 # Get documentation for all components
-npx @cloudflare/kumo docs
-```
+
+npx @cloudflare/kumo docs`} lang="bash" />
 
 ## Try it out
 

--- a/packages/kumo-docs-astro/src/pages/colors.mdx
+++ b/packages/kumo-docs-astro/src/pages/colors.mdx
@@ -45,7 +45,6 @@ Set `data-mode` on a parent element to control light/dark mode. Never use Tailwi
 <html data-mode="dark">   // Dark mode
 
 // Components automatically adapt - no dark: variants needed
-
 <div className="bg-kumo-base text-kumo-default" />`} lang="tsx" />
 
 ## Themes
@@ -64,7 +63,6 @@ Themes override semantic token values while preserving the same token names. Set
 </div>
 
 // Themes work with both light and dark mode
-
 <html data-mode="dark" data-theme="fedramp">`} lang="tsx" />
 
 ### Theme Generator
@@ -75,11 +73,9 @@ Themes are defined in a centralized config and generated as CSS files. The theme
 pnpm --filter @cloudflare/kumo codegen:themes --list
 
 # Generate theme CSS files
-
 pnpm --filter @cloudflare/kumo codegen:themes
 
 # Preview changes without writing files
-
 pnpm --filter @cloudflare/kumo codegen:themes --dry-run`} lang="bash" />
 
 Theme config: `packages/kumo/scripts/theme-generator/config.ts`
@@ -138,44 +134,27 @@ Surfaces establish depth and layering in the UI. Use them in order from the oute
     </thead>
     <tbody>
       <tr>
-        <td>
-          <code>bg-kumo-canvas</code>
-        </td>
+        <td><code>bg-kumo-canvas</code></td>
         <td>The outermost page background — sits behind everything</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-base</code>
-        </td>
+        <td><code>bg-kumo-base</code></td>
         <td>Default component background</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-elevated</code>
-        </td>
-        <td>
-          Slightly elevated surface, e.g. <code>LayerCard.Secondary</code>
-        </td>
+        <td><code>bg-kumo-elevated</code></td>
+        <td>Slightly elevated surface, e.g. <code>LayerCard.Secondary</code></td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-recessed</code>
-        </td>
-        <td>
-          Recessed surface with a subtly darker fill, e.g. segmented{" "}
-          <code>Tabs</code> background
-        </td>
+        <td><code>bg-kumo-recessed</code></td>
+        <td>Recessed surface with a subtly darker fill, e.g. segmented <code>Tabs</code> background</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-tint</code>
-        </td>
+        <td><code>bg-kumo-tint</code></td>
         <td>Subtle tinted background for tables or hover states</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-contrast</code>
-        </td>
+        <td><code>bg-kumo-contrast</code></td>
         <td>High-contrast, inverted background</td>
       </tr>
     </tbody>
@@ -198,15 +177,11 @@ Surfaces establish depth and layering in the UI. Use them in order from the oute
     </thead>
     <tbody>
       <tr>
-        <td>
-          <code>bg-kumo-brand</code>
-        </td>
+        <td><code>bg-kumo-brand</code></td>
         <td>Primary brand background</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-brand-hover</code>
-        </td>
+        <td><code>bg-kumo-brand-hover</code></td>
         <td>Hover state for brand backgrounds</td>
       </tr>
     </tbody>
@@ -231,27 +206,19 @@ Each status color comes in two variants: a solid color for icons and indicators,
     </thead>
     <tbody>
       <tr>
-        <td>
-          <code>bg-kumo-info</code>
-        </td>
+        <td><code>bg-kumo-info</code></td>
         <td>Info indicator (icon, dot, bar)</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-success</code>
-        </td>
+        <td><code>bg-kumo-success</code></td>
         <td>Success indicator</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-warning</code>
-        </td>
+        <td><code>bg-kumo-warning</code></td>
         <td>Warning indicator</td>
       </tr>
       <tr>
-        <td>
-          <code>bg-kumo-danger</code>
-        </td>
+        <td><code>bg-kumo-danger</code></td>
         <td>Error/destructive indicator</td>
       </tr>
     </tbody>
@@ -285,69 +252,47 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
     </thead>
     <tbody>
       <tr>
-        <td>
-          <code>text-kumo-default</code>
-        </td>
+        <td><code>text-kumo-default</code></td>
         <td>Primary body text</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-strong</code>
-        </td>
+        <td><code>text-kumo-strong</code></td>
         <td>Secondary text with slightly less contrast than default</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-subtle</code>
-        </td>
+        <td><code>text-kumo-subtle</code></td>
         <td>Muted text for descriptions, captions, or secondary labels</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-inactive</code>
-        </td>
+        <td><code>text-kumo-inactive</code></td>
         <td>Disabled or inactive text</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-placeholder</code>
-        </td>
+        <td><code>text-kumo-placeholder</code></td>
         <td>Placeholder text in inputs</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-inverse</code>
-        </td>
+        <td><code>text-kumo-inverse</code></td>
         <td>Text intended for use on high-contrast or inverted backgrounds</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-link</code>
-        </td>
+        <td><code>text-kumo-link</code></td>
         <td>Link text</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-info</code>
-        </td>
+        <td><code>text-kumo-info</code></td>
         <td>Info-colored text</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-success</code>
-        </td>
+        <td><code>text-kumo-success</code></td>
         <td>Success-colored text</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-warning</code>
-        </td>
+        <td><code>text-kumo-warning</code></td>
         <td>Warning-colored text</td>
       </tr>
       <tr>
-        <td>
-          <code>text-kumo-danger</code>
-        </td>
+        <td><code>text-kumo-danger</code></td>
         <td>Error/destructive text</td>
       </tr>
     </tbody>
@@ -376,19 +321,11 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
             <Badge variant="info">New</Badge>
           </span>
         </td>
-        <td>
-          A border/ring color to distinguish between flat surfaces where no
-          shadow is present (i.e. <code>LayerCard</code>).
-        </td>
+        <td>A border/ring color to distinguish between flat surfaces where no shadow is present (i.e. <code>LayerCard</code>).</td>
       </tr>
       <tr>
-        <td>
-          <code>kumo-hairline</code>
-        </td>
-        <td>
-          A thicker border/ring color that defines the edge of an elevated
-          surface alongside a shadow.
-        </td>
+        <td><code>kumo-hairline</code></td>
+        <td>A thicker border/ring color that defines the edge of an elevated surface alongside a shadow.</td>
       </tr>
     </tbody>
   </table>

--- a/packages/kumo-docs-astro/src/pages/colors.mdx
+++ b/packages/kumo-docs-astro/src/pages/colors.mdx
@@ -6,6 +6,7 @@ description: "Kumo uses semantic color tokens that automatically adapt to light 
 
 import { TailwindColorTokens } from "~/components/demos/ColorsDemo";
 import { Badge } from "@cloudflare/kumo";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 
 ## Usage
 
@@ -13,23 +14,25 @@ Always use semantic tokens instead of raw Tailwind colors. This ensures your UI 
 
 **Correct**
 
-```tsx
-<div className="bg-kumo-base text-kumo-default border-kumo-hairline">
+<CodeBlock
+  code={`<div className="bg-kumo-base text-kumo-default border-kumo-hairline">
   <button className="bg-kumo-brand text-white">Primary</button>
   <button className="bg-kumo-control text-kumo-default">Secondary</button>
-</div>
-```
+</div>`}
+  lang="tsx"
+/>
 
 **Incorrect**
 
-```tsx
-{
+<CodeBlock
+  code={`{
   /* Never use raw Tailwind colors */
 }
 <div className="bg-white dark:bg-gray-900 text-black dark:text-white">
   <button className="bg-blue-500">Primary</button>
-</div>;
-```
+</div>;`}
+  lang="tsx"
+/>
 
 > Lint rules enforce this: The `no-primitive-colors` rule will flag any raw Tailwind colors like `bg-blue-500`.
 
@@ -37,14 +40,13 @@ Always use semantic tokens instead of raw Tailwind colors. This ensures your UI 
 
 Set `data-mode` on a parent element to control light/dark mode. Never use Tailwind's `dark:` variant — semantic tokens handle dark mode automatically via CSS `light-dark()`.
 
-```tsx
-// Set mode on html or body
+<CodeBlock code={`// Set mode on html or body
 <html data-mode="light">  // Light mode
 <html data-mode="dark">   // Dark mode
 
 // Components automatically adapt - no dark: variants needed
-<div className="bg-kumo-base text-kumo-default" />
-```
+
+<div className="bg-kumo-base text-kumo-default" />`} lang="tsx" />
 
 ## Themes
 
@@ -55,31 +57,30 @@ Themes override semantic token values while preserving the same token names. Set
 - `kumo` — Default theme (no attribute needed)
 - `fedramp` — Government compliance styling
 
-```tsx
-// Apply a theme to a section or the whole app
+<CodeBlock code={`// Apply a theme to a section or the whole app
 <div data-theme="fedramp">
   {/* All Kumo components inside use fedramp token overrides */}
   <Button>FedRAMP Styled</Button>
 </div>
 
 // Themes work with both light and dark mode
-<html data-mode="dark" data-theme="fedramp">
-```
+
+<html data-mode="dark" data-theme="fedramp">`} lang="tsx" />
 
 ### Theme Generator
 
 Themes are defined in a centralized config and generated as CSS files. The theme generator ensures consistency across all themes.
 
-```bash
-# List all tokens and their theme overrides
+<CodeBlock code={`# List all tokens and their theme overrides
 pnpm --filter @cloudflare/kumo codegen:themes --list
 
 # Generate theme CSS files
+
 pnpm --filter @cloudflare/kumo codegen:themes
 
 # Preview changes without writing files
-pnpm --filter @cloudflare/kumo codegen:themes --dry-run
-```
+
+pnpm --filter @cloudflare/kumo codegen:themes --dry-run`} lang="bash" />
 
 Theme config: `packages/kumo/scripts/theme-generator/config.ts`
 
@@ -87,8 +88,7 @@ Theme config: `packages/kumo/scripts/theme-generator/config.ts`
 
 Add theme overrides in the config file. Only override tokens that need to change — all other tokens inherit from the base kumo theme.
 
-```ts
-// In scripts/theme-generator/config.ts
+<CodeBlock code={`// In scripts/theme-generator/config.ts
 export const THEME_CONFIG: ThemeConfig = {
   color: {
     "kumo-base": {
@@ -110,8 +110,7 @@ export const THEME_CONFIG: ThemeConfig = {
 };
 
 // Add to available themes
-export const AVAILABLE_THEMES = ["kumo", "fedramp", "myTheme"] as const;
-```
+export const AVAILABLE_THEMES = ["kumo", "fedramp", "myTheme"] as const;`} lang="ts" />
 
 Then run `pnpm codegen:themes` to generate the CSS.
 
@@ -139,27 +138,44 @@ Surfaces establish depth and layering in the UI. Use them in order from the oute
     </thead>
     <tbody>
       <tr>
-        <td><code>bg-kumo-canvas</code></td>
+        <td>
+          <code>bg-kumo-canvas</code>
+        </td>
         <td>The outermost page background — sits behind everything</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-base</code></td>
+        <td>
+          <code>bg-kumo-base</code>
+        </td>
         <td>Default component background</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-elevated</code></td>
-        <td>Slightly elevated surface, e.g. <code>LayerCard.Secondary</code></td>
+        <td>
+          <code>bg-kumo-elevated</code>
+        </td>
+        <td>
+          Slightly elevated surface, e.g. <code>LayerCard.Secondary</code>
+        </td>
       </tr>
       <tr>
-        <td><code>bg-kumo-recessed</code></td>
-        <td>Recessed surface with a subtly darker fill, e.g. segmented <code>Tabs</code> background</td>
+        <td>
+          <code>bg-kumo-recessed</code>
+        </td>
+        <td>
+          Recessed surface with a subtly darker fill, e.g. segmented{" "}
+          <code>Tabs</code> background
+        </td>
       </tr>
       <tr>
-        <td><code>bg-kumo-tint</code></td>
+        <td>
+          <code>bg-kumo-tint</code>
+        </td>
         <td>Subtle tinted background for tables or hover states</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-contrast</code></td>
+        <td>
+          <code>bg-kumo-contrast</code>
+        </td>
         <td>High-contrast, inverted background</td>
       </tr>
     </tbody>
@@ -182,11 +198,15 @@ Surfaces establish depth and layering in the UI. Use them in order from the oute
     </thead>
     <tbody>
       <tr>
-        <td><code>bg-kumo-brand</code></td>
+        <td>
+          <code>bg-kumo-brand</code>
+        </td>
         <td>Primary brand background</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-brand-hover</code></td>
+        <td>
+          <code>bg-kumo-brand-hover</code>
+        </td>
         <td>Hover state for brand backgrounds</td>
       </tr>
     </tbody>
@@ -211,19 +231,27 @@ Each status color comes in two variants: a solid color for icons and indicators,
     </thead>
     <tbody>
       <tr>
-        <td><code>bg-kumo-info</code></td>
+        <td>
+          <code>bg-kumo-info</code>
+        </td>
         <td>Info indicator (icon, dot, bar)</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-success</code></td>
+        <td>
+          <code>bg-kumo-success</code>
+        </td>
         <td>Success indicator</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-warning</code></td>
+        <td>
+          <code>bg-kumo-warning</code>
+        </td>
         <td>Warning indicator</td>
       </tr>
       <tr>
-        <td><code>bg-kumo-danger</code></td>
+        <td>
+          <code>bg-kumo-danger</code>
+        </td>
         <td>Error/destructive indicator</td>
       </tr>
     </tbody>
@@ -232,13 +260,14 @@ Each status color comes in two variants: a solid color for icons and indicators,
 
 Use the solid token on icons, status dots, borders and rings. Banners and badges use the `-tint` variant with varying opacity values for the different instances.
 
-```tsx
-// Banner with tinted background and solid icon
+<CodeBlock
+  code={`// Banner with tinted background and solid icon
 <div className="bg-kumo-danger-tint text-kumo-danger">
   <AlertIcon className="text-kumo-danger" />
   <p>Something went wrong.</p>
-</div>
-```
+</div>`}
+  lang="tsx"
+/>
 
 ### Text Colors
 
@@ -256,47 +285,69 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
     </thead>
     <tbody>
       <tr>
-        <td><code>text-kumo-default</code></td>
+        <td>
+          <code>text-kumo-default</code>
+        </td>
         <td>Primary body text</td>
       </tr>
       <tr>
-        <td><code>text-kumo-strong</code></td>
+        <td>
+          <code>text-kumo-strong</code>
+        </td>
         <td>Secondary text with slightly less contrast than default</td>
       </tr>
       <tr>
-        <td><code>text-kumo-subtle</code></td>
+        <td>
+          <code>text-kumo-subtle</code>
+        </td>
         <td>Muted text for descriptions, captions, or secondary labels</td>
       </tr>
       <tr>
-        <td><code>text-kumo-inactive</code></td>
+        <td>
+          <code>text-kumo-inactive</code>
+        </td>
         <td>Disabled or inactive text</td>
       </tr>
       <tr>
-        <td><code>text-kumo-placeholder</code></td>
+        <td>
+          <code>text-kumo-placeholder</code>
+        </td>
         <td>Placeholder text in inputs</td>
       </tr>
       <tr>
-        <td><code>text-kumo-inverse</code></td>
+        <td>
+          <code>text-kumo-inverse</code>
+        </td>
         <td>Text intended for use on high-contrast or inverted backgrounds</td>
       </tr>
       <tr>
-        <td><code>text-kumo-link</code></td>
+        <td>
+          <code>text-kumo-link</code>
+        </td>
         <td>Link text</td>
       </tr>
       <tr>
-        <td><code>text-kumo-info</code></td>
+        <td>
+          <code>text-kumo-info</code>
+        </td>
         <td>Info-colored text</td>
       </tr>
       <tr>
-        <td><code>text-kumo-success</code></td>
+        <td>
+          <code>text-kumo-success</code>
+        </td>
         <td>Success-colored text</td>
       </tr>
       <tr>
-        <td><code>text-kumo-warning</code></td>
+        <td>
+          <code>text-kumo-warning</code>
+        </td>
         <td>Warning-colored text</td>
       </tr>
       <tr>
-        <td><code>text-kumo-danger</code></td>
+        <td>
+          <code>text-kumo-danger</code>
+        </td>
         <td>Error/destructive text</td>
       </tr>
     </tbody>
@@ -325,11 +376,19 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
             <Badge variant="info">New</Badge>
           </span>
         </td>
-        <td>A border/ring color to distinguish between flat surfaces where no shadow is present (i.e. <code>LayerCard</code>).</td>
+        <td>
+          A border/ring color to distinguish between flat surfaces where no
+          shadow is present (i.e. <code>LayerCard</code>).
+        </td>
       </tr>
       <tr>
-        <td><code>kumo-hairline</code></td>
-        <td>A thicker border/ring color that defines the edge of an elevated surface alongside a shadow.</td>
+        <td>
+          <code>kumo-hairline</code>
+        </td>
+        <td>
+          A thicker border/ring color that defines the edge of an elevated
+          surface alongside a shadow.
+        </td>
       </tr>
     </tbody>
   </table>

--- a/packages/kumo-docs-astro/src/pages/components-vs-blocks.mdx
+++ b/packages/kumo-docs-astro/src/pages/components-vs-blocks.mdx
@@ -5,6 +5,7 @@ description: "Understanding how Kumo delivers different types of building blocks
 ---
 
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 
 ## The Building Block Spectrum
 
@@ -28,12 +29,10 @@ Components are the atomic, reusable UI elements that form the foundation of your
 
 Import directly from the package:
 
-```tsx
-import { Button, Input, Dialog, Badge } from "@cloudflare/kumo";
+<CodeBlock code={`import { Button, Input, Dialog, Badge } from "@cloudflare/kumo";
 
 // Or use granular imports for better tree-shaking
-import { Button } from "@cloudflare/kumo/components/button";
-```
+import { Button } from "@cloudflare/kumo/components/button";`} lang="tsx" />
 
 When Kumo ships a new version, you get bug fixes and improvements automatically. Your code doesn't change — just bump the version.
 
@@ -53,24 +52,25 @@ Blocks are compositions of components that solve common patterns, but aren't agn
 
 Install via CLI, then import from your project:
 
-```bash
-# Initialize config (first time only)
+<CodeBlock code={`# Initialize config (first time only)
 npx @cloudflare/kumo init
 
 # List available blocks
+
 npx @cloudflare/kumo blocks
 
 # Install a block to your project
-npx @cloudflare/kumo add PageHeader
-```
+
+npx @cloudflare/kumo add PageHeader`} lang="bash" />
 
 After installation, import from your local path:
 
-```tsx
-// Path depends on your kumo.json blocksDir setting
+<CodeBlock
+  code={`// Path depends on your kumo.json blocksDir setting
 // Default: src/components/kumo/
-import { PageHeader } from "./components/kumo/page-header/page-header";
-```
+import { PageHeader } from "./components/kumo/page-header/page-header";`}
+  lang="tsx"
+/>
 
 The block code is now yours. Customize it, extend it, break it apart — whatever your product needs.
 
@@ -78,8 +78,7 @@ The block code is now yours. Customize it, extend it, break it apart — whateve
 
 Consider a `ProductCard`. It's a specific arrangement of components for a specific use case:
 
-```tsx
-// This is a "block" or "recipe" - a specific composition
+<CodeBlock code={`// This is a "block" or "recipe" - a specific composition
 // of design system components for a particular pattern
 
 <Surface className="rounded-lg p-4">
@@ -94,8 +93,7 @@ Consider a `ProductCard`. It's a specific arrangement of components for a specif
   <div className="mt-4">
     <Button variant="primary">Add to cart</Button>
   </div>
-</Surface>
-```
+</Surface>`} lang="tsx" />
 
 All those components (`Surface`, `Text`, `Button`) come from Kumo. But the specific arrangement? That's a pattern you own and customize.
 

--- a/packages/kumo-docs-astro/src/pages/components/badge.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/badge.mdx
@@ -6,13 +6,13 @@ sourceFile: "components/badge"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   BadgeSemanticVariantsDemo,
   BadgeColorVariantsDemo,
   BadgeInSentenceDemo,
 } from "~/components/demos/BadgeDemo";
-
 
 <ComponentExample demo="BadgeSemanticVariantsDemo">
   <BadgeSemanticVariantsDemo client:visible />
@@ -22,25 +22,22 @@ import {
 
 ### Barrel
 
-```tsx
-import { Badge } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Badge } from "@cloudflare/kumo";`} lang="tsx" />
 
 ### Granular
 
-```tsx
-import { Badge } from "@cloudflare/kumo/components/badge";
-```
+<CodeBlock
+  code={`import { Badge } from "@cloudflare/kumo/components/badge";`}
+  lang="tsx"
+/>
 
 ## Usage
 
-```tsx
-import { Badge } from "@cloudflare/kumo";
+<CodeBlock code={`import { Badge } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Badge variant="secondary">New</Badge>;
-}
-```
+}`} lang="tsx" />
 
 ## Examples
 

--- a/packages/kumo-docs-astro/src/pages/components/banner.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/banner.mdx
@@ -47,8 +47,7 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Banner } from "@cloudflare/kumo";
+<CodeBlock code={`import { Banner } from "@cloudflare/kumo";
 import { Info } from "@phosphor-icons/react";
 
 export default function Example() {
@@ -59,8 +58,7 @@ export default function Example() {
       description="A new version is ready to install."
     />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -91,15 +89,15 @@ export default function Example() {
   <BannerWithIconDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>With action</Heading>
-  <ComponentExample demo="BannerWithActionDemo">
-    <BannerWithActionDemo client:visible />
-  </ComponentExample>
+<Heading level={3}>With action</Heading>
+<ComponentExample demo="BannerWithActionDemo">
+  <BannerWithActionDemo client:visible />
+</ComponentExample>
 
-  <Heading level={3}>With multiple actions</Heading>
-  <ComponentExample demo="BannerWithActionsDemo">
-    <BannerWithActionsDemo client:visible />
-  </ComponentExample>
+<Heading level={3}>With multiple actions</Heading>
+<ComponentExample demo="BannerWithActionsDemo">
+  <BannerWithActionsDemo client:visible />
+</ComponentExample>
 
   <Heading level={3}>Custom content</Heading>
   <ComponentExample demo="BannerCustomContentDemo">

--- a/packages/kumo-docs-astro/src/pages/components/button.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/button.mdx
@@ -52,13 +52,11 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Button } from "@cloudflare/kumo";
+<CodeBlock code={`import { Button } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Button variant="secondary">Click me</Button>;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -49,13 +49,11 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Checkbox } from "@cloudflare/kumo";
+<CodeBlock code={`import { Checkbox } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Checkbox label="Accept terms" />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/clipboard-text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/clipboard-text.mdx
@@ -6,6 +6,7 @@ sourceFile: "components/clipboard-text"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
@@ -32,15 +33,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { ClipboardText } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { ClipboardText } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";
-```
+<CodeBlock
+  code={`import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -49,13 +52,11 @@ import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { ClipboardText } from "@cloudflare/kumo";
+<CodeBlock code={`import { ClipboardText } from "@cloudflare/kumo";
 
 export default function Example() {
   return <ClipboardText text="Copy this text" />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/cloudflare-logo.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/cloudflare-logo.mdx
@@ -6,6 +6,7 @@ sourceFile: "components/cloudflare-logo"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
 import {
@@ -34,23 +35,25 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import {
+<CodeBlock
+  code={`import {
   CloudflareLogo,
   PoweredByCloudflare,
   generateCloudflareLogoSvg,
-} from "@cloudflare/kumo";
-```
+} from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import {
+<CodeBlock
+  code={`import {
   CloudflareLogo,
   PoweredByCloudflare,
   generateCloudflareLogoSvg,
-} from "@cloudflare/kumo/components/cloudflare-logo";
-```
+} from "@cloudflare/kumo/components/cloudflare-logo";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -59,13 +62,11 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { CloudflareLogo } from "@cloudflare/kumo";
+<CodeBlock code={`import { CloudflareLogo } from "@cloudflare/kumo";
 
 export default function Example() {
   return <CloudflareLogo className="w-36" />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -145,8 +146,7 @@ export default function Example() {
     Use <code>generateCloudflareLogoSvg()</code> to get copy-paste ready SVG markup for non-React contexts.
   </p>
 
-```tsx
-import { generateCloudflareLogoSvg } from "@cloudflare/kumo";
+<CodeBlock code={`import { generateCloudflareLogoSvg } from "@cloudflare/kumo";
 
 // Generate glyph SVG (cloud only)
 const glyphSvg = generateCloudflareLogoSvg({ variant: "glyph" });
@@ -159,9 +159,8 @@ const blackSvg = generateCloudflareLogoSvg({ color: "black" });
 
 // Copy to clipboard
 await navigator.clipboard.writeText(
-  generateCloudflareLogoSvg({ variant: "glyph", color: "color" }),
-);
-```
+generateCloudflareLogoSvg({ variant: "glyph", color: "color" }),
+);`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
@@ -7,6 +7,7 @@ sourceFile: "code"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import {
   CodeHighlightedBasicDemo,
@@ -57,9 +58,10 @@ import {
     CodeHighlighted is exported from a separate entry point to avoid bundling Shiki for apps that don't need it.
   </p>
 
-```tsx
-import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
-```
+<CodeBlock
+  code={`import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";`}
+  lang="tsx"
+/>
 
   <div class="mt-4 rounded-md border border-kumo-warning/20 bg-kumo-warning/5 p-4">
     <p class="text-sm text-kumo-strong">
@@ -78,8 +80,7 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
     All `CodeHighlighted` components inside share the same Shiki instance.
   </p>
 
-```tsx
-import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
+<CodeBlock code={`import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
 
 export function App() {
   return (
@@ -91,8 +92,7 @@ export function App() {
       <CodeHighlighted code="const x = 1;" lang="typescript" />
     </ShikiProvider>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -207,21 +207,18 @@ export function App() {
 
 <h4 class="mb-3 text-base font-medium">One-off highlighting</h4>
 
-```tsx
-// Next.js RSC or Astro
+<CodeBlock code={`// Next.js RSC or Astro
 import { highlightCode } from "@cloudflare/kumo/code/server";
 
 export default async function Page() {
-  const html = await highlightCode(`const x = 1;`, "typescript");
+  const html = await highlightCode(\`const x = 1;\`, "typescript");
 
   return <pre dangerouslySetInnerHTML={{ __html: html }} />;
-}
-```
+}`} lang="tsx" />
 
 <h4 class="mb-3 text-base font-medium">Reusable highlighter</h4>
 
-```tsx
-// For multiple highlights, reuse the highlighter
+<CodeBlock code={`// For multiple highlights, reuse the highlighter
 import { createServerHighlighter } from "@cloudflare/kumo/code/server";
 
 const highlighter = await createServerHighlighter({
@@ -231,8 +228,7 @@ const highlighter = await createServerHighlighter({
 const html1 = highlighter.highlight(code1, "tsx");
 const html2 = highlighter.highlight(code2, "bash");
 
-highlighter.dispose(); // Clean up when done
-```
+highlighter.dispose(); // Clean up when done`} lang="tsx" />
 
 </ComponentSection>
 
@@ -244,8 +240,7 @@ highlighter.dispose(); // Clean up when done
     Use `useShikiHighlighter` for custom implementations.
   </p>
 
-```tsx
-import { useShikiHighlighter } from "@cloudflare/kumo/code";
+<CodeBlock code={`import { useShikiHighlighter } from "@cloudflare/kumo/code";
 
 function CustomCodeBlock({ code, lang }) {
   const { highlight, isLoading, isReady, error } = useShikiHighlighter();
@@ -274,8 +269,7 @@ function CustomCodeBlock({ code, lang }) {
   }
 
   return <pre dangerouslySetInnerHTML={{ __html: html }} />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -287,8 +281,7 @@ function CustomCodeBlock({ code, lang }) {
     Customize button labels at the provider level for all code blocks, or override per-component.
   </p>
 
-```tsx
-// Set labels at the provider level for all code blocks
+<CodeBlock code={`// Set labels at the provider level for all code blocks
 <ShikiProvider
   engine="javascript"
   languages={["tsx", "bash"]}
@@ -298,13 +291,13 @@ function CustomCodeBlock({ code, lang }) {
 </ShikiProvider>
 
 // Or override at the component level
+
 <CodeHighlighted
   code={code}
   lang="tsx"
   showCopyButton
   labels={{ copy: "Copy code", copied: "Done!" }}
-/>
-```
+/>`} lang="tsx" />
 
 </ComponentSection>
 
@@ -315,8 +308,7 @@ function CustomCodeBlock({ code, lang }) {
 
 <Heading level={3}>Next.js App Router</Heading>
 
-```tsx
-// app/providers.tsx
+<CodeBlock code={`// app/providers.tsx
 "use client";
 
 import { ShikiProvider } from "@cloudflare/kumo/code";
@@ -340,8 +332,7 @@ export default function RootLayout({ children }) {
       </body>
     </html>
   );
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>Astro (Static)</Heading>
 <p>
@@ -349,17 +340,16 @@ export default function RootLayout({ children }) {
   JavaScript.
 </p>
 
-```tsx
----
+<CodeBlock code={`---
 // src/components/CodeBlock.astro
 import { highlightCode } from "@cloudflare/kumo/code/server";
 
 const { code, lang } = Astro.props;
 const html = await highlightCode(code, lang);
+
 ---
 
-<div class="code-block" set:html={html} />
-```
+<div class="code-block" set:html={html} />`} lang="tsx" />
 
 </ComponentSection>
 
@@ -417,8 +407,7 @@ const html = await highlightCode(code, lang);
     They will be removed in v2.0.
   </p>
 
-```tsx
-// Before (deprecated)
+<CodeBlock code={`// Before (deprecated)
 import { Code, CodeBlock } from "@cloudflare/kumo";
 <CodeBlock code="const x = 1;" lang="ts" />
 
@@ -426,13 +415,14 @@ import { Code, CodeBlock } from "@cloudflare/kumo";
 import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
 
 // Once at app root
+
 <ShikiProvider engine="javascript" languages={["tsx"]}>
   <App />
 </ShikiProvider>
 
 // In components
-<CodeHighlighted code="const x = 1;" lang="tsx" />
-```
+
+<CodeHighlighted code="const x = 1;" lang="tsx" />`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
@@ -7,6 +7,7 @@ baseUIComponent: "collapsible"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
@@ -30,15 +31,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Collapsible } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { Collapsible } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Collapsible } from "@cloudflare/kumo/components/collapsible";
-```
+<CodeBlock
+  code={`import { Collapsible } from "@cloudflare/kumo/components/collapsible";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -47,13 +50,11 @@ import { Collapsible } from "@cloudflare/kumo/components/collapsible";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Collapsible } from "@cloudflare/kumo";
+<CodeBlock code={`import { Collapsible } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Collapsible label="Question">Answer content goes here.</Collapsible>;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -49,8 +49,7 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { useState } from "react";
+<CodeBlock code={`import { useState } from "react";
 import { Combobox } from "@cloudflare/kumo";
 
 const fruits = ["Apple", "Banana", "Cherry", "Date", "Elderberry"];
@@ -73,8 +72,7 @@ export default function Example() {
       </Combobox.Content>
     </Combobox>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -137,7 +135,10 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={3}>Disabled</Heading>
-  <p>Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` and `TriggerValue`.</p>
+  <p>
+    Pass the `disabled` prop to prevent interaction. Works with both
+    `TriggerInput` and `TriggerValue`.
+  </p>
   <ComponentExample demo="ComboboxDisabledDemo">
     <ComboboxDisabledDemo client:load />
   </ComponentExample>
@@ -160,17 +161,17 @@ export default function Example() {
     To customize the max height, pass a className to <code class="text-surface">Combobox.Content</code>:
   </p>
 
-```tsx
-// Shorter dropdown (200px)
+<CodeBlock code={`// Shorter dropdown (200px)
 <Combobox.Content className="max-h-[200px]">
 
 // Taller dropdown (500px)
+
 <Combobox.Content className="max-h-[500px]">
 
 // Use Tailwind presets
+
 <Combobox.Content className="max-h-64">  // 256px
-<Combobox.Content className="max-h-96">  // 384px (same as default)
-```
+<Combobox.Content className="max-h-96">  // 384px (same as default)`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/command-palette.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/command-palette.mdx
@@ -6,6 +6,7 @@ sourceFile: "components/command-palette"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
 import KeyboardShortcuts from "~/components/docs/KeyboardShortcuts.astro";
@@ -31,15 +32,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { CommandPalette } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { CommandPalette } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { CommandPalette } from "@cloudflare/kumo/components/command-palette";
-```
+<CodeBlock
+  code={`import { CommandPalette } from "@cloudflare/kumo/components/command-palette";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -53,8 +56,7 @@ import { CommandPalette } from "@cloudflare/kumo/components/command-palette";
     styling for command palette interfaces.
   </p>
 
-```tsx
-import { useState } from "react";
+<CodeBlock code={`import { useState } from "react";
 import { CommandPalette } from "@cloudflare/kumo";
 
 interface Item {
@@ -101,8 +103,7 @@ export default function Example() {
       </CommandPalette.Root>
     </>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -223,8 +224,7 @@ export default function Example() {
 
 <Heading level={3}>CommandPalette.Root Props</Heading>
 
-```tsx
-interface CommandPaletteRootProps<TGroup, TItem> {
+<CodeBlock code={`interface CommandPaletteRootProps<TGroup, TItem> {
   // Dialog state
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -243,13 +243,12 @@ interface CommandPaletteRootProps<TGroup, TItem> {
   getSelectableItems?: (items: TGroup[]) => TItem[];
 
   children: React.ReactNode;
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>CommandPalette.ResultItem Props</Heading>
 
-```tsx
-interface CommandPaletteResultItemProps<T> {
+<CodeBlock
+  code={`interface CommandPaletteResultItemProps<T> {
   value: T;
   title: string;
   breadcrumbs?: string[];
@@ -261,7 +260,8 @@ interface CommandPaletteResultItemProps<T> {
   showArrow?: boolean; // default: true
   external?: boolean; // shows external link icon
   nonInteractive?: boolean;
-}
-```
+}`}
+  lang="tsx"
+/>
 
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -6,6 +6,7 @@ sourceFile: "components/date-picker"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
@@ -34,18 +35,20 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { DatePicker, type DateRange } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { DatePicker, type DateRange } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import {
+<CodeBlock
+  code={`import {
   DatePicker,
   type DateRange,
-} from "@cloudflare/kumo/components/date-picker";
-```
+} from "@cloudflare/kumo/components/date-picker";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -59,16 +62,14 @@ import {
     `range`.
   </p>
 
-```tsx
-import { useState } from "react";
+<CodeBlock code={`import { useState } from "react";
 import { DatePicker } from "@cloudflare/kumo";
 
 export default function Example() {
   const [date, setDate] = useState<Date>();
 
   return <DatePicker mode="single" selected={date} onChange={setDate} />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -148,8 +149,7 @@ export default function Example() {
     Here's a complete example showing how to compose DatePicker with Popover:
   </p>
 
-```tsx
-import { useState } from "react";
+<CodeBlock code={`import { useState } from "react";
 import { DatePicker, Popover, Button } from "@cloudflare/kumo";
 import { CalendarDotsIcon } from "@phosphor-icons/react";
 
@@ -172,8 +172,7 @@ export function DatePickerDropdown() {
       </Popover.Content>
     </Popover>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -47,8 +47,7 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Dialog, Button } from "@cloudflare/kumo";
+<CodeBlock code={`import { Dialog, Button } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -69,8 +68,7 @@ export default function Example() {
       </Dialog>
     </Dialog.Root>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
@@ -7,6 +7,7 @@ baseUIComponent: "menu"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
@@ -32,15 +33,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { DropdownMenu } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { DropdownMenu } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { DropdownMenu } from "@cloudflare/kumo/components/dropdown";
-```
+<CodeBlock
+  code={`import { DropdownMenu } from "@cloudflare/kumo/components/dropdown";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -49,8 +52,7 @@ import { DropdownMenu } from "@cloudflare/kumo/components/dropdown";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { DropdownMenu, Button } from "@cloudflare/kumo";
+<CodeBlock code={`import { DropdownMenu, Button } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -62,8 +64,7 @@ export default function Example() {
       </DropdownMenu.Content>
     </DropdownMenu>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/empty.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/empty.mdx
@@ -5,6 +5,7 @@ description: "A component to display when there's no content or data to show, wi
 sourceFile: "components/empty"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -31,9 +32,7 @@ import {
 <ComponentSection>
   <Heading level={2}>Installation</Heading>
 
-```tsx
-import { Empty } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Empty } from "@cloudflare/kumo";`} lang="tsx" />
 
 </ComponentSection>
 
@@ -42,8 +41,7 @@ import { Empty } from "@cloudflare/kumo";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Empty } from "@cloudflare/kumo";
+<CodeBlock code={`import { Empty } from "@cloudflare/kumo";
 import { PackageIcon } from "@phosphor-icons/react";
 
 export default function Example() {
@@ -55,8 +53,7 @@ export default function Example() {
       commandLine="npm install @kumo/ui"
     />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/flow.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/flow.mdx
@@ -5,6 +5,7 @@ description: "A group of components for building directed flow diagrams with nod
 sourceFile: "components/flow"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -36,15 +37,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Flow } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Flow } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Flow } from "@cloudflare/kumo/components/flow";
-```
+<CodeBlock
+  code={`import { Flow } from "@cloudflare/kumo/components/flow";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -61,8 +61,7 @@ import { Flow } from "@cloudflare/kumo/components/flow";
     branching paths.
   </p>
 
-```tsx
-import { Flow } from "@cloudflare/kumo";
+<CodeBlock code={`import { Flow } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -72,8 +71,7 @@ export default function Example() {
       <Flow.Node>Step 3</Flow.Node>
     </Flow>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/grid.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/grid.mdx
@@ -5,6 +5,7 @@ description: "A responsive grid layout component for organizing content into col
 sourceFile: "components/grid"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -30,9 +31,10 @@ import {
 <ComponentSection>
   <Heading level={2}>Installation</Heading>
 
-```tsx
-import { Grid, GridItem } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { Grid, GridItem } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -5,6 +5,7 @@ description: "A multi-line text input for longer content with built-in label, de
 sourceFile: "components/input"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -37,15 +38,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { InputArea } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { InputArea } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { InputArea } from "@cloudflare/kumo/components/input";
-```
+<CodeBlock
+  code={`import { InputArea } from "@cloudflare/kumo/components/input";`}
+  lang="tsx"
+/>
 
 `Textarea` is also exported as an alias for `InputArea` for discoverability when migrating from other libraries.
 
@@ -62,8 +62,7 @@ import { InputArea } from "@cloudflare/kumo/components/input";
   description, and error support.
 </p>
 
-```tsx
-import { InputArea } from "@cloudflare/kumo";
+<CodeBlock code={`import { InputArea } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -73,8 +72,7 @@ export default function Example() {
       description="Provide details about your project"
     />
   );
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>Bare InputArea (Custom Layouts)</Heading>
 
@@ -83,13 +81,11 @@ export default function Example() {
   `aria-label` or `aria-labelledby` for accessibility.
 </p>
 
-```tsx
-import { InputArea } from "@cloudflare/kumo";
+<CodeBlock code={`import { InputArea } from "@cloudflare/kumo";
 
 export default function Example() {
   return <InputArea placeholder="Add notes..." aria-label="Notes" rows={3} />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -55,8 +55,7 @@ import {
     Use the `label` prop to enable the built-in Field wrapper with label, description, and error support.
   </p>
 
-```tsx
-import { Input } from "@cloudflare/kumo";
+<CodeBlock code={`import { Input } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -66,8 +65,7 @@ export default function Example() {
       description="We'll never share your email"
     />
   );
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>Bare Input (Custom Layouts)</Heading>
 <p>
@@ -75,13 +73,11 @@ export default function Example() {
   or `aria-labelledby` for accessibility.
 </p>
 
-```tsx
-import { Input } from "@cloudflare/kumo";
+<CodeBlock code={`import { Input } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Input placeholder="Search..." aria-label="Search products" />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/label.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/label.mdx
@@ -5,6 +5,7 @@ description: "A label component for form fields with support for required/option
 sourceFile: "components/label"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -31,15 +32,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Label } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Label } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Label } from "@cloudflare/kumo/components/label";
-```
+<CodeBlock
+  code={`import { Label } from "@cloudflare/kumo/components/label";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -52,8 +52,7 @@ import { Label } from "@cloudflare/kumo/components/label";
     Label features are automatically available through form components like `Input`, `Select`, `Checkbox`, and `Switch` via the `required` and `labelTooltip` props.
   </p>
 
-```tsx
-import { Input } from "@cloudflare/kumo";
+<CodeBlock code={`import { Input } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -68,19 +67,16 @@ export default function Example() {
       />
     </>
   );
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>Standalone Label</Heading>
 <p>For custom form layouts, use the `Label` component directly.</p>
 
-```tsx
-import { Label } from "@cloudflare/kumo";
+<CodeBlock code={`import { Label } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Label tooltip="This field is mandatory">Username</Label>;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
@@ -5,6 +5,7 @@ description: "A card component with a layered visual effect, perfect for navigat
 sourceFile: "components/layer-card"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -29,15 +30,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { LayerCard } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { LayerCard } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { LayerCard } from "@cloudflare/kumo/components/layer-card";
-```
+<CodeBlock
+  code={`import { LayerCard } from "@cloudflare/kumo/components/layer-card";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -46,8 +46,7 @@ import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { LayerCard } from "@cloudflare/kumo";
+<CodeBlock code={`import { LayerCard } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -56,8 +55,7 @@ export default function Example() {
       <LayerCard.Primary>Learn how to use Kumo components</LayerCard.Primary>
     </LayerCard>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -5,6 +5,7 @@ description: "A styled anchor component for inline text links with multiple vari
 sourceFile: "components/link"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -30,15 +31,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Link } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Link } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Link } from "@cloudflare/kumo/components/link";
-```
+<CodeBlock
+  code={`import { Link } from "@cloudflare/kumo/components/link";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -51,8 +51,7 @@ import { Link } from "@cloudflare/kumo/components/link";
     The default Link component renders an underlined anchor with primary color styling.
   </p>
 
-```tsx
-import { Link } from "@cloudflare/kumo";
+<CodeBlock code={`import { Link } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -60,8 +59,7 @@ export default function Example() {
       Read our <Link href="/docs">documentation</Link> for more details.
     </p>
   );
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>External Links</Heading>
 <p>
@@ -69,8 +67,7 @@ export default function Example() {
   tab.
 </p>
 
-```tsx
-import { Link } from "@cloudflare/kumo";
+<CodeBlock code={`import { Link } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -82,8 +79,7 @@ export default function Example() {
       Visit Cloudflare <Link.ExternalIcon />
     </Link>
   );
-}
-```
+}`} lang="tsx" />
 
 <Heading level={3}>Framework Integration (render prop)</Heading>
 <p>
@@ -91,8 +87,7 @@ export default function Example() {
   components like React Router's Link or Next.js Link.
 </p>
 
-```tsx
-import { Link } from "@cloudflare/kumo";
+<CodeBlock code={`import { Link } from "@cloudflare/kumo";
 import { Link as RouterLink } from "react-router-dom";
 
 export default function Example() {
@@ -101,8 +96,7 @@ export default function Example() {
       Dashboard
     </Link>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -242,11 +236,12 @@ export default function Example() {
   attributes.
 </p>
 
-```tsx
-<Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+<CodeBlock
+  code={`<Link href="https://example.com" target="_blank" rel="noopener noreferrer">
   External Site <Link.ExternalIcon />
-</Link>
-```
+</Link>`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/loader.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/loader.mdx
@@ -5,6 +5,7 @@ description: "A loading spinner to indicate loading state."
 sourceFile: "components/loader"
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import Heading from "~/components/docs/Heading.astro";
@@ -28,15 +29,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Loader } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Loader } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Loader } from "@cloudflare/kumo/components/loader";
-```
+<CodeBlock
+  code={`import { Loader } from "@cloudflare/kumo/components/loader";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -45,13 +45,11 @@ import { Loader } from "@cloudflare/kumo/components/loader";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Loader } from "@cloudflare/kumo";
+<CodeBlock code={`import { Loader } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Loader />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/menu-bar.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/menu-bar.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/menubar"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -29,15 +30,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { MenuBar } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { MenuBar } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { MenuBar } from "@cloudflare/kumo/components/menubar";
-```
+<CodeBlock
+  code={`import { MenuBar } from "@cloudflare/kumo/components/menubar";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -46,8 +46,7 @@ import { MenuBar } from "@cloudflare/kumo/components/menubar";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { MenuBar } from "@cloudflare/kumo";
+<CodeBlock code={`import { MenuBar } from "@cloudflare/kumo";
 import { TextBolderIcon } from "@phosphor-icons/react";
 
 export default function Example() {
@@ -63,8 +62,7 @@ export default function Example() {
       ]}
     />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/meter.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/meter.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/meter"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -31,15 +32,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Meter } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Meter } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Meter } from "@cloudflare/kumo/components/meter";
-```
+<CodeBlock
+  code={`import { Meter } from "@cloudflare/kumo/components/meter";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -48,13 +48,11 @@ import { Meter } from "@cloudflare/kumo/components/meter";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Meter } from "@cloudflare/kumo";
+<CodeBlock code={`import { Meter } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Meter label="Storage used" value={65} />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/pagination.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/pagination.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/pagination"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -37,15 +38,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Pagination } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Pagination } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Pagination } from "@cloudflare/kumo/components/pagination";
-```
+<CodeBlock
+  code={`import { Pagination } from "@cloudflare/kumo/components/pagination";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -54,8 +54,7 @@ import { Pagination } from "@cloudflare/kumo/components/pagination";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { useState } from "react";
+<CodeBlock code={`import { useState } from "react";
 import { Pagination } from "@cloudflare/kumo";
 
 export default function Example() {
@@ -64,8 +63,7 @@ export default function Example() {
   return (
     <Pagination page={page} setPage={setPage} perPage={10} totalCount={100} />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -8,6 +8,7 @@ baseUIComponent: "popover"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -34,15 +35,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Popover } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Popover } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Popover } from "@cloudflare/kumo/components/popover";
-```
+<CodeBlock
+  code={`import { Popover } from "@cloudflare/kumo/components/popover";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -51,8 +51,7 @@ import { Popover } from "@cloudflare/kumo/components/popover";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Popover, Button } from "@cloudflare/kumo";
+<CodeBlock code={`import { Popover, Button } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -66,8 +65,7 @@ export default function Example() {
       </Popover.Content>
     </Popover>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -8,6 +8,7 @@ baseUIComponent: "radio-group"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -36,15 +37,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Radio } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Radio } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Radio } from "@cloudflare/kumo/components/radio";
-```
+<CodeBlock
+  code={`import { Radio } from "@cloudflare/kumo/components/radio";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -53,8 +53,7 @@ import { Radio } from "@cloudflare/kumo/components/radio";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Radio } from "@cloudflare/kumo";
+<CodeBlock code={`import { Radio } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -63,8 +62,7 @@ export default function Example() {
       <Radio.Item label="Option B" value="b" />
     </Radio.Group>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -55,8 +55,7 @@ import {
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Select } from "@cloudflare/kumo";
+<CodeBlock code={`import { Select } from "@cloudflare/kumo";
 
 export default function Example() {
   const [value, setValue] = useState("apple");
@@ -69,8 +68,7 @@ export default function Example() {
       items={{ apple: "Apple", banana: "Banana", cherry: "Cherry" }}
     />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -168,8 +166,8 @@ export default function Example() {
   <strong>isItemEqualToValue</strong> prop.
 </p>
 
-```tsx
-<Select
+<CodeBlock
+  code={`<Select
   className="w-[200px]"
   renderValue={(v) => (
     <span>
@@ -186,8 +184,9 @@ export default function Example() {
       {language.emoji} {language.label}
     </Select.Option>
   ))}
-</Select>
-```
+</Select>`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -318,11 +317,23 @@ export default function Example() {
 <Heading level={3}>Select.Option</Heading>
 <PropsTable component="Select.Option" />
 
-  <Heading level={3}>Select.Group</Heading>
-  <p>Groups related options together with an accessible <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>. Use with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.GroupLabel</code> to provide a visible heading.</p>
+<Heading level={3}>Select.Group</Heading>
+<p>
+  Groups related options together with an accessible{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>.
+  Use with{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
+    Select.GroupLabel
+  </code>{" "}
+  to provide a visible heading.
+</p>
 
-  <Heading level={3}>Select.GroupLabel</Heading>
-  <p>A visible heading for a <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>. Automatically associated with its parent group for accessibility.</p>
+<Heading level={3}>Select.GroupLabel</Heading>
+<p>
+  A visible heading for a{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>.
+  Automatically associated with its parent group for accessibility.
+</p>
 
   <Heading level={3}>Select.Separator</Heading>
   <p>A visual divider line between option groups. Renders with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="separator"</code>.</p>

--- a/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/sensitive-input"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -30,15 +31,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { SensitiveInput } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { SensitiveInput } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { SensitiveInput } from "@cloudflare/kumo/components/sensitive-input";
-```
+<CodeBlock
+  code={`import { SensitiveInput } from "@cloudflare/kumo/components/sensitive-input";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -47,13 +50,11 @@ import { SensitiveInput } from "@cloudflare/kumo/components/sensitive-input";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { SensitiveInput } from "@cloudflare/kumo";
+<CodeBlock code={`import { SensitiveInput } from "@cloudflare/kumo";
 
 export default function Example() {
   return <SensitiveInput label="Secret" defaultValue="my-secret-key" />;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -7,6 +7,7 @@ sourceFile: "primitives/skeleton-line"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import {
   SkeletonLineDemo,
@@ -29,9 +30,10 @@ import {
 <ComponentSection>
   <Heading level={2}>Installation</Heading>
 
-```tsx
-import { SkeletonLine } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { SkeletonLine } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/surface.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/surface.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/surface"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -28,9 +29,7 @@ import {
 <ComponentSection>
   <Heading level={2}>Installation</Heading>
 
-```tsx
-import { Surface } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Surface } from "@cloudflare/kumo";`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/switch.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/switch.mdx
@@ -8,6 +8,7 @@ baseUIComponent: "switch"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -36,15 +37,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Switch } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Switch } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Switch } from "@cloudflare/kumo/components/switch";
-```
+<CodeBlock
+  code={`import { Switch } from "@cloudflare/kumo/components/switch";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -53,8 +53,7 @@ import { Switch } from "@cloudflare/kumo/components/switch";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Switch } from "@cloudflare/kumo";
+<CodeBlock code={`import { Switch } from "@cloudflare/kumo";
 import { useState } from "react";
 
 export default function Example() {
@@ -63,8 +62,7 @@ export default function Example() {
   return (
     <Switch checked={checked} onCheckedChange={(val) => setChecked(val)} />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/table.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/table"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -34,15 +35,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Table } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Table } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Table } from "@cloudflare/kumo/components/table";
-```
+<CodeBlock
+  code={`import { Table } from "@cloudflare/kumo/components/table";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -51,8 +51,7 @@ import { Table } from "@cloudflare/kumo/components/table";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Table, LayerCard } from "@cloudflare/kumo";
+<CodeBlock code={`import { Table, LayerCard } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -77,8 +76,7 @@ export default function Example() {
       </LayerCard.Primary>
     </LayerCard>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -193,8 +191,7 @@ export default function Example() {
     For advanced features like sorting, filtering, and resizable columns, integrate with <a href="https://tanstack.com/table" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">TanStack Table</a>. The Table component is designed to work seamlessly with TanStack's headless API.
   </p>
 
-```tsx
-import {
+<CodeBlock code={`import {
   flexRender,
   getCoreRowModel,
   useReactTable,
@@ -247,8 +244,7 @@ function DataTable({ data, columns }) {
       </Table.Body>
     </Table>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/tabs"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -31,15 +32,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Tabs } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Tabs } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Tabs } from "@cloudflare/kumo/components/tabs";
-```
+<CodeBlock
+  code={`import { Tabs } from "@cloudflare/kumo/components/tabs";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -48,8 +48,7 @@ import { Tabs } from "@cloudflare/kumo/components/tabs";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Tabs } from "@cloudflare/kumo";
+<CodeBlock code={`import { Tabs } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -61,8 +60,7 @@ export default function Example() {
       selectedValue="overview"
     />
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/text"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -28,15 +29,14 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Text } from "@cloudflare/kumo";
-```
+<CodeBlock code={`import { Text } from "@cloudflare/kumo";`} lang="tsx" />
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Text } from "@cloudflare/kumo/components/text";
-```
+<CodeBlock
+  code={`import { Text } from "@cloudflare/kumo/components/text";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -45,13 +45,11 @@ import { Text } from "@cloudflare/kumo/components/text";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Text } from "@cloudflare/kumo";
+<CodeBlock code={`import { Text } from "@cloudflare/kumo";
 
 export default function Example() {
   return <Text>Your content here</Text>;
-}
-```
+}`} lang="tsx" />
 
 <section class="mt-8 space-y-4">
   <h3 class="text-lg font-semibold">Restrictions</h3>
@@ -59,33 +57,36 @@ export default function Example() {
     The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
   </p>
 
-```tsx
-<Text size="sm" bold>Body</Text>
+<CodeBlock
+  code={`<Text size="sm" bold>Body</Text>
 <Text variant="secondary" bold>Body secondary</Text>
 <Text variant="success" size="lg">Success</Text>
-<Text variant="error">Error</Text>
-```
+<Text variant="error">Error</Text>`}
+  lang="tsx"
+/>
 
 <p class="text-kumo-strong">
   Monospace variants (`mono` and `mono-secondary`) can only set `size` to `lg`
   and cannot use the `bold` prop:
 </p>
 
-```tsx
-<Text variant="mono">Monospace</Text>
+<CodeBlock
+  code={`<Text variant="mono">Monospace</Text>
 <Text variant="mono" size="lg">Monospace</Text>
-<Text variant="mono" bold>Monospace</Text> // Doesn't compile
-```
+<Text variant="mono" bold>Monospace</Text> // Doesn't compile`}
+  lang="tsx"
+/>
 
 <p class="text-kumo-strong">
   Headings (i.e. `h1`, `h2` and `h3` variants) cannot use these props at all:
 </p>
 
-```tsx
-<Text variant="h1" bold>
+<CodeBlock
+  code={`<Text variant="h1" bold>
   Heading 1
-</Text> // Doesn't compile
-```
+</Text> // Doesn't compile`}
+  lang="tsx"
+/>
 
 </section>
 
@@ -102,9 +103,10 @@ export default function Example() {
     <TextTruncateDemo client:visible />
   </ComponentExample>
 
-```tsx
-<Text truncate>This is a long piece of text that will be truncated...</Text>
-```
+<CodeBlock
+  code={`<Text truncate>This is a long piece of text that will be truncated...</Text>`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/toast.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/toast.mdx
@@ -7,6 +7,7 @@ sourceFile: "components/toast"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -37,15 +38,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Toasty, useKumoToastManager } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { Toasty, useKumoToastManager } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Toasty, useKumoToastManager } from "@cloudflare/kumo/components/toast";
-```
+<CodeBlock
+  code={`import { Toasty, useKumoToastManager } from "@cloudflare/kumo/components/toast";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -57,8 +60,7 @@ import { Toasty, useKumoToastManager } from "@cloudflare/kumo/components/toast";
     The toast system consists of two parts: the `Toasty` provider component and the `useKumoToastManager()` hook for triggering toasts.
   </p>
 
-```tsx
-import { Toasty, useKumoToastManager, Button } from "@cloudflare/kumo";
+<CodeBlock code={`import { Toasty, useKumoToastManager, Button } from "@cloudflare/kumo";
 
 function ToastTrigger() {
   const toastManager = useKumoToastManager();
@@ -84,8 +86,7 @@ export default function App() {
       {/* Rest of your app */}
     </Toasty>
   );
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -97,14 +98,12 @@ export default function App() {
     Wrap your application (or a section of it) with the `Toasty` provider. This sets up the toast context and renders the toast viewport.
   </p>
 
-```tsx
-// In your app root or layout
+<CodeBlock code={`// In your app root or layout
 import { Toasty } from "@cloudflare/kumo";
 
 export function Layout({ children }) {
   return <Toasty>{children}</Toasty>;
-}
-```
+}`} lang="tsx" />
 
 </ComponentSection>
 
@@ -199,8 +198,7 @@ export function Layout({ children }) {
 <Heading level={3}>useKumoToastManager()</Heading>
 <p>A hook that returns the toast manager for creating toasts.</p>
 
-```tsx
-const toastManager = useKumoToastManager();
+<CodeBlock code={`const toastManager = useKumoToastManager();
 
 // Add a toast
 toastManager.add(options);
@@ -210,8 +208,7 @@ toastManager.promise(asyncFn(), {
   loading: options,
   success: (data) => options,
   error: (err) => options,
-});
-```
+});`} lang="tsx" />
 
 <Heading level={3}>Toast Options</Heading>
 <p>Options passed to `toastManager.add()` and promise handlers.</p>

--- a/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
@@ -8,6 +8,7 @@ baseUIComponent: "tooltip"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -31,15 +32,17 @@ import {
   <Heading level={2}>Installation</Heading>
   <Heading level={3}>Barrel</Heading>
 
-```tsx
-import { Tooltip, TooltipProvider } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { Tooltip, TooltipProvider } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 <Heading level={3}>Granular</Heading>
 
-```tsx
-import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";
-```
+<CodeBlock
+  code={`import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";`}
+  lang="tsx"
+/>
 
 </ComponentSection>
 
@@ -48,8 +51,7 @@ import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";
 <ComponentSection>
   <Heading level={2}>Usage</Heading>
 
-```tsx
-import { Tooltip, Button } from "@cloudflare/kumo";
+<CodeBlock code={`import { Tooltip, Button } from "@cloudflare/kumo";
 
 export default function Example() {
   return (
@@ -57,8 +59,7 @@ export default function Example() {
       <Button>Hover me</Button>
     </Tooltip>
   );
-}
-```
+}`} lang="tsx" />
 
 For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovider).
 
@@ -101,17 +102,16 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
   app root or layout — not around each individual `Tooltip`.
 </p>
 
-```tsx
-// Wrap your app or layout once
+<CodeBlock code={`// Wrap your app or layout once
 <TooltipProvider>
   <App />
 </TooltipProvider>
 
 // Then use Tooltip anywhere inside
+
 <Tooltip content="Add" asChild>
   <Button shape="square" icon={PlusIcon} />
-</Tooltip>
-```
+</Tooltip>`} lang="tsx" />
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/contributing.mdx
+++ b/packages/kumo-docs-astro/src/pages/contributing.mdx
@@ -4,6 +4,8 @@ title: "Contributing"
 description: "Learn how to contribute to Kumo, from setup and workflows to PR and release guidelines. Everything you need for setup, development, quality checks, and PR process is documented here."
 ---
 
+import CodeBlock from "~/components/docs/CodeBlock.astro";
+
 ## Before You Start
 
 For non-trivial changes, start with alignment before coding:
@@ -18,10 +20,11 @@ For non-trivial changes, start with alignment before coding:
 
 From repo root:
 
-```bash
-pnpm install
-pnpm build
-```
+<CodeBlock
+  code={`pnpm install
+pnpm build`}
+  lang="bash"
+/>
 
 Requirements:
 
@@ -38,11 +41,12 @@ Recommended local setup:
 
 Internal contributors normally clone and push directly to `cloudflare/kumo`:
 
-```bash
-git clone https://github.com/cloudflare/kumo.git
+<CodeBlock
+  code={`git clone https://github.com/cloudflare/kumo.git
 git switch -c <branch-name>
-git push -u origin <branch-name>
-```
+git push -u origin <branch-name>`}
+  lang="bash"
+/>
 
 If you do not have write access, contact your manager or Kumo maintainers.
 
@@ -58,9 +62,7 @@ Use this to decide where your change belongs:
 
 When adding a new **component**, scaffold it (do not create files manually):
 
-```bash
-pnpm --filter @cloudflare/kumo new:component
-```
+<CodeBlock code={`pnpm --filter @cloudflare/kumo new:component`} lang="bash" />
 
 ---
 
@@ -68,13 +70,12 @@ pnpm --filter @cloudflare/kumo new:component
 
 Run these in separate terminals:
 
-```bash
-# Terminal 1: watch Kumo package output
+<CodeBlock code={`# Terminal 1: watch Kumo package output
 pnpm --filter @cloudflare/kumo dev
 
 # Terminal 2: docs site
-pnpm dev
-```
+
+pnpm dev`} lang="bash" />
 
 This gives you a fast loop while verifying your change in the actual docs environment.
 
@@ -106,24 +107,24 @@ Implementation expectations:
 
 Run these from repo root before opening or updating your PR:
 
-```bash
-pnpm lint
+<CodeBlock
+  code={`pnpm lint
 pnpm typecheck
-pnpm --filter @cloudflare/kumo test
-```
+pnpm --filter @cloudflare/kumo test`}
+  lang="bash"
+/>
 
 If you changed exports/build behavior, also run:
 
-```bash
-pnpm --filter @cloudflare/kumo build
-```
+<CodeBlock code={`pnpm --filter @cloudflare/kumo build`} lang="bash" />
 
 Optional (when relevant):
 
-```bash
-pnpm format
-pnpm --filter @cloudflare/kumo test:run
-```
+<CodeBlock
+  code={`pnpm format
+pnpm --filter @cloudflare/kumo test:run`}
+  lang="bash"
+/>
 
 Windsurf and hooks catch additional issues, but you should still run checks locally before requesting review.
 
@@ -133,9 +134,7 @@ Windsurf and hooks catch additional issues, but you should still run checks loca
 
 If your change touches `packages/kumo/` and should ship, add a changeset:
 
-```bash
-pnpm changeset
-```
+<CodeBlock code={`pnpm changeset`} lang="bash" />
 
 Changeset guidance:
 
@@ -197,6 +196,7 @@ Common pitfalls to avoid:
 ---
 
 ## Questions?
+
 If you have any questions for Kumo, please reach out to the team in our Kumo channel.
 
 ---

--- a/packages/kumo-docs-astro/src/pages/figma.mdx
+++ b/packages/kumo-docs-astro/src/pages/figma.mdx
@@ -5,6 +5,7 @@ description: "Generate Figma components from Kumo definitions using the Figma pl
 ---
 
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 
 ## Kumo Figma Plugin
 
@@ -20,9 +21,7 @@ Follow these steps to build and test the Figma plugin locally on any Figma file.
 
 From the repository root, run:
 
-```bash
-pnpm --filter @cloudflare/kumo-figma build
-```
+<CodeBlock code={`pnpm --filter @cloudflare/kumo-figma build`} lang="bash" />
 
 This generates theme data, loader data, and icons, then bundles the plugin code into `src/code.js`.
 
@@ -60,9 +59,10 @@ The token sync script requires environment variables to authenticate with the Fi
 1. Get a [Figma personal access token](https://www.figma.com/developers/api#authentication) from Figma Settings → Personal Access Tokens
 2. Copy the environment template:
 
-```bash
-cp packages/kumo-figma/scripts/.env.example packages/kumo-figma/scripts/.env
-```
+<CodeBlock
+  code={`cp packages/kumo-figma/scripts/.env.example packages/kumo-figma/scripts/.env`}
+  lang="bash"
+/>
 
 3. Configure the environment variables in `.env`
 
@@ -74,12 +74,13 @@ cp packages/kumo-figma/scripts/.env.example packages/kumo-figma/scripts/.env
 | `FIGMA_FILE_KEY`        | Yes      | The file key from your Figma URL: `figma.com/file/{FILE_KEY}/...` |
 | `FIGMA_COLLECTION_NAME` | No       | Variable collection name in Figma. Defaults to `kumo-colors`      |
 
-```bash
-# packages/kumo-figma/scripts/.env
+<CodeBlock
+  code={`# packages/kumo-figma/scripts/.env
 FIGMA_TOKEN=figd_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 FIGMA_FILE_KEY=sKKZc6pC6W1TtzWBLxDGSU
-FIGMA_COLLECTION_NAME=kumo-colors
-```
+FIGMA_COLLECTION_NAME=kumo-colors`}
+  lang="bash"
+/>
 
 <Callout type="warning">
   **Security:** Never commit your Figma token. The `.env` file is gitignored.
@@ -91,9 +92,10 @@ Before generating components, sync Kumo's semantic color tokens to Figma. This c
 
 ### Run Token Sync
 
-```bash
-pnpm --filter @cloudflare/kumo-figma figma:sync
-```
+<CodeBlock
+  code={`pnpm --filter @cloudflare/kumo-figma figma:sync`}
+  lang="bash"
+/>
 
 This parses tokens from `theme-kumo.css`, resolves `light-dark()` values for both modes, and pushes them to Figma via the Variables API.
 
@@ -132,8 +134,7 @@ The plugin uses **destructive sync** — it purges all existing generated conten
 
 The typical workflow when updating components:
 
-```bash
-# 1. Make changes to Kumo components
+<CodeBlock code={`# 1. Make changes to Kumo components
 # ...edit packages/kumo/src/components/...
 
 # 2. Regenerate component registry
@@ -145,8 +146,7 @@ pnpm --filter @cloudflare/kumo-figma figma:sync
 # 4. Build the plugin
 pnpm --filter @cloudflare/kumo-figma build
 
-# 5. Run in Figma: Plugins > Development > Kumo UI Kit Generator
-```
+# 5. Run in Figma: Plugins > Development > Kumo UI Kit Generator`} lang="bash" />
 
 ## Plugin Architecture
 
@@ -175,9 +175,10 @@ If a component doesn't need Figma representation (utility or layout-only), add i
 
 The target Figma file needs the variable collection. Run the token sync script first:
 
-```bash
-pnpm --filter @cloudflare/kumo-figma figma:sync
-```
+<CodeBlock
+  code={`pnpm --filter @cloudflare/kumo-figma figma:sync`}
+  lang="bash"
+/>
 
 ### "Variable not found: color-primary"
 

--- a/packages/kumo-docs-astro/src/pages/installation.mdx
+++ b/packages/kumo-docs-astro/src/pages/installation.mdx
@@ -5,6 +5,7 @@ description: "Get started with Kumo by installing the package and importing comp
 ---
 
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 
 export const kumoVersion =
   typeof __KUMO_VERSION__ !== "undefined" ? __KUMO_VERSION__ : "latest";
@@ -19,30 +20,25 @@ Install Kumo using your preferred package manager. The current version is <code>
 
 **npm**
 
-```bash
-npm install @cloudflare/kumo
-```
+<CodeBlock code={`npm install @cloudflare/kumo`} lang="bash" />
 
 **pnpm**
 
-```bash
-pnpm add @cloudflare/kumo
-```
+<CodeBlock code={`pnpm add @cloudflare/kumo`} lang="bash" />
 
 **yarn**
 
-```bash
-yarn add @cloudflare/kumo
-```
+<CodeBlock code={`yarn add @cloudflare/kumo`} lang="bash" />
 
 **Peer Dependencies**
 
 Kumo requires the following peer dependencies. Most React projects will already have these installed:
 
-```bash
-# Required peer dependencies
-pnpm add react react-dom @phosphor-icons/react
-```
+<CodeBlock
+  code={`# Required peer dependencies
+pnpm add react react-dom @phosphor-icons/react`}
+  lang="bash"
+/>
 
 ## Import Components
 
@@ -50,16 +46,18 @@ Import components from the main package or use granular imports for better tree-
 
 **Main Package Import**
 
-```tsx
-import { Button, Input, Surface } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { Button, Input, Surface } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 **Granular Import (Recommended)**
 
-```tsx
-import { Button } from "@cloudflare/kumo/components/button";
-import { Input } from "@cloudflare/kumo/components/input";
-```
+<CodeBlock
+  code={`import { Button } from "@cloudflare/kumo/components/button";
+import { Input } from "@cloudflare/kumo/components/input";`}
+  lang="tsx"
+/>
 
 ## Base UI Primitives
 
@@ -67,19 +65,21 @@ Kumo is built on top of [Base UI](https://base-ui.com), a library of unstyled, a
 
 **Barrel Import (Convenient)**
 
-```tsx
-// Import multiple primitives at once
-import { Popover, Slider, Accordion } from "@cloudflare/kumo/primitives";
-```
+<CodeBlock
+  code={`// Import multiple primitives at once
+import { Popover, Slider, Accordion } from "@cloudflare/kumo/primitives";`}
+  lang="tsx"
+/>
 
 **Granular Imports (Recommended for Performance)**
 
-```tsx
-// Import individual primitives for better tree-shaking
+<CodeBlock
+  code={`// Import individual primitives for better tree-shaking
 import { Popover } from "@cloudflare/kumo/primitives/popover";
 import { Slider } from "@cloudflare/kumo/primitives/slider";
-import { Accordion } from "@cloudflare/kumo/primitives/accordion";
-```
+import { Accordion } from "@cloudflare/kumo/primitives/accordion";`}
+  lang="tsx"
+/>
 
 Granular imports result in smaller bundle sizes by only including the primitives you actually use.
 
@@ -114,14 +114,12 @@ If your application uses Tailwind CSS, add Kumo's source files to your content c
   styles (e.g. Dialogs not centered).
 </Callout>
 
-```css
-/* app.css or main.css */
+<CodeBlock code={`/* app.css or main.css */
 @source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
 @import "@cloudflare/kumo/styles/tailwind";
 @import "tailwindcss";
 
-/* Your custom styles */
-```
+/_ Your custom styles _/`} lang="css" />
 
 <Callout type="info">
   The `@source` path is relative to your CSS file. Adjust it based on your
@@ -135,10 +133,11 @@ Note: You can also use the default export `@cloudflare/kumo/styles` which is equ
 
 If your application doesn't use Tailwind CSS, use the standalone build which includes all compiled styles:
 
-```tsx
-// In your app entry point (e.g., main.tsx, index.tsx)
-import "@cloudflare/kumo/styles/standalone";
-```
+<CodeBlock
+  code={`// In your app entry point (e.g., main.tsx, index.tsx)
+import "@cloudflare/kumo/styles/standalone";`}
+  lang="tsx"
+/>
 
 The standalone build includes all Tailwind utilities and Kumo component styles pre-compiled. No Tailwind configuration needed!
 
@@ -148,18 +147,18 @@ Here's a complete example of using Kumo components with Tailwind CSS:
 
 **CSS File (app.css)**
 
-```css
-@source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
+<CodeBlock
+  code={`@source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
 @import "@cloudflare/kumo/styles/tailwind";
-@import "tailwindcss";
-```
+@import "tailwindcss";`}
+  lang="css"
+/>
 
 Note: The `@source` path is relative to your CSS file. Adjust it based on your project structure.
 
 **Component File (App.tsx)**
 
-```tsx
-import { Button, Input, Surface } from "@cloudflare/kumo";
+<CodeBlock code={`import { Button, Input, Surface } from "@cloudflare/kumo";
 import "./app.css";
 
 export default function App() {
@@ -170,8 +169,7 @@ export default function App() {
       <Button variant="primary">Submit</Button>
     </Surface>
   );
-}
-```
+}`} lang="tsx" />
 
 ## Blocks vs Components
 
@@ -181,9 +179,10 @@ Kumo provides two types of building blocks for your application:
 
 Components are published as NPM exports and can be imported directly from the package. These are the core UI primitives like `Button`, `Input`, and `Dialog`.
 
-```tsx
-import { Button, Input, Dialog } from "@cloudflare/kumo";
-```
+<CodeBlock
+  code={`import { Button, Input, Dialog } from "@cloudflare/kumo";`}
+  lang="tsx"
+/>
 
 Use components when you need consistent, pre-styled UI primitives that integrate seamlessly with your application. Components are versioned, tree-shakeable, and receive automatic updates.
 
@@ -191,22 +190,23 @@ Use components when you need consistent, pre-styled UI primitives that integrate
 
 Blocks are higher-level compositions (like `PageHeader` and `ResourceListPage`) that are installed via the Kumo CLI. Blocks give you full ownership of the code, allowing you to customize them to your specific needs.
 
-```bash
-# Initialize Kumo configuration
+<CodeBlock code={`# Initialize Kumo configuration
 npx @cloudflare/kumo init
 
 # List available blocks
+
 npx @cloudflare/kumo blocks
 
 # Install a block
-npx @cloudflare/kumo add PageHeader
-```
+
+npx @cloudflare/kumo add PageHeader`} lang="bash" />
 
 After installation, blocks live in your project (e.g., `src/components/kumo/`) and can be customized as needed. The CLI automatically transforms imports from relative paths to `@cloudflare/kumo` for seamless integration.
 
-```tsx
-import { PageHeader } from "src/components/kumo/page-header/page-header";
-```
+<CodeBlock
+  code={`import { PageHeader } from "src/components/kumo/page-header/page-header";`}
+  lang="tsx"
+/>
 
 <Callout type="info">
   <strong>When to use blocks:</strong>
@@ -222,8 +222,7 @@ import { PageHeader } from "src/components/kumo/page-header/page-header";
 
 Kumo also exports utility functions for common tasks:
 
-```tsx
-import { cn, safeRandomId, LinkProvider } from "@cloudflare/kumo";
+<CodeBlock code={`import { cn, safeRandomId, LinkProvider } from "@cloudflare/kumo";
 
 // Merge class names with Tailwind
 const className = cn("base-class", condition && "conditional-class");
@@ -232,5 +231,5 @@ const className = cn("base-class", condition && "conditional-class");
 const id = safeRandomId();
 
 // Configure link component for your framework
-<LinkProvider component={YourLinkComponent}>{/* Your app */}</LinkProvider>;
-```
+
+<LinkProvider component={YourLinkComponent}>{/* Your app */}</LinkProvider>;`} lang="tsx" />

--- a/packages/kumo-docs-astro/src/pages/registry.mdx
+++ b/packages/kumo-docs-astro/src/pages/registry.mdx
@@ -5,6 +5,7 @@ description: "AI-readable component metadata for LLMs and code generation tools.
 ---
 
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 import { ComponentRegistryView } from "~/components/demos/RegistryDemo";
 
 ## Overview
@@ -17,30 +18,27 @@ The component registry is a machine-readable JSON file that describes all Kumo c
 
 ### Via CLI
 
-```bash
-# List all components
+<CodeBlock code={`# List all components
 npx @cloudflare/kumo ls
 
 # Get docs for a specific component
-npx @cloudflare/kumo doc Button
-```
+npx @cloudflare/kumo doc Button`} lang="bash" />
 
 ### Via HTTP API
 
-```bash
-# JSON endpoint
-curl https://kumo-ui.com/api/component-registry
-```
+<CodeBlock
+  code={`# JSON endpoint
+curl https://kumo-ui.com/api/component-registry`}
+  lang="bash"
+/>
 
 ### Via jq (Local)
 
-```bash
-# Get Button props
+<CodeBlock code={`# Get Button props
 jq '.components.Button.props' packages/kumo/ai/component-registry.json
 
 # List components by category
-jq '.search.byCategory' packages/kumo/ai/component-registry.json
-```
+jq '.search.byCategory' packages/kumo/ai/component-registry.json`} lang="bash" />
 
 ## Registry Contents
 

--- a/packages/kumo-docs-astro/src/pages/streaming.mdx
+++ b/packages/kumo-docs-astro/src/pages/streaming.mdx
@@ -5,6 +5,7 @@ description: "Render AI-generated UI from JSON using Kumo's auto-generated schem
 ---
 
 import Callout from "~/components/docs/Callout.astro";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
 
 ## Overview
 
@@ -35,21 +36,21 @@ The generated schemas in `ai/schemas.ts` include:
 
 ## Installation
 
-```ts
-import {
+<CodeBlock
+  code={`import {
   createKumoCatalog,
   initCatalog,
   resolveProps,
   evaluateVisibility,
-} from "@cloudflare/kumo/catalog";
-```
+} from "@cloudflare/kumo/catalog";`}
+  lang="ts"
+/>
 
 ## Creating a Catalog
 
 Create a catalog instance that validates AI-generated JSON against the auto-generated schemas:
 
-```ts
-import { createKumoCatalog, initCatalog } from "@cloudflare/kumo/catalog";
+<CodeBlock code={`import { createKumoCatalog, initCatalog } from "@cloudflare/kumo/catalog";
 
 // Create a catalog with optional actions
 const catalog = createKumoCatalog({
@@ -67,15 +68,14 @@ const result = catalog.validateTree(aiGeneratedJson);
 if (result.success) {
   // Render the validated tree
   renderTree(result.data);
-}
-```
+}`} lang="ts" />
 
 ## UI Tree Format
 
 The UI tree uses a flat structure optimized for LLM generation and streaming. Elements reference each other by key rather than nesting, enabling progressive rendering as elements stream in.
 
-```json
-{
+<CodeBlock
+  code={`{
   "root": "card-1",
   "elements": {
     "card-1": {
@@ -114,8 +114,9 @@ The UI tree uses a flat structure optimized for LLM generation and streaming. El
       }
     }
   }
-}
-```
+}`}
+  lang="json"
+/>
 
 **Why a flat structure?**
 
@@ -128,8 +129,7 @@ The UI tree uses a flat structure optimized for LLM generation and streaming. El
 
 Props can reference values from a data model using JSON Pointer paths. This allows the AI to declare data bindings that your application resolves at render time.
 
-```ts
-import { resolveProps, resolveDynamicValue } from "@cloudflare/kumo/catalog";
+<CodeBlock code={`import { resolveProps, resolveDynamicValue } from "@cloudflare/kumo/catalog";
 
 // Data model backing the UI
 const dataModel = {
@@ -155,15 +155,13 @@ const resolved = resolveProps(props, dataModel);
 
 // Or resolve individual values
 const name = resolveDynamicValue({ path: "/user/name" }, dataModel);
-// "Alice"
-```
+// "Alice"`} lang="ts" />
 
 ## Visibility Conditions
 
 Elements can be conditionally rendered based on data values, authentication state, or complex logic expressions.
 
-```ts
-import {
+<CodeBlock code={`import {
   evaluateVisibility,
   createVisibilityContext,
 } from "@cloudflare/kumo/catalog";
@@ -203,8 +201,7 @@ evaluateVisibility(
     ],
   },
   ctx,
-);
-```
+);`} lang="ts" />
 
 ### Available Operators
 
@@ -221,8 +218,7 @@ evaluateVisibility(
 
 Elements can declare actions that your application handles. The AI describes the intent, and your handlers execute the logic.
 
-```ts
-// In your UI tree element
+<CodeBlock code={`// In your UI tree element
 {
   "key": "delete-btn",
   "type": "Button",
@@ -254,19 +250,17 @@ const catalog = createKumoCatalog({
     delete_item: {
       description: "Delete an item by ID",
       params: {
-        itemId: { type: "string", description: "Item ID to delete" }
-      }
-    }
-  }
-});
-```
+        itemId: { type: "string", description: "Item ID to delete" },
+      },
+    },
+  },
+});`} lang="ts" />
 
 ## Validation
 
 The catalog validates AI-generated JSON against auto-generated Zod schemas derived from component TypeScript types.
 
-```ts
-// Validate a complete tree
+<CodeBlock code={`// Validate a complete tree
 const result = catalog.validateTree(aiJson);
 
 if (result.success) {
@@ -289,15 +283,13 @@ catalog.hasComponent("Foobar"); // false
 
 // List all component names
 console.log(catalog.componentNames);
-// ["Badge", "Banner", "Button", ...]
-```
+// ["Badge", "Banner", "Button", ...]`} lang="ts" />
 
 ## AI Prompt Generation
 
 Generate prompts describing the catalog for AI models:
 
-```ts
-const prompt = catalog.generatePrompt();
+<CodeBlock code={`const prompt = catalog.generatePrompt();
 
 // Returns markdown describing:
 // - Available components
@@ -306,21 +298,19 @@ const prompt = catalog.generatePrompt();
 // - Dynamic value syntax
 
 // Use in your LLM prompt
-const systemPrompt = `
+const systemPrompt = \`
 You are a UI generation assistant.
 
-${catalog.generatePrompt()}
+\${catalog.generatePrompt()}
 
 Generate UI based on the user's request.
-`;
-```
+\`;`} lang="ts" />
 
 ## Type Exports
 
 All types are exported for TypeScript integration:
 
-```ts
-import type {
+<CodeBlock code={`import type {
   // Core types
   UIElement,
   UITree,
@@ -348,15 +338,13 @@ import type {
   KumoCatalog,
   CatalogConfig,
   ValidationResult,
-} from "@cloudflare/kumo/catalog";
-```
+} from "@cloudflare/kumo/catalog";`} lang="ts" />
 
 ## Full Example
 
 A complete example showing catalog creation, validation, and rendering:
 
-```tsx
-import {
+<CodeBlock code={`import {
   createKumoCatalog,
   initCatalog,
   resolveProps,
@@ -439,8 +427,7 @@ function renderElement(element, elements) {
 
 // 5. Render the tree
 const tree = result.data;
-const ui = renderElement(tree.elements[tree.root], tree.elements);
-```
+const ui = renderElement(tree.elements[tree.root], tree.elements);`} lang="tsx" />
 
 ## Key Benefits
 


### PR DESCRIPTION
Adds a copy-to-clipboard button to every code block in the docs site.

Users frequently need to copy code snippets from the docs (install commands, usage examples, API references) but had no way to do so without manually selecting text. The button makes this a single click.

<img width="860" height="505" alt="Screenshot 2026-04-13 at 17 31 38" src="https://github.com/user-attachments/assets/54e841bd-04b2-4fc7-b0a8-fcf010f59ad8" />

<img width="860" height="505" alt="Screenshot 2026-04-13 at 17 31 45" src="https://github.com/user-attachments/assets/5af22f6a-e252-4124-be80-80670392fd1a" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->
- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only change, no modifications to the published `@cloudflare/kumo` component library
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: docs-only content changes (MDX pages and Astro components)
