### PR TITLE
Docs: Accessibility improvements and polish (5/5)

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -40,6 +40,7 @@ const baseStyles = levelStyles[level];
   <a
     href={`#${slug}`}
     class="no-underline hover:underline"
+    aria-label={`Link to section: ${textContent}`}
   >
     <span
       class="absolute -left-6 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100"

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -39,6 +39,7 @@ const buildDate =
     <meta name="build-date" content={buildDate} />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/kumo-docs-astro/src/lib/astro-markdown-pages.ts
+++ b/packages/kumo-docs-astro/src/lib/astro-markdown-pages.ts
@@ -99,6 +99,11 @@ export function markdownPages(): AstroIntegration {
 
             const markdown = htmlToMarkdown(html);
 
+            if (!markdown.trim()) {
+              skipped++;
+              continue;
+            }
+
             // changelog/all/index.html → changelog.md, others → sibling .md
             const mdFile = htmlFile.endsWith(changelogAllPage)
               ? join(outDir, "changelog.md")


### PR DESCRIPTION
## Summary

Small accessibility and polish improvements for the docs site.

## Changes

- Add `<meta name="color-scheme" content="light dark">` to `BaseLayout.astro` — tells the browser about color scheme support for scrollbar and form control theming in dark mode
- Add `aria-label` to heading anchor links in `Heading.astro` for screen reader accessibility
- Fix empty `dist.md` file generation bug — skip writing empty markdown in the `markdownPages` build integration

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only accessibility and polish changes
- Tests
  - [x] Additional testing not necessary because: docs-site-only changes with no component library modifications