### PR TITLE
fix(Checkbox): preserve native event APIs in onChange compat layer

### DIFF
--- a/.changeset/fix-checkbox-onchange-target.md
+++ b/.changeset/fix-checkbox-onchange-target.md
@@ -2,7 +2,7 @@
 "@cloudflare/kumo": patch
 ---
 
-fix(Checkbox): use Object.create instead of Object.assign to avoid crashing on read-only Event.target
+fix(Checkbox): use Proxy instead of Object.assign to avoid crashing on read-only Event.target
 
 The deprecated `onChange` handler used `Object.assign(event, { target: ... })` which throws
 `TypeError: Cannot set property target of #<Event> which has only a getter` because `Event.target`

--- a/.changeset/fix-checkbox-onchange-target.md
+++ b/.changeset/fix-checkbox-onchange-target.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(Checkbox): use Object.create instead of Object.assign to avoid crashing on read-only Event.target
+
+The deprecated `onChange` handler used `Object.assign(event, { target: ... })` which throws
+`TypeError: Cannot set property target of #<Event> which has only a getter` because `Event.target`
+is a read-only getter property. Replaced with `Object.create` to create a new object that shadows
+the prototype getter with an own `target` property.
+
+Fixes #409

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,21 +5,100 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.0"
+        "@opencode-ai/plugin": "1.4.6"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.0.tgz",
-      "integrity": "sha512-VFIff6LHp/RVaJdrK3EQ1ijx0K1tV5i1DY5YJ+pRqwC6trunPHbvqSN0GHSTZX39RdnSc+XuzCTZQCy1W2qNOg==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.6.tgz",
+      "integrity": "sha512-w+55uE4tCpFoK+MtWeGoPDmpuuabw8m5WVpmucIKoTO5SgD/3EwXVPBqAh44iS72ve1Eu+uhhzeVQ070x9bVjg==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.0",
+        "@opencode-ai/sdk": "1.4.6",
+        "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.97",
-        "@opentui/solid": ">=0.1.97"
+        "@opentui/core": ">=0.1.99",
+        "@opentui/solid": ">=0.1.99"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -31,13 +110,19 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.6.tgz",
+      "integrity": "sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -53,11 +138,134 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
+      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -67,6 +275,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -89,6 +313,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -102,6 +348,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/packages/kumo/src/components/checkbox/checkbox.test.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLegacyCheckboxChangeEvent } from "./checkbox";
+
+describe("Checkbox", () => {
+  it("preserves native event APIs on deprecated onChange callbacks", () => {
+    const nativeEvent = new MouseEvent("click", { cancelable: true });
+    const onChange = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+      expect(event.target.checked).toBe(true);
+      expect(event.currentTarget.checked).toBe(true);
+      expect(event instanceof Event).toBe(true);
+
+      event.preventDefault();
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(typeof event.timeStamp).toBe("number");
+    });
+
+    const event = createLegacyCheckboxChangeEvent(nativeEvent, true);
+
+    expect(() => onChange(event)).not.toThrow();
+    expect(onChange).toHaveBeenCalledWith(event);
+  });
+});

--- a/packages/kumo/src/components/checkbox/checkbox.test.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.test.tsx
@@ -1,23 +1,32 @@
-import { describe, expect, it, vi } from "vitest";
-import { createLegacyCheckboxChangeEvent } from "./checkbox";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Checkbox } from "./checkbox";
 
 describe("Checkbox", () => {
   it("preserves native event APIs on deprecated onChange callbacks", () => {
-    const nativeEvent = new MouseEvent("click", { cancelable: true });
-    const onChange = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
-      expect(event.target.checked).toBe(true);
-      expect(event.currentTarget.checked).toBe(true);
-      expect(event instanceof Event).toBe(true);
+    const events: Array<React.ChangeEvent<HTMLInputElement>> = [];
 
-      event.preventDefault();
+    render(
+      <Checkbox
+        label="Accept terms"
+        onChange={(event) => {
+          events.push(event);
+        }}
+      />,
+    );
 
-      expect(event.defaultPrevented).toBe(true);
-      expect(typeof event.timeStamp).toBe("number");
-    });
+    expect(() => fireEvent.click(screen.getByRole("checkbox"))).not.toThrow();
+    expect(events.length).toBeGreaterThan(0);
 
-    const event = createLegacyCheckboxChangeEvent(nativeEvent, true);
+    const event = events[0];
 
-    expect(() => onChange(event)).not.toThrow();
-    expect(onChange).toHaveBeenCalledWith(event);
+    expect(event).toBeDefined();
+    expect(event.target.checked).toBe(true);
+    expect(event.currentTarget.checked).toBe(true);
+    expect(event instanceof Event).toBe(true);
+
+    expect(() => event.preventDefault()).not.toThrow();
+    expect(event.defaultPrevented).toBe(true);
+    expect(typeof event.timeStamp).toBe("number");
   });
 });

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -56,48 +56,38 @@ const CheckboxGroupContext = createContext<{ controlFirst: boolean }>({
   controlFirst: true,
 });
 
