### PR TITLE
[Preview] Docs: Typography overhaul and heading system (combined 1/5–5/5)

### DIFF
--- a/packages/kumo-docs-astro/astro.config.mjs
+++ b/packages/kumo-docs-astro/astro.config.mjs
@@ -11,6 +11,7 @@ import { kumoColorsPlugin } from "./src/lib/vite-plugin-kumo-colors.js";
 import { kumoRegistryPlugin } from "./src/lib/vite-plugin-kumo-registry.js";
 import { kumoHmrPlugin } from "./src/lib/vite-plugin-kumo-hmr.js";
 import { markdownPages } from "./src/lib/astro-markdown-pages.js";
+import { remarkHeadingComponents } from "./src/lib/remark-heading-components.js";
 
 import sitemap from "@astrojs/sitemap";
 
@@ -71,7 +72,12 @@ const kumoSrc = resolve(__dirname, "../kumo/src");
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [mdx(), react(), sitemap(), markdownPages()],
+  integrations: [
+    mdx({ remarkPlugins: [remarkHeadingComponents] }),
+    react(),
+    sitemap(),
+    markdownPages(),
+  ],
   site: "https://kumo-ui.com/",
   markdown: {
     shikiConfig: {

--- a/packages/kumo-docs-astro/package.json
+++ b/packages/kumo-docs-astro/package.json
@@ -39,6 +39,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^4.2.1",
     "@tailwindcss/vite": "catalog:",
+    "@types/mdast": "^4.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "oxlint": "catalog:",

--- a/packages/kumo-docs-astro/package.json
+++ b/packages/kumo-docs-astro/package.json
@@ -39,7 +39,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^4.2.1",
     "@tailwindcss/vite": "catalog:",
-    "@types/mdast": "^4.0.4",
+    "@types/mdast": "4.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "oxlint": "catalog:",

--- a/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
@@ -11,8 +11,7 @@ const proseStyles = cn(
   "[&>:first-child]:mt-0 [&>:last-child]:mb-0",
   "[&_h1]:text-xl [&_h2]:text-lg [&_h3]:text-base",
   "[&_:is(h1,h2,h3)]:font-semibold [&_:is(h1,h2,h3)]:text-kumo-default",
-  "[&_p]:text-kumo-default",
-  "[&_pre]:overflow-x-auto",
+  "[&_pre]:overflow-x-auto [&_pre]:text-base",
 );
 
 interface ChangelogEntryProps {

--- a/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
@@ -12,7 +12,7 @@ const proseStyles = cn(
   "[&_h1]:text-xl [&_h2]:text-lg [&_h3]:text-base",
   "[&_:is(h1,h2,h3)]:font-semibold [&_:is(h1,h2,h3)]:text-kumo-default",
   "[&_p]:text-kumo-default",
-  "[&_pre]:overflow-x-auto",
+  "[&_pre]:overflow-x-auto [&_pre]:text-base",
 );
 
 interface ChangelogEntryProps {

--- a/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
@@ -11,7 +11,7 @@ const proseStyles = cn(
   "[&>:first-child]:mt-0 [&>:last-child]:mb-0",
   "[&_h1]:text-xl [&_h2]:text-lg [&_h3]:text-base",
   "[&_:is(h1,h2,h3)]:font-semibold [&_:is(h1,h2,h3)]:text-kumo-default",
-  "[&_pre]:overflow-x-auto [&_pre]:text-base",
+  "[&_pre]:overflow-x-auto",
 );
 
 interface ChangelogEntryProps {

--- a/packages/kumo-docs-astro/src/components/docs/ComponentSection.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentSection.astro
@@ -2,6 +2,6 @@
 // Simple section wrapper for component documentation
 ---
 
-<section class="mb-12">
+<section class="mb-8">
   <slot />
 </section>

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -40,6 +40,7 @@ const baseStyles = levelStyles[level];
   <a
     href={`#${slug}`}
     class="no-underline hover:underline"
+    aria-label={`Link to section: ${textContent}`}
   >
     <span
       class="absolute -left-6 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100"

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -35,7 +35,7 @@ const baseStyles = levelStyles[level];
 
 <Element
   id={slug}
-  class:list={["group relative scroll-mt-24", baseStyles, className]}
+  class:list={["group relative scroll-mt-24 tracking-[-0.02em]", baseStyles, className]}
 >
   <a
     href={`#${slug}`}

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -1,5 +1,5 @@
 ---
-import { LinkSimple } from "@phosphor-icons/react";
+import { LinkSimple as LinkSimpleIcon } from "@phosphor-icons/react";
 
 interface Props {
   level: 2 | 3 | 4;
@@ -45,7 +45,7 @@ const baseStyles = levelStyles[level];
       class="absolute -left-6 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100"
       aria-hidden="true"
     >
-      <LinkSimple className="size-4 text-kumo-subtle" />
+      <LinkSimpleIcon className="size-4 text-kumo-subtle" />
     </span>
     <slot />
   </a>

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -23,9 +23,9 @@ const slug =
 
 // Define styles for each heading level
 const levelStyles = {
-  2: "mb-4 text-2xl font-bold",
+  2: "mb-4 text-2xl font-semibold",
   3: "mb-4 text-xl font-semibold",
-  4: "mb-3 text-base font-medium",
+  4: "mb-3 text-base font-semibold",
 };
 
 // Dynamic tag - must be capitalized for Astro

--- a/packages/kumo-docs-astro/src/components/docs/mdx/H2.astro
+++ b/packages/kumo-docs-astro/src/components/docs/mdx/H2.astro
@@ -1,0 +1,7 @@
+---
+import Heading from "../Heading.astro";
+const { id, class: className } = Astro.props;
+---
+<Heading level={2} id={id} class={className}>
+  <slot />
+</Heading>

--- a/packages/kumo-docs-astro/src/components/docs/mdx/H3.astro
+++ b/packages/kumo-docs-astro/src/components/docs/mdx/H3.astro
@@ -1,0 +1,7 @@
+---
+import Heading from "../Heading.astro";
+const { id, class: className } = Astro.props;
+---
+<Heading level={3} id={id} class={className}>
+  <slot />
+</Heading>

--- a/packages/kumo-docs-astro/src/components/docs/mdx/H4.astro
+++ b/packages/kumo-docs-astro/src/components/docs/mdx/H4.astro
@@ -1,0 +1,7 @@
+---
+import Heading from "../Heading.astro";
+const { id, class: className } = Astro.props;
+---
+<Heading level={4} id={id} class={className}>
+  <slot />
+</Heading>

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -39,6 +39,7 @@ const buildDate =
     <meta name="build-date" content={buildDate} />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -29,7 +29,7 @@ const buildDate =
 ---
 
 <!doctype html>
-<html class="bg-kumo-canvas" lang="en">
+<html class="bg-kumo-canvas text-kumo-default" lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kumo-docs-astro/src/lib/astro-markdown-pages.ts
+++ b/packages/kumo-docs-astro/src/lib/astro-markdown-pages.ts
@@ -99,6 +99,11 @@ export function markdownPages(): AstroIntegration {
 
             const markdown = htmlToMarkdown(html);
 
+            if (!markdown.trim()) {
+              skipped++;
+              continue;
+            }
+
             // changelog/all/index.html → changelog.md, others → sibling .md
             const mdFile = htmlFile.endsWith(changelogAllPage)
               ? join(outDir, "changelog.md")

--- a/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
+++ b/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
@@ -12,8 +12,7 @@ import type { Root } from "mdast";
 export function remarkHeadingComponents() {
   return (tree: Root) => {
     // Inject import statements at the top of the MDX AST.
-    // Uses underscore-prefixed names to avoid conflicts with any
-    // existing imports in MDX files.
+    // Uses underscore-prefixed names to avoid conflicts with existing imports in MDX files.
     const importNode = {
       type: "mdxjsEsm",
       value: `import _H2 from '~/components/docs/mdx/H2.astro';

--- a/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
+++ b/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
@@ -1,0 +1,134 @@
+import type { Root } from "mdast";
+
+/**
+ * Remark plugin that injects MDX component overrides for headings.
+ * This makes markdown ## / ### / #### render using the Heading.astro component
+ * instead of plain HTML heading elements.
+ *
+ * Replaces the old rehype-heading-links plugin by delegating heading rendering
+ * entirely to Heading.astro via MDX component overrides, eliminating duplicated
+ * heading logic (slugification, styling, link icon).
+ */
+export function remarkHeadingComponents() {
+  return (tree: Root) => {
+    // Inject import statements at the top of the MDX AST.
+    // Uses underscore-prefixed names to avoid conflicts with any
+    // existing imports in MDX files.
+    const importNode = {
+      type: "mdxjsEsm",
+      value: `import _H2 from '~/components/docs/mdx/H2.astro';
+import _H3 from '~/components/docs/mdx/H3.astro';
+import _H4 from '~/components/docs/mdx/H4.astro';`,
+      data: {
+        estree: {
+          type: "Program",
+          sourceType: "module",
+          body: [
+            {
+              type: "ImportDeclaration",
+              source: {
+                type: "Literal",
+                value: "~/components/docs/mdx/H2.astro",
+              },
+              specifiers: [
+                {
+                  type: "ImportDefaultSpecifier",
+                  local: { type: "Identifier", name: "_H2" },
+                },
+              ],
+            },
+            {
+              type: "ImportDeclaration",
+              source: {
+                type: "Literal",
+                value: "~/components/docs/mdx/H3.astro",
+              },
+              specifiers: [
+                {
+                  type: "ImportDefaultSpecifier",
+                  local: { type: "Identifier", name: "_H3" },
+                },
+              ],
+            },
+            {
+              type: "ImportDeclaration",
+              source: {
+                type: "Literal",
+                value: "~/components/docs/mdx/H4.astro",
+              },
+              specifiers: [
+                {
+                  type: "ImportDefaultSpecifier",
+                  local: { type: "Identifier", name: "_H4" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    // Inject: export const components = { h2: _H2, h3: _H3, h4: _H4 };
+    const exportNode = {
+      type: "mdxjsEsm",
+      value: "export const components = { h2: _H2, h3: _H3, h4: _H4 };",
+      data: {
+        estree: {
+          type: "Program",
+          sourceType: "module",
+          body: [
+            {
+              type: "ExportNamedDeclaration",
+              declaration: {
+                type: "VariableDeclaration",
+                kind: "const" as const,
+                declarations: [
+                  {
+                    type: "VariableDeclarator",
+                    id: { type: "Identifier", name: "components" },
+                    init: {
+                      type: "ObjectExpression",
+                      properties: [
+                        {
+                          type: "Property",
+                          key: { type: "Identifier", name: "h2" },
+                          value: { type: "Identifier", name: "_H2" },
+                          kind: "init" as const,
+                          computed: false,
+                          method: false,
+                          shorthand: false,
+                        },
+                        {
+                          type: "Property",
+                          key: { type: "Identifier", name: "h3" },
+                          value: { type: "Identifier", name: "_H3" },
+                          kind: "init" as const,
+                          computed: false,
+                          method: false,
+                          shorthand: false,
+                        },
+                        {
+                          type: "Property",
+                          key: { type: "Identifier", name: "h4" },
+                          value: { type: "Identifier", name: "_H4" },
+                          kind: "init" as const,
+                          computed: false,
+                          method: false,
+                          shorthand: false,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              specifiers: [],
+            },
+          ],
+        },
+      },
+    };
+
+    // Prepend import and export nodes to the tree
+    tree.children.unshift(importNode as any, exportNode as any);
+  };
+}

--- a/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
+++ b/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
@@ -1,5 +1,18 @@
 import type { Root } from "mdast";
 
+/** MDX ESM node shape used by mdast-util-mdxjs-esm / remark-mdx. */
+interface MdxjsEsmNode {
+  type: "mdxjsEsm";
+  value: string;
+  data: {
+    estree: {
+      type: "Program";
+      sourceType: "module";
+      body: Record<string, unknown>[];
+    };
+  };
+}
+
 /**
  * Remark plugin that injects MDX component overrides for headings.
  * This makes markdown ## / ### / #### render using the Heading.astro component
@@ -13,7 +26,7 @@ export function remarkHeadingComponents() {
   return (tree: Root) => {
     // Inject import statements at the top of the MDX AST.
     // Uses underscore-prefixed names to avoid conflicts with existing imports in MDX files.
-    const importNode = {
+    const importNode: MdxjsEsmNode = {
       type: "mdxjsEsm",
       value: `import _H2 from '~/components/docs/mdx/H2.astro';
 import _H3 from '~/components/docs/mdx/H3.astro';
@@ -68,7 +81,7 @@ import _H4 from '~/components/docs/mdx/H4.astro';`,
     };
 
     // Inject: export const components = { h2: _H2, h3: _H3, h4: _H4 };
-    const exportNode = {
+    const exportNode: MdxjsEsmNode = {
       type: "mdxjsEsm",
       value: "export const components = { h2: _H2, h3: _H3, h4: _H4 };",
       data: {
@@ -127,7 +140,12 @@ import _H4 from '~/components/docs/mdx/H4.astro';`,
       },
     };
 
-    // Prepend import and export nodes to the tree
-    tree.children.unshift(importNode as any, exportNode as any);
+    // Prepend import and export nodes to the tree.
+    // MdxjsEsmNode (from mdx-js/mdx) isn't part of mdast's RootContent union,
+    // so we widen the array type to accept both standard and MDX ESM nodes.
+    (tree.children as (Root["children"][number] | MdxjsEsmNode)[]).unshift(
+      importNode,
+      exportNode,
+    );
   };
 }

--- a/packages/kumo-docs-astro/src/pages/blocks/delete-resource.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/delete-resource.mdx
@@ -5,7 +5,6 @@ description: "A confirmation dialog for safely deleting resources, requiring use
 sourceFile: "blocks/delete-resource"
 ---
 
-import Heading from "~/components/docs/Heading.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
@@ -27,7 +26,9 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
+
   <p>
     DeleteResource is a <strong>block</strong> - a CLI-installed component that
     you own and can customize. Unlike regular components, blocks are copied into
@@ -72,7 +73,8 @@ import { DeleteResource } from "./components/kumo/delete-resource/delete-resourc
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { useState } from "react";
@@ -116,9 +118,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Worker Deletion</Heading>
+## Examples
+
+### Worker Deletion
+
 <p>
   Works with any resource type - just change the resourceType and resourceName
   props.
@@ -127,7 +131,8 @@ export default function Example() {
   <DeleteResourceWorkerDemo client:load />
 </ComponentExample>
 
-  <Heading level={3}>Error State</Heading>
+### Error State
+
   <p>
     Use the errorMessage prop to show an error message.
   </p>
@@ -139,6 +144,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="DeleteResource" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
@@ -5,7 +5,6 @@ description: "A composite component that combines breadcrumbs and tabs for page 
 sourceFile: "blocks/page-header"
 ---
 
-import Heading from "~/components/docs/Heading.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
@@ -31,7 +30,9 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
+
   <p>
     PageHeader is a <strong>block</strong> - a CLI-installed component that you
     own and can customize. Unlike regular components, blocks are copied into
@@ -71,7 +72,8 @@ import { PageHeader } from "./components/kumo/page-header/page-header";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { PageHeader } from "./components/kumo/page-header/page-header";
@@ -107,39 +109,47 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic</Heading>
+## Examples
+
+### Basic
+
 <ComponentExample demo="PageHeaderBasicDemo">
   <PageHeaderBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Icons</Heading>
+### With Icons
+
 <ComponentExample demo="PageHeaderWithIconsDemo">
   <PageHeaderWithIconsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Tabs</Heading>
+### With Tabs
+
 <ComponentExample demo="PageHeaderWithTabsDemo">
   <PageHeaderWithTabsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Actions</Heading>
+### With Actions
+
 <ComponentExample demo="PageHeaderWithActionsDemo">
   <PageHeaderWithActionsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Title</Heading>
+### With Title
+
 <ComponentExample demo="PageHeaderWithTitleDemo">
   <PageHeaderWithTitleDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Title and Description</Heading>
+### With Title and Description
+
 <ComponentExample demo="PageHeaderWithTitleDescriptionDemo">
   <PageHeaderWithTitleDescriptionDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Complete Example</Heading>
+### Complete Example
+
   <p>Combining breadcrumbs, title, description, tabs, and actions.</p>
   <ComponentExample demo="PageHeaderCompleteDemo">
     <PageHeaderCompleteDemo client:visible />
@@ -149,10 +159,13 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="PageHeader" />
 
-  <Heading level={3}>TabsItem</Heading>
+### TabsItem
+
   <div class="overflow-x-auto">
     <table class="w-full text-sm">
       <thead>

--- a/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
@@ -161,7 +161,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Type</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">label</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
@@ -161,7 +161,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Type</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">label</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
@@ -5,7 +5,6 @@ description: "A layout component for resource list pages with optional sidebar c
 sourceFile: "blocks/resource-list"
 ---
 
-import Heading from "~/components/docs/Heading.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import Callout from "~/components/docs/Callout.astro";
@@ -26,7 +25,9 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
+
   <p>
     ResourceListPage is a <strong>block</strong> - a CLI-installed component
     that you own and can customize. Unlike regular components, blocks are copied
@@ -71,7 +72,8 @@ import { ResourceListPage } from "./components/kumo/resource-list/resource-list"
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { ResourceListPage } from "./components/kumo/resource-list/resource-list";
@@ -96,15 +98,18 @@ export default function DatabasesPage() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic</Heading>
+## Examples
+
+### Basic
+
 <p>A minimal resource list page with title, description, and icon.</p>
 <ComponentExample demo="ResourceListBasicDemo">
   <ResourceListBasicDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>With Usage Sidebar</Heading>
+### With Usage Sidebar
+
   <p>Include a sidebar with usage examples or quick start guides.</p>
   <ComponentExample demo="ResourceListWithUsageDemo">
     <ResourceListWithUsageDemo client:visible />
@@ -114,7 +119,9 @@ export default function DatabasesPage() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <div class="overflow-x-auto">
     <table class="w-full text-sm">
       <thead>

--- a/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
@@ -124,7 +124,7 @@ export default function DatabasesPage() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">title</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
@@ -124,7 +124,7 @@ export default function DatabasesPage() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">title</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/charts/custom.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/custom.mdx
@@ -11,10 +11,10 @@ import {
   CustomTooltipChartDemo,
 } from "~/components/demos/Chart/ChartDemo";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
-import Heading from "~/components/docs/Heading.astro";
 
 <ComponentSection>
-  <Heading level={2}>Custom Chart</Heading>
+
+## Custom Chart
 
   <ComponentExample demo="PieChartDemo">
     <PieChartDemo client:visible />
@@ -22,7 +22,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Custom Tooltip with HTML</Heading>
+
+## Custom Tooltip with HTML
 
 For tooltips that require custom HTML formatting, use the `dangerousHtmlFormatter` property instead of the standard `formatter`. This makes the security implications more explicit.
 

--- a/packages/kumo-docs-astro/src/pages/charts/index.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/index.mdx
@@ -15,7 +15,6 @@ import {
 } from "~/components/demos/Chart/ChartDemo";
 import { ColorDemo } from "~/components/demos/Chart/ColorDemo";
 import ChartCard from "~/components/demos/Chart/ChartCard.astro";
-import Heading from "~/components/docs/Heading.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 
 <ComponentSection>
@@ -61,7 +60,8 @@ echarts.use([
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Available Charts</Heading>
+
+## Available Charts
 
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
     <ChartCard
@@ -84,7 +84,8 @@ echarts.use([
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Coloring</Heading>
+
+## Coloring
 
   <div class="space-y-6">
     <p>
@@ -105,19 +106,22 @@ const series0 = ChartPalette.color(0, isDarkMode);
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Legend</Heading>
+
+## Legend
 
 <p class="mb-6">
   Use <code>LegendItem</code> to display chart series information with color
   indicators.
 </p>
 
-<Heading level={3}>LargeItem</Heading>
+### LargeItem
+
 <ComponentExample demo="LegendDefaultDemo">
   <LegendDefaultDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>SmallItem</Heading>
+### SmallItem
+
   <ComponentExample demo="LegendCompactDemo">
     <LegendCompactDemo client:visible />
   </ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -16,7 +16,6 @@ import {
   LoadingChartDemo,
   TimeRangeSelectionChartDemo,
 } from "~/components/demos/Chart/ChartDemo";
-import Heading from "~/components/docs/Heading.astro";
 
 <p>
   The timeseries chart is a specialized chart for displaying time-based data.
@@ -24,7 +23,8 @@ import Heading from "~/components/docs/Heading.astro";
 </p>
 
 <ComponentSection>
-  <Heading level={3}>Basic Line Chart</Heading>
+
+### Basic Line Chart
 
 <p>A simple line chart displaying multiple data series over time.</p>
 
@@ -34,7 +34,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Custom X-Axis Label Format</Heading>
+
+### Custom X-Axis Label Format
 
 <p>
   Use the <code>xAxisTickLabelFormat</code> prop to control how x-axis tick
@@ -48,7 +49,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Gradient Fill</Heading>
+
+### Gradient Fill
 
 <p>
   Set <code>gradient</code> to <code>true</code> to render a vertical gradient
@@ -63,7 +65,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Incomplete Data</Heading>
+
+### Incomplete Data
 
 <p>
   Use the <code>incomplete</code> prop to indicate regions where data may be
@@ -76,7 +79,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Time Range Selection</Heading>
+
+### Time Range Selection
 
 <p>
   Enable time range selection by providing the <code>onTimeRangeChange</code>
@@ -89,7 +93,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Bar Chart</Heading>
+
+### Bar Chart
 
 <p>
   Set <code>type="bar"</code> to render series as stacked bars instead of lines.
@@ -102,7 +107,8 @@ import Heading from "~/components/docs/Heading.astro";
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Loading State</Heading>
+
+### Loading State
 
 <p>
   Set <code>loading</code> to <code>true</code> to display an animated sine-wave

--- a/packages/kumo-docs-astro/src/pages/colors.mdx
+++ b/packages/kumo-docs-astro/src/pages/colors.mdx
@@ -11,7 +11,7 @@ import { Badge } from "@cloudflare/kumo";
 
 Always use semantic tokens instead of raw Tailwind colors. This ensures your UI automatically adapts to light and dark mode, and that your components remain consistent across themes.
 
-**Correct**
+#### Correct
 
 ```tsx
 <div className="bg-kumo-base text-kumo-default border-kumo-hairline">
@@ -20,7 +20,7 @@ Always use semantic tokens instead of raw Tailwind colors. This ensures your UI 
 </div>
 ```
 
-**Incorrect**
+#### Incorrect
 
 ```tsx
 {
@@ -71,13 +71,17 @@ Themes override semantic token values while preserving the same token names. Set
 Themes are defined in a centralized config and generated as CSS files. The theme generator ensures consistency across all themes.
 
 ```bash
+
 # List all tokens and their theme overrides
+
 pnpm --filter @cloudflare/kumo codegen:themes --list
 
 # Generate theme CSS files
+
 pnpm --filter @cloudflare/kumo codegen:themes
 
 # Preview changes without writing files
+
 pnpm --filter @cloudflare/kumo codegen:themes --dry-run
 ```
 

--- a/packages/kumo-docs-astro/src/pages/components-vs-blocks.mdx
+++ b/packages/kumo-docs-astro/src/pages/components-vs-blocks.mdx
@@ -16,7 +16,7 @@ This isn't just organizational preference — it's about responsibility. Compone
 
 Components are the atomic, reusable UI elements that form the foundation of your application. Button, Input, Dialog, Badge — these are content-agnostic, context-agnostic building blocks designed for maximum reuse across any product.
 
-**Characteristics**
+#### Characteristics
 
 - **Versioned & maintained** — We own the API, fix bugs, and ship updates
 - **Tree-shakeable** — Import only what you use, no bloat
@@ -41,7 +41,7 @@ When Kumo ships a new version, you get bug fixes and improvements automatically.
 
 Blocks are compositions of components that solve common patterns, but aren't agnostic enough to live in the core library. `PageHeader`, `ResourceList` — these are valuable, reusable patterns, but they may only apply to certain products or need product-specific customization.
 
-**Characteristics**
+#### Characteristics
 
 - **You own it** — Code lives in your project, you control the implementation
 - **Fully customizable** — Modify anything beyond what props allow
@@ -54,13 +54,17 @@ Blocks are compositions of components that solve common patterns, but aren't agn
 Install via CLI, then import from your project:
 
 ```bash
+
 # Initialize config (first time only)
+
 npx @cloudflare/kumo init
 
 # List available blocks
+
 npx @cloudflare/kumo blocks
 
 # Install a block to your project
+
 npx @cloudflare/kumo add PageHeader
 ```
 
@@ -103,7 +107,7 @@ All those components (`Surface`, `Text`, `Button`) come from Kumo. But the speci
 
 Asking "is this a component or a block?" really means asking about ownership and reuse:
 
-**Use a Component when...**
+#### Use a Component when...
 
 - It's content-agnostic (works with any data)
 - It's context-agnostic (works in any layout)
@@ -111,7 +115,7 @@ Asking "is this a component or a block?" really means asking about ownership and
 - Accessibility and consistency matter most
 - You want automatic updates and maintenance
 
-**Use a Block when...**
+#### Use a Block when...
 
 - You need to customize beyond props
 - The pattern is product-specific

--- a/packages/kumo-docs-astro/src/pages/components/banner.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/banner.mdx
@@ -9,7 +9,6 @@ import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   BannerVariantsDemo,
   BannerDefaultDemo,
@@ -32,10 +31,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Banner } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Banner } from "@cloudflare/kumo/components/banner";`}
     lang="tsx"
@@ -45,7 +49,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Banner } from "@cloudflare/kumo";
@@ -67,41 +72,49 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Variants</Heading>
+## Examples
 
-<h4 class="mb-3 text-base font-medium">Default</h4>
+### Variants
+
+#### Default
+
 <ComponentExample demo="BannerDefaultDemo">
   <BannerDefaultDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Alert</h4>
+#### Alert
+
 <ComponentExample demo="BannerAlertDemo">
   <BannerAlertDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Error</h4>
+#### Error
+
 <ComponentExample demo="BannerErrorDemo">
   <BannerErrorDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With icon</Heading>
+### With icon
+
 <ComponentExample demo="BannerWithIconDemo">
   <BannerWithIconDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>With action</Heading>
+### With action
+
   <ComponentExample demo="BannerWithActionDemo">
     <BannerWithActionDemo client:visible />
   </ComponentExample>
 
-  <Heading level={3}>With multiple actions</Heading>
+### With multiple actions
+
   <ComponentExample demo="BannerWithActionsDemo">
     <BannerWithActionsDemo client:visible />
   </ComponentExample>
 
-  <Heading level={3}>Custom content</Heading>
+### Custom content
+
   <ComponentExample demo="BannerCustomContentDemo">
     <BannerCustomContentDemo client:visible />
   </ComponentExample>
@@ -110,6 +123,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Banner" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/breadcrumbs.mdx
@@ -9,7 +9,6 @@ import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   BreadcrumbsDemo,
   BreadcrumbsWithIconsDemo,
@@ -25,7 +24,9 @@ import {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
+
   <CodeBlock
     code={`import { Breadcrumbs } from "@cloudflare/kumo";`}
     lang="tsx"
@@ -33,57 +34,73 @@ import {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
+
   <ComponentExample demo="BreadcrumbsDemo">
     <BreadcrumbsDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-  <Heading level={3}>Basic</Heading>
+## Examples
+
+### Basic
+
   <ComponentExample demo="BreadcrumbsDemo">
     <BreadcrumbsDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Loading</Heading>
+
+### Loading
+
   <ComponentExample demo="BreadcrumbsLoadingDemo">
     <BreadcrumbsLoadingDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Root</Heading>
+
+### Root
+
   <ComponentExample demo="BreadcrumbsRootDemo">
     <BreadcrumbsRootDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Clipboard</Heading>
+
+### Clipboard
+
   <ComponentExample demo="BreadcrumbsWithClipboardDemo">
     <BreadcrumbsWithClipboardDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Breadcrumbs</Heading>
+## API Reference
+
+### Breadcrumbs
+
 <PropsTable component="Breadcrumbs" />
 
-<Heading level={3}>Breadcrumbs.Link</Heading>
+### Breadcrumbs.Link
+
 <PropsTable component="Breadcrumbs.Link" />
 
-<Heading level={3}>Breadcrumbs.Current</Heading>
+### Breadcrumbs.Current
+
 <PropsTable component="Breadcrumbs.Current" />
 
-<Heading level={3}>Breadcrumbs.Separator</Heading>
+### Breadcrumbs.Separator
+
 <PropsTable component="Breadcrumbs.Separator" />
 
-  <Heading level={3}>Breadcrumbs.Clipboard</Heading>
+### Breadcrumbs.Clipboard
+
   <PropsTable component="Breadcrumbs.Clipboard" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/button.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/button.mdx
@@ -9,7 +9,6 @@ import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   ButtonBasicDemo,
   ButtonPrimaryDemo,
@@ -37,10 +36,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Button } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Button } from "@cloudflare/kumo/components/button";`}
     lang="tsx"
@@ -50,7 +54,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Button } from "@cloudflare/kumo";
@@ -65,13 +70,15 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
+
+## Examples
 
 {/* Variants */}
 
-<Heading level={3}>Variants</Heading>
+### Variants
 
-<h4 class="mb-3 text-base font-medium">Primary</h4>
+#### Primary
+
 <ComponentExample
   demo="ButtonPrimaryDemo"
   vrSection="variant-primary"
@@ -80,7 +87,8 @@ export default function Example() {
   <ButtonPrimaryDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Secondary</h4>
+#### Secondary
+
 <ComponentExample
   demo="ButtonSecondaryDemo"
   vrSection="variant-secondary"
@@ -89,7 +97,8 @@ export default function Example() {
   <ButtonSecondaryDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Ghost</h4>
+#### Ghost
+
 <ComponentExample
   demo="ButtonGhostDemo"
   vrSection="variant-ghost"
@@ -98,7 +107,8 @@ export default function Example() {
   <ButtonGhostDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Destructive</h4>
+#### Destructive
+
 <ComponentExample
   demo="ButtonDestructiveDemo"
   vrSection="variant-destructive"
@@ -107,7 +117,8 @@ export default function Example() {
   <ButtonDestructiveDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Outline</h4>
+#### Outline
+
 <ComponentExample
   demo="ButtonOutlineDemo"
   vrSection="variant-outline"
@@ -116,7 +127,8 @@ export default function Example() {
   <ButtonOutlineDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Secondary Destructive</h4>
+#### Secondary Destructive
+
 <ComponentExample
   demo="ButtonSecondaryDestructiveDemo"
   vrSection="variant-secondary-destructive"
@@ -127,14 +139,16 @@ export default function Example() {
 
 {/* Sizes */}
 
-<Heading level={3}>Sizes</Heading>
+### Sizes
+
 <ComponentExample demo="ButtonSizesDemo" vrSection="sizes" vrTitle="Sizes">
   <ButtonSizesDemo client:visible />
 </ComponentExample>
 
 {/* With Icon */}
 
-<Heading level={3}>With Icon</Heading>
+### With Icon
+
 <ComponentExample
   demo="ButtonWithIconDemo"
   vrSection="with-icon"
@@ -145,7 +159,8 @@ export default function Example() {
 
 {/* Icon Only */}
 
-<Heading level={3}>Icon Only</Heading>
+### Icon Only
+
 <p>
   For icon-only buttons, use `shape="square"` or `shape="circle"` with the
   `icon` prop.
@@ -163,7 +178,8 @@ export default function Example() {
 
 {/* Loading State */}
 
-<Heading level={3}>Loading State</Heading>
+### Loading State
+
 <ComponentExample
   demo="ButtonLoadingDemo"
   vrSection="loading"
@@ -174,7 +190,8 @@ export default function Example() {
 
 {/* Disabled State */}
 
-<Heading level={3}>Disabled State</Heading>
+### Disabled State
+
 <ComponentExample
   demo="ButtonDisabledDemo"
   vrSection="disabled"
@@ -185,7 +202,8 @@ export default function Example() {
 
 {/* Title (Tooltip) */}
 
-  <Heading level={3}>Title</Heading>
+### Title
+
   <p>
     Use the `title` prop to wrap the button in a tooltip. This is useful for
     icon-only buttons or whenever additional context helps the user understand
@@ -203,7 +221,9 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Button" />
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -10,7 +10,6 @@ import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   CheckboxBasicDemo,
   CheckboxDefaultDemo,
@@ -34,10 +33,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Checkbox } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Checkbox } from "@cloudflare/kumo/components/checkbox";`}
     lang="tsx"
@@ -47,7 +51,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Checkbox } from "@cloudflare/kumo";
@@ -62,9 +67,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Default</Heading>
+## Examples
+
+### Default
+
 <p>
   Checkbox with built-in label. The label automatically displays in a horizontal
   layout (checkbox before label).
@@ -73,29 +80,34 @@ export default function Example() {
   <CheckboxDefaultDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Checked</Heading>
+### Checked
+
 <ComponentExample demo="CheckboxCheckedDemo">
   <CheckboxCheckedDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Indeterminate</Heading>
+### Indeterminate
+
 <p>Used for "select all" patterns when some but not all items are selected.</p>
 <ComponentExample demo="CheckboxIndeterminateDemo">
   <CheckboxIndeterminateDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Label First Layout</Heading>
+### Label First Layout
+
 <p>Use `controlFirst={false}` to place the label before the checkbox.</p>
 <ComponentExample demo="CheckboxLabelFirstDemo">
   <CheckboxLabelFirstDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Disabled</Heading>
+### Disabled
+
 <ComponentExample demo="CheckboxDisabledDemo">
   <CheckboxDisabledDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Error</Heading>
+### Error
+
 <p>
   Error variant provides visual styling (red ring). For error messages, use
   Checkbox.Group.
@@ -104,7 +116,8 @@ export default function Example() {
   <CheckboxErrorDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Checkbox Group</Heading>
+### Checkbox Group
+
 <p>
   Group multiple checkboxes with a legend, description, and shared error
   messages. Uses Checkbox.Group and Checkbox.Item.
@@ -113,7 +126,8 @@ export default function Example() {
   <CheckboxGroupDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Checkbox Group with Error</Heading>
+### Checkbox Group with Error
+
   <p>
     Show validation errors at the group level. Error replaces description
     when present.
@@ -126,19 +140,23 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Checkbox</Heading>
+## API Reference
+
+### Checkbox
+
 <p>Single checkbox component with built-in label and horizontal layout.</p>
 <PropsTable component="Checkbox" />
 
-<Heading level={3}>Checkbox.Group</Heading>
+### Checkbox.Group
+
 <p>
   Wrapper for multiple checkboxes with legend, description, and error support.
 </p>
 <PropsTable component="Checkbox.Group" />
 
-  <Heading level={3}>Checkbox.Item</Heading>
+### Checkbox.Item
+
   <p>Individual checkbox within Checkbox.Group.</p>
   <PropsTable component="Checkbox.Item" />
 </ComponentSection>
@@ -146,17 +164,23 @@ export default function Example() {
 {/* Accessibility */}
 
 <ComponentSection>
-  <Heading level={2}>Accessibility</Heading>
+
+## Accessibility
+
   <div class="space-y-4 text-sm">
     <div>
-      <h3 class="mb-2 font-semibold">Label Requirement</h3>
+
+      ### Label Requirement
+
       <p class="text-kumo-strong">
         Single checkboxes require a `label` prop or `aria-label` for accessibility.
         Missing labels trigger console warnings in development.
       </p>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
+
+      ### Keyboard Navigation
+
       <p class="text-kumo-strong">
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> toggles
         the checkbox.
@@ -165,7 +189,9 @@ export default function Example() {
       </p>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Screen Readers</h3>
+
+      ### Screen Readers
+
       <p class="text-kumo-strong">
         Checkbox.Group uses semantic `<fieldset>` and `<legend>` elements for
         proper grouping announcement.

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -150,14 +150,14 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-default">
+      <p>
         Single checkboxes require a `label` prop or `aria-label` for accessibility.
         Missing labels trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-default">
+      <p>
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> toggles
         the checkbox.
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
@@ -166,7 +166,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-default">
+      <p>
         Checkbox.Group uses semantic `<fieldset>` and `<legend>` elements for
         proper grouping announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -150,14 +150,14 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Single checkboxes require a `label` prop or `aria-label` for accessibility.
         Missing labels trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> toggles
         the checkbox.
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
@@ -166,7 +166,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Checkbox.Group uses semantic `<fieldset>` and `<legend>` elements for
         proper grouping announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/clipboard-text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/clipboard-text.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/clipboard-text"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   ClipboardTextBasicDemo,
@@ -29,14 +28,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { ClipboardText } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";
@@ -47,7 +48,8 @@ import { ClipboardText } from "@cloudflare/kumo/components/clipboard-text";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { ClipboardText } from "@cloudflare/kumo";
@@ -62,29 +64,35 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Short Text</Heading>
+## Examples
+
+### Short Text
+
 <ComponentExample demo="ClipboardTextShortDemo">
   <ClipboardTextShortDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>API Key</Heading>
+### API Key
+
 <ComponentExample demo="ClipboardTextApiKeyDemo">
   <ClipboardTextApiKeyDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Copy Alternate Text</Heading>
+### Copy Alternate Text
+
 <ComponentExample demo="ClipboardTextAlternateTextToCopyDemo">
   <ClipboardTextAlternateTextToCopyDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Long Text</Heading>
+### Long Text
+
 <ComponentExample demo="ClipboardTextLongDemo">
   <ClipboardTextLongDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Tooltip</Heading>
+### With Tooltip
+
 <p>Shows "Copy" tooltip on hover, "Copied!" toast on click.</p>
 <ComponentExample demo="ClipboardTextWithTooltipDemo">
   <ClipboardTextWithTooltipDemo client:visible />
@@ -95,6 +103,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="ClipboardText" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/cloudflare-logo.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/cloudflare-logo.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/cloudflare-logo"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   CloudflareLogoBasicDemo,
   CloudflareLogoGlyphDemo,
@@ -31,8 +30,10 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import {
@@ -42,7 +43,7 @@ import {
 } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import {
@@ -57,7 +58,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { CloudflareLogo } from "@cloudflare/kumo";
@@ -72,9 +74,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Glyph Only</Heading>
+## Examples
+
+### Glyph Only
+
 <p>
   Use <code>variant="glyph"</code> to display just the cloud icon without the
   wordmark.
@@ -83,18 +87,21 @@ export default function Example() {
   <CloudflareLogoGlyphDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Color Variants</Heading>
+### Color Variants
+
 <p>The logo supports three color schemes: brand colors, black, and white.</p>
 <ComponentExample demo="CloudflareLogoColorVariantsDemo">
   <CloudflareLogoColorVariantsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Glyph Color Variants</Heading>
+### Glyph Color Variants
+
 <ComponentExample demo="CloudflareLogoGlyphVariantsDemo">
   <CloudflareLogoGlyphVariantsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Sizing</Heading>
+### Sizing
+
 <p>
   Size the logo using CSS width classes. The height adjusts automatically to
   maintain aspect ratio.
@@ -103,7 +110,8 @@ export default function Example() {
   <CloudflareLogoSizesDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Brand Assets Menu</Heading>
+### Brand Assets Menu
+
   <p>
     Combine with DropdownMenu to create a brand assets menu. Use <code>generateCloudflareLogoSvg()</code> to
     get copy-paste ready SVG markup.
@@ -116,22 +124,27 @@ export default function Example() {
 {/* PoweredByCloudflare */}
 
 <ComponentSection>
-  <Heading level={2}>PoweredByCloudflare</Heading>
+
+## PoweredByCloudflare
+
   <p>
     A pre-built "Powered by Cloudflare" badge component for footers and attribution.
   </p>
 
-<Heading level={3}>Basic Usage</Heading>
+### Basic Usage
+
 <ComponentExample demo="PoweredByCloudflareBasicDemo">
   <PoweredByCloudflareBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Color Variants</Heading>
+### Color Variants
+
 <ComponentExample demo="PoweredByCloudflareVariantsDemo">
   <PoweredByCloudflareVariantsDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Footer Example</Heading>
+### Footer Example
+
   <ComponentExample demo="PoweredByCloudflareFooterDemo">
     <PoweredByCloudflareFooterDemo client:visible />
   </ComponentExample>
@@ -140,7 +153,9 @@ export default function Example() {
 {/* SVG Generation */}
 
 <ComponentSection>
-  <Heading level={2}>SVG Generation</Heading>
+
+## SVG Generation
+
   <p>
     Use <code>generateCloudflareLogoSvg()</code> to get copy-paste ready SVG markup for non-React contexts.
   </p>
@@ -168,7 +183,9 @@ await navigator.clipboard.writeText(
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <p>
     CloudflareLogo extends <code>SVGSVGElement</code> and accepts all standard SVG attributes.
   </p>
@@ -205,7 +222,8 @@ await navigator.clipboard.writeText(
     </table>
   </div>
 
-  <Heading level={3}>PoweredByCloudflare</Heading>
+### PoweredByCloudflare
+
   <p>
     Extends <code>HTMLAnchorElement</code> and accepts all standard anchor attributes.
   </p>

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
@@ -7,7 +7,6 @@ sourceFile: "code"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   CodeHighlightedBasicDemo,
   CodeHighlightedTypeScriptDemo,
@@ -40,7 +39,9 @@ import {
 {/* Overview */}
 
 <ComponentSection>
-  <Heading level={2}>Overview</Heading>
+
+## Overview
+
   <p>
     A Shiki-powered syntax highlighter. Supports 200+ languages with TextMate
     grammars, dual light/dark themes, and lazy loading. Exported from a separate
@@ -52,7 +53,9 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
+
   <p>
     CodeHighlighted is exported from a separate entry point to avoid bundling Shiki for apps that don't need it.
   </p>
@@ -72,7 +75,9 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
 {/* Basic Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Basic Usage</Heading>
+
+## Basic Usage
+
   <p>
     Wrap your app with `ShikiProvider` to configure Shiki once.
     All `CodeHighlighted` components inside share the same Shiki instance.
@@ -99,71 +104,84 @@ export function App() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Languages</Heading>
+## Examples
+
+### Languages
+
 <p>
   CodeHighlighted supports 200+ languages through Shiki. Only load the languages
   you need.
 </p>
 
-<h4 class="mb-3 text-base font-medium">TypeScript</h4>
+#### TypeScript
+
 <ComponentExample demo="CodeHighlightedTypeScriptDemo">
   <CodeHighlightedTypeScriptDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">React / TSX</h4>
+#### React / TSX
+
 <ComponentExample demo="CodeHighlightedReactDemo">
   <CodeHighlightedReactDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Bash / Shell</h4>
+#### Bash / Shell
+
 <ComponentExample demo="CodeHighlightedBashDemo">
   <CodeHighlightedBashDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">JSON</h4>
+#### JSON
+
 <ComponentExample demo="CodeHighlightedJsonDemo">
   <CodeHighlightedJsonDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">CSS</h4>
+#### CSS
+
 <ComponentExample demo="CodeHighlightedCssDemo">
   <CodeHighlightedCssDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Highlight Lines</Heading>
+### Highlight Lines
+
 <p>Emphasize specific lines with `highlightLines` (1-indexed).</p>
 <ComponentExample demo="CodeHighlightedHighlightLinesDemo">
   <CodeHighlightedHighlightLinesDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Highlight Color</Heading>
+### Custom Highlight Color
+
 <p>
   Customize the highlight color with the `--kumo-code-highlight-bg` CSS
   variable.
 </p>
 <CodeHighlightedCustomHighlightDemo client:load />
 
-<Heading level={3}>Line Numbers</Heading>
+### Line Numbers
+
 <p>Display line numbers with `showLineNumbers` .</p>
 <ComponentExample demo="CodeHighlightedLineNumbersDemo">
   <CodeHighlightedLineNumbersDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Copy Button</Heading>
+### Copy Button
+
 <p>Add a copy-to-clipboard button with `showCopyButton` .</p>
 <ComponentExample demo="CodeHighlightedCopyButtonDemo">
   <CodeHighlightedCopyButtonDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Full Featured</Heading>
+### Full Featured
+
 <p>Combine all features for a complete code display experience.</p>
 <ComponentExample demo="CodeHighlightedFullFeaturedDemo">
   <CodeHighlightedFullFeaturedDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Shared Provider</Heading>
+### Shared Provider
+
   <p>
     Multiple code blocks can share a single `ShikiProvider`.
     Shiki loads once and is reused for all blocks.
@@ -176,7 +194,9 @@ export function App() {
 {/* Themes */}
 
 <ComponentSection>
-  <Heading level={2}>Themes</Heading>
+
+## Themes
+
   <p>
     CodeHighlighted uses hardcoded themes for consistent styling across all Kumo
     applications:
@@ -200,12 +220,14 @@ export function App() {
 {/* Server-Side Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Server-Side Usage</Heading>
+
+## Server-Side Usage
+
   <p>
     For SSR frameworks (Next.js RSC, Astro, Remix), use the server utilities to highlight at build time.
   </p>
 
-<h4 class="mb-3 text-base font-medium">One-off highlighting</h4>
+#### One-off highlighting
 
 ```tsx
 // Next.js RSC or Astro
@@ -218,7 +240,7 @@ export default async function Page() {
 }
 ```
 
-<h4 class="mb-3 text-base font-medium">Reusable highlighter</h4>
+#### Reusable highlighter
 
 ```tsx
 // For multiple highlights, reuse the highlighter
@@ -239,7 +261,9 @@ highlighter.dispose(); // Clean up when done
 {/* Custom Hook */}
 
 <ComponentSection>
-  <Heading level={2}>Custom Hook</Heading>
+
+## Custom Hook
+
   <p>
     Use `useShikiHighlighter` for custom implementations.
   </p>
@@ -282,7 +306,9 @@ function CustomCodeBlock({ code, lang }) {
 {/* Internationalization */}
 
 <ComponentSection>
-  <Heading level={2}>Internationalization</Heading>
+
+## Internationalization
+
   <p>
     Customize button labels at the provider level for all code blocks, or override per-component.
   </p>
@@ -311,9 +337,10 @@ function CustomCodeBlock({ code, lang }) {
 {/* Framework Integration */}
 
 <ComponentSection>
-  <Heading level={2}>Framework Integration</Heading>
 
-<Heading level={3}>Next.js App Router</Heading>
+## Framework Integration
+
+### Next.js App Router
 
 ```tsx
 // app/providers.tsx
@@ -343,7 +370,8 @@ export default function RootLayout({ children }) {
 }
 ```
 
-<Heading level={3}>Astro (Static)</Heading>
+### Astro (Static)
+
 <p>
   For static sites, use server-side highlighting for zero client-side
   JavaScript.
@@ -366,7 +394,9 @@ const html = await highlightCode(code, lang);
 {/* Bundle Size */}
 
 <ComponentSection>
-  <Heading level={2}>Bundle Size</Heading>
+
+## Bundle Size
+
   <p>
     Shiki is lazy-loaded on first render. The size depends on your
     configuration:
@@ -411,7 +441,9 @@ const html = await highlightCode(code, lang);
 {/* Migration */}
 
 <ComponentSection>
-  <Heading level={2}>Migration from Code/CodeBlock</Heading>
+
+## Migration from Code/CodeBlock
+
   <p>
     The legacy `Code` and `CodeBlock` components are deprecated.
     They will be removed in v2.0.
@@ -439,9 +471,11 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>ShikiProvider Props</Heading>
+## API Reference
+
+### ShikiProvider Props
+
 <div class="overflow-x-auto">
   <table class="w-full text-sm">
     <thead>
@@ -499,7 +533,8 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
   </table>
 </div>
 
-<Heading level={3}>CodeHighlighted Props</Heading>
+### CodeHighlighted Props
+
 <div class="overflow-x-auto">
   <table class="w-full text-sm">
     <thead>
@@ -587,7 +622,8 @@ import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
   </table>
 </div>
 
-  <Heading level={3}>useShikiHighlighter Return Value</Heading>
+### useShikiHighlighter Return Value
+
   <div class="overflow-x-auto">
     <table class="w-full text-sm">
       <thead>

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
@@ -181,7 +181,7 @@ export function App() {
     CodeHighlighted uses hardcoded themes for consistent styling across all Kumo
     applications:
   </p>
-  <ul class="mb-4 list-disc pl-6 text-kumo-strong">
+  <ul class="mb-4 list-disc pl-6 text-kumo-default">
     <li>
       <strong>Light mode:</strong>
       `github-light`

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
@@ -181,7 +181,7 @@ export function App() {
     CodeHighlighted uses hardcoded themes for consistent styling across all Kumo
     applications:
   </p>
-  <ul class="mb-4 list-disc pl-6 text-kumo-default">
+  <ul class="mb-4 list-disc pl-6">
     <li>
       <strong>Light mode:</strong>
       `github-light`

--- a/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
@@ -8,7 +8,6 @@ baseUIComponent: "collapsible"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   CollapsibleHeroDemo,
@@ -27,14 +26,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Collapsible } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Collapsible } from "@cloudflare/kumo/components/collapsible";
@@ -45,7 +46,8 @@ import { Collapsible } from "@cloudflare/kumo/components/collapsible";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Collapsible } from "@cloudflare/kumo";
@@ -60,14 +62,17 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Single Item</Heading>
+## Examples
+
+### Single Item
+
 <ComponentExample demo="CollapsibleBasicDemo">
   <CollapsibleBasicDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Multiple Items</Heading>
+### Multiple Items
+
 <ComponentExample demo="CollapsibleMultipleDemo">
   <CollapsibleMultipleDemo client:load />
 </ComponentExample>
@@ -77,6 +82,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Collapsible" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -9,7 +9,6 @@ baseUIComponent: "combobox"
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   ComboboxDemo,
@@ -34,10 +33,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Combobox } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Combobox } from "@cloudflare/kumo/components/combobox";`}
     lang="tsx"
@@ -47,7 +51,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { useState } from "react";
@@ -81,9 +86,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Sizes</Heading>
+## Examples
+
+### Sizes
+
 <p>
   The Combobox supports four size variants that match the Input component: `xs`,
   `sm`, `base` (default), and `lg`.
@@ -101,7 +108,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Searchable Item (Inside)</Heading>
+
+### Searchable Item (Inside)
+
   <p>
     A searchable select component inside popup that allows users to filter and
     select.
@@ -112,7 +121,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Grouped</Heading>
+
+### Grouped
+
   <p>Group items into categories using the Group and GroupLabel components.</p>
   <ComponentExample demo="ComboboxGroupedDemo">
     <ComboboxGroupedDemo client:load />
@@ -120,7 +131,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Multiple</Heading>
+
+### Multiple
+
   <p>Allow users to select multiple options from the list.</p>
   <ComponentExample demo="ComboboxMultipleDemo">
     <ComboboxMultipleDemo client:load />
@@ -128,7 +141,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>With Field</Heading>
+
+### With Field
+
   <p>Add label and description using the built-in Field wrapper.</p>
   <ComponentExample demo="ComboboxWithFieldDemo">
     <ComboboxWithFieldDemo client:load />
@@ -136,7 +151,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Disabled</Heading>
+
+### Disabled
+
   <p>Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` and `TriggerValue`.</p>
   <ComponentExample demo="ComboboxDisabledDemo">
     <ComboboxDisabledDemo client:load />
@@ -144,7 +161,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={3}>Error State</Heading>
+
+### Error State
+
   <p>Display validation errors with the error prop.</p>
   <ComponentExample demo="ComboboxErrorDemo">
     <ComboboxErrorDemo client:load />
@@ -152,7 +171,9 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>Customizing Dropdown Height</Heading>
+
+## Customizing Dropdown Height
+
   <p>
     By default, <code class="text-surface">Combobox.Content</code> has a max height of <code class="text-surface">24rem</code> (384px) or the available viewport space, whichever is smaller. The dropdown scrolls automatically when content exceeds this height.
   </p>
@@ -175,21 +196,26 @@ export default function Example() {
 </ComponentSection>
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Combobox</Heading>
+## API Reference
+
+### Combobox
+
 <p>Root component for the searchable select.</p>
 <PropsTable component="Combobox" />
 
-<Heading level={3}>Combobox.Content</Heading>
+### Combobox.Content
+
 <p>Dropdown container for the list.</p>
 <PropsTable component="Combobox.Content" />
 
-<Heading level={3}>Combobox.Item</Heading>
+### Combobox.Item
+
 <p>Individual selectable option.</p>
 <PropsTable component="Combobox.Item" />
 
-  <Heading level={3}>Additional Sub-components</Heading>
+### Additional Sub-components
+
   <ul class="list-disc list-inside text-kumo-strong space-y-1">
     <li>`Combobox.TriggerInput` - Single-select input trigger</li>
     <li>`Combobox.TriggerValue` - Button trigger showing selected value</li>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -137,7 +137,10 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={3}>Disabled</Heading>
-  <p>Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` and `TriggerValue`.</p>
+  <p>
+    Pass the `disabled` prop to prevent interaction. Works with both
+    `TriggerInput` and `TriggerValue`.
+  </p>
   <ComponentExample demo="ComboboxDisabledDemo">
     <ComboboxDisabledDemo client:load />
   </ComponentExample>
@@ -190,7 +193,7 @@ export default function Example() {
 <PropsTable component="Combobox.Item" />
 
   <Heading level={3}>Additional Sub-components</Heading>
-  <ul class="list-disc list-inside text-kumo-strong space-y-1">
+  <ul class="list-disc list-inside text-kumo-default space-y-1">
     <li>`Combobox.TriggerInput` - Single-select input trigger</li>
     <li>`Combobox.TriggerValue` - Button trigger showing selected value</li>
     <li>`Combobox.TriggerMultipleWithInput` - Multi-select with chips</li>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -193,7 +193,7 @@ export default function Example() {
 <PropsTable component="Combobox.Item" />
 
   <Heading level={3}>Additional Sub-components</Heading>
-  <ul class="list-disc list-inside text-kumo-default space-y-1">
+  <ul class="list-disc list-inside space-y-1">
     <li>`Combobox.TriggerInput` - Single-select input trigger</li>
     <li>`Combobox.TriggerValue` - Button trigger showing selected value</li>
     <li>`Combobox.TriggerMultipleWithInput` - Multi-select with chips</li>

--- a/packages/kumo-docs-astro/src/pages/components/command-palette.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/command-palette.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/command-palette"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import KeyboardShortcuts from "~/components/docs/KeyboardShortcuts.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
@@ -28,14 +27,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { CommandPalette } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { CommandPalette } from "@cloudflare/kumo/components/command-palette";
@@ -46,7 +47,9 @@ import { CommandPalette } from "@cloudflare/kumo/components/command-palette";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
+
   <p>
     CommandPalette is a compound component built on Base UI's Autocomplete
     primitive. It provides accessible keyboard navigation and customizable
@@ -109,7 +112,9 @@ export default function Example() {
 {/* Keyboard Navigation */}
 
 <ComponentSection>
-  <Heading level={2}>Keyboard Navigation</Heading>
+
+## Keyboard Navigation
+
   <p>Built-in keyboard navigation is provided automatically:</p>
   <KeyboardShortcuts
     shortcuts={[
@@ -124,27 +129,32 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>With Grouped Items</Heading>
+## Examples
+
+### With Grouped Items
+
 <p>Group related commands together with labels.</p>
 <ComponentExample demo="CommandPaletteBasicDemo">
   <CommandPaletteBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Simple Flat List</Heading>
+### Simple Flat List
+
 <p>For simpler use cases, use a flat array of items without grouping.</p>
 <ComponentExample demo="CommandPaletteSimpleDemo">
   <CommandPaletteSimpleDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Loading State</Heading>
+### Loading State
+
 <p>Show a loading spinner while fetching results.</p>
 <ComponentExample demo="CommandPaletteLoadingDemo">
   <CommandPaletteLoadingDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>ResultItem with Breadcrumbs</Heading>
+### ResultItem with Breadcrumbs
+
   <p>
     Use `ResultItem` for rich items with
     breadcrumbs, icons, and optional text highlighting.
@@ -157,60 +167,76 @@ export default function Example() {
 {/* Component Parts */}
 
 <ComponentSection>
-  <Heading level={2}>Component Parts</Heading>
 
-<Heading level={3}>CommandPalette.Root</Heading>
+## Component Parts
+
+### CommandPalette.Root
+
 <p>
   The main wrapper that combines Dialog + Panel. Manages open state and
   Autocomplete functionality.
 </p>
 
-<Heading level={3}>CommandPalette.Dialog</Heading>
+### CommandPalette.Dialog
+
 <p>
   Modal dialog wrapper. Use with Panel for swappable content (e.g., drill-down
   navigation).
 </p>
 
-<Heading level={3}>CommandPalette.Panel</Heading>
+### CommandPalette.Panel
+
 <p>
   Autocomplete panel without dialog. Use inside Dialog for content that can swap
   without re-mounting.
 </p>
 
-<Heading level={3}>CommandPalette.Input</Heading>
+### CommandPalette.Input
+
 <p>Search input field with auto-focus and keyboard handling.</p>
 
-<Heading level={3}>CommandPalette.List</Heading>
+### CommandPalette.List
+
 <p>Scrollable container for results.</p>
 
-<Heading level={3}>CommandPalette.Results</Heading>
+### CommandPalette.Results
+
 <p>Render prop iterator for items/groups.</p>
 
-<Heading level={3}>CommandPalette.Group</Heading>
+### CommandPalette.Group
+
 <p>Category grouping container.</p>
 
-<Heading level={3}>CommandPalette.GroupLabel</Heading>
+### CommandPalette.GroupLabel
+
 <p>Section header text within a group.</p>
 
-<Heading level={3}>CommandPalette.Items</Heading>
+### CommandPalette.Items
+
 <p>Render prop iterator for items within a group.</p>
 
-<Heading level={3}>CommandPalette.Item</Heading>
+### CommandPalette.Item
+
 <p>Basic selectable item.</p>
 
-<Heading level={3}>CommandPalette.ResultItem</Heading>
+### CommandPalette.ResultItem
+
 <p>Rich item with breadcrumbs, icons, and text highlighting.</p>
 
-<Heading level={3}>CommandPalette.HighlightedText</Heading>
+### CommandPalette.HighlightedText
+
 <p>Renders text with highlighted portions based on match indices.</p>
 
-<Heading level={3}>CommandPalette.Empty</Heading>
+### CommandPalette.Empty
+
 <p>Empty state when no results match.</p>
 
-<Heading level={3}>CommandPalette.Loading</Heading>
+### CommandPalette.Loading
+
 <p>Loading spinner state.</p>
 
-  <Heading level={3}>CommandPalette.Footer</Heading>
+### CommandPalette.Footer
+
   <p>
     Footer for keyboard hints or other content.
   </p>
@@ -219,9 +245,10 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>CommandPalette.Root Props</Heading>
+## API Reference
+
+### CommandPalette.Root Props
 
 ```tsx
 interface CommandPaletteRootProps<TGroup, TItem> {
@@ -246,7 +273,7 @@ interface CommandPaletteRootProps<TGroup, TItem> {
 }
 ```
 
-<Heading level={3}>CommandPalette.ResultItem Props</Heading>
+### CommandPalette.ResultItem Props
 
 ```tsx
 interface CommandPaletteResultItemProps<T> {

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/date-picker"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   DatePickerSingleDemo,
@@ -31,14 +30,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { DatePicker, type DateRange } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import {
@@ -52,7 +53,9 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
+
   <p>
     DatePicker supports three selection modes: `single`,
     `multiple`, and
@@ -75,15 +78,18 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Single Date Selection</Heading>
+## Examples
+
+### Single Date Selection
+
 <p>Select a single date. The most common use case for date pickers.</p>
 <ComponentExample demo="DatePickerSingleDemo">
   <DatePickerSingleDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Multiple Date Selection</Heading>
+### Multiple Date Selection
+
 <p>
   Select multiple individual dates. Use `max` to limit the number of selections.
 </p>
@@ -91,7 +97,8 @@ export default function Example() {
   <DatePickerMultipleDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Date Range Selection</Heading>
+### Date Range Selection
+
 <p>
   Select a continuous range of dates. Works well with `numberOfMonths={2}` for a
   side-by-side view.
@@ -100,13 +107,15 @@ export default function Example() {
   <DatePickerRangeDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Range with Min/Max Constraints</Heading>
+### Range with Min/Max Constraints
+
 <p>Constrain the range length using `min` and `max` props (in days/nights).</p>
 <ComponentExample demo="DatePickerRangeMinMaxDemo">
   <DatePickerRangeMinMaxDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>With Popover</Heading>
+### With Popover
+
 <p>
   Compose with the
   <a href="/components/popover" class="text-kumo-link hover:underline">
@@ -118,19 +127,22 @@ export default function Example() {
   <DatePickerPopoverDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Date Range with Popover</Heading>
+### Date Range with Popover
+
 <p>A date range picker in a popover with two months displayed.</p>
 <ComponentExample demo="DatePickerRangePopoverDemo">
   <DatePickerRangePopoverDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Date Range with Presets</Heading>
+### Date Range with Presets
+
 <p>Combine the date picker with preset options for quick selection.</p>
 <ComponentExample demo="DatePickerRangeWithPresetsDemo">
   <DatePickerRangeWithPresetsDemo client:load />
 </ComponentExample>
 
-  <Heading level={3}>Disabled Dates with Usage Limits</Heading>
+### Disabled Dates with Usage Limits
+
   <p>
     Use the `disabled` prop to make certain dates unselectable,
     and `footer` to display usage information.
@@ -143,7 +155,9 @@ export default function Example() {
 {/* Full Popover Example */}
 
 <ComponentSection>
-  <Heading level={2}>Full Popover Example</Heading>
+
+## Full Popover Example
+
   <p>
     Here's a complete example showing how to compose DatePicker with Popover:
   </p>
@@ -180,7 +194,9 @@ export function DatePickerDropdown() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <p>
     DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
     Key props include:
@@ -200,7 +216,8 @@ export function DatePickerDropdown() {
     See the <a href="https://daypicker.dev/docs" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">react-day-picker documentation</a> for the full API.
   </p>
 
-  <Heading level={3}>Differences from react-day-picker</Heading>
+### Differences from react-day-picker
+
   <p>
     For consistency with other Kumo form components, DatePicker uses `onChange` instead of react-day-picker's `onSelect`.
     Full type inference is preserved — TypeScript will correctly narrow the callback signature based on the `mode` prop.

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -182,7 +182,7 @@ export function DatePickerDropdown() {
     DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
     Key props include:
   </p>
-  <ul class="mt-4 list-disc list-inside text-kumo-default space-y-2">
+  <ul class="mt-4 list-disc list-inside space-y-2">
     <li>`mode` — <code class="text-xs">"single" | "multiple" | "range"</code> — Selection mode (required)</li>
     <li>`selected` — Currently selected date(s)</li>
     <li>`onChange` — Callback when selection changes</li>

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -108,11 +108,8 @@ export default function Example() {
 
 <Heading level={3}>With Popover</Heading>
 <p>
-  Compose with the
-  <a href="/components/popover" class="text-kumo-link hover:underline">
-    Popover
-  </a>
-  component to create a dropdown date picker.
+  Compose with the [Popover](/components/popover) component to create a dropdown
+  date picker.
 </p>
 <ComponentExample demo="DatePickerPopoverDemo">
   <DatePickerPopoverDemo client:load />
@@ -182,10 +179,10 @@ export function DatePickerDropdown() {
 <ComponentSection>
   <Heading level={2}>API Reference</Heading>
   <p>
-    DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
+    DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
     Key props include:
   </p>
-  <ul class="mt-4 list-disc list-inside text-kumo-strong space-y-2">
+  <ul class="mt-4 list-disc list-inside text-kumo-default space-y-2">
     <li>`mode` — <code class="text-xs">"single" | "multiple" | "range"</code> — Selection mode (required)</li>
     <li>`selected` — Currently selected date(s)</li>
     <li>`onChange` — Callback when selection changes</li>
@@ -197,7 +194,7 @@ export function DatePickerDropdown() {
     <li>`className` — Additional CSS classes</li>
   </ul>
   <p class="mt-4 text-kumo-subtle text-sm">
-    See the <a href="https://daypicker.dev/docs" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">react-day-picker documentation</a> for the full API.
+    See the <a href="https://daypicker.dev/docs" target="_blank" rel="noopener noreferrer">react-day-picker documentation</a> for the full API.
   </p>
 
   <Heading level={3}>Differences from react-day-picker</Heading>

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -9,7 +9,6 @@ baseUIComponent: "dialog"
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   DialogBasicDemo,
@@ -32,10 +31,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Dialog } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Dialog } from "@cloudflare/kumo/components/dialog";`}
     lang="tsx"
@@ -45,7 +49,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Dialog, Button } from "@cloudflare/kumo";
@@ -77,7 +82,9 @@ export default function Example() {
 {/* Dialog vs Alert Dialog */}
 
 <ComponentSection>
-  <Heading level={2}>Dialog vs Alert Dialog</Heading>
+
+## Dialog vs Alert Dialog
+
   <p>
     The Dialog component supports two ARIA roles to properly convey semantic
     meaning to assistive technologies:
@@ -118,16 +125,17 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic Dialog</Heading>
+## Examples
+
+### Basic Dialog
+
 <ComponentExample demo="DialogBasicDemo">
   <DialogBasicDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>
-  Alert Dialog (<code class="font-normal">role="alertdialog"</code>)
-</Heading>
+### Alert Dialog (`role="alertdialog"`)
+
 <p>
   For destructive or confirmation dialogs, use `role="alertdialog"` on
   `Dialog.Root`. This provides proper accessibility semantics by rendering the
@@ -149,10 +157,8 @@ export default function Example() {
   <DialogAlertDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>
-  Confirmation Dialog (with{" "}
-  <code class="font-normal">disablePointerDismissal</code>)
-</Heading>
+### Confirmation Dialog (with `disablePointerDismissal`)
+
 <p>
   For confirmation dialogs that should not be dismissed by clicking outside, use
   `disablePointerDismissal` on `Dialog.Root`. This can be combined with
@@ -162,24 +168,28 @@ export default function Example() {
   <DialogConfirmationDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>With Actions</Heading>
+### With Actions
+
 <ComponentExample demo="DialogWithActionsDemo">
   <DialogWithActionsDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>With Select</Heading>
+### With Select
+
 <p>Dialog containing a Select dropdown.</p>
 <ComponentExample demo="DialogWithSelectDemo">
   <DialogWithSelectDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>With Combobox</Heading>
+### With Combobox
+
 <p>Dialog containing a Combobox for searchable selection.</p>
 <ComponentExample demo="DialogWithComboboxDemo">
   <DialogWithComboboxDemo client:load />
 </ComponentExample>
 
-  <Heading level={3}>With Dropdown</Heading>
+### With Dropdown
+
   <p>Dialog containing a Dropdown menu.</p>
   <ComponentExample demo="DialogWithDropdownDemo">
     <DialogWithDropdownDemo client:load />
@@ -189,13 +199,16 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Dialog</Heading>
+## API Reference
+
+### Dialog
+
 <p>The main dialog container that renders the modal overlay and popup.</p>
 <PropsTable component="Dialog" />
 
-<Heading level={3}>Dialog.Root</Heading>
+### Dialog.Root
+
 <p>
   Controls the open state of the dialog. Doesn't render its own HTML element.
 </p>
@@ -233,19 +246,23 @@ export default function Example() {
 </div>
 <PropsTable component="Dialog.Root" />
 
-<Heading level={3}>Dialog.Trigger</Heading>
+### Dialog.Trigger
+
 <p>A button that opens the dialog when clicked.</p>
 <PropsTable component="Dialog.Trigger" />
 
-<Heading level={3}>Dialog.Title</Heading>
+### Dialog.Title
+
 <p>A heading that labels the dialog for accessibility.</p>
 <PropsTable component="Dialog.Title" />
 
-<Heading level={3}>Dialog.Description</Heading>
+### Dialog.Description
+
 <p>A paragraph providing additional context about the dialog.</p>
 <PropsTable component="Dialog.Description" />
 
-  <Heading level={3}>Dialog.Close</Heading>
+### Dialog.Close
+
   <p>A button that closes the dialog when clicked.</p>
   <PropsTable component="Dialog.Close" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -134,11 +134,11 @@ export default function Example() {
   dialog with `role="alertdialog"` instead of `role="dialog"`.
 </p>
 <div class="mb-4 rounded-lg border border-kumo-info/30 bg-kumo-info/10 p-4 text-sm text-kumo-info">
-  <p class="font-medium mb-2">
+  <p class="font-medium mb-2 text-sm">
     When to use{" "}
     <code class="bg-kumo-info/20 px-1 rounded">role="alertdialog"</code>:
   </p>
-  <ul class="list-disc list-inside space-y-1 ml-2">
+  <ul class="list-disc list-inside space-y-1 ml-2 mb-0">
     <li>Destructive actions (delete, discard, remove)</li>
     <li>Confirmation flows requiring explicit user acknowledgment</li>
     <li>Actions that cannot be undone</li>

--- a/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
@@ -8,7 +8,6 @@ baseUIComponent: "menu"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   DropdownBasicDemo,
@@ -29,14 +28,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { DropdownMenu } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { DropdownMenu } from "@cloudflare/kumo/components/dropdown";
@@ -47,7 +48,8 @@ import { DropdownMenu } from "@cloudflare/kumo/components/dropdown";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { DropdownMenu, Button } from "@cloudflare/kumo";
@@ -70,14 +72,17 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic Dropdown</Heading>
+## Examples
+
+### Basic Dropdown
+
 <ComponentExample demo="DropdownBasicDemo">
   <DropdownBasicDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Checkbox Items</Heading>
+### Checkbox Items
+
 <p>
   Use `DropdownMenu.CheckboxItem` for toggleable options that can be
   independently checked or unchecked.
@@ -86,7 +91,8 @@ export default function Example() {
   <DropdownCheckboxDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Nested Menu with Radio Selection</Heading>
+### Nested Menu with Radio Selection
+
 <p>
   Use `DropdownMenu.Sub`, `DropdownMenu.SubTrigger`, and
   `DropdownMenu.SubContent` to create nested submenus. For single-selection
@@ -97,7 +103,8 @@ export default function Example() {
   <DropdownNestedDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Custom Trigger with Avatar</Heading>
+### Custom Trigger with Avatar
+
 <p>
   Use the `render` prop to customize the trigger element while passing children
   to render inside it. This is useful when you need a non-button trigger (like
@@ -107,7 +114,8 @@ export default function Example() {
   <DropdownAvatarTriggerDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Navigation Links</Heading>
+### Navigation Links
+
 <p>
   Use `DropdownMenu.LinkItem` for menu items that navigate to a URL.
   This renders a semantic `<a>` element with full control over link attributes like `target` and `rel`.
@@ -121,69 +129,82 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>DropdownMenu</Heading>
+## API Reference
+
+### DropdownMenu
+
 <p>Root component that manages the dropdown state.</p>
 <PropsTable component="DropdownMenu" />
 
-<Heading level={3}>DropdownMenu.Trigger</Heading>
+### DropdownMenu.Trigger
+
 <p>Button that opens the dropdown when clicked.</p>
 <PropsTable component="DropdownMenu.Trigger" />
 
-<Heading level={3}>DropdownMenu.Item</Heading>
+### DropdownMenu.Item
+
 <p>Individual menu item for actions.</p>
 <PropsTable component="DropdownMenu.Item" />
 
-<Heading level={3}>DropdownMenu.LinkItem</Heading>
+### DropdownMenu.LinkItem
+
 <p>
   A menu item that navigates to a URL. Renders a semantic `<a>` element. Use this instead of `Item` for navigation links.
 </p>
 <PropsTable component="DropdownMenu.LinkItem" />
 
-<Heading level={3}>DropdownMenu.CheckboxItem</Heading>
+### DropdownMenu.CheckboxItem
+
 <p>
   A menu item that can be toggled on or off. Use for independent boolean
   options.
 </p>
 <PropsTable component="DropdownMenu.CheckboxItem" />
 
-<Heading level={3}>DropdownMenu.Sub</Heading>
+### DropdownMenu.Sub
+
 <p>
   Root component for a nested submenu. Wrap SubTrigger and SubContent inside
   this.
 </p>
 <PropsTable component="DropdownMenu.Sub" />
 
-<Heading level={3}>DropdownMenu.SubTrigger</Heading>
+### DropdownMenu.SubTrigger
+
 <p>
   Menu item that opens a nested submenu when hovered or clicked. Displays a
   caret icon automatically.
 </p>
 <PropsTable component="DropdownMenu.SubTrigger" />
 
-<Heading level={3}>DropdownMenu.SubContent</Heading>
+### DropdownMenu.SubContent
+
 <p>Container for submenu items. Positioned relative to the SubTrigger.</p>
 <PropsTable component="DropdownMenu.SubContent" />
 
-<Heading level={3}>DropdownMenu.Separator</Heading>
+### DropdownMenu.Separator
+
 <p>A visual divider between menu items.</p>
 <PropsTable component="DropdownMenu.Separator" />
 
-<Heading level={3}>DropdownMenu.RadioGroup</Heading>
+### DropdownMenu.RadioGroup
+
 <p>
   Groups radio items for single-selection behavior. Only one item can be
   selected at a time.
 </p>
 <PropsTable component="DropdownMenu.RadioGroup" />
 
-<Heading level={3}>DropdownMenu.RadioItem</Heading>
+### DropdownMenu.RadioItem
+
 <p>
   A menu item that works like a radio button. Must be used inside a RadioGroup.
 </p>
 <PropsTable component="DropdownMenu.RadioItem" />
 
-<Heading level={3}>DropdownMenu.RadioItemIndicator</Heading>
+### DropdownMenu.RadioItemIndicator
+
 <p>
   Shows the selected state for a RadioItem. Displays a checkmark by default.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/empty.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/empty.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/empty"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   EmptyDemo,
@@ -29,7 +28,8 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
 
 ```tsx
 import { Empty } from "@cloudflare/kumo";
@@ -40,7 +40,8 @@ import { Empty } from "@cloudflare/kumo";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Empty } from "@cloudflare/kumo";
@@ -63,9 +64,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic</Heading>
+## Examples
+
+### Basic
+
 <ComponentExample demo="EmptyBasicDemo">
   <EmptyBasicDemo client:visible />
 </ComponentExample>
@@ -75,7 +78,9 @@ export default function Example() {
 {/* Sizes */}
 
 <ComponentSection>
-  <Heading level={2}>Sizes</Heading>
+
+## Sizes
+
   <p>Empty states come in three sizes to fit different container contexts.</p>
   <ComponentExample demo="EmptySizesDemo">
     <EmptySizesDemo client:visible />
@@ -85,7 +90,9 @@ export default function Example() {
 {/* With Command Line */}
 
 <ComponentSection>
-  <Heading level={2}>With Command Line</Heading>
+
+## With Command Line
+
   <p>Include a copyable command to help users get started.</p>
   <ComponentExample demo="EmptyWithCommandDemo">
     <EmptyWithCommandDemo client:visible />
@@ -95,7 +102,9 @@ export default function Example() {
 {/* With Actions */}
 
 <ComponentSection>
-  <Heading level={2}>With Actions</Heading>
+
+## With Actions
+
   <p>Add custom action buttons using the contents prop.</p>
   <ComponentExample demo="EmptyWithActionsDemo">
     <EmptyWithActionsDemo client:visible />
@@ -105,7 +114,9 @@ export default function Example() {
 {/* Minimal */}
 
 <ComponentSection>
-  <Heading level={2}>Minimal</Heading>
+
+## Minimal
+
   <p>At minimum, only a title is required.</p>
   <ComponentExample demo="EmptyMinimalDemo">
     <EmptyMinimalDemo client:visible />
@@ -115,6 +126,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Empty" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/flow.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/flow.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/flow"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   FlowBasicDemo,
   FlowParallelDemo,
@@ -33,14 +32,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Flow } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Flow } from "@cloudflare/kumo/components/flow";
@@ -51,7 +52,9 @@ import { Flow } from "@cloudflare/kumo/components/flow";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
+
   <p>
     The Flow components work together to create directed flow diagrams. Use
     `Flow` as the container,
@@ -80,21 +83,25 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Sequential Flow</Heading>
+## Examples
+
+### Sequential Flow
+
 <p>A simple linear flow with nodes connected in sequence.</p>
 <ComponentExample demo="FlowBasicDemo">
   <FlowBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Parallel Branches</Heading>
+### Parallel Branches
+
 <p>Use `Flow.Parallel` to create branching paths that run in parallel.</p>
 <ComponentExample demo="FlowParallelDemo">
   <FlowParallelDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Node Styling</Heading>
+### Custom Node Styling
+
 <p>
   Use the `render` prop to completely customize node appearance. The render prop
   accepts a React element that will be used instead of the default styled node.
@@ -103,7 +110,8 @@ export default function Example() {
   <FlowCustomContentDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Centered Alignment</Heading>
+### Centered Alignment
+
 <p>
   Use the `align` prop to vertically center nodes. This is useful when nodes
   have different heights.
@@ -112,13 +120,15 @@ export default function Example() {
   <FlowCenteredDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Complex Flow</Heading>
+### Complex Flow
+
 <p>Combine sequential and parallel nodes to build complex workflows.</p>
 <ComponentExample demo="FlowComplexDemo">
   <FlowComplexDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Anchor Points</Heading>
+### Custom Anchor Points
+
 <p>
   By default, connectors attach to the center of each node. Use `Flow.Anchor`
   with its `render` prop to specify custom attachment points. The `type` prop
@@ -129,7 +139,8 @@ export default function Example() {
   <FlowAnchorDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Panning Large Diagrams</Heading>
+### Panning Large Diagrams
+
 <p>
   When a diagram exceeds its container, Flow automatically enables panning. Drag
   to pan the viewport, or use the scroll wheel. Scrollbars appear on hover to
@@ -139,7 +150,8 @@ export default function Example() {
   <FlowPanningDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Disabled Nodes</Heading>
+### Disabled Nodes
+
 <p>
   Use the `disabled` prop on a node to visually indicate it's inactive.
   Connectors linking to disabled nodes are rendered with reduced opacity.
@@ -148,7 +160,8 @@ export default function Example() {
   <FlowDisabledDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Parallel Node Alignment</Heading>
+### Parallel Node Alignment
+
   <p>
     Use the
     `align` prop on
@@ -167,7 +180,9 @@ export default function Example() {
 {/* Known Issue */}
 
 <ComponentSection>
-  <Heading level={2}>Known Issue: Sidebar / Layout Shift</Heading>
+
+## Known Issue: Sidebar / Layout Shift
+
   <p>
     Toggling the sidebar shifts the Flow container's viewport position. Because
     connector coordinates are computed from stale `getBoundingClientRect` values
@@ -183,9 +198,11 @@ export default function Example() {
 {/* Other Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Other Examples</Heading>
 
-  <Heading level={3}>Nested Node Lists in Parallel</Heading>
+## Other Examples
+
+### Nested Node Lists in Parallel
+
   <p>
     Use
     `Flow.List`
@@ -202,9 +219,11 @@ export default function Example() {
 {/* Components */}
 
 <ComponentSection>
-  <Heading level={2}>Components</Heading>
 
-<Heading level={3}>Flow</Heading>
+## Components
+
+### Flow
+
 <p>
   The root container for flow diagrams. Provides panning and scrolling for large
   diagrams.
@@ -241,7 +260,8 @@ export default function Example() {
   </table>
 </div>
 
-<Heading level={3}>Flow.Node</Heading>
+### Flow.Node
+
 <p>
   A single node in the flow diagram. Renders as a styled card with automatic
   connector points. Use the `render` prop to customize the element.
@@ -280,7 +300,8 @@ export default function Example() {
   </table>
 </div>
 
-<Heading level={3}>Flow.Anchor</Heading>
+### Flow.Anchor
+
 <p>
   A component that marks a custom attachment point for connectors within a
   Flow.Node. Use this to control exactly where connector lines attach instead of
@@ -318,7 +339,8 @@ export default function Example() {
   </table>
 </div>
 
-<Heading level={3}>Flow.Parallel</Heading>
+### Flow.Parallel
+
 <p>
   A container for parallel branches. Child Flow.Node components are displayed in
   parallel with junction connectors.
@@ -352,7 +374,8 @@ export default function Example() {
   </table>
 </div>
 
-  <Heading level={3}>Flow.List</Heading>
+### Flow.List
+
   <p>
     A container for a sequence of Flow.Node components with automatic
     connectors between them. Use inside Flow.Parallel to create branches

--- a/packages/kumo-docs-astro/src/pages/components/flow.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/flow.mdx
@@ -218,7 +218,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "center"</td>
@@ -255,7 +255,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">render</td>
         <td class="px-4 py-3 font-mono">ReactElement</td>
@@ -295,7 +295,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">type</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -332,7 +332,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -367,7 +367,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono">children</td>
           <td class="px-4 py-3 font-mono">ReactNode</td>

--- a/packages/kumo-docs-astro/src/pages/components/flow.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/flow.mdx
@@ -218,7 +218,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "center"</td>
@@ -255,7 +255,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">render</td>
         <td class="px-4 py-3 font-mono">ReactElement</td>
@@ -295,7 +295,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">type</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -332,7 +332,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -367,7 +367,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono">children</td>
           <td class="px-4 py-3 font-mono">ReactNode</td>

--- a/packages/kumo-docs-astro/src/pages/components/grid.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/grid.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/grid"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   GridDemo,
@@ -28,7 +27,8 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
 
 ```tsx
 import { Grid, GridItem } from "@cloudflare/kumo";
@@ -39,7 +39,9 @@ import { Grid, GridItem } from "@cloudflare/kumo";
 {/* Grid Variants */}
 
 <ComponentSection>
-  <Heading level={2}>Grid Variants</Heading>
+
+## Grid Variants
+
   <p>
     The Grid component supports multiple column layouts that adapt responsively
     across breakpoints.
@@ -52,7 +54,9 @@ import { Grid, GridItem } from "@cloudflare/kumo";
 {/* Asymmetric Layouts */}
 
 <ComponentSection>
-  <Heading level={2}>Asymmetric Layouts</Heading>
+
+## Asymmetric Layouts
+
   <p>Use asymmetric variants for sidebar/main content layouts.</p>
   <ComponentExample demo="GridAsymmetricDemo">
     <GridAsymmetricDemo client:visible />
@@ -62,7 +66,9 @@ import { Grid, GridItem } from "@cloudflare/kumo";
 {/* Gap Sizes */}
 
 <ComponentSection>
-  <Heading level={2}>Gap Sizes</Heading>
+
+## Gap Sizes
+
   <p>Control the spacing between grid items with the gap prop.</p>
   <ComponentExample demo="GridGapDemo">
     <GridGapDemo client:visible />
@@ -72,7 +78,9 @@ import { Grid, GridItem } from "@cloudflare/kumo";
 {/* Mobile Dividers */}
 
 <ComponentSection>
-  <Heading level={2}>Mobile Dividers</Heading>
+
+## Mobile Dividers
+
   <p>
     Add dividers between items on mobile with the mobileDivider prop (only works
     with the 4up variant).
@@ -85,7 +93,9 @@ import { Grid, GridItem } from "@cloudflare/kumo";
 {/* All Variants */}
 
 <ComponentSection>
-  <Heading level={2}>All Variants</Heading>
+
+## All Variants
+
   <p>Reference for all available grid variants:</p>
   <div class="overflow-x-auto">
     <table class="w-full text-left text-sm">
@@ -140,11 +150,15 @@ import { Grid, GridItem } from "@cloudflare/kumo";
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
-  <Heading level={3}>Grid</Heading>
+
+## API Reference
+
+### Grid
+
   <PropsTable component="Grid" />
 
-<Heading level={3}>GridItem</Heading>
+### GridItem
+
 <p>
   GridItem is a wrapper component for grid children. It accepts standard div
   props including `className` and `children`.

--- a/packages/kumo-docs-astro/src/pages/components/grid.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/grid.mdx
@@ -95,7 +95,7 @@ import { Grid, GridItem } from "@cloudflare/kumo";
           <th class="py-3 pr-4 font-medium">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="py-3 pr-4">`2up`</td>
           <td class="py-3 pr-4">1 column mobile, 2 columns medium+</td>

--- a/packages/kumo-docs-astro/src/pages/components/grid.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/grid.mdx
@@ -95,7 +95,7 @@ import { Grid, GridItem } from "@cloudflare/kumo";
           <th class="py-3 pr-4 font-medium">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="py-3 pr-4">`2up`</td>
           <td class="py-3 pr-4">1 column mobile, 2 columns medium+</td>

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/input"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   InputAreaBasicDemo,
@@ -34,14 +33,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { InputArea } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { InputArea } from "@cloudflare/kumo/components/input";
@@ -54,8 +55,10 @@ import { InputArea } from "@cloudflare/kumo/components/input";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
-  <Heading level={3}>With Built-in Field (Recommended)</Heading>
+
+## Usage
+
+### With Built-in Field (Recommended)
 
 <p>
   Use the `label` prop to enable the built-in Field wrapper with label,
@@ -76,7 +79,7 @@ export default function Example() {
 }
 ```
 
-<Heading level={3}>Bare InputArea (Custom Layouts)</Heading>
+### Bare InputArea (Custom Layouts)
 
 <p>
   For custom form layouts, use InputArea without `label`. Must provide
@@ -96,43 +99,51 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>With Label</Heading>
+## Examples
+
+### With Label
+
 <ComponentExample demo="InputAreaWithLabelDemo">
   <InputAreaWithLabelDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Row Count</Heading>
+### Custom Row Count
+
 <p>Use the `rows` prop to control the initial height.</p>
 <ComponentExample demo="InputAreaRowsDemo">
   <InputAreaRowsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Error State (String)</Heading>
+### Error State (String)
+
 <p>Error styling is automatically applied when the `error` prop is truthy.</p>
 <ComponentExample demo="InputAreaErrorStringDemo">
   <InputAreaErrorStringDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Error State (Object)</Heading>
+### Error State (Object)
+
 <p>Use an error object with `match` for constraint validation.</p>
 <ComponentExample demo="InputAreaErrorObjectDemo">
   <InputAreaErrorObjectDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Sizes</Heading>
+### Sizes
+
 <p>Four sizes available: `xs`, `sm`, `base` (default), `lg`.</p>
 <ComponentExample demo="InputAreaSizesDemo">
   <InputAreaSizesDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Disabled</Heading>
+### Disabled
+
 <ComponentExample demo="InputAreaDisabledDemo">
   <InputAreaDisabledDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Bare InputArea</Heading>
+### Bare InputArea
+
 <p>
   InputArea without `label` renders as a bare textarea. Must provide
   `aria-label` for accessibility.
@@ -141,19 +152,22 @@ export default function Example() {
   <InputAreaBareDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Optional Field</Heading>
+### Optional Field
+
 <p>Set `required={false}` to show "(optional)" text after the label.</p>
 <ComponentExample demo="InputAreaOptionalFieldDemo">
   <InputAreaOptionalFieldDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Label with Tooltip</Heading>
+### Label with Tooltip
+
 <p>Use `labelTooltip` to add an info icon with additional context on hover.</p>
 <ComponentExample demo="InputAreaLabelTooltipDemo">
   <InputAreaLabelTooltipDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>React Node Label</Heading>
+### React Node Label
+
 <p>The `label` prop accepts ReactNode for rich formatting.</p>
 <ComponentExample demo="InputAreaReactNodeLabelDemo">
   <InputAreaReactNodeLabelDemo client:visible />
@@ -164,7 +178,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
 
 <p>
   InputArea accepts all standard HTML textarea attributes plus the following:
@@ -177,9 +192,10 @@ export default function Example() {
 {/* Accessibility */}
 
 <ComponentSection>
-  <Heading level={2}>Accessibility</Heading>
 
-<h3 class="mb-2 font-semibold">Label Requirement</h3>
+## Accessibility
+
+### Label Requirement
 
 <p class="text-kumo-strong">
   InputArea requires an accessible name via one of:
@@ -195,7 +211,7 @@ export default function Example() {
   Missing accessible names trigger console warnings in development.
 </p>
 
-<h3 class="mb-2 mt-4 font-semibold">Error Association</h3>
+### Error Association
 
 <p class="text-kumo-strong">
   Error messages are automatically associated with the textarea via ARIA

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -181,23 +181,21 @@ export default function Example() {
 
 <h3 class="mb-2 font-semibold">Label Requirement</h3>
 
-<p class="text-kumo-default">
-  InputArea requires an accessible name via one of:
-</p>
+<p>InputArea requires an accessible name via one of:</p>
 
-<ul class="ml-4 list-disc space-y-1 text-kumo-default">
+<ul class="ml-4 list-disc space-y-1">
   <li>`label` prop (recommended)</li>
   <li>`placeholder` + `aria-label` for bare textareas</li>
   <li>`aria-labelledby` for custom label association</li>
 </ul>
 
-<p class="mt-2 text-kumo-default">
+<p class="mt-2">
   Missing accessible names trigger console warnings in development.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Error Association</h3>
 
-<p class="text-kumo-default">
+<p>
   Error messages are automatically associated with the textarea via ARIA
   attributes for screen reader announcement.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -181,23 +181,23 @@ export default function Example() {
 
 <h3 class="mb-2 font-semibold">Label Requirement</h3>
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   InputArea requires an accessible name via one of:
 </p>
 
-<ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+<ul class="ml-4 list-disc space-y-1 text-kumo-default">
   <li>`label` prop (recommended)</li>
   <li>`placeholder` + `aria-label` for bare textareas</li>
   <li>`aria-labelledby` for custom label association</li>
 </ul>
 
-<p class="mt-2 text-kumo-strong">
+<p class="mt-2 text-kumo-default">
   Missing accessible names trigger console warnings in development.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Error Association</h3>
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Error messages are automatically associated with the textarea via ARIA
   attributes for screen reader announcement.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -9,7 +9,6 @@ baseUIComponent: "input"
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   InputBasicDemo,
@@ -38,10 +37,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Input } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Input } from "@cloudflare/kumo/components/input";`}
     lang="tsx"
@@ -51,8 +55,11 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
-  <Heading level={3}>With Built-in Field (Recommended)</Heading>
+
+## Usage
+
+### With Built-in Field (Recommended)
+
   <p>
     Use the `label` prop to enable the built-in Field wrapper with label, description, and error support.
   </p>
@@ -71,7 +78,8 @@ export default function Example() {
 }
 ```
 
-<Heading level={3}>Bare Input (Custom Layouts)</Heading>
+### Bare Input (Custom Layouts)
+
 <p>
   For custom form layouts, use Input without `label`. Must provide `aria-label`
   or `aria-labelledby` for accessibility.
@@ -90,9 +98,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>With Label and Description</Heading>
+## Examples
+
+### With Label and Description
+
 <p>
   The `label` prop enables the built-in Field wrapper with automatic vertical
   layout (label above input).
@@ -101,7 +111,8 @@ export default function Example() {
   <InputWithLabelDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Error (String)</Heading>
+### With Error (String)
+
 <p>
   Pass `error` as a string for simple error messages. Error styling is
   automatically applied when the `error` prop is truthy.
@@ -110,7 +121,8 @@ export default function Example() {
   <InputErrorStringDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Error (Validation Object)</Heading>
+### With Error (Validation Object)
+
 <p>
   Pass `error` as an object with `message` and `match` for HTML5 validation.
   Error shows when field validity matches.
@@ -119,36 +131,42 @@ export default function Example() {
   <InputErrorObjectDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Input Sizes</Heading>
+### Input Sizes
+
 <p>Four sizes available: `xs`, `sm`, `base` (default), `lg`.</p>
 <ComponentExample demo="InputSizesDemo">
   <InputSizesDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Disabled</Heading>
+### Disabled
+
 <ComponentExample demo="InputDisabledDemo">
   <InputDisabledDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Optional Field</Heading>
+### Optional Field
+
 <p>Set `required={false}` to show "(optional)" text after the label.</p>
 <ComponentExample demo="InputOptionalFieldDemo">
   <InputOptionalFieldDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Label Tooltip</Heading>
+### With Label Tooltip
+
 <p>Use `labelTooltip` to add an info icon with additional context on hover.</p>
 <ComponentExample demo="InputLabelTooltipDemo">
   <InputLabelTooltipDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>ReactNode Label</Heading>
+### ReactNode Label
+
 <p>The `label` prop accepts ReactNode for rich formatting.</p>
 <ComponentExample demo="InputReactNodeLabelDemo">
   <InputReactNodeLabelDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Controlled with onChange</Heading>
+### Controlled with onChange
+
 <p>
   The standard React `onChange` handler receives the full event object. Use
   `e.target.value` to get the value.
@@ -157,7 +175,8 @@ export default function Example() {
   <InputControlledOnChangeDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Controlled with onValueChange</Heading>
+### Controlled with onValueChange
+
 <p>
   `onValueChange` is a convenience handler from Base UI that gives you the
   string value directly — no event unwrapping needed. This is the same pattern
@@ -167,7 +186,8 @@ export default function Example() {
   <InputControlledOnValueChangeDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Bare Input (No Label)</Heading>
+### Bare Input (No Label)
+
 <p>
   Input without `label` renders as a bare input. Must provide `aria-label` for
   accessibility.
@@ -176,7 +196,8 @@ export default function Example() {
   <InputBareDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Input Types</Heading>
+### Input Types
+
   <p>
     Supports all HTML input types: `text`, `email`, `password`, `number`, `tel`, `url`, etc.
   </p>
@@ -188,13 +209,16 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <p>
     Input accepts all standard HTML input attributes plus the following:
   </p>
   <PropsTable component="Input" />
 
-  <Heading level={3}>Validation Error Types</Heading>
+### Validation Error Types
+
   <p>
     When using `error` as an object, the `match` property corresponds to HTML5 ValidityState values:
   </p>
@@ -247,10 +271,14 @@ export default function Example() {
 {/* Accessibility */}
 
 <ComponentSection>
-  <Heading level={2}>Accessibility</Heading>
+
+## Accessibility
+
   <div class="space-y-4 text-sm">
     <div>
-      <h3 class="mb-2 font-semibold">Label Requirement</h3>
+
+      ### Label Requirement
+
       <p class="text-kumo-strong">
         Inputs require an accessible name via one of:
       </p>
@@ -264,7 +292,9 @@ export default function Example() {
       </p>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Error Association</h3>
+
+      ### Error Association
+
       <p class="text-kumo-strong">
         Error messages are automatically associated with the input via ARIA
         attributes for screen reader announcement.

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -206,7 +206,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">valueMissing</td>
           <td class="px-4 py-3 text-xs">Required field is empty</td>
@@ -251,21 +251,21 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Inputs require an accessible name via one of:
       </p>
-      <ul class="mt-2 ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="mt-2 ml-4 list-disc space-y-1 text-kumo-default">
         <li>`label` prop (recommended)</li>
         <li>`placeholder` + `aria-label` for bare inputs</li>
         <li>`aria-labelledby` for custom label association</li>
       </ul>
-      <p class="mt-2 text-kumo-strong">
+      <p class="mt-2 text-kumo-default">
         Missing accessible names trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Error Association</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Error messages are automatically associated with the input via ARIA
         attributes for screen reader announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -206,7 +206,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">valueMissing</td>
           <td class="px-4 py-3 text-xs">Required field is empty</td>
@@ -251,21 +251,19 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-default">
-        Inputs require an accessible name via one of:
-      </p>
-      <ul class="mt-2 ml-4 list-disc space-y-1 text-kumo-default">
+      <p>Inputs require an accessible name via one of:</p>
+      <ul class="mt-2 ml-4 list-disc space-y-1">
         <li>`label` prop (recommended)</li>
         <li>`placeholder` + `aria-label` for bare inputs</li>
         <li>`aria-labelledby` for custom label association</li>
       </ul>
-      <p class="mt-2 text-kumo-default">
+      <p class="mt-2">
         Missing accessible names trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Error Association</h3>
-      <p class="text-kumo-default">
+      <p>
         Error messages are automatically associated with the input via ARIA
         attributes for screen reader announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/label.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/label.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/label"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   LabelBasicDemo,
   LabelOptionalFieldDemo,
@@ -28,14 +27,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Label } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Label } from "@cloudflare/kumo/components/label";
@@ -46,8 +47,11 @@ import { Label } from "@cloudflare/kumo/components/label";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
-  <Heading level={3}>With Form Components (Recommended)</Heading>
+
+## Usage
+
+### With Form Components (Recommended)
+
   <p>
     Label features are automatically available through form components like `Input`, `Select`, `Checkbox`, and `Switch` via the `required` and `labelTooltip` props.
   </p>
@@ -71,7 +75,8 @@ export default function Example() {
 }
 ```
 
-<Heading level={3}>Standalone Label</Heading>
+### Standalone Label
+
 <p>For custom form layouts, use the `Label` component directly.</p>
 
 ```tsx
@@ -87,33 +92,39 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Optional Field</Heading>
+## Examples
+
+### Optional Field
+
 <p>Shows gray "(optional)" text when `required={false}`.</p>
 <ComponentExample demo="LabelOptionalFieldDemo">
   <LabelOptionalFieldDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Tooltip</Heading>
+### With Tooltip
+
 <p>Shows an info icon with a tooltip for additional context.</p>
 <ComponentExample demo="LabelWithTooltipDemo">
   <LabelWithTooltipDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>ReactNode Label Content</Heading>
+### ReactNode Label Content
+
 <p>Labels support ReactNode content for rich formatting.</p>
 <ComponentExample demo="LabelReactNodeDemo">
   <LabelReactNodeDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Form with Mixed Fields</Heading>
+### Form with Mixed Fields
+
 <p>Real-world example showing required and optional fields together.</p>
 <ComponentExample demo="LabelFormMixedDemo">
   <LabelFormMixedDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Standalone Label</Heading>
+### Standalone Label
+
 <p>Use Label directly for custom layouts or non-form contexts.</p>
 <ComponentExample demo="LabelStandaloneDemo">
   <LabelStandaloneDemo client:visible />
@@ -124,9 +135,11 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Label Props</Heading>
+## API Reference
+
+### Label Props
+
 <p>Props for the standalone Label component:</p>
 <div class="overflow-x-auto">
   <table class="w-full text-sm">
@@ -169,7 +182,8 @@ export default function Example() {
   </table>
 </div>
 
-<Heading level={3}>Form Component Label Props</Heading>
+### Form Component Label Props
+
 <p>
   These props are available on Input, InputArea, Select, Checkbox, Switch,
   SensitiveInput, and Combobox:
@@ -217,10 +231,14 @@ export default function Example() {
 {/* Design Guidelines */}
 
 <ComponentSection>
-  <Heading level={2}>Design Guidelines</Heading>
+
+## Design Guidelines
+
   <div class="space-y-4 text-sm">
     <div>
-      <h3 class="mb-2 font-semibold">When to Use Optional Indicators</h3>
+
+      ### When to Use Optional Indicators
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>
           Use "(optional)" for optional fields when most fields are required
@@ -230,7 +248,9 @@ export default function Example() {
       </ul>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">When to Use Tooltips</h3>
+
+      ### When to Use Tooltips
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>Provide additional context that doesn't fit in the label</li>
         <li>Explain format requirements or validation rules</li>
@@ -239,7 +259,9 @@ export default function Example() {
       </ul>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Accessibility</h3>
+
+      ### Accessibility
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>
           Optional indicators are purely visual - use the `required` attribute

--- a/packages/kumo-docs-astro/src/pages/components/label.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/label.mdx
@@ -138,7 +138,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">children</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -184,7 +184,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">label</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -221,7 +221,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Optional Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           Use "(optional)" for optional fields when most fields are required
         </li>
@@ -231,7 +231,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">When to Use Tooltips</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>Provide additional context that doesn't fit in the label</li>
         <li>Explain format requirements or validation rules</li>
         <li>Link to help documentation for complex fields</li>
@@ -240,7 +240,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           Optional indicators are purely visual - use the `required` attribute
           for validation

--- a/packages/kumo-docs-astro/src/pages/components/label.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/label.mdx
@@ -138,7 +138,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">children</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -184,7 +184,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">label</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -221,7 +221,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Optional Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           Use "(optional)" for optional fields when most fields are required
         </li>
@@ -231,7 +231,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">When to Use Tooltips</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>Provide additional context that doesn't fit in the label</li>
         <li>Explain format requirements or validation rules</li>
         <li>Link to help documentation for complex fields</li>
@@ -240,7 +240,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           Optional indicators are purely visual - use the `required` attribute
           for validation

--- a/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/layer-card"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   LayerCardDemo,
@@ -27,14 +26,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { LayerCard } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { LayerCard } from "@cloudflare/kumo/components/layer-card";
@@ -45,7 +46,8 @@ import { LayerCard } from "@cloudflare/kumo/components/layer-card";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { LayerCard } from "@cloudflare/kumo";
@@ -84,14 +86,17 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic Card</Heading>
+## Examples
+
+### Basic Card
+
 <ComponentExample demo="LayerCardBasicDemo">
   <LayerCardBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Surface-style Card</Heading>
+### Surface-style Card
+
 <p>
   For simple card containers, render content directly inside <code>LayerCard</code>
   without <code>LayerCard.Primary</code>.
@@ -100,7 +105,8 @@ export default function Example() {
   <LayerCardSurfaceDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Multiple Cards</Heading>
+### Multiple Cards
+
 <ComponentExample demo="LayerCardMultipleDemo">
   <LayerCardMultipleDemo client:visible />
 </ComponentExample>
@@ -110,6 +116,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="LayerCard" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/link"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   LinkBasicDemo,
   LinkInParagraphDemo,
@@ -27,14 +26,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Link } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Link } from "@cloudflare/kumo/components/link";
@@ -45,8 +46,11 @@ import { Link } from "@cloudflare/kumo/components/link";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
-  <Heading level={3}>Basic Link</Heading>
+
+## Usage
+
+### Basic Link
+
   <p>
     The default Link component renders an underlined anchor with primary color styling.
   </p>
@@ -63,7 +67,8 @@ export default function Example() {
 }
 ```
 
-<Heading level={3}>External Links</Heading>
+### External Links
+
 <p>
   Use the `Link.ExternalIcon` subcomponent to indicate links that open in a new
   tab.
@@ -85,7 +90,8 @@ export default function Example() {
 }
 ```
 
-<Heading level={3}>Framework Integration (render prop)</Heading>
+### Framework Integration (render prop)
+
 <p>
   Use the `render` prop to compose Link styles onto framework-specific routing
   components like React Router's Link or Next.js Link.
@@ -109,15 +115,18 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Inline in Paragraph</Heading>
+## Examples
+
+### Inline in Paragraph
+
 <p>Links flow naturally within paragraph text with proper underline offset.</p>
 <ComponentExample demo="LinkInParagraphDemo">
   <LinkInParagraphDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>External Link with Icon</Heading>
+### External Link with Icon
+
 <p>
   Use `Link.ExternalIcon` to visually indicate links that navigate away from
   your site.
@@ -126,7 +135,8 @@ export default function Example() {
   <LinkExternalDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Current Variant (Color Inheritance)</Heading>
+### Current Variant (Color Inheritance)
+
 <p>
   The `current` variant inherits color from its parent, useful for links within
   colored contexts like alerts.
@@ -135,7 +145,8 @@ export default function Example() {
   <LinkCurrentVariantDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Composition with render prop</Heading>
+### Composition with render prop
+
 <p>
   The `render` prop lets you compose Link styling onto any element, enabling
   integration with framework routing components.
@@ -149,9 +160,11 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Link Props</Heading>
+## API Reference
+
+### Link Props
+
 <p>Extends all native anchor element attributes.</p>
 <div class="overflow-x-auto">
   <table class="w-full text-sm">
@@ -202,7 +215,8 @@ export default function Example() {
   </table>
 </div>
 
-<Heading level={3}>Variants</Heading>
+### Variants
+
 <div class="overflow-x-auto">
   <table class="w-full text-sm">
     <thead>
@@ -236,7 +250,8 @@ export default function Example() {
   </table>
 </div>
 
-<Heading level={3}>Link.ExternalIcon</Heading>
+### Link.ExternalIcon
+
 <p>
   SVG icon component to indicate external links. Accepts all SVG element
   attributes.
@@ -253,10 +268,14 @@ export default function Example() {
 {/* Design Guidelines */}
 
 <ComponentSection>
-  <Heading level={2}>Design Guidelines</Heading>
+
+## Design Guidelines
+
   <div class="space-y-4 text-sm">
     <div>
-      <h3 class="mb-2 font-semibold">When to Use Each Variant</h3>
+
+      ### When to Use Each Variant
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>
           <strong>inline</strong>: Default choice for links within body text
@@ -272,7 +291,9 @@ export default function Example() {
       </ul>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">External Link Indicators</h3>
+
+      ### External Link Indicators
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>Always use `Link.ExternalIcon` for links that open in new tabs</li>
         <li>
@@ -284,7 +305,9 @@ export default function Example() {
       </ul>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Framework Integration</h3>
+
+      ### Framework Integration
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>
           Use the `render` prop with React Router, Next.js, or other framework
@@ -301,7 +324,9 @@ export default function Example() {
       </ul>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Accessibility</h3>
+
+      ### Accessibility
+
       <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
         <li>Links are keyboard focusable by default</li>
         <li>

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -163,7 +163,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">variant</td>
         <td class="px-4 py-3 font-mono text-xs">
@@ -212,7 +212,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Use Case</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">inline</td>
         <td class="px-4 py-3 text-xs">Primary color with underline</td>
@@ -257,7 +257,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Each Variant</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           <strong>inline</strong>: Default choice for links within body text
         </li>
@@ -273,7 +273,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">External Link Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>Always use `Link.ExternalIcon` for links that open in new tabs</li>
         <li>
           Set `target="_blank"` and `rel="noopener noreferrer"` for security
@@ -285,7 +285,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Framework Integration</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           Use the `render` prop with React Router, Next.js, or other framework
           links
@@ -302,7 +302,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>Links are keyboard focusable by default</li>
         <li>
           The external icon has `aria-hidden="true"` - add descriptive text for

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -163,7 +163,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">variant</td>
         <td class="px-4 py-3 font-mono text-xs">
@@ -212,7 +212,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Use Case</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">inline</td>
         <td class="px-4 py-3 text-xs">Primary color with underline</td>
@@ -257,7 +257,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Each Variant</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           <strong>inline</strong>: Default choice for links within body text
         </li>
@@ -273,7 +273,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">External Link Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>Always use `Link.ExternalIcon` for links that open in new tabs</li>
         <li>
           Set `target="_blank"` and `rel="noopener noreferrer"` for security
@@ -285,7 +285,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Framework Integration</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           Use the `render` prop with React Router, Next.js, or other framework
           links
@@ -302,7 +302,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>Links are keyboard focusable by default</li>
         <li>
           The external icon has `aria-hidden="true"` - add descriptive text for

--- a/packages/kumo-docs-astro/src/pages/components/loader.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/loader.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/loader"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   LoaderBasicDemo,
@@ -25,14 +24,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Loader } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Loader } from "@cloudflare/kumo/components/loader";
@@ -43,7 +44,8 @@ import { Loader } from "@cloudflare/kumo/components/loader";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Loader } from "@cloudflare/kumo";
@@ -58,14 +60,17 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Default Size</Heading>
+## Examples
+
+### Default Size
+
 <ComponentExample demo="LoaderBasicDemo">
   <LoaderBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Size</Heading>
+### Custom Size
+
 <ComponentExample demo="LoaderCustomSizeDemo">
   <LoaderCustomSizeDemo client:visible />
 </ComponentExample>
@@ -75,6 +80,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Loader" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/menu-bar.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/menu-bar.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/menubar"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   MenuBarBasicDemo,
@@ -26,14 +25,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { MenuBar } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { MenuBar } from "@cloudflare/kumo/components/menubar";
@@ -44,7 +45,8 @@ import { MenuBar } from "@cloudflare/kumo/components/menubar";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { MenuBar } from "@cloudflare/kumo";
@@ -71,14 +73,17 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Text Formatting</Heading>
+## Examples
+
+### Text Formatting
+
 <ComponentExample demo="MenuBarTextFormattingDemo">
   <MenuBarTextFormattingDemo client:visible />
 </ComponentExample>
 
-  <Heading level={3}>Without Active State</Heading>
+### Without Active State
+
   <ComponentExample demo="MenuBarNoActiveDemo">
     <MenuBarNoActiveDemo client:visible />
   </ComponentExample>
@@ -87,6 +92,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="MenuBar" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/meter.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/meter.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/meter"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   MeterBasicDemo,
@@ -28,14 +27,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Meter } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Meter } from "@cloudflare/kumo/components/meter";
@@ -46,7 +47,8 @@ import { Meter } from "@cloudflare/kumo/components/meter";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Meter } from "@cloudflare/kumo";
@@ -61,33 +63,39 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic Meter</Heading>
+## Examples
+
+### Basic Meter
+
 <p>The default meter displays a label and percentage value.</p>
 <ComponentExample demo="MeterBasicDemo">
   <MeterBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Value Display</Heading>
+### Custom Value Display
+
 <p>Use `customValue` to show a custom string instead of the percentage.</p>
 <ComponentExample demo="MeterCustomValueDemo">
   <MeterCustomValueDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Hidden Value</Heading>
+### Hidden Value
+
 <p>Set `showValue={false}` to hide the value display.</p>
 <ComponentExample demo="MeterHiddenValueDemo">
   <MeterHiddenValueDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Full Meter</Heading>
+### Full Meter
+
 <p>A meter at 100% capacity.</p>
 <ComponentExample demo="MeterFullDemo">
   <MeterFullDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Low Value</Heading>
+### Low Value
+
 <p>A meter with a low value.</p>
 <ComponentExample demo="MeterLowDemo">
   <MeterLowDemo client:visible />
@@ -98,6 +106,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Meter" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/pagination.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/pagination.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/pagination"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   PaginationBasicDemo,
@@ -35,14 +34,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Pagination } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Pagination } from "@cloudflare/kumo/components/pagination";
@@ -53,7 +54,8 @@ import { Pagination } from "@cloudflare/kumo/components/pagination";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { useState } from "react";
@@ -73,9 +75,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Full Controls (Default)</Heading>
+## Examples
+
+### Full Controls (Default)
+
 <p>
   The default pagination includes first, previous, page input, next, and last
   buttons.
@@ -84,7 +88,8 @@ export default function Example() {
   <PaginationFullDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Simple Controls</Heading>
+### Simple Controls
+
 <p>
   Use `controls="simple"` for a minimal pagination with only previous and next
   buttons.
@@ -93,19 +98,22 @@ export default function Example() {
   <PaginationSimpleDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Mid-Page State</Heading>
+### Mid-Page State
+
 <p>Pagination in the middle of a dataset with all navigation enabled.</p>
 <ComponentExample demo="PaginationMidPageDemo">
   <PaginationMidPageDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Large Dataset</Heading>
+### Large Dataset
+
 <p>Pagination handles large datasets with many pages.</p>
 <ComponentExample demo="PaginationLargeDatasetDemo">
   <PaginationLargeDatasetDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Text</Heading>
+### Custom Text
+
 <p>You can set custom pagination text.</p>
 <ComponentExample demo="PaginationCustomTextDemo">
   <PaginationCustomTextDemo client:visible />
@@ -116,18 +124,22 @@ export default function Example() {
 {/* Compound Components */}
 
 <ComponentSection>
-  <Heading level={2}>Compound Components</Heading>
+
+## Compound Components
+
   <p>
     For more control over layout and features, use the compound component API. This allows you to compose `Pagination.Info`, `Pagination.PageSize`, `Pagination.Controls`, and `Pagination.Separator` in any order.
   </p>
 
-<Heading level={3}>Page Size Selector</Heading>
+### Page Size Selector
+
 <p>Add a dropdown to let users select the number of items per page.</p>
 <ComponentExample demo="PaginationPageSizeSelectorDemo">
   <PaginationPageSizeSelectorDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Page Size Options</Heading>
+### Custom Page Size Options
+
 <p>
   Customize the available page size options with the `options` prop. Defaults to
   `[25, 50, 100, 250]`.
@@ -136,13 +148,15 @@ export default function Example() {
   <PaginationCustomPageSizeOptionsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Info Text</Heading>
+### Custom Info Text
+
 <p>Use a render function to customize the info text.</p>
 <ComponentExample demo="PaginationCompoundCustomInfoDemo">
   <PaginationCompoundCustomInfoDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Layout</Heading>
+### Custom Layout
+
 <p>
   Arrange components in any order. Here the page size selector is on the right.
 </p>
@@ -150,7 +164,8 @@ export default function Example() {
   <PaginationPageSizeRightDemo client:visible />
 </ComponentExample>
 
-    <Heading level={3}>Dropdown Page Selector</Heading>
+### Dropdown Page Selector
+
     <p>
       Use `pageSelector="dropdown"` on `Pagination.Controls` to render a dropdown
       select instead of a text input for page navigation. This is useful when you
@@ -178,7 +193,9 @@ export default function Example() {
 {/* Internationalization */}
 
 <ComponentSection>
-  <Heading level={2}>Internationalization</Heading>
+
+## Internationalization
+
   <p>
     Use the `labels` prop to customize all UI strings for different locales. All labels default to English.
   </p>
@@ -192,6 +209,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Pagination" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -8,7 +8,6 @@ baseUIComponent: "popover"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   PopoverHeroDemo,
@@ -31,14 +30,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Popover } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Popover } from "@cloudflare/kumo/components/popover";
@@ -49,7 +50,8 @@ import { Popover } from "@cloudflare/kumo/components/popover";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Popover, Button } from "@cloudflare/kumo";
@@ -72,7 +74,9 @@ export default function Example() {
 {/* Popover vs Tooltip */}
 
 <ComponentSection>
-  <Heading level={2}>Popover vs Tooltip</Heading>
+
+## Popover vs Tooltip
+
   <p>
     While popovers can be triggered on hover (using `openOnHover`), they serve a
     different purpose than tooltips. Understanding when to use each is important
@@ -143,19 +147,23 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic Popover</Heading>
+## Examples
+
+### Basic Popover
+
 <ComponentExample demo="PopoverBasicDemo">
   <PopoverBasicDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>With Close Button</Heading>
+### With Close Button
+
 <ComponentExample demo="PopoverWithCloseDemo">
   <PopoverWithCloseDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Positioning</Heading>
+### Positioning
+
 <p>
   Use the `side` prop to control where the popover appears relative to the
   trigger.
@@ -164,7 +172,8 @@ export default function Example() {
   <PopoverPositionDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Custom Content</Heading>
+### Custom Content
+
 <p>
   Popovers can contain any content, including custom layouts with avatars,
   buttons, and more.
@@ -173,7 +182,8 @@ export default function Example() {
   <PopoverCustomContentDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Open on Hover</Heading>
+### Open on Hover
+
 <p>
   Use `openOnHover` on the trigger to open the popover when the user hovers over
   it. You can also specify a `delay` in milliseconds before the popover appears.
@@ -182,7 +192,8 @@ export default function Example() {
   <PopoverOpenOnHoverDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Virtual Anchor</Heading>
+### Virtual Anchor
+
 <p>
   Use the `anchor` prop on `Popover.Content` to position the popover against an
   element other than the trigger, or against a virtual point (e.g., a `DOMRect`
@@ -198,20 +209,24 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Popover</Heading>
+## API Reference
+
+### Popover
+
 <p>The root component that manages the popover's open state.</p>
 <PropsTable component="Popover" />
 
-<Heading level={3}>Popover.Trigger</Heading>
+### Popover.Trigger
+
 <p>
   A button that opens the popover when clicked. Use `render` to render your own
   element.
 </p>
 <PropsTable component="Popover.Trigger" />
 
-<Heading level={3}>Popover.Content</Heading>
+### Popover.Content
+
 <p>
   The container for popover content. Controls positioning via `side`, `align`,
   `sideOffset`, and `alignOffset` props. Use the `anchor` prop to position
@@ -221,15 +236,18 @@ export default function Example() {
 </p>
 <PropsTable component="Popover.Content" />
 
-<Heading level={3}>Popover.Title</Heading>
+### Popover.Title
+
 <p>A heading that labels the popover for accessibility.</p>
 <PropsTable component="Popover.Title" />
 
-<Heading level={3}>Popover.Description</Heading>
+### Popover.Description
+
 <p>A paragraph providing additional context about the popover content.</p>
 <PropsTable component="Popover.Description" />
 
-<Heading level={3}>Popover.Close</Heading>
+### Popover.Close
+
 <p>
   A button that closes the popover when clicked. Use `render` to render your own
   element.

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -8,7 +8,6 @@ baseUIComponent: "radio-group"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   RadioBasicDemo,
@@ -33,14 +32,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Radio } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Radio } from "@cloudflare/kumo/components/radio";
@@ -51,7 +52,8 @@ import { Radio } from "@cloudflare/kumo/components/radio";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Radio } from "@cloudflare/kumo";
@@ -71,9 +73,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Default (Vertical)</Heading>
+## Examples
+
+### Default (Vertical)
+
 <p>
   Radio groups display vertically by default. Each radio has a label displayed
   to its right.
@@ -82,7 +86,8 @@ export default function Example() {
   <RadioDefaultDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Horizontal</Heading>
+### Horizontal
+
 <p>
   Use `orientation="horizontal"` for inline layouts. Items wrap when there isn't
   enough space.
@@ -91,19 +96,22 @@ export default function Example() {
   <RadioHorizontalDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Description</Heading>
+### With Description
+
 <p>Add helper text below the radio items using the `description` prop.</p>
 <ComponentExample demo="RadioDescriptionDemo">
   <RadioDescriptionDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Control Position</Heading>
+### Control Position
+
 <p>Use `controlPosition="end"` to place labels before radio buttons.</p>
 <ComponentExample demo="RadioControlPositionDemo">
   <RadioControlPositionDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Radio Card</Heading>
+### Radio Card
+
 <p>
   Use `appearance="card"` on the group to display each option as a selectable
   card. Combine with the `description` prop on each item for richer content.
@@ -112,7 +120,8 @@ export default function Example() {
   <RadioCardDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Radio Card (Horizontal)</Heading>
+### Radio Card (Horizontal)
+
 <p>
   Combine `appearance="card"` with `orientation="horizontal"` for a side-by-side
   card layout.
@@ -121,13 +130,15 @@ export default function Example() {
   <RadioCardHorizontalDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>With Error</Heading>
+### With Error
+
 <p>Show validation errors at the group level using the `error` prop.</p>
 <ComponentExample demo="RadioErrorDemo">
   <RadioErrorDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Disabled</Heading>
+### Disabled
+
 <p>Disable the entire group or individual items.</p>
 <ComponentExample demo="RadioDisabledDemo">
   <RadioDisabledDemo client:visible />
@@ -138,13 +149,16 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Radio.Group</Heading>
+## API Reference
+
+### Radio.Group
+
 <p>Container for radio buttons with legend, description, and error support.</p>
 <PropsTable component="Radio.Group" />
 
-<Heading level={3}>Radio.Item</Heading>
+### Radio.Item
+
 <p>Individual radio button within Radio.Group.</p>
 <PropsTable component="Radio.Item" />
 
@@ -153,22 +167,30 @@ export default function Example() {
 {/* Accessibility */}
 
 <ComponentSection>
-  <Heading level={2}>Accessibility</Heading>
+
+## Accessibility
+
   <div class="space-y-4 text-sm">
     <div>
-      <h3 class="mb-2 font-semibold">Semantic HTML</h3>
+
+      ### Semantic HTML
+
       <p class="text-kumo-strong">
         Radio.Group uses semantic `<fieldset>` and `<legend>` elements for proper grouping and screen reader announcement.
       </p>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
+
+      ### Keyboard Navigation
+
       <p class="text-kumo-strong">
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Up/Down</kbd> or <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Left/Right</kbd> moves between options. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> selects the focused option. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus to and from the radio group.
       </p>
     </div>
     <div>
-      <h3 class="mb-2 font-semibold">Screen Readers</h3>
+
+      ### Screen Readers
+
       <p class="text-kumo-strong">
         Each radio is announced with its label and selection state. The group legend provides context for all options.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -157,19 +157,19 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-      <p class="text-kumo-default">
+      <p>
         Radio.Group uses semantic `<fieldset>` and `<legend>` elements for proper grouping and screen reader announcement.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-default">
+      <p>
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Up/Down</kbd> or <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Left/Right</kbd> moves between options. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> selects the focused option. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus to and from the radio group.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-default">
+      <p>
         Each radio is announced with its label and selection state. The group legend provides context for all options.
       </p>
     </div>

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -157,19 +157,19 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Radio.Group uses semantic `<fieldset>` and `<legend>` elements for proper grouping and screen reader announcement.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Up/Down</kbd> or <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Left/Right</kbd> moves between options. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> selects the focused option. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus to and from the radio group.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Each radio is announced with its label and selection state. The group legend provides context for all options.
       </p>
     </div>

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -9,7 +9,6 @@ baseUIComponent: "select"
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
 import CodeBlock from "~/components/docs/CodeBlock.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   SelectBasicDemo,
@@ -41,10 +40,15 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
+
   <CodeBlock code={`import { Select } from "@cloudflare/kumo";`} lang="tsx" />
-  <Heading level={3}>Granular</Heading>
+
+### Granular
+
   <CodeBlock
     code={`import { Select } from "@cloudflare/kumo/components/select";`}
     lang="tsx"
@@ -54,7 +58,8 @@ import {
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Select } from "@cloudflare/kumo";
@@ -78,9 +83,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic</Heading>
+## Examples
+
+### Basic
+
 <p>
   A select with a visible label. When you provide the{" "}
   <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code> prop,
@@ -96,7 +103,9 @@ export default function Example() {
 {/* Sizes */}
 
 <ComponentSection>
-  <Heading level={3}>Sizes</Heading>
+
+### Sizes
+
   <p>
     Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">size</code> prop
     to match Input sizing (xs, sm, base, lg).
@@ -110,7 +119,9 @@ export default function Example() {
 {/* Without Visible Label */}
 
 <ComponentSection>
-  <Heading level={3}>Without Visible Label</Heading>
+
+### Without Visible Label
+
   <p>
     When a visible label isn't needed (e.g., in compact UIs or when context is clear),
     use `aria-label` for accessibility.
@@ -124,7 +135,9 @@ export default function Example() {
 {/* With Description and Error */}
 
 <ComponentSection>
-  <Heading level={3}>With Description and Error</Heading>
+
+### With Description and Error
+
   <p>
     Select integrates with the Field wrapper to show description text and validation errors.
   </p>
@@ -137,7 +150,9 @@ export default function Example() {
 {/* Placeholder */}
 
 <ComponentSection>
-  <Heading level={3}>Placeholder</Heading>
+
+### Placeholder
+
   <p>
     Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> prop
     to show text when no value is selected. When using <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to
@@ -161,7 +176,9 @@ export default function Example() {
 {/* Label Tooltip */}
 
 <ComponentSection>
-  <Heading level={3}>Label with Tooltip</Heading>
+
+### Label with Tooltip
+
   <p>
     Add a tooltip icon next to the label for additional context using <code
       class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
@@ -175,7 +192,9 @@ export default function Example() {
 {/* Custom Rendering */}
 
 <ComponentSection>
-  <Heading level={3}>Custom Rendering</Heading>
+
+### Custom Rendering
+
   <p>
     Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to customize how the selected value
     appears in the trigger button. This is useful when working with complex object
@@ -231,7 +250,9 @@ export default function Example() {
 {/* Loading */}
 
 <ComponentSection>
-  <Heading level={3}>Loading</Heading>
+
+### Loading
+
   <p>
     A select component with loading state. The loading state is passed to
     the component via the <code
@@ -251,7 +272,9 @@ export default function Example() {
 {/* Multiple Item */}
 
 <ComponentSection>
-  <Heading level={3}>Multiple Selection</Heading>
+
+### Multiple Selection
+
   <p>
     Enable multiple selection with the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">multiple</code> prop.
     The value becomes an array of selected items. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> for the empty state
@@ -279,7 +302,8 @@ export default function Example() {
 {/* More Example */}
 
 <ComponentSection>
-  <Heading level={3}>More Example</Heading>
+
+### More Example
 
   <ComponentExample demo="SelectComplexDemo">
     <SelectComplexDemo client:load />
@@ -289,7 +313,9 @@ export default function Example() {
 {/* Disabled Options */}
 
 <ComponentSection>
-  <Heading level={3}>Disabled Options</Heading>
+
+### Disabled Options
+
   <p>
     Options can be disabled with the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> prop.
     Disabled options are greyed out and cannot be selected.
@@ -303,7 +329,9 @@ export default function Example() {
 {/* Disabled Items via Prop */}
 
 <ComponentSection>
-  <Heading level={3}>Disabled Items (via items prop)</Heading>
+
+### Disabled Items (via items prop)
+
   <p>
     The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code> object-map prop
     accepts descriptor objects with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> alongside
@@ -318,7 +346,9 @@ export default function Example() {
 {/* Grouped Options */}
 
 <ComponentSection>
-  <Heading level={3}>Grouped Options</Heading>
+
+### Grouped Options
+
   <p>
     Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>,{" "}
     <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.GroupLabel</code>, and{" "}
@@ -334,7 +364,9 @@ export default function Example() {
 {/* Groups with Disabled */}
 
 <ComponentSection>
-  <Heading level={3}>Groups with Disabled Options</Heading>
+
+### Groups with Disabled Options
+
   <p>
     Combine groups, separators, and disabled options with info tooltips to
     clearly separate available and unavailable choices.
@@ -348,7 +380,9 @@ export default function Example() {
 {/* Long List - Test scrolling behavior */}
 
 <ComponentSection>
-  <Heading level={3}>Long List (Scrolling Test)</Heading>
+
+### Long List (Scrolling Test)
+
   <p>
     A select component with many options to test popup scrolling behavior.
     The popup should scroll smoothly without bounce/overscroll issues.
@@ -362,14 +396,19 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
-  <Heading level={3}>Select</Heading>
+
+## API Reference
+
+### Select
+
   <PropsTable component="Select" />
 
-<Heading level={3}>Select.Option</Heading>
+### Select.Option
+
 <PropsTable component="Select.Option" />
 
-<Heading level={3}>Select.Group</Heading>
+### Select.Group
+
 <p>
   Groups related options together with an accessible{" "}
   <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>.
@@ -380,13 +419,15 @@ export default function Example() {
   to provide a visible heading.
 </p>
 
-<Heading level={3}>Select.GroupLabel</Heading>
+### Select.GroupLabel
+
 <p>
   A visible heading for a{" "}
   <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>.
   Automatically associated with its parent group for accessibility.
 </p>
 
-  <Heading level={3}>Select.Separator</Heading>
+### Select.Separator
+
   <p>A visual divider line between option groups. Renders with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="separator"</code>.</p>
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -240,9 +240,9 @@ export default function Example() {
 
   <ComponentExample demo="SelectLoadingDemo">
     <div class="flex flex-col gap-4">
-      <p class="text-kumo-strong">Loading State</p>
+      <p class="text-kumo-default">Loading State</p>
       <SelectLoadingDemo client:load />
-      <p class="text-kumo-strong">Loading From Server (simulated 2s delay)</p>
+      <p class="text-kumo-default">Loading From Server (simulated 2s delay)</p>
       <SelectLoadingDataDemo client:load />
     </div>
   </ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/sensitive-input"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   SensitiveInputDemo,
@@ -27,14 +26,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { SensitiveInput } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { SensitiveInput } from "@cloudflare/kumo/components/sensitive-input";
@@ -45,7 +46,8 @@ import { SensitiveInput } from "@cloudflare/kumo/components/sensitive-input";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { SensitiveInput } from "@cloudflare/kumo";
@@ -60,7 +62,9 @@ export default function Example() {
 {/* Sizes */}
 
 <ComponentSection>
-  <Heading level={2}>Sizes</Heading>
+
+## Sizes
+
   <p>SensitiveInput supports multiple sizes to fit different contexts.</p>
   <ComponentExample demo="SensitiveInputSizesDemo">
     <SensitiveInputSizesDemo client:visible />
@@ -70,7 +74,9 @@ export default function Example() {
 {/* Controlled */}
 
 <ComponentSection>
-  <Heading level={2}>Controlled</Heading>
+
+## Controlled
+
   <p>Use controlled mode for full control over the input value.</p>
   <ComponentExample demo="SensitiveInputControlledDemo">
     <SensitiveInputControlledDemo client:load />
@@ -80,7 +86,9 @@ export default function Example() {
 {/* States */}
 
 <ComponentSection>
-  <Heading level={2}>States</Heading>
+
+## States
+
   <p>
     Various input states including error, disabled, read-only, and with
     description.
@@ -93,6 +101,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="SensitiveInput" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -7,7 +7,6 @@ sourceFile: "primitives/skeleton-line"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import {
   SkeletonLineDemo,
   SkeletonLineWidthDemo,
@@ -27,7 +26,8 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
+
+## Installation
 
 ```tsx
 import { SkeletonLine } from "@cloudflare/kumo";
@@ -38,7 +38,9 @@ import { SkeletonLine } from "@cloudflare/kumo";
 {/* Custom Widths */}
 
 <ComponentSection>
-  <Heading level={2}>Custom Widths</Heading>
+
+## Custom Widths
+
   <p class="text-kumo-strong mb-4">
     Control the randomized width range for more natural-looking skeletons.
   </p>
@@ -50,7 +52,9 @@ import { SkeletonLine } from "@cloudflare/kumo";
 {/* Custom Height */}
 
 <ComponentSection>
-  <Heading level={2}>Custom Height</Heading>
+
+## Custom Height
+
   <p class="text-kumo-strong mb-4">
     Override the default height using Tailwind utility classes via{" "}
     <code>className</code>. The default height is <code>0.5rem</code>.
@@ -63,7 +67,9 @@ import { SkeletonLine } from "@cloudflare/kumo";
 {/* Block Height */}
 
 <ComponentSection>
-  <Heading level={2}>Block Height</Heading>
+
+## Block Height
+
   <p class="text-kumo-strong mb-4">
     Use <code>blockHeight</code> to set the height of a container that
     vertically centers the skeleton line. Useful when replacing text of a known
@@ -78,7 +84,9 @@ import { SkeletonLine } from "@cloudflare/kumo";
 {/* Card Loading State */}
 
 <ComponentSection>
-  <Heading level={2}>Card Loading State</Heading>
+
+## Card Loading State
+
   <p class="text-kumo-strong mb-4">
     Use skeleton lines to create loading states for cards and content areas.
   </p>
@@ -90,7 +98,9 @@ import { SkeletonLine } from "@cloudflare/kumo";
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <div class="overflow-x-auto">
     <table class="w-full text-sm">
       <thead>

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -39,7 +39,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Widths</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Control the randomized width range for more natural-looking skeletons.
   </p>
   <ComponentExample demo="SkeletonLineWidthDemo">
@@ -51,7 +51,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Height</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Override the default height using Tailwind utility classes via{" "}
     <code>className</code>. The default height is <code>0.5rem</code>.
   </p>
@@ -64,7 +64,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Block Height</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Use <code>blockHeight</code> to set the height of a container that
     vertically centers the skeleton line. Useful when replacing text of a known
     line height. Accepts a number (treated as <code>px</code>) or any CSS string
@@ -79,7 +79,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Card Loading State</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Use skeleton lines to create loading states for cards and content areas.
   </p>
   <ComponentExample demo="SkeletonLineCardDemo">
@@ -100,7 +100,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
           <th class="px-4 py-3 text-left font-semibold">Default</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">minWidth</td>
           <td class="px-4 py-3 font-mono text-xs">number</td>

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -39,7 +39,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Widths</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Control the randomized width range for more natural-looking skeletons.
   </p>
   <ComponentExample demo="SkeletonLineWidthDemo">
@@ -51,7 +51,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Height</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Override the default height using Tailwind utility classes via{" "}
     <code>className</code>. The default height is <code>0.5rem</code>.
   </p>
@@ -64,7 +64,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Block Height</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Use <code>blockHeight</code> to set the height of a container that
     vertically centers the skeleton line. Useful when replacing text of a known
     line height. Accepts a number (treated as <code>px</code>) or any CSS string
@@ -79,7 +79,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Card Loading State</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Use skeleton lines to create loading states for cards and content areas.
   </p>
   <ComponentExample demo="SkeletonLineCardDemo">
@@ -100,7 +100,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
           <th class="px-4 py-3 text-left font-semibold">Default</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">minWidth</td>
           <td class="px-4 py-3 font-mono text-xs">number</td>

--- a/packages/kumo-docs-astro/src/pages/components/switch.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/switch.mdx
@@ -8,7 +8,6 @@ baseUIComponent: "switch"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   SwitchBasicDemo,
@@ -33,14 +32,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Switch } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Switch } from "@cloudflare/kumo/components/switch";
@@ -51,7 +52,8 @@ import { Switch } from "@cloudflare/kumo/components/switch";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Switch } from "@cloudflare/kumo";
@@ -71,24 +73,29 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Off State</Heading>
+## Examples
+
+### Off State
+
 <ComponentExample demo="SwitchOffDemo">
   <SwitchOffDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>On State</Heading>
+### On State
+
 <ComponentExample demo="SwitchOnDemo">
   <SwitchOnDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Disabled</Heading>
+### Disabled
+
 <ComponentExample demo="SwitchDisabledDemo">
   <SwitchDisabledDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Variants</Heading>
+### Variants
+
 <p>
   The Switch supports two variants: `default` (blue when on) and `neutral`
   (monochrome). Both use a squircle shape.
@@ -97,7 +104,8 @@ export default function Example() {
   <SwitchVariantsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Neutral Variant</Heading>
+### Neutral Variant
+
 <p>
   The neutral variant uses monochrome colors and a squircle shape, ideal for
   subtle, less prominent toggles.
@@ -106,18 +114,21 @@ export default function Example() {
   <SwitchNeutralDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Neutral States</Heading>
+### Neutral States
+
 <ComponentExample demo="SwitchNeutralStatesDemo">
   <SwitchNeutralStatesDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Sizes</Heading>
+### Sizes
+
 <p>Three sizes available: `sm`, `base` (default), and `lg`.</p>
 <ComponentExample demo="SwitchSizesDemo">
   <SwitchSizesDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom ID</Heading>
+### Custom ID
+
 <p>
   When a custom `id` is provided, clicking the label still toggles the switch.
   The `id` is forwarded to Base UI so the label's `htmlFor` stays in sync.
@@ -131,6 +142,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Switch" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table-of-contents.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/table-of-contents"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   TableOfContentsBasicDemo,
@@ -29,14 +28,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { TableOfContents } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { TableOfContents } from "@cloudflare/kumo/components/table-of-contents";
@@ -47,7 +48,8 @@ import { TableOfContents } from "@cloudflare/kumo/components/table-of-contents";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { TableOfContents } from "@cloudflare/kumo";
@@ -78,9 +80,11 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Interactive</Heading>
+## Examples
+
+### Interactive
+
 <p>
   Click an item to set it as active. The consumer controls state via `active`
   and `onClick`.
@@ -89,7 +93,8 @@ export default function Example() {
   <TableOfContentsInteractiveDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>No active item</Heading>
+### No active item
+
 <p>
   When no item has `active` set, all items show the default subtle text style
   with a hover indicator.
@@ -98,7 +103,8 @@ export default function Example() {
   <TableOfContentsNoActiveDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Groups</Heading>
+### Groups
+
 <p>
   Use `TableOfContents.Group` to organize items into labeled sections with
   indented children.
@@ -107,7 +113,8 @@ export default function Example() {
   <TableOfContentsGroupDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Without title</Heading>
+### Without title
+
 <p>
   The title sub-component is optional — use `TableOfContents.List` directly if
   you don't need a heading.
@@ -116,7 +123,8 @@ export default function Example() {
   <TableOfContentsWithoutTitleDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom element</Heading>
+### Custom element
+
 <p>
   Use the `render` prop to swap the default anchor for a button, router link, or
   any element.
@@ -142,7 +150,7 @@ export default function Example() {
 </TableOfContents.Item>
 ```
 
-**With Next.js**
+#### With Next.js
 
 ```tsx
 import Link from "next/link";
@@ -157,6 +165,8 @@ import Link from "next/link";
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="TableOfContents" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/table.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/table"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   TableBasicDemo,
@@ -31,14 +30,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Table } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Table } from "@cloudflare/kumo/components/table";
@@ -49,7 +50,8 @@ import { Table } from "@cloudflare/kumo/components/table";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Table, LayerCard } from "@cloudflare/kumo";
@@ -83,15 +85,18 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>With Checkboxes</Heading>
+## Examples
+
+### With Checkboxes
+
 <p>Add row selection with `Table.CheckHead` and `Table.CheckCell`.</p>
 <ComponentExample demo="TableWithCheckboxDemo">
   <TableWithCheckboxDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Compact Header</Heading>
+### Compact Header
+
 <p>
   Use `variant="compact"` on `Table.Header` for a more condensed header style.
 </p>
@@ -99,13 +104,15 @@ export default function Example() {
   <TableWithCompactHeaderDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Selected Row</Heading>
+### Selected Row
+
 <p>Use `variant="selected"` on `Table.Row` to highlight selected rows.</p>
 <ComponentExample demo="TableSelectedRowDemo">
   <TableSelectedRowDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Fixed Layout with Column Sizes</Heading>
+### Fixed Layout with Column Sizes
+
 <p>
   For precise control over column widths, set `layout="fixed"` and use
   `colgroup` with `col` elements.
@@ -114,7 +121,8 @@ export default function Example() {
   <TableFixedLayoutDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Sticky Column</Heading>
+### Sticky Column
+
 <p>
   Pin a column to the left or right edge of the scroll container with
   `sticky="left"` or `sticky="right"` on `Table.Head` and `Table.Cell`. The
@@ -125,13 +133,15 @@ export default function Example() {
   <TableStickyColumnDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Compact Header with Sticky Column</Heading>
+### Compact Header with Sticky Column
+
 <p>Combining `variant="compact"` on `Table.Header` with `sticky` columns.</p>
 <ComponentExample demo="TableCompactStickyDemo">
   <TableCompactStickyDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Full Example</Heading>
+### Full Example
+
 <p>
   Complete table with checkboxes, badges, action buttons, and fixed column
   widths.
@@ -145,37 +155,47 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Table</Heading>
+## API Reference
+
+### Table
+
 <p>Root table component. Renders a semantic `<table>` element.</p>
 <PropsTable component="Table" />
 
-<Heading level={3}>Table.Header</Heading>
+### Table.Header
+
 <p>Table header section. Renders `<thead>`. Set `sticky` to pin the header row to the top of the scroll container.</p>
 
-<Heading level={3}>Table.Body</Heading>
+### Table.Body
+
 <p>Table body section. Renders `<tbody>`.</p>
 
-<Heading level={3}>Table.Row</Heading>
+### Table.Row
+
 <p>Table row. Supports `variant="selected"` for highlighting.</p>
 <PropsTable component="Table.Row" />
 
-<Heading level={3}>Table.Head</Heading>
+### Table.Head
+
 <p>Header cell. Renders `<th>`. Accepts `sticky="left"` or `sticky="right"` to pin the column.</p>
 
-<Heading level={3}>Table.Cell</Heading>
+### Table.Cell
+
 <p>Body cell. Renders `<td>`. Accepts `sticky="left"` or `sticky="right"` to pin the column.</p>
 
-<Heading level={3}>Table.CheckHead</Heading>
+### Table.CheckHead
+
 <p>Header cell with checkbox for "select all" functionality.</p>
 <PropsTable component="Table.CheckHead" />
 
-<Heading level={3}>Table.CheckCell</Heading>
+### Table.CheckCell
+
 <p>Body cell with checkbox for row selection.</p>
 <PropsTable component="Table.CheckCell" />
 
-<Heading level={3}>Table.ResizeHandle</Heading>
+### Table.ResizeHandle
+
 <p>
   Draggable handle for column resizing. Use with TanStack Table or custom resize
   logic.
@@ -186,7 +206,9 @@ export default function Example() {
 {/* TanStack Table Integration */}
 
 <ComponentSection>
-  <Heading level={2}>TanStack Table Integration</Heading>
+
+## TanStack Table Integration
+
   <p>
     For advanced features like sorting, filtering, and resizable columns, integrate with <a href="https://tanstack.com/table" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">TanStack Table</a>. The Table component is designed to work seamlessly with TanStack's headless API.
   </p>
@@ -253,20 +275,24 @@ function DataTable({ data, columns }) {
 {/* Accessibility */}
 
 <ComponentSection>
-  <Heading level={2}>Accessibility</Heading>
 
-<h3 class="mb-2 font-semibold">Semantic HTML</h3>
+## Accessibility
+
+### Semantic HTML
+
 <p class="text-kumo-strong">
   Table uses semantic `<table>`, `<thead>`, `<tbody>`, `<th>`, and `<td>` elements for proper screen reader navigation.
 </p>
 
-<h3 class="mb-2 mt-4 font-semibold">Checkbox Labels</h3>
+### Checkbox Labels
+
 <p class="text-kumo-strong">
   Always provide `aria-label` for `Table.CheckHead` and `Table.CheckCell` to
   describe their purpose.
 </p>
 
-<h3 class="mb-2 mt-4 font-semibold">Keyboard Navigation</h3>
+### Keyboard Navigation
+
 <p class="text-kumo-strong">
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
   through interactive elements. Checkboxes respond to{" "}

--- a/packages/kumo-docs-astro/src/pages/components/table.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table.mdx
@@ -256,18 +256,18 @@ function DataTable({ data, columns }) {
   <Heading level={2}>Accessibility</Heading>
 
 <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-<p class="text-kumo-default">
+<p>
   Table uses semantic `<table>`, `<thead>`, `<tbody>`, `<th>`, and `<td>` elements for proper screen reader navigation.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Checkbox Labels</h3>
-<p class="text-kumo-default">
+<p>
   Always provide `aria-label` for `Table.CheckHead` and `Table.CheckCell` to
   describe their purpose.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Keyboard Navigation</h3>
-<p class="text-kumo-default">
+<p>
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
   through interactive elements. Checkboxes respond to{" "}
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd>.

--- a/packages/kumo-docs-astro/src/pages/components/table.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table.mdx
@@ -188,7 +188,7 @@ export default function Example() {
 <ComponentSection>
   <Heading level={2}>TanStack Table Integration</Heading>
   <p>
-    For advanced features like sorting, filtering, and resizable columns, integrate with <a href="https://tanstack.com/table" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">TanStack Table</a>. The Table component is designed to work seamlessly with TanStack's headless API.
+    For advanced features like sorting, filtering, and resizable columns, integrate with <a href="https://tanstack.com/table" target="_blank" rel="noopener noreferrer">TanStack Table</a>. The Table component is designed to work seamlessly with TanStack's headless API.
   </p>
 
 ```tsx
@@ -256,18 +256,18 @@ function DataTable({ data, columns }) {
   <Heading level={2}>Accessibility</Heading>
 
 <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Table uses semantic `<table>`, `<thead>`, `<tbody>`, `<th>`, and `<td>` elements for proper screen reader navigation.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Checkbox Labels</h3>
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Always provide `aria-label` for `Table.CheckHead` and `Table.CheckCell` to
   describe their purpose.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Keyboard Navigation</h3>
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
   through interactive elements. Checkboxes respond to{" "}
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd>.

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/tabs"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   TabsDefaultDemo,
@@ -28,14 +27,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Tabs } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Tabs } from "@cloudflare/kumo/components/tabs";
@@ -46,7 +47,8 @@ import { Tabs } from "@cloudflare/kumo/components/tabs";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Tabs } from "@cloudflare/kumo";
@@ -69,17 +71,20 @@ export default function Example() {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Variants</Heading>
+## Examples
 
-<h4 class="mb-3 text-base font-medium">Segmented (Default)</h4>
+### Variants
+
+#### Segmented (Default)
+
 <p>A pill-shaped indicator slides between tabs on a subtle background.</p>
 <ComponentExample demo="TabsSegmentedDemo">
   <TabsSegmentedDemo client:visible />
 </ComponentExample>
 
-<h4 class="mb-3 text-base font-medium">Underline</h4>
+#### Underline
+
 <p>
   A bottom border with a primary-colored indicator. The active tab has bolder
   text for emphasis.
@@ -88,13 +93,15 @@ export default function Example() {
   <TabsUnderlineDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Controlled</Heading>
+### Controlled
+
 <p>Use the `value` and `onValueChange` props for controlled state.</p>
 <ComponentExample demo="TabsControlledDemo">
   <TabsControlledDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Many Tabs</Heading>
+### Many Tabs
+
 <p>Tabs automatically scroll horizontally when there are many items.</p>
 <ComponentExample demo="TabsManyDemo">
   <TabsManyDemo client:visible />
@@ -105,10 +112,13 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Tabs" />
 
-<Heading level={3}>TabsItem</Heading>
+### TabsItem
+
 <div class="overflow-x-auto">
   <table class="w-full text-sm">
     <thead>

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/text"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   TextVariantsDemo,
@@ -25,14 +24,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Text } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Text } from "@cloudflare/kumo/components/text";
@@ -43,7 +44,8 @@ import { Text } from "@cloudflare/kumo/components/text";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Text } from "@cloudflare/kumo";
@@ -54,7 +56,9 @@ export default function Example() {
 ```
 
 <section class="mt-8 space-y-4">
-  <h3 class="text-lg font-semibold">Restrictions</h3>
+
+  ### Restrictions
+
   <p class="text-kumo-strong">
     The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
   </p>
@@ -94,7 +98,9 @@ export default function Example() {
 {/* Truncate */}
 
 <ComponentSection>
-  <Heading level={2}>Truncate</Heading>
+
+## Truncate
+
   <p class="text-kumo-strong">
     Use the `truncate` prop to clip overflowing text with an ellipsis. This adds `truncate min-w-0` classes, which is useful when `Text` is inside a flex or grid container.
   </p>
@@ -111,6 +117,8 @@ export default function Example() {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Text" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -55,7 +55,7 @@ export default function Example() {
 
 <section class="mt-8 space-y-4">
   <h3 class="text-lg font-semibold">Restrictions</h3>
-  <p class="text-kumo-default">
+  <p>
     The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
   </p>
 
@@ -66,7 +66,7 @@ export default function Example() {
 <Text variant="error">Error</Text>
 ```
 
-<p class="text-kumo-default">
+<p>
   Monospace variants (`mono` and `mono-secondary`) can only set `size` to `lg`
   and cannot use the `bold` prop:
 </p>
@@ -77,7 +77,7 @@ export default function Example() {
 <Text variant="mono" bold>Monospace</Text> // Doesn't compile
 ```
 
-<p class="text-kumo-default">
+<p>
   Headings (i.e. `h1`, `h2` and `h3` variants) cannot use these props at all:
 </p>
 
@@ -95,7 +95,7 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={2}>Truncate</Heading>
-  <p class="text-kumo-default">
+  <p>
     Use the `truncate` prop to clip overflowing text with an ellipsis. This adds `truncate min-w-0` classes, which is useful when `Text` is inside a flex or grid container.
   </p>
   <ComponentExample demo="TextTruncateDemo">

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -55,7 +55,7 @@ export default function Example() {
 
 <section class="mt-8 space-y-4">
   <h3 class="text-lg font-semibold">Restrictions</h3>
-  <p class="text-kumo-strong">
+  <p class="text-kumo-default">
     The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
   </p>
 
@@ -66,7 +66,7 @@ export default function Example() {
 <Text variant="error">Error</Text>
 ```
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Monospace variants (`mono` and `mono-secondary`) can only set `size` to `lg`
   and cannot use the `bold` prop:
 </p>
@@ -77,7 +77,7 @@ export default function Example() {
 <Text variant="mono" bold>Monospace</Text> // Doesn't compile
 ```
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Headings (i.e. `h1`, `h2` and `h3` variants) cannot use these props at all:
 </p>
 
@@ -95,7 +95,7 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={2}>Truncate</Heading>
-  <p class="text-kumo-strong">
+  <p class="text-kumo-default">
     Use the `truncate` prop to clip overflowing text with an ellipsis. This adds `truncate min-w-0` classes, which is useful when `Text` is inside a flex or grid container.
   </p>
   <ComponentExample demo="TextTruncateDemo">

--- a/packages/kumo-docs-astro/src/pages/components/toast.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/toast.mdx
@@ -7,7 +7,6 @@ sourceFile: "components/toast"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   ToastBasicDemo,
@@ -34,14 +33,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Toasty, useKumoToastManager } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Toasty, useKumoToastManager } from "@cloudflare/kumo/components/toast";
@@ -52,7 +53,9 @@ import { Toasty, useKumoToastManager } from "@cloudflare/kumo/components/toast";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
+
   <p>
     The toast system consists of two parts: the `Toasty` provider component and the `useKumoToastManager()` hook for triggering toasts.
   </p>
@@ -92,7 +95,9 @@ export default function App() {
 {/* Setup */}
 
 <ComponentSection>
-  <Heading level={2}>Setup</Heading>
+
+## Setup
+
   <p>
     Wrap your application (or a section of it) with the `Toasty` provider. This sets up the toast context and renders the toast viewport.
   </p>
@@ -111,33 +116,39 @@ export function Layout({ children }) {
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Title and Description</Heading>
+## Examples
+
+### Title and Description
+
 <p>A complete toast with both title and description.</p>
 <ComponentExample demo="ToastBasicDemo">
   <ToastBasicDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Title Only</Heading>
+### Title Only
+
 <p>A simple toast with just a title for brief messages.</p>
 <ComponentExample demo="ToastTitleOnlyDemo">
   <ToastTitleOnlyDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Description Only</Heading>
+### Description Only
+
 <p>A toast with only a description for more detailed messages.</p>
 <ComponentExample demo="ToastDescriptionOnlyDemo">
   <ToastDescriptionOnlyDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Success Variant</Heading>
+### Success Variant
+
 <p>Use the success variant for confirmations and positive outcomes.</p>
 <ComponentExample demo="ToastSuccessDemo">
   <ToastSuccessDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Multiple Toasts</Heading>
+### Multiple Toasts
+
 <p>
   Multiple toasts stack and animate smoothly. Hover over the stack to expand
   them.
@@ -146,37 +157,43 @@ export function Layout({ children }) {
   <ToastMultipleDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Error Variant</Heading>
+### Error Variant
+
 <p>Use the error variant for critical issues that need attention.</p>
 <ComponentExample demo="ToastErrorDemo">
   <ToastErrorDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Warning Variant</Heading>
+### Warning Variant
+
 <p>Use the warning variant for cautionary messages.</p>
 <ComponentExample demo="ToastWarningDemo">
   <ToastWarningDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Info Variant</Heading>
+### Info Variant
+
 <p>Use the info variant for neutral informational messages.</p>
 <ComponentExample demo="ToastInfoDemo">
   <ToastInfoDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Custom Content</Heading>
+### Custom Content
+
 <p>Use the content prop to render completely custom toast content.</p>
 <ComponentExample demo="ToastCustomContentDemo">
   <ToastCustomContentDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Action Buttons</Heading>
+### Action Buttons
+
 <p>Add action buttons to toasts for user interaction.</p>
 <ComponentExample demo="ToastActionsDemo">
   <ToastActionsDemo client:visible />
 </ComponentExample>
 
-<Heading level={3}>Promise</Heading>
+### Promise
+
 <p>
   Use the promise method to show loading, success, and error states
   automatically.
@@ -190,13 +207,16 @@ export function Layout({ children }) {
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
 
-<Heading level={3}>Toasty</Heading>
+## API Reference
+
+### Toasty
+
 <p>The provider component that wraps your app and manages the toast system.</p>
 <PropsTable component="Toasty" />
 
-<Heading level={3}>useKumoToastManager()</Heading>
+### useKumoToastManager()
+
 <p>A hook that returns the toast manager for creating toasts.</p>
 
 ```tsx
@@ -213,7 +233,8 @@ toastManager.promise(asyncFn(), {
 });
 ```
 
-<Heading level={3}>Toast Options</Heading>
+### Toast Options
+
 <p>Options passed to `toastManager.add()` and promise handlers.</p>
 <div class="overflow-x-auto">
   <table class="w-full text-left text-sm">

--- a/packages/kumo-docs-astro/src/pages/components/toast.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/toast.mdx
@@ -219,10 +219,10 @@ toastManager.promise(asyncFn(), {
   <table class="w-full text-left text-sm">
     <thead>
       <tr class="border-b border-kumo-hairline">
-        <th class="py-3 pr-4 font-semibold text-kumo-default">Prop</th>
-        <th class="py-3 pr-4 font-semibold text-kumo-default">Type</th>
-        <th class="py-3 pr-4 font-semibold text-kumo-default">Default</th>
-        <th class="py-3 font-semibold text-kumo-default">Description</th>
+        <th class="py-3 pr-4 font-semibold">Prop</th>
+        <th class="py-3 pr-4 font-semibold">Type</th>
+        <th class="py-3 pr-4 font-semibold">Default</th>
+        <th class="py-3 font-semibold">Description</th>
       </tr>
     </thead>
     <tbody class="text-kumo-subtle">

--- a/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
@@ -8,7 +8,6 @@ baseUIComponent: "tooltip"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import Heading from "~/components/docs/Heading.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   TooltipHeroDemo,
@@ -28,14 +27,16 @@ import {
 {/* Installation */}
 
 <ComponentSection>
-  <Heading level={2}>Installation</Heading>
-  <Heading level={3}>Barrel</Heading>
+
+## Installation
+
+### Barrel
 
 ```tsx
 import { Tooltip, TooltipProvider } from "@cloudflare/kumo";
 ```
 
-<Heading level={3}>Granular</Heading>
+### Granular
 
 ```tsx
 import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";
@@ -46,7 +47,8 @@ import { Tooltip, TooltipProvider } from "@cloudflare/kumo/components/tooltip";
 {/* Usage */}
 
 <ComponentSection>
-  <Heading level={2}>Usage</Heading>
+
+## Usage
 
 ```tsx
 import { Tooltip, Button } from "@cloudflare/kumo";
@@ -67,19 +69,23 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
 {/* Examples */}
 
 <ComponentSection>
-  <Heading level={2}>Examples</Heading>
 
-<Heading level={3}>Basic Tooltip</Heading>
+## Examples
+
+### Basic Tooltip
+
 <ComponentExample demo="TooltipBasicDemo">
   <TooltipBasicDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Multiple Tooltips</Heading>
+### Multiple Tooltips
+
 <ComponentExample demo="TooltipMultipleDemo">
   <TooltipMultipleDemo client:load />
 </ComponentExample>
 
-<Heading level={3}>Delay Control</Heading>
+### Delay Control
+
 <p>
   Use `delay` to control how long to wait before opening (default: 600ms) and
   `closeDelay` to control how long to wait before closing (default: 0ms).
@@ -93,7 +99,7 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
 {/* TooltipProvider */}
 
 <ComponentSection>
-  <Heading level={2} id="tooltipprovider">TooltipProvider</Heading>
+## TooltipProvider
 
 <p>
   `TooltipProvider` groups multiple tooltips so that after the first tooltip has
@@ -116,6 +122,8 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
 {/* API Reference */}
 
 <ComponentSection>
-  <Heading level={2}>API Reference</Heading>
+
+## API Reference
+
   <PropsTable component="Tooltip" />
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/figma.mdx
+++ b/packages/kumo-docs-astro/src/pages/figma.mdx
@@ -75,7 +75,9 @@ cp packages/kumo-figma/scripts/.env.example packages/kumo-figma/scripts/.env
 | `FIGMA_COLLECTION_NAME` | No       | Variable collection name in Figma. Defaults to `kumo-colors`      |
 
 ```bash
+
 # packages/kumo-figma/scripts/.env
+
 FIGMA_TOKEN=figd_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 FIGMA_FILE_KEY=sKKZc6pC6W1TtzWBLxDGSU
 FIGMA_COLLECTION_NAME=kumo-colors
@@ -120,7 +122,7 @@ The plugin generates a **"ui kit"** page containing ComponentSets for each Kumo 
 - **Auto-layout** — Components use Figma auto-layout matching the CSS flexbox behavior
 - **Proper sizing** — Spacing, padding, border-radius, and font sizes match the code implementation
 
-**Currently Generated Components (30+)**
+#### Currently Generated Components (30+)
 
 Badge, Banner, Breadcrumbs, Button, Checkbox, ClipboardText, Code, CodeBlock, Collapsible, Combobox, CommandPalette, Dialog, Dropdown, Empty, Input, InputArea, Label, LayerCard, LinkButton, Loader, MenuBar, Meter, Pagination, Radio, RefreshButton, Select, SensitiveInput, Surface, Switch, Table, Tabs, Text, Toast, Tooltip
 
@@ -133,19 +135,25 @@ The plugin uses **destructive sync** — it purges all existing generated conten
 The typical workflow when updating components:
 
 ```bash
+
 # 1. Make changes to Kumo components
+
 # ...edit packages/kumo/src/components/...
 
 # 2. Regenerate component registry
+
 pnpm --filter @cloudflare/kumo codegen:registry
 
 # 3. Sync tokens to Figma (if colors changed)
+
 pnpm --filter @cloudflare/kumo-figma figma:sync
 
 # 4. Build the plugin
+
 pnpm --filter @cloudflare/kumo-figma build
 
 # 5. Run in Figma: Plugins > Development > Kumo UI Kit Generator
+
 ```
 
 ## Plugin Architecture

--- a/packages/kumo-docs-astro/src/pages/installation.mdx
+++ b/packages/kumo-docs-astro/src/pages/installation.mdx
@@ -17,30 +17,32 @@ The `@cloudflare/kumo` package is published to the public npm registry. No speci
 
 Install Kumo using your preferred package manager. The current version is <code>v{kumoVersion}</code>.
 
-**npm**
+#### npm
 
 ```bash
 npm install @cloudflare/kumo
 ```
 
-**pnpm**
+#### pnpm
 
 ```bash
 pnpm add @cloudflare/kumo
 ```
 
-**yarn**
+#### yarn
 
 ```bash
 yarn add @cloudflare/kumo
 ```
 
-**Peer Dependencies**
+#### Peer Dependencies
 
 Kumo requires the following peer dependencies. Most React projects will already have these installed:
 
 ```bash
+
 # Required peer dependencies
+
 pnpm add react react-dom @phosphor-icons/react
 ```
 
@@ -48,13 +50,13 @@ pnpm add react react-dom @phosphor-icons/react
 
 Import components from the main package or use granular imports for better tree-shaking:
 
-**Main Package Import**
+#### Main Package Import
 
 ```tsx
 import { Button, Input, LayerCard } from "@cloudflare/kumo";
 ```
 
-**Granular Import (Recommended)**
+#### Granular Import (Recommended)
 
 ```tsx
 import { Button } from "@cloudflare/kumo/components/button";
@@ -65,14 +67,14 @@ import { Input } from "@cloudflare/kumo/components/input";
 
 Kumo is built on top of [Base UI](https://base-ui.com), a library of unstyled, accessible React components. For advanced use cases where you need access to the underlying primitives, Kumo re-exports all 37 Base UI components with both barrel and granular imports:
 
-**Barrel Import (Convenient)**
+#### Barrel Import (Convenient)
 
 ```tsx
 // Import multiple primitives at once
 import { Popover, Slider, Accordion } from "@cloudflare/kumo/primitives";
 ```
 
-**Granular Imports (Recommended for Performance)**
+#### Granular Imports (Recommended for Performance)
 
 ```tsx
 // Import individual primitives for better tree-shaking
@@ -146,7 +148,7 @@ The standalone build includes all Tailwind utilities and Kumo component styles p
 
 Here's a complete example of using Kumo components with Tailwind CSS:
 
-**CSS File (app.css)**
+#### CSS File (app.css)
 
 ```css
 @source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
@@ -156,7 +158,7 @@ Here's a complete example of using Kumo components with Tailwind CSS:
 
 Note: The `@source` path is relative to your CSS file. Adjust it based on your project structure.
 
-**Component File (App.tsx)**
+#### Component File (App.tsx)
 
 ```tsx
 import { Button, Input, LayerCard } from "@cloudflare/kumo";
@@ -192,13 +194,17 @@ Use components when you need consistent, pre-styled UI primitives that integrate
 Blocks are higher-level compositions (like `PageHeader` and `ResourceListPage`) that are installed via the Kumo CLI. Blocks give you full ownership of the code, allowing you to customize them to your specific needs.
 
 ```bash
+
 # Initialize Kumo configuration
+
 npx @cloudflare/kumo init
 
 # List available blocks
+
 npx @cloudflare/kumo blocks
 
 # Install a block
+
 npx @cloudflare/kumo add PageHeader
 ```
 

--- a/packages/kumo-docs-astro/src/pages/installation.mdx
+++ b/packages/kumo-docs-astro/src/pages/installation.mdx
@@ -40,9 +40,7 @@ yarn add @cloudflare/kumo
 Kumo requires the following peer dependencies. Most React projects will already have these installed:
 
 ```bash
-
 # Required peer dependencies
-
 pnpm add react react-dom @phosphor-icons/react
 ```
 

--- a/packages/kumo-docs-astro/src/pages/streaming.mdx
+++ b/packages/kumo-docs-astro/src/pages/streaming.mdx
@@ -10,7 +10,7 @@ import Callout from "~/components/docs/Callout.astro";
 
 The Kumo catalog module enables rendering UI from JSON structures, designed specifically for AI-generated interfaces. It provides runtime validation, data binding, conditional rendering, and action handling for JSON-based UI trees.
 
-**Schemas Derived from Your Codebase**
+#### Schemas Derived from Your Codebase
 
 Unlike approaches that require maintaining separate schema definitions, Kumo automatically derives validation schemas from your actual component TypeScript types. When you update a component's props, the validation schemas update automatically via the component registry codegen process. No manual synchronization required — your schemas are always in sync with your components.
 
@@ -117,7 +117,7 @@ The UI tree uses a flat structure optimized for LLM generation and streaming. El
 }
 ```
 
-**Why a flat structure?**
+#### Why a flat structure?
 
 - Elements can be rendered as soon as they arrive (streaming)
 - Easy updates without deep tree traversal

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -125,7 +125,7 @@ html {
   text-decoration: underline;
 }
 
-/* Heading anchor links — inherit parent heading styles */
+/* Heading anchor links */
 .kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) a {
   color: inherit;
   font-weight: inherit;

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -183,10 +183,14 @@ html {
   box-shadow: none;
 }
 
-/* Pre / code blocks — don't interfere with our CodeBlock component */
-.kumo-prose :where(pre) {
+/* Pre / code blocks — better defaults for changelog <pre> without affecting
+   CodeBlock (wrapped in .not-prose) or Shiki blocks (inline styles override) */
+.kumo-prose :where(pre):not(:where(.not-prose, .not-prose *)) {
+  @apply text-base;
   border-radius: 0.5rem;
   letter-spacing: normal;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
 }
 
 /* Table styling */

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -97,6 +97,12 @@ html {
   --tw-prose-invert-td-borders: var(--color-kumo-hairline);
 }
 
+/* Reset prose styles inside not-prose wrappers */
+.kumo-prose .not-prose {
+  letter-spacing: normal;
+  line-height: normal;
+}
+
 /* Inline code styling — match existing site style */
 .kumo-prose :where(code):not(:where(pre code)) {
   font-weight: 500;

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -187,6 +187,8 @@ html {
    CodeBlock (wrapped in .not-prose) or Shiki blocks (inline styles override) */
 .kumo-prose :where(pre):not(:where(.not-prose, .not-prose *)) {
   @apply text-base;
+  background-color: var(--tw-prose-pre-bg);
+  border: 1px solid var(--color-kumo-hairline);
   border-radius: 0.5rem;
   letter-spacing: normal;
   padding: 0.75rem 1rem;

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -36,42 +36,62 @@ html {
    ========================================================================== */
 
 .kumo-prose {
-  /* Base typography token overrides */
-  --tw-prose-body: var(--color-kumo-strong);
-  --tw-prose-headings: var(--color-kumo-default);
-  --tw-prose-lead: var(--color-kumo-strong);
-  --tw-prose-links: var(--color-kumo-link);
-  --tw-prose-bold: var(--color-kumo-default);
-  --tw-prose-counters: var(--color-kumo-subtle);
-  --tw-prose-bullets: var(--color-kumo-strong);
+  /* Base letter-spacing for prose content */
+  letter-spacing: -0.01em;
+
+  /* Body text — use default weight, not strong */
+  --tw-prose-body: var(--text-color-kumo-default);
+  /* Headings — strong emphasis */
+  --tw-prose-headings: var(--text-color-kumo-strong);
+  /* Lead paragraphs */
+  --tw-prose-lead: var(--text-color-kumo-default);
+  /* Link color */
+  --tw-prose-links: var(--text-color-kumo-link);
+  /* Bold text */
+  --tw-prose-bold: var(--text-color-kumo-strong);
+  /* List counters (ordered lists) */
+  --tw-prose-counters: var(--text-color-kumo-subtle);
+  /* Bullet markers */
+  --tw-prose-bullets: var(--text-color-kumo-default);
+  /* Horizontal rules */
   --tw-prose-hr: var(--color-kumo-hairline);
-  --tw-prose-quotes: var(--color-kumo-default);
+  /* Blockquote text */
+  --tw-prose-quotes: var(--text-color-kumo-default);
+  /* Blockquote left border */
   --tw-prose-quote-borders: var(--color-kumo-hairline);
-  --tw-prose-captions: var(--color-kumo-subtle);
-  --tw-prose-kbd: var(--color-kumo-default);
+  /* Figure captions */
+  --tw-prose-captions: var(--text-color-kumo-subtle);
+  /* Keyboard input */
+  --tw-prose-kbd: var(--text-color-kumo-default);
+  /* Keyboard shadow */
   --tw-prose-kbd-shadows: transparent;
-  --tw-prose-code: var(--color-kumo-default);
-  --tw-prose-pre-code: var(--color-kumo-default);
+  /* Inline code */
+  --tw-prose-code: var(--text-color-kumo-default);
+  /* Code inside pre blocks */
+  --tw-prose-pre-code: var(--text-color-kumo-default);
+  /* Pre block background */
   --tw-prose-pre-bg: var(--color-kumo-canvas);
+  /* Table header borders */
   --tw-prose-th-borders: var(--color-kumo-hairline);
+  /* Table cell borders */
   --tw-prose-td-borders: var(--color-kumo-hairline);
 
-  /* Dark mode — same tokens, they auto-adapt via light-dark() */
-  --tw-prose-invert-body: var(--color-kumo-strong);
-  --tw-prose-invert-headings: var(--color-kumo-default);
-  --tw-prose-invert-lead: var(--color-kumo-strong);
-  --tw-prose-invert-links: var(--color-kumo-link);
-  --tw-prose-invert-bold: var(--color-kumo-default);
-  --tw-prose-invert-counters: var(--color-kumo-subtle);
-  --tw-prose-invert-bullets: var(--color-kumo-strong);
+  /* Dark/invert mode — same tokens, they auto-adapt via light-dark() */
+  --tw-prose-invert-body: var(--text-color-kumo-default);
+  --tw-prose-invert-headings: var(--text-color-kumo-strong);
+  --tw-prose-invert-lead: var(--text-color-kumo-default);
+  --tw-prose-invert-links: var(--text-color-kumo-link);
+  --tw-prose-invert-bold: var(--text-color-kumo-strong);
+  --tw-prose-invert-counters: var(--text-color-kumo-subtle);
+  --tw-prose-invert-bullets: var(--text-color-kumo-default);
   --tw-prose-invert-hr: var(--color-kumo-hairline);
-  --tw-prose-invert-quotes: var(--color-kumo-default);
+  --tw-prose-invert-quotes: var(--text-color-kumo-default);
   --tw-prose-invert-quote-borders: var(--color-kumo-hairline);
-  --tw-prose-invert-captions: var(--color-kumo-subtle);
-  --tw-prose-invert-kbd: var(--color-kumo-default);
+  --tw-prose-invert-captions: var(--text-color-kumo-subtle);
+  --tw-prose-invert-kbd: var(--text-color-kumo-default);
   --tw-prose-invert-kbd-shadows: transparent;
-  --tw-prose-invert-code: var(--color-kumo-default);
-  --tw-prose-invert-pre-code: var(--color-kumo-default);
+  --tw-prose-invert-code: var(--text-color-kumo-default);
+  --tw-prose-invert-pre-code: var(--text-color-kumo-default);
   --tw-prose-invert-pre-bg: var(--color-kumo-canvas);
   --tw-prose-invert-th-borders: var(--color-kumo-hairline);
   --tw-prose-invert-td-borders: var(--color-kumo-hairline);
@@ -105,30 +125,46 @@ html {
   text-decoration: underline;
 }
 
-/* Headings — use Heading component anchor style where possible */
+/* Heading anchor links — inherit parent heading styles */
+.kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) a {
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+}
+
+/* Headings — shared spacing and tracking */
 .kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) {
   scroll-margin-top: 6rem;
-  margin-bottom: 1rem 0;
+  margin-bottom: 1rem;
   font-weight: 600;
   letter-spacing: -0.02em;
 }
 
-/* Typography Styling */
-.kumo-prose :where(h2):not(:where(.not-prose, .not-prose *)) {
-  font-size: 1.5rem;
+/* Adjacent sibling spacing after headings */
+.kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) + * {
+  margin-top: 0;
 }
 
-.kumo-prose :where(h3):not(:where(.not-prose, .not-prose *)) {
-  font-size: 1.25rem;
-}
-
+/* Paragraphs — base size with relaxed line-height */
 .kumo-prose :where(p):not(:where(.not-prose, .not-prose *)) {
-  margin: 0.5rem 0;
+  @apply text-base leading-relaxed;
 }
 
-.kumo-prose :where(ul):not(:where(.not-prose, .not-prose *)) {
+/* Adjacent sibling spacing between paragraphs */
+.kumo-prose :where(p + p):not(:where(.not-prose, .not-prose *)) {
+  margin-top: 0.75rem;
+}
+
+/* Unordered and ordered lists */
+.kumo-prose :where(ul, ol):not(:where(.not-prose, .not-prose *)) {
+  @apply text-base leading-relaxed;
   margin: 0;
   margin-bottom: 1rem;
+}
+
+/* List items */
+.kumo-prose :where(li):not(:where(.not-prose, .not-prose *)) {
+  @apply text-base leading-relaxed;
 }
 
 /* Divider styling */
@@ -159,19 +195,21 @@ html {
   width: 100%;
 }
 
+/* Table header border */
 .kumo-prose :where(thead) {
   border-bottom-color: var(--color-kumo-hairline);
 }
 
+/* Table header cells — use strong text color */
 .kumo-prose :where(thead th) {
-  color: var(--color-kumo-default);
+  color: var(--text-color-kumo-strong);
   font-weight: 600;
 }
 
-/* Blockquote */
+/* Blockquote — branded left border with default text */
 .kumo-prose :where(blockquote) {
   border-left-color: var(--color-kumo-brand);
-  color: var(--color-kumo-strong);
+  color: var(--text-color-kumo-default);
   font-style: normal;
 }
 
@@ -223,11 +261,12 @@ pre.astro-code {
    Code block copy button
    ========================================================================== */
 
+/* Copy button — positioned over code blocks */
 .code-block-copy-btn {
   @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);
   color: var(--text-color-kumo-subtle);
-  ring-color: var(--color-kumo-hairline);
+  --tw-ring-color: var(--color-kumo-hairline);
 
   &:hover {
     background: var(--color-kumo-tint);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -76,7 +76,7 @@ html {
   /* Table cell borders */
   --tw-prose-td-borders: var(--color-kumo-hairline);
 
-  /* Dark/invert mode — same tokens, they auto-adapt via light-dark() */
+  /* Dark mode — same tokens, they auto-adapt via light-dark() */
   --tw-prose-invert-body: var(--text-color-kumo-default);
   --tw-prose-invert-headings: var(--text-color-kumo-strong);
   --tw-prose-invert-lead: var(--text-color-kumo-default);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -108,6 +108,7 @@ html {
   font-family:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     "Courier New", monospace;
+  letter-spacing: normal;
 }
 
 /* Remove backtick decoration from inline code */
@@ -185,6 +186,7 @@ html {
 /* Pre / code blocks — don't interfere with our CodeBlock component */
 .kumo-prose :where(pre) {
   border-radius: 0.5rem;
+  letter-spacing: normal;
 }
 
 /* Table styling */

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -145,7 +145,7 @@ html {
   margin-top: 0;
 }
 
-/* Paragraphs — base size with relaxed line-height */
+/* Paragraphs */
 .kumo-prose :where(p):not(:where(.not-prose, .not-prose *)) {
   @apply text-base leading-relaxed;
 }
@@ -200,13 +200,13 @@ html {
   border-bottom-color: var(--color-kumo-hairline);
 }
 
-/* Table header cells — use strong text color */
+/* Table header cells */
 .kumo-prose :where(thead th) {
   color: var(--text-color-kumo-strong);
   font-weight: 600;
 }
 
-/* Blockquote — branded left border with default text */
+/* Blockquote */
 .kumo-prose :where(blockquote) {
   border-left-color: var(--color-kumo-brand);
   color: var(--text-color-kumo-default);
@@ -261,7 +261,6 @@ pre.astro-code {
    Code block copy button
    ========================================================================== */
 
-/* Copy button — positioned over code blocks */
 .code-block-copy-btn {
   @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -39,9 +39,9 @@ html {
   /* Base letter-spacing for prose content */
   letter-spacing: -0.01em;
 
-  /* Body text — use default weight, not strong */
+  /* Body text */
   --tw-prose-body: var(--text-color-kumo-default);
-  /* Headings — use default (near-black), not strong (medium gray) */
+  /* Headings */
   --tw-prose-headings: var(--text-color-kumo-default);
   /* Lead paragraphs */
   --tw-prose-lead: var(--text-color-kumo-default);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -167,12 +167,9 @@ html {
   @apply text-base leading-relaxed;
 }
 
-/* Divider styling */
-.kumo-prose :where(hr) {
-  justify-self: center;
-  width: 100%;
-  margin: 4rem 0;
-  padding: 0;
+/* Horizontal rule */
+.kumo-prose :where(hr):not(:where(.not-prose, .not-prose *)) {
+  margin: 1.5rem 0;
 }
 
 /* kbd styling */

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -41,8 +41,8 @@ html {
 
   /* Body text — use default weight, not strong */
   --tw-prose-body: var(--text-color-kumo-default);
-  /* Headings — strong emphasis */
-  --tw-prose-headings: var(--text-color-kumo-strong);
+  /* Headings — use default (near-black), not strong (medium gray) */
+  --tw-prose-headings: var(--text-color-kumo-default);
   /* Lead paragraphs */
   --tw-prose-lead: var(--text-color-kumo-default);
   /* Link color */
@@ -78,7 +78,7 @@ html {
 
   /* Dark mode — same tokens, they auto-adapt via light-dark() */
   --tw-prose-invert-body: var(--text-color-kumo-default);
-  --tw-prose-invert-headings: var(--text-color-kumo-strong);
+  --tw-prose-invert-headings: var(--text-color-kumo-default);
   --tw-prose-invert-lead: var(--text-color-kumo-default);
   --tw-prose-invert-links: var(--text-color-kumo-link);
   --tw-prose-invert-bold: var(--text-color-kumo-strong);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.17(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.4
@@ -1487,89 +1490,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1818,21 +1837,25 @@ packages:
     resolution: {integrity: sha512-j4QzfCM8ks+OyM+KKYWDiBEQsm5RCW50H1Wz16wUyoFsobJ+X5qqcJxq6HvkE07m8euYmZelyB0WqsiDoz1v8g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.42.0':
     resolution: {integrity: sha512-g5b1Uw7zo6yw4Ymzyd1etKzAY7xAaGA3scwB8tAp3QzuY7CYdfTwlhiLKSAKbd7T/JBgxOXAGNcLDorJyVTXcg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.42.0':
     resolution: {integrity: sha512-HnD99GD9qAbpV4q9iQil7mXZUJFpoBdDavfcC2CgGLPlawfcV5COzQPNwOgvPVkr7C0cBx6uNCq3S6r9IIiEIg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.42.0':
     resolution: {integrity: sha512-8NTe8A78HHFn+nBi+8qMwIjgv9oIBh+9zqCPNLH56ah4vKOPvbePLI6NIv9qSkmzrBuu8SB+FJ2TH/G05UzbNA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.42.0':
     resolution: {integrity: sha512-lAPS2YAuu+qFqoTNPFcNsxXjwSV0M+dOgAzzVTAN7Yo2ifj+oLOx0GsntWoM78PvQWI7Q827ZxqtU2ImBmDapA==}
@@ -1873,36 +1896,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -2032,121 +2061,145 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2334,24 +2387,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -4251,24 +4308,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.17(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))
       '@types/mdast':
-        specifier: ^4.0.4
+        specifier: 4.0.4
         version: 4.0.4
       '@types/react':
         specifier: 'catalog:'


### PR DESCRIPTION
> ⚠️ **This PR is for preview only — do not merge.** It combines PRs 1/5 through 5/5 into a single branch so the preview deployment shows all changes together. Review and merge the individual PRs instead.

## Individual PRs

1. #419 — Docs: Fix prose text colors and typography after MDX migration
2. #421 — Docs: Add automatic heading anchors via remark plugin
3. #420 — Docs: Convert all JSX headings to plain markdown
4. #422 — Docs: Remove redundant inline styles now handled by prose
5. #418 — Docs: Accessibility improvements and polish

## What's in this preview

- Fixed prose text colors (were rendering as #000 after MDX migration)
- Aligned typography to kumo's Text component styles
- Automatic heading anchors via remark plugin
- 600+ JSX headings converted to plain markdown
- Removed ~90 redundant inline styles
- Accessibility and polish improvements
- Fixed heading color (was rendering as light gray instead of near-black)
- Reduced horizontal rule margin for tighter spacing

---

- Reviews
  - [x] automated review not possible because: preview-only PR combining 5 individual PRs — review those instead
- Tests
  - [x] Additional testing not necessary because: preview-only — individual PRs have their own validation
