### PR TITLE
fix(pagination, input): accessibility and i18n improvements

### DIFF
--- a/.changeset/pagination-a11y-i18n.md
+++ b/.changeset/pagination-a11y-i18n.md
@@ -1,0 +1,34 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(pagination, input): accessibility and i18n improvements
+
+**Pagination:**
+
+- Add `labels` prop for internationalization of all UI strings
+- All aria-labels and visible text can now be customized for different locales
+- Default English labels maintained for backwards compatibility
+
+**Input:**
+
+- Fix accessibility check that incorrectly required both `placeholder` AND `aria-label`
+- Now `aria-label` alone is sufficient (correct per WCAG)
+
+Example i18n usage:
+
+```tsx
+<Pagination
+  labels={{
+    firstPage: "Première page",
+    previousPage: "Page précédente",
+    nextPage: "Page suivante",
+    lastPage: "Dernière page",
+    pageNumber: "Numéro de page",
+    pageSize: "Taille de page",
+    perPageLabel: "Par page :",
+    showingInfo: (range, total) => `Affichage de ${range} sur ${total}`,
+  }}
+  // ...
+/>
+```

--- a/.changeset/pagination-a11y-i18n.md
+++ b/.changeset/pagination-a11y-i18n.md
@@ -6,9 +6,12 @@ fix(pagination, input): accessibility and i18n improvements
 
 **Pagination:**
 
-- Add `labels` prop for internationalization of all UI strings
-- All aria-labels and visible text can now be customized for different locales
+- Add `labels` prop for internationalization of aria-label strings
+- Customizable labels: `firstPage`, `previousPage`, `nextPage`, `lastPage`, `pageNumber`, `pageSize`
 - Default English labels maintained for backwards compatibility
+- For visible text customization, use existing render props:
+  - `Pagination.Info` children for "Showing X of Y" text
+  - `Pagination.PageSize` label prop for "Per page:" text
 
 **Input:**
 
@@ -26,9 +29,24 @@ Example i18n usage:
     lastPage: "Dernière page",
     pageNumber: "Numéro de page",
     pageSize: "Taille de page",
-    perPageLabel: "Par page :",
-    showingInfo: (range, total) => `Affichage de ${range} sur ${total}`,
   }}