-type CheckboxLikeTarget = EventTarget & HTMLInputElement;
-
-function createLegacyCheckboxTarget(
-  target: EventTarget | null,
-  checked: boolean,
-): CheckboxLikeTarget {
-  if (!target || (typeof target !== "object" && typeof target !== "function")) {
-    return { checked } as CheckboxLikeTarget;
-  }
-
-  return new Proxy(target as object, {
-    get(targetObject, property) {
-      if (property === "checked") {
-        return checked;
+function brandSafeProxy<T extends object>(
+  source: T,
+  overrides: Record<PropertyKey, unknown>,
+): T {
+  return new Proxy(source, {
+    get(target, property) {
+      if (Object.hasOwn(overrides, property)) {
+        return overrides[property];
       }
 
-      const value = Reflect.get(targetObject, property, targetObject);
-      return typeof value === "function" ? value.bind(targetObject) : value;
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
     },
-  }) as CheckboxLikeTarget;
+  });
 }
 
-export function createLegacyCheckboxChangeEvent(
+function createLegacyCheckboxChangeEvent(
   event: Event,
   checked: boolean,
 ): React.ChangeEvent<HTMLInputElement> {
-  const target = createLegacyCheckboxTarget(event.target, checked);
-  const currentTarget = createLegacyCheckboxTarget(event.currentTarget, checked);
+  const target = brandSafeProxy(
+    (event.target ?? {}) as EventTarget & HTMLInputElement,
+    { checked },
+  );
+  const currentTarget = brandSafeProxy(
+    (event.currentTarget ?? {}) as EventTarget & HTMLInputElement,
+    { checked },
+  );
 
-  return new Proxy(event, {
-    get(targetEvent, property) {
-      if (property === "target") {
-        return target;
-      }
-
-      if (property === "currentTarget") {
-        return currentTarget;
-      }
-
-      const value = Reflect.get(targetEvent, property, targetEvent);
-      return typeof value === "function" ? value.bind(targetEvent) : value;
-    },
+  return brandSafeProxy(event, {
+    target,
+    currentTarget,
   }) as unknown as React.ChangeEvent<HTMLInputElement>;
 }
 

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -245,8 +245,8 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       if (onChange) {
         // Backwards compatibility: extend native event with target.checked
         // so existing code using `e.target.checked` continues to work
-        const event = Object.assign(eventDetails.event, {
-          target: { checked: newChecked },
+        const event = Object.create(eventDetails.event, {
+          target: { value: { checked: newChecked } },
         });
         onChange(event as never);
       }

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -56,6 +56,51 @@ const CheckboxGroupContext = createContext<{ controlFirst: boolean }>({
   controlFirst: true,
 });
 
+type CheckboxLikeTarget = EventTarget & HTMLInputElement;
+
+function createLegacyCheckboxTarget(
+  target: EventTarget | null,
+  checked: boolean,
+): CheckboxLikeTarget {
+  if (!target || (typeof target !== "object" && typeof target !== "function")) {
+    return { checked } as CheckboxLikeTarget;
+  }
+
+  return new Proxy(target as object, {
+    get(targetObject, property) {
+      if (property === "checked") {
+        return checked;
+      }
+
+      const value = Reflect.get(targetObject, property, targetObject);
+      return typeof value === "function" ? value.bind(targetObject) : value;
+    },
+  }) as CheckboxLikeTarget;
+}
+
+export function createLegacyCheckboxChangeEvent(
+  event: Event,
+  checked: boolean,
+): React.ChangeEvent<HTMLInputElement> {
+  const target = createLegacyCheckboxTarget(event.target, checked);
+  const currentTarget = createLegacyCheckboxTarget(event.currentTarget, checked);
+
+  return new Proxy(event, {
+    get(targetEvent, property) {
+      if (property === "target") {
+        return target;
+      }
+
+      if (property === "currentTarget") {
+        return currentTarget;
+      }
+
+      const value = Reflect.get(targetEvent, property, targetEvent);
+      return typeof value === "function" ? value.bind(targetEvent) : value;
+    },
+  }) as unknown as React.ChangeEvent<HTMLInputElement>;
+}
+
 /**
  * Single checkbox component props with accessibility guidance.
  *
@@ -245,9 +290,10 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       if (onChange) {
         // Backwards compatibility: extend native event with target.checked
         // so existing code using `e.target.checked` continues to work
-        const event = Object.create(eventDetails.event, {
-          target: { value: { checked: newChecked } },
-        });
+        const event = createLegacyCheckboxChangeEvent(
+          eventDetails.event,
+          newChecked,
+        );
         onChange(event as never);
       }
     };


### PR DESCRIPTION
## What

Fix the deprecated `onChange` compatibility path on `Checkbox` so it no longer crashes on read-only `Event.target` and still preserves native event APIs.

## Why

`Object.assign(eventDetails.event, { target: { checked: newChecked } })` tries to write to `Event.target`, which is a read-only getter on native DOM events and crashes in modern browsers.

The first fix using `Object.create(eventDetails.event, { target: ... })` avoided that write, but it also stopped passing a real native event object through the deprecated `onChange` path. Brand-checked APIs like `preventDefault()`, `defaultPrevented`, and `timeStamp` could then break.

This version proxies the original event and only overrides `target.checked` and `currentTarget.checked`, while binding the rest of the event API back to the native event object.

## Test Results

Added a focused unit test for the deprecated `onChange` compatibility path that verifies:

- `target.checked` and `currentTarget.checked` reflect the new value
- native event APIs like `preventDefault()`, `defaultPrevented`, and `timeStamp` still work

Commands run:

- `pnpm --filter @cloudflare/kumo exec vitest run src/components/checkbox/checkbox.test.tsx`
- `pnpm --filter @cloudflare/kumo exec tsc --noEmit`
- `pnpm --filter @cloudflare/kumo test` (still hits the pre-existing `tests/imports/export-path-validation.test.ts` failures for `table-of-contents` dist artifacts)

Fixes #409

---

AI disclosure: Claude Opus 4.6 (via Amp) authored the original patch; GPT 5.4 (via Codex) updated the fix after review to preserve native event semantics and added regression coverage.

- Reviews
- [x] bonk has reviewed the change
- [x] automated review not possible because: external contributor without access to bonk
- Tests
- [x] Tests included/updated
