### PR TITLE
Add copy to clipboard to all code blocks

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/CodeBlock.astro
+++ b/packages/kumo-docs-astro/src/components/docs/CodeBlock.astro
@@ -9,9 +9,7 @@ interface Props {
 const { code, lang = "tsx" } = Astro.props;
 ---
 
-<div
-  class="not-prose code-block"
->
+<div class="not-prose code-block relative">
   <Code 
     code={code} 
     lang={lang} 
@@ -21,27 +19,22 @@ const { code, lang = "tsx" } = Astro.props;
     }}
     defaultColor={false}
   />
+  <button
+    type="button"
+    class="code-block-copy-btn"
+    aria-label="Copy code to clipboard"
+  >
+    <span class="code-block-copy-btn__icons">
+      <span class="code-block-copy-btn__icon code-block-copy-btn__icon--check" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+          <path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"></path>
+        </svg>
+      </span>
+      <span class="code-block-copy-btn__icon code-block-copy-btn__icon--copy" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+          <path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"></path>
+        </svg>
+      </span>
+    </span>
+  </button>
 </div>
-
-<style is:global>
-  .code-block .astro-code {
-    padding: 1rem;
-    margin: 0;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    overflow-x: auto;
-  }
-
-  .code-block .astro-code,
-  .code-block .astro-code span {
-    color: var(--shiki-light) !important;
-    background-color: var(--shiki-light-bg) !important;
-  }
-  
-  /* Dark mode - use dark theme colors */
-  [data-mode="dark"] .code-block .astro-code,
-  [data-mode="dark"] .code-block .astro-code span {
-    color: var(--shiki-dark) !important;
-    background-color: var(--shiki-dark-bg) !important;
-  }
-</style>

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -16,10 +16,16 @@ declare const __DOCS_VERSION__: string;
 declare const __BUILD_COMMIT__: string;
 declare const __BUILD_DATE__: string;
 
-const kumoVersion = typeof __KUMO_VERSION__ !== "undefined" ? __KUMO_VERSION__ : "dev";
-const docsVersion = typeof __DOCS_VERSION__ !== "undefined" ? __DOCS_VERSION__ : "dev";
-const buildCommit = typeof __BUILD_COMMIT__ !== "undefined" ? __BUILD_COMMIT__ : "local";
-const buildDate = typeof __BUILD_DATE__ !== "undefined" ? __BUILD_DATE__ : new Date().toISOString();
+const kumoVersion =
+  typeof __KUMO_VERSION__ !== "undefined" ? __KUMO_VERSION__ : "dev";
+const docsVersion =
+  typeof __DOCS_VERSION__ !== "undefined" ? __DOCS_VERSION__ : "dev";
+const buildCommit =
+  typeof __BUILD_COMMIT__ !== "undefined" ? __BUILD_COMMIT__ : "local";
+const buildDate =
+  typeof __BUILD_DATE__ !== "undefined"
+    ? __BUILD_DATE__
+    : new Date().toISOString();
 ---
 
 <!doctype html>
@@ -44,7 +50,7 @@ const buildDate = typeof __BUILD_DATE__ !== "undefined" ? __BUILD_DATE__ : new D
     <script is:inline>
       // Initialize theme from localStorage or system preference
       // This runs immediately (blocking) to prevent flash of unstyled content