-  // ...
-/>
+  page={page}
+  setPage={setPage}
+  perPage={10}
+  totalCount={100}
+>
+  <Pagination.Info>
+    {({ pageShowingRange, totalCount }) => (
+      <>
+        Affichage de {pageShowingRange} sur {totalCount}
+      </>
+    )}
+  </Pagination.Info>
+  <Pagination.PageSize
+    label="Par page :"
+    value={perPage}
+    onChange={setPerPage}
+  />
+  <Pagination.Controls />
+</Pagination>
 ```

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.4.0"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.0.tgz",
+      "integrity": "sha512-VFIff6LHp/RVaJdrK3EQ1ijx0K1tV5i1DY5YJ+pRqwC6trunPHbvqSN0GHSTZX39RdnSc+XuzCTZQCy1W2qNOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.4.0",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
@@ -208,16 +208,17 @@ export function PaginationI18nDemo() {
         lastPage: "Dernière page",
         pageNumber: "Numéro de page",
         pageSize: "Taille de page",
-        perPageLabel: "Par page :",
-        showingInfo: (range, total) => (
-          <>
-            Affichage de <span className="tabular-nums">{range}</span> sur{" "}
-            <span className="tabular-nums">{total}</span>
-          </>
-        ),
       }}
     >
-      <Pagination.Info />
+      <Pagination.Info>
+        {({ pageShowingRange, totalCount }) => (
+          <>
+            Affichage de{" "}
+            <span className="tabular-nums">{pageShowingRange}</span> sur{" "}
+            <span className="tabular-nums">{totalCount}</span>
+          </>
+        )}
+      </Pagination.Info>
       <Pagination.Controls />
     </Pagination>
   );

--- a/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
@@ -190,3 +190,35 @@ export function PaginationPageSizeRightDemo() {
     </Pagination>
   );
 }
+
+/** Pagination with French labels for internationalization. */
+export function PaginationI18nDemo() {
+  const [page, setPage] = useState(1);
+
+  return (
+    <Pagination
+      page={page}
+      setPage={setPage}
+      perPage={10}
+      totalCount={100}
+      labels={{
+        firstPage: "Première page",
+        previousPage: "Page précédente",
+        nextPage: "Page suivante",
+        lastPage: "Dernière page",
+        pageNumber: "Numéro de page",
+        pageSize: "Taille de page",
+        perPageLabel: "Par page :",
+        showingInfo: (range, total) => (
+          <>
+            Affichage de <span className="tabular-nums">{range}</span> sur{" "}
+            <span className="tabular-nums">{total}</span>
+          </>
+        ),
+      }}
+    >
+      <Pagination.Info />
+      <Pagination.Controls />
+    </Pagination>
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/components/pagination.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/pagination.mdx
@@ -174,6 +174,43 @@ export default function Example() {
     </ComponentExample>
 </ComponentSection>
 
+{/* Internationalization */}
+
+<ComponentSection>
+  <Heading level={2}>Internationalization</Heading>
+  <p>
+    Use the `labels` prop to customize all UI strings for different locales. All labels default to English.
+  </p>
+
+```tsx
+<Pagination
+  page={page}
+  setPage={setPage}
+  perPage={10}
+  totalCount={100}
+  labels={{
+    firstPage: "Première page",
+    previousPage: "Page précédente",
+    nextPage: "Page suivante",
+    lastPage: "Dernière page",
+    pageNumber: "Numéro de page",
+    pageSize: "Taille de page",
+    perPageLabel: "Par page :",
+    showingInfo: (range, total) => (
+      <>
+        Affichage de <span className="tabular-nums">{range}</span> sur{" "}
+        <span className="tabular-nums">{total}</span>
+      </>
+    ),
+  }}
+>
+  <Pagination.Info />
+  <Pagination.Controls />
+</Pagination>
+```
+
+</ComponentSection>
+
 {/* API Reference */}
 
 <ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/pagination.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/pagination.mdx
@@ -21,6 +21,7 @@ import {
   PaginationCompoundCustomInfoDemo,
   PaginationDropdownSelectorDemo,
   PaginationPageSizeRightDemo,
+  PaginationI18nDemo,
 } from "~/components/demos/PaginationDemo";
 
 {/* Hero Demo */}
@@ -182,32 +183,9 @@ export default function Example() {
     Use the `labels` prop to customize all UI strings for different locales. All labels default to English.
   </p>
 
-```tsx
-<Pagination
-  page={page}
-  setPage={setPage}
-  perPage={10}
-  totalCount={100}
-  labels={{
-    firstPage: "Première page",
-    previousPage: "Page précédente",
-    nextPage: "Page suivante",
-    lastPage: "Dernière page",
-    pageNumber: "Numéro de page",
-    pageSize: "Taille de page",
-    perPageLabel: "Par page :",
-    showingInfo: (range, total) => (
-      <>
-        Affichage de <span className="tabular-nums">{range}</span> sur{" "}
-        <span className="tabular-nums">{total}</span>
-      </>
-    ),
-  }}
->
-  <Pagination.Info />
-  <Pagination.Controls />
-</Pagination>
-```
+<ComponentExample demo="PaginationI18nDemo">
+  <PaginationI18nDemo client:visible />
+</ComponentExample>
 
 </ComponentSection>
 

--- a/packages/kumo/src/components/input/input.tsx
+++ b/packages/kumo/src/components/input/input.tsx
@@ -150,16 +150,14 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   // A11y enforcement: warn in dev if no accessible name provided
   if (process.env.NODE_ENV !== "production") {
     const hasLabel = Boolean(label);
-    const hasPlaceholderAndAriaLabel = Boolean(
-      inputProps.placeholder && inputProps["aria-label"],
-    );
+    const hasAriaLabel = Boolean(inputProps["aria-label"]);
     const hasAriaLabelledBy = Boolean(inputProps["aria-labelledby"]);
 
-    if (!hasLabel && !hasPlaceholderAndAriaLabel && !hasAriaLabelledBy) {
+    if (!hasLabel && !hasAriaLabel && !hasAriaLabelledBy) {
       console.warn(
         "[Kumo Input]: Input must have an accessible name. Provide either:\n" +
           "  - label prop: <Input label='Email' />\n" +
-          "  - placeholder + aria-label: <Input placeholder='Email' aria-label='Email address' />\n" +
+          "  - aria-label: <Input aria-label='Email address' />\n" +
           "  - aria-labelledby for custom label association",
       );
     }

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -22,6 +22,52 @@ const DEFAULT_PAGE_SIZE_OPTIONS = [25, 50, 100, 250] as const;
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
 
+// ============================================================================
+// i18n Labels
+// ============================================================================
+
+/**
+ * Labels for internationalization of Pagination component.
+ * All labels have English defaults and can be overridden for other locales.
+ */
+export interface PaginationLabels {
+  /** Aria label for the first page button. @default "First page" */
+  firstPage?: string;
+  /** Aria label for the previous page button. @default "Previous page" */
+  previousPage?: string;
+  /** Aria label for the next page button. @default "Next page" */
+  nextPage?: string;
+  /** Aria label for the last page button. @default "Last page" */
+  lastPage?: string;
+  /** Aria label for the page number input/select. @default "Page number" */
+  pageNumber?: string;
+  /** Aria label for the page size select. @default "Page size" */
+  pageSize?: string;
+  /** Label text shown before the page size selector. @default "Per page:" */
+  perPageLabel?: string;
+  /**
+   * Function to format the "Showing X-Y of Z" info text.
+   * @default (range, total) => `Showing ${range} of ${total}`
+   */
+  showingInfo?: (range: string, total: number) => ReactNode;
+}
+
+const DEFAULT_LABELS: Required<PaginationLabels> = {
+  firstPage: "First page",
+  previousPage: "Previous page",
+  nextPage: "Next page",
+  lastPage: "Last page",
+  pageNumber: "Page number",
+  pageSize: "Page size",
+  perPageLabel: "Per page:",
+  showingInfo: (range, total) => (
+    <>
+      Showing <span className="tabular-nums">{range}</span> of{" "}
+      <span className="tabular-nums">{total}</span>
+    </>
+  ),
+};
+
 /** Pagination controls variant definitions. */
 export const KUMO_PAGINATION_VARIANTS = {
   controls: {
@@ -71,6 +117,7 @@ interface PaginationContextValue {
   setPage: (page: number) => void;
   editingPage: number;
   setEditingPage: (page: number) => void;
+  labels: Required<PaginationLabels>;
 }
 
 const PaginationContext = createContext<PaginationContextValue | null>(null);
@@ -102,17 +149,14 @@ export interface PaginationInfoProps {
 }
 
 function PaginationInfo({ children, className }: PaginationInfoProps) {
-  const { page, perPage, totalCount, pageShowingRange } =
+  const { page, perPage, totalCount, pageShowingRange, labels } =
     usePaginationContext();
 
-  const content = children ? (
-    children({ page, perPage, totalCount, pageShowingRange })
-  ) : totalCount && totalCount > 0 ? (
-    <>
-      Showing <span className="tabular-nums">{pageShowingRange}</span> of{" "}
-      <span className="tabular-nums">{totalCount}</span>
-    </>
-  ) : null;
+  const content = children
+    ? children({ page, perPage, totalCount, pageShowingRange })
+    : totalCount && totalCount > 0
+      ? labels.showingInfo(pageShowingRange, totalCount)
+      : null;
 
   return (
     <div
@@ -137,7 +181,10 @@ export interface PaginationPageSizeProps {
   onChange: (size: number) => void;
   /** Available page size options */
   options?: number[];
-  /** Label text shown before the selector */
+  /**
+   * Label text shown before the selector.
+   * @default "Per page:" (or i18n override from Pagination labels prop)
+   */
   label?: ReactNode;
   /** Additional CSS classes */
   className?: string;
@@ -147,17 +194,23 @@ function PaginationPageSize({
   value,
   onChange,
   options = DEFAULT_PAGE_SIZE_OPTIONS as unknown as number[],
-  label = "Per page:",
+  label,
   className,
 }: PaginationPageSizeProps) {
+  const { labels } = usePaginationContext();
+  // Use explicit label if provided, otherwise fall back to i18n label from context
+  const displayLabel = label ?? labels.perPageLabel;
+
   return (
     <div
       data-slot="pagination-page-size"
       className={cn("flex items-center gap-2", className)}
     >
-      {label && <span className="text-sm text-kumo-strong">{label}</span>}
+      {displayLabel && (
+        <span className="text-sm text-kumo-strong">{displayLabel}</span>
+      )}
       <Select
-        aria-label="Page size"
+        aria-label={labels.pageSize}
         value={value}
         onValueChange={(v) => onChange(v as number)}
       >
@@ -197,7 +250,7 @@ function PaginationControls({
   pageSelector = "input",
   className,
 }: PaginationControlsProps) {
-  const { page, maxPage, setPage, editingPage, setEditingPage } =
+  const { page, maxPage, setPage, editingPage, setEditingPage, labels } =
     usePaginationContext();
 
   return (
@@ -210,7 +263,7 @@ function PaginationControls({
           {controls === "full" && (
             <InputGroup.Button
               variant="secondary"
-              aria-label="First page"
+              aria-label={labels.firstPage}
               disabled={page <= 1}
               onClick={() => {
                 setPage(1);
@@ -222,7 +275,7 @@ function PaginationControls({
           )}
           <InputGroup.Button
             variant="secondary"
-            aria-label="Previous page"
+            aria-label={labels.previousPage}
             disabled={page <= 1}
             onClick={() => {
               const previousPage = Math.max(page - 1, 1);
@@ -235,7 +288,7 @@ function PaginationControls({
           {controls === "full" &&
             (pageSelector === "dropdown" ? (
               <Select
-                aria-label="Page number"
+                aria-label={labels.pageNumber}
                 className="rounded-none ring-kumo-hairline"
                 value={page}
                 onValueChange={(value) => {
@@ -254,7 +307,7 @@ function PaginationControls({
               <InputGroup.Input
                 style={{ width: 50 }}
                 className="text-center"
-                aria-label="Page number"
+                aria-label={labels.pageNumber}
                 value={editingPage}
                 onValueChange={(value: string) => {
                   setEditingPage(Number(value));
@@ -280,7 +333,7 @@ function PaginationControls({
             ))}
           <InputGroup.Button
             variant="secondary"
-            aria-label="Next page"
+            aria-label={labels.nextPage}
             disabled={page === maxPage}
             onClick={() => {
               const nextPage = Math.min(page + 1, maxPage);
@@ -293,7 +346,7 @@ function PaginationControls({
           {controls === "full" && (
             <InputGroup.Button
               variant="secondary"
-              aria-label="Last page"
+              aria-label={labels.lastPage}
               disabled={page === maxPage}
               onClick={() => {
                 setPage(maxPage);
@@ -350,6 +403,26 @@ interface PaginationBaseProps {
   totalCount?: number;
   /** Additional CSS classes for the container */
   className?: string;
+  /**
+   * Labels for internationalization. All labels have English defaults.
+   * @example
+   * ```tsx
+   * <Pagination
+   *   labels={{
+   *     firstPage: "Première page",
+   *     previousPage: "Page précédente",
+   *     nextPage: "Page suivante",
+   *     lastPage: "Dernière page",
+   *     pageNumber: "Numéro de page",
+   *     pageSize: "Taille de page",
+   *     perPageLabel: "Par page :",
+   *     showingInfo: (range, total) => `Affichage de ${range} sur ${total}`,
+   *   }}
+   *   // ...
+   * />
+   * ```
+   */
+  labels?: PaginationLabels;
 }
 
 /**
@@ -392,8 +465,7 @@ export interface PaginationCompoundProps extends PaginationBaseProps {
  * ```
  */
 export interface PaginationLegacyProps
