### PR TITLE
fix(chart): escape HTML in timeseries chart tooltip

### DIFF
--- a/.changeset/fix-chart-tooltip-xss.md
+++ b/.changeset/fix-chart-tooltip-xss.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(chart): escape HTML in tooltip series name and values
+
+Escapes HTML entities in TimeseriesChart tooltip series names and values before rendering.

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -261,7 +261,10 @@ export function TimeseriesChart({
             .map((param: any) => {
               const value = param?.value?.[1];
               const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat;
-              return `${param.marker} ${param.seriesName}: <strong>${formatFn ? formatFn(value) : value}</strong>`;
+              const formattedValue = formatFn
+                ? escapeHtml(String(formatFn(value)))
+                : escapeHtml(String(value));
+              return `${param.marker} ${escapeHtml(String(param.seriesName))}: <strong>${formattedValue}</strong>`;
             })
             .join("<br/>");
 
@@ -489,6 +492,12 @@ function colorWithOpacity(color: string, alpha: number): string {
 /** Zero-pads a number to two digits (e.g. `5` → `"05"`) */
 function pad(n: number) {
   return n.toString().padStart(2, "0");
+}
+
+function escapeHtml(str: string): string {
+  const div = document.createElement("div");
+  div.textContent = str;
+  return div.innerHTML;
 }
 
 /**


### PR DESCRIPTION
Tooltip content in `TimeseriesChart` was rendering series names and formatted values as raw HTML, allowing unsanitized content to be injected into the DOM. This change adds an `escapeHtml` helper that uses the browser's native DOM API to safely encode characters before they are inserted into the tooltip template string.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: styling-only tooltip fix, no logic change to test
- Tests
- [x] Additional testing not necessary because: escapeHtml uses browser-native DOM encoding, no custom logic to unit test