-      (function() {
+      (function () {
         const stored = localStorage.getItem("theme");
         if (stored) {
           document.documentElement.setAttribute("data-mode", stored);
@@ -56,5 +62,87 @@ const buildDate = typeof __BUILD_DATE__ !== "undefined" ? __BUILD_DATE__ : new D
   </head>
   <body>
     <slot />
+    <script>
+      function initCopyButtons() {
+        document.querySelectorAll("pre.astro-code").forEach((pre) => {
+          // Skip <pre> elements already inside a .code-block parent
+          if (pre.parentElement?.classList.contains("code-block")) return;
+
+          // Wrap in .code-block relative
+          const wrapper = document.createElement("div");
+          wrapper.className = "code-block relative";
+
+          if (!pre.parentNode) return;
+
+          pre.parentNode.insertBefore(wrapper, pre);
+          wrapper.appendChild(pre);
+
+          // Create button with innerHTML for simplicity
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "code-block-copy-btn";
+          button.setAttribute("aria-label", "Copy code to clipboard");
+          button.innerHTML = `
+            <span class="code-block-copy-btn__icons">
+              <span class="code-block-copy-btn__icon code-block-copy-btn__icon--check" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"></path>
+                </svg>
+              </span>
+              <span class="code-block-copy-btn__icon code-block-copy-btn__icon--copy" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256">
+                  <path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"></path>
+                </svg>
+              </span>
+            </span>
+          `;
+
+          // Append button to the wrapper, as a sibling of <pre>
+          wrapper.appendChild(button);
+        });
+
+        // Click handler via event delegation
+        const timers = new WeakMap<Element, ReturnType<typeof setTimeout>>();
+        document.addEventListener("click", async (e) => {
+          const btn = (e.target as Element).closest(".code-block-copy-btn");
+
+          if (!btn) return;
+
+          const pre = btn.closest(".code-block")?.querySelector("pre");
+
+          if (!pre) return;
+
+          const code = pre.textContent || "";
+
+          const existingTimer = timers.get(btn);
+
+          if (existingTimer) clearTimeout(existingTimer);
+
+          // Set animation immediately (optimistic)
+          btn.setAttribute("data-copied", "");
+          btn.setAttribute("aria-label", "Copied!");
+
+          try {
+            await navigator.clipboard.writeText(code);
+          } catch {
+            // Roll back on failure
+            btn.removeAttribute("data-copied");
+            btn.setAttribute("aria-label", "Copy code to clipboard");
+            return;
+          }
+
+          timers.set(
+            btn,
+            setTimeout(() => {
+              btn.removeAttribute("data-copied");
+              btn.setAttribute("aria-label", "Copy code to clipboard");
+              timers.delete(btn);
+            }, 1500),
+          );
+        });
+      }
+
+      initCopyButtons();
+    </script>
   </body>
 </html>

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -224,16 +224,13 @@ pre.astro-code {
    ========================================================================== */
 
 .code-block-copy-btn {
-  @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none focus-visible:outline-none;
+  @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);
   color: var(--text-color-kumo-subtle);
+  ring-color: var(--color-kumo-hairline);
 
   &:hover {
     background: var(--color-kumo-tint);
-  }
-
-  &:focus-visible {
-    box-shadow: 0 0 0 2px var(--color-kumo-ring);
   }
 }
 

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -100,6 +100,7 @@ html {
 .kumo-prose :where(a):not(:where(.not-prose, .not-prose *)) {
   text-decoration: none;
 }
+
 .kumo-prose :where(a):not(:where(.not-prose, .not-prose *)):hover {
   text-decoration: underline;
 }
@@ -157,9 +158,11 @@ html {
 .kumo-prose :where(table) {
   width: 100%;
 }
+
 .kumo-prose :where(thead) {
   border-bottom-color: var(--color-kumo-hairline);
 }
+
 .kumo-prose :where(thead th) {
   color: var(--color-kumo-default);
   font-weight: 600;
@@ -185,7 +188,16 @@ html {
    Dual theme support: light (github-light) and dark (vesper)
    ========================================================================== */
 
-/* Container styling for all code blocks (markdown + CodeBlock component) */
+/* Code block inside wrapper — extra right padding so text clears the copy button */
+.code-block .astro-code {
+  padding: 0.875rem 2rem 0.875rem 1rem;
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+/* Container styling for standalone code blocks (not yet wrapped by JS) */
 pre.astro-code {
   overflow: hidden;
   border-radius: 0.5rem;
@@ -205,4 +217,64 @@ pre.astro-code {
 [data-mode="dark"] .astro-code span {
   color: var(--shiki-dark) !important;
   background-color: var(--shiki-dark-bg) !important;
+}
+
+/* ==========================================================================
+   Code block copy button
+   ========================================================================== */
+
+.code-block-copy-btn {
+  @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none focus-visible:outline-none;
+  background: var(--color-kumo-base);
+  color: var(--text-color-kumo-subtle);
+
+  &:hover {
+    background: var(--color-kumo-tint);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--color-kumo-ring);
+  }
+}
+
+/* Icon wrapper — relative + overflow-hidden for slide animation */
+.code-block-copy-btn__icons {
+  @apply relative overflow-hidden size-4;
+}
+
+/* Both icons stacked absolutely */
+.code-block-copy-btn__icon {
+  @apply absolute inset-0 flex items-center justify-center;
+  transition:
+    transform 200ms,
+    opacity 200ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-block-copy-btn__icon {
+    transition: none;
+  }
+}
+
+/* Check icon: hidden below by default, slides up when copied */
+.code-block-copy-btn__icon--check {
+  opacity: 0;
+  transform: translateY(100%);
+}
+
+/* Copy icon: visible by default, slides up when copied */
+.code-block-copy-btn__icon--copy {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Copied state */
+.code-block-copy-btn[data-copied] .code-block-copy-btn__icon--check {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.code-block-copy-btn[data-copied] .code-block-copy-btn__icon--copy {
+  opacity: 0;
+  transform: translateY(-100%);
 }


### PR DESCRIPTION
Adds a copy-to-clipboard button to every code block in the docs site.

Users frequently need to copy code snippets from the docs (install commands, usage examples, API references) but had no way to do so without manually selecting text. The button makes this a single click.

https://github.com/user-attachments/assets/159a91ef-9bdc-4fce-8aea-8efcda5b91e3

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->
- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only change, no modifications to the published `@cloudflare/kumo` component library
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: docs-only content changes