-  extends PaginationBaseProps,
-    KumoPaginationVariantsProps {
+  extends PaginationBaseProps, KumoPaginationVariantsProps {
   children?: never;
   /** @deprecated Use Pagination.Info with children prop instead */
   text?: (props: {
@@ -442,7 +514,15 @@ export type PaginationProps = PaginationCompoundProps | PaginationLegacyProps;
  * ```
  */
 function PaginationRoot(props: PaginationProps) {
-  const { page = 1, perPage, totalCount, setPage, children, className } = props;
+  const {
+    page = 1,
+    perPage,
+    totalCount,
+    setPage,
+    children,
+    className,
+    labels: labelsProp,
+  } = props;
 
   // Extract legacy props (only present when children is not provided)
   const text = "text" in props ? props.text : undefined;
@@ -451,6 +531,12 @@ function PaginationRoot(props: PaginationProps) {
       ? (props.controls ?? KUMO_PAGINATION_DEFAULT_VARIANTS.controls)
       : KUMO_PAGINATION_DEFAULT_VARIANTS.controls;
   const [editingPage, setEditingPage] = useState<number>(1);
+
+  // Merge provided labels with defaults
+  const labels = useMemo<Required<PaginationLabels>>(
+    () => ({ ...DEFAULT_LABELS, ...labelsProp }),
+    [labelsProp],
+  );
 
   useEffect(() => {
     setEditingPage(page);
@@ -479,6 +565,7 @@ function PaginationRoot(props: PaginationProps) {
     setPage,
     editingPage,
     setEditingPage,
+    labels,
   };
 
   // Compound component mode: render children within context
@@ -500,12 +587,7 @@ function PaginationRoot(props: PaginationProps) {
     if (text) {
       return text({ page, perPage, totalCount, pageShowingRange });
     } else if (totalCount && totalCount > 0) {
-      return (
-        <>
-          Showing <span className="tabular-nums">{pageShowingRange}</span> of{" "}
-          <span className="tabular-nums">{totalCount}</span>
-        </>
-      );
+      return labels.showingInfo(pageShowingRange, totalCount);
     }
     return null;
   };

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -29,6 +29,10 @@ const clamp = (value: number, min: number, max: number) =>
 /**
  * Labels for internationalization of Pagination component.
  * All labels have English defaults and can be overridden for other locales.
+ *
+ * Note: To customize the "Showing X-Y of Z" text, use the `children` render prop
+ * on `Pagination.Info` instead. To customize the "Per page:" label, use the
+ * `label` prop on `Pagination.PageSize`.
  */
 export interface PaginationLabels {
   /** Aria label for the first page button. @default "First page" */
@@ -43,13 +47,6 @@ export interface PaginationLabels {
   pageNumber?: string;
   /** Aria label for the page size select. @default "Page size" */
   pageSize?: string;
-  /** Label text shown before the page size selector. @default "Per page:" */
-  perPageLabel?: string;
-  /**
-   * Function to format the "Showing X-Y of Z" info text.
-   * @default (range, total) => `Showing ${range} of ${total}`
-   */
-  showingInfo?: (range: string, total: number) => ReactNode;
 }
 
 const DEFAULT_LABELS: Required<PaginationLabels> = {
@@ -59,13 +56,6 @@ const DEFAULT_LABELS: Required<PaginationLabels> = {
   lastPage: "Last page",
   pageNumber: "Page number",
   pageSize: "Page size",
-  perPageLabel: "Per page:",
-  showingInfo: (range, total) => (
-    <>
-      Showing <span className="tabular-nums">{range}</span> of{" "}
-      <span className="tabular-nums">{total}</span>
-    </>
-  ),
 };
 
 /** Pagination controls variant definitions. */
@@ -149,14 +139,17 @@ export interface PaginationInfoProps {
 }
 
 function PaginationInfo({ children, className }: PaginationInfoProps) {
-  const { page, perPage, totalCount, pageShowingRange, labels } =
+  const { page, perPage, totalCount, pageShowingRange } =
     usePaginationContext();
 
-  const content = children
-    ? children({ page, perPage, totalCount, pageShowingRange })
-    : totalCount && totalCount > 0
-      ? labels.showingInfo(pageShowingRange, totalCount)
-      : null;
+  const content = children ? (
+    children({ page, perPage, totalCount, pageShowingRange })
+  ) : totalCount && totalCount > 0 ? (
+    <>
+      Showing <span className="tabular-nums">{pageShowingRange}</span> of{" "}
+      <span className="tabular-nums">{totalCount}</span>
+    </>
+  ) : null;
 
   return (
     <div
@@ -183,7 +176,7 @@ export interface PaginationPageSizeProps {
   options?: number[];
   /**
    * Label text shown before the selector.
-   * @default "Per page:" (or i18n override from Pagination labels prop)
+   * @default "Per page:"
    */
   label?: ReactNode;
   /** Additional CSS classes */
@@ -194,21 +187,17 @@ function PaginationPageSize({
   value,
   onChange,
   options = DEFAULT_PAGE_SIZE_OPTIONS as unknown as number[],
-  label,
+  label = "Per page:",
   className,
 }: PaginationPageSizeProps) {
   const { labels } = usePaginationContext();
-  // Use explicit label if provided, otherwise fall back to i18n label from context
-  const displayLabel = label ?? labels.perPageLabel;
 
   return (
     <div
       data-slot="pagination-page-size"
       className={cn("flex items-center gap-2", className)}
     >
-      {displayLabel && (
-        <span className="text-sm text-kumo-strong">{displayLabel}</span>
-      )}
+      {label && <span className="text-sm text-kumo-strong">{label}</span>}
       <Select
         aria-label={labels.pageSize}
         value={value}
@@ -404,7 +393,12 @@ interface PaginationBaseProps {
   /** Additional CSS classes for the container */
   className?: string;
   /**
-   * Labels for internationalization. All labels have English defaults.
+   * Labels for internationalization of aria-labels. All labels have English defaults.
+   *
+   * For visible text like "Showing X of Y", use render props on sub-components:
+   * - `Pagination.Info` children for the info text
+   * - `Pagination.PageSize` label prop for the "Per page:" text
+   *
    * @example
    * ```tsx
    * <Pagination
@@ -415,8 +409,6 @@ interface PaginationBaseProps {
    *     lastPage: "Dernière page",
    *     pageNumber: "Numéro de page",
    *     pageSize: "Taille de page",
-   *     perPageLabel: "Par page :",
-   *     showingInfo: (range, total) => `Affichage de ${range} sur ${total}`,
    *   }}
    *   // ...
    * />
@@ -587,7 +579,12 @@ function PaginationRoot(props: PaginationProps) {
     if (text) {
       return text({ page, perPage, totalCount, pageShowingRange });
     } else if (totalCount && totalCount > 0) {
-      return labels.showingInfo(pageShowingRange, totalCount);
+      return (
+        <>
+          Showing <span className="tabular-nums">{pageShowingRange}</span> of{" "}
+          <span className="tabular-nums">{totalCount}</span>
+        </>
+      );
     }
     return null;
   };


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### Pagination i18n

Adds a `labels` prop to the Pagination component for internationalization of **aria-label strings only**:
- `firstPage`, `previousPage`, `nextPage`, `lastPage` - navigation button aria-labels
- `pageNumber` - page input/select aria-label
- `pageSize` - page size select aria-label

All labels have English defaults for backwards compatibility.

For **visible text** customization, use the existing render prop APIs:
- `Pagination.Info` children for "Showing X of Y" text
- `Pagination.PageSize` label prop for "Per page:" text

### Input accessibility fix

Fixes the dev-mode accessibility warning that incorrectly required **both** `placeholder` AND `aria-label`. Now `aria-label` alone is sufficient, which is correct per WCAG guidelines.

## Usage

```tsx
<Pagination
  labels={{
    firstPage: "Première page",
    previousPage: "Page précédente",
    nextPage: "Page suivante",
    lastPage: "Dernière page",
    pageNumber: "Numéro de page",
    pageSize: "Taille de page",
  }}
  page={page}
  setPage={setPage}
  perPage={10}
  totalCount={100}
>
  <Pagination.Info>
    {({ pageShowingRange, totalCount }) => (
      <>
        Affichage de {pageShowingRange} sur {totalCount}
      </>
    )}
  </Pagination.Info>
  <Pagination.PageSize label="Par page :" value={perPage} onChange={setPerPage} />
  <Pagination.Controls />
</Pagination>
```

---

- Reviews
  - [x] bonk has reviewed the change
  - [x] automated review not possible because: i18n API design requires human review
- Tests
  - [x] Additional testing not necessary because: backwards compatible change with sensible defaults, no runtime behavior changes