### PR TITLE
fix(docs): resolve TableOfContents hydration mismatch

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/TableOfContents.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/TableOfContents.tsx
@@ -41,12 +41,21 @@ export function TableOfContents({
   headings: headingsProp,
   layout = "sidebar",
 }: TableOfContentsProps) {
+  // Track whether we've hydrated to avoid SSR/client mismatch when scraping
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
   const headings = useMemo(() => {
     if (headingsProp && headingsProp.length > 0) {
       return headingsProp.filter((h) => h.depth <= 2);
     }
+    // Only scrape after mount to avoid hydration mismatch
+    if (!hasMounted) return [];
     return scrapeHeadings();
-  }, [headingsProp]);
+  }, [headingsProp, hasMounted]);
 
   const [activeId, setActiveId] = useState<string>(headings[0]?.slug ?? "");
 


### PR DESCRIPTION
## Summary

Fixes React hydration mismatch error in TableOfContents component when `headings` prop is not provided (i.e., when scraping headings from the DOM).

**The problem:**
- Server: `scrapeHeadings()` returns `[]` because `document` is undefined
- Client: `scrapeHeadings()` returns actual headings from the DOM
- This mismatch causes React to throw a hydration error

**The fix:**
Defer DOM scraping until after the component has mounted by tracking `hasMounted` state. On initial render (both server and client), we return an empty array. After mount, we re-run the memo and scrape the actual headings.

---

- Reviews
  - [x] automated review not possible because: simple hydration fix, no complex logic changes
- Tests
  - [x] Additional testing not necessary because: fix verified by absence of console hydration errors in dev