### PR TITLE
Docs: Fix prose text colors and typography after MDX migration (1/5)

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
@@ -12,7 +12,7 @@ const proseStyles = cn(
   "[&_h1]:text-xl [&_h2]:text-lg [&_h3]:text-base",
   "[&_:is(h1,h2,h3)]:font-semibold [&_:is(h1,h2,h3)]:text-kumo-default",
   "[&_p]:text-kumo-default",
-  "[&_pre]:overflow-x-auto",
+  "[&_pre]:overflow-x-auto [&_pre]:text-base",
 );
 
 interface ChangelogEntryProps {

--- a/packages/kumo-docs-astro/src/components/docs/ComponentSection.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentSection.astro
@@ -2,6 +2,6 @@
 // Simple section wrapper for component documentation
 ---
 
-<section class="mb-12">
+<section class="mb-8">
   <slot />
 </section>

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -29,7 +29,7 @@ const buildDate =
 ---
 
 <!doctype html>
-<html class="bg-kumo-canvas" lang="en">
+<html class="bg-kumo-canvas text-kumo-default" lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -125,7 +125,7 @@ html {
   text-decoration: underline;
 }
 
-/* Heading anchor links — inherit parent heading styles */
+/* Heading anchor links */
 .kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) a {
   color: inherit;
   font-weight: inherit;

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -183,10 +183,14 @@ html {
   box-shadow: none;
 }
 
-/* Pre / code blocks — don't interfere with our CodeBlock component */
-.kumo-prose :where(pre) {
+/* Pre / code blocks — better defaults for changelog <pre> without affecting
+   CodeBlock (wrapped in .not-prose) or Shiki blocks (inline styles override) */
+.kumo-prose :where(pre):not(:where(.not-prose, .not-prose *)) {
+  @apply text-base;
   border-radius: 0.5rem;
   letter-spacing: normal;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
 }
 
 /* Table styling */

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -97,6 +97,12 @@ html {
   --tw-prose-invert-td-borders: var(--color-kumo-hairline);
 }
 
+/* Reset prose styles inside not-prose wrappers */
+.kumo-prose .not-prose {
+  letter-spacing: normal;
+  line-height: normal;
+}
+
 /* Inline code styling — match existing site style */
 .kumo-prose :where(code):not(:where(pre code)) {
   font-weight: 500;

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -187,6 +187,8 @@ html {
    CodeBlock (wrapped in .not-prose) or Shiki blocks (inline styles override) */
 .kumo-prose :where(pre):not(:where(.not-prose, .not-prose *)) {
   @apply text-base;
+  background-color: var(--tw-prose-pre-bg);
+  border: 1px solid var(--color-kumo-hairline);
   border-radius: 0.5rem;
   letter-spacing: normal;
   padding: 0.75rem 1rem;

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -36,42 +36,62 @@ html {
    ========================================================================== */
 
 .kumo-prose {
-  /* Base typography token overrides */
-  --tw-prose-body: var(--color-kumo-strong);
-  --tw-prose-headings: var(--color-kumo-default);
-  --tw-prose-lead: var(--color-kumo-strong);
-  --tw-prose-links: var(--color-kumo-link);
-  --tw-prose-bold: var(--color-kumo-default);
-  --tw-prose-counters: var(--color-kumo-subtle);
-  --tw-prose-bullets: var(--color-kumo-strong);
+  /* Base letter-spacing for prose content */
+  letter-spacing: -0.01em;
+
+  /* Body text — use default weight, not strong */
+  --tw-prose-body: var(--text-color-kumo-default);
+  /* Headings — strong emphasis */
+  --tw-prose-headings: var(--text-color-kumo-strong);
+  /* Lead paragraphs */
+  --tw-prose-lead: var(--text-color-kumo-default);
+  /* Link color */
+  --tw-prose-links: var(--text-color-kumo-link);
+  /* Bold text */
+  --tw-prose-bold: var(--text-color-kumo-strong);
+  /* List counters (ordered lists) */
+  --tw-prose-counters: var(--text-color-kumo-subtle);
+  /* Bullet markers */
+  --tw-prose-bullets: var(--text-color-kumo-default);
+  /* Horizontal rules */
   --tw-prose-hr: var(--color-kumo-hairline);
-  --tw-prose-quotes: var(--color-kumo-default);
+  /* Blockquote text */
+  --tw-prose-quotes: var(--text-color-kumo-default);
+  /* Blockquote left border */
   --tw-prose-quote-borders: var(--color-kumo-hairline);
-  --tw-prose-captions: var(--color-kumo-subtle);
-  --tw-prose-kbd: var(--color-kumo-default);
+  /* Figure captions */
+  --tw-prose-captions: var(--text-color-kumo-subtle);
+  /* Keyboard input */
+  --tw-prose-kbd: var(--text-color-kumo-default);
+  /* Keyboard shadow */
   --tw-prose-kbd-shadows: transparent;
-  --tw-prose-code: var(--color-kumo-default);
-  --tw-prose-pre-code: var(--color-kumo-default);
+  /* Inline code */
+  --tw-prose-code: var(--text-color-kumo-default);
+  /* Code inside pre blocks */
+  --tw-prose-pre-code: var(--text-color-kumo-default);
+  /* Pre block background */
   --tw-prose-pre-bg: var(--color-kumo-canvas);
+  /* Table header borders */
   --tw-prose-th-borders: var(--color-kumo-hairline);
+  /* Table cell borders */
   --tw-prose-td-borders: var(--color-kumo-hairline);
 
-  /* Dark mode — same tokens, they auto-adapt via light-dark() */
-  --tw-prose-invert-body: var(--color-kumo-strong);
-  --tw-prose-invert-headings: var(--color-kumo-default);
-  --tw-prose-invert-lead: var(--color-kumo-strong);
-  --tw-prose-invert-links: var(--color-kumo-link);
-  --tw-prose-invert-bold: var(--color-kumo-default);
-  --tw-prose-invert-counters: var(--color-kumo-subtle);
-  --tw-prose-invert-bullets: var(--color-kumo-strong);
+  /* Dark/invert mode — same tokens, they auto-adapt via light-dark() */
+  --tw-prose-invert-body: var(--text-color-kumo-default);
+  --tw-prose-invert-headings: var(--text-color-kumo-strong);
+  --tw-prose-invert-lead: var(--text-color-kumo-default);
+  --tw-prose-invert-links: var(--text-color-kumo-link);
+  --tw-prose-invert-bold: var(--text-color-kumo-strong);
+  --tw-prose-invert-counters: var(--text-color-kumo-subtle);
+  --tw-prose-invert-bullets: var(--text-color-kumo-default);
   --tw-prose-invert-hr: var(--color-kumo-hairline);
-  --tw-prose-invert-quotes: var(--color-kumo-default);
+  --tw-prose-invert-quotes: var(--text-color-kumo-default);
   --tw-prose-invert-quote-borders: var(--color-kumo-hairline);
-  --tw-prose-invert-captions: var(--color-kumo-subtle);
-  --tw-prose-invert-kbd: var(--color-kumo-default);
+  --tw-prose-invert-captions: var(--text-color-kumo-subtle);
+  --tw-prose-invert-kbd: var(--text-color-kumo-default);
   --tw-prose-invert-kbd-shadows: transparent;
-  --tw-prose-invert-code: var(--color-kumo-default);
-  --tw-prose-invert-pre-code: var(--color-kumo-default);
+  --tw-prose-invert-code: var(--text-color-kumo-default);
+  --tw-prose-invert-pre-code: var(--text-color-kumo-default);
   --tw-prose-invert-pre-bg: var(--color-kumo-canvas);
   --tw-prose-invert-th-borders: var(--color-kumo-hairline);
   --tw-prose-invert-td-borders: var(--color-kumo-hairline);
@@ -105,30 +125,46 @@ html {
   text-decoration: underline;
 }
 
-/* Headings — use Heading component anchor style where possible */
+/* Heading anchor links — inherit parent heading styles */
+.kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) a {
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+}
+
+/* Headings — shared spacing and tracking */
 .kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) {
   scroll-margin-top: 6rem;
-  margin-bottom: 1rem 0;
+  margin-bottom: 1rem;
   font-weight: 600;
   letter-spacing: -0.02em;
 }
 
-/* Typography Styling */
-.kumo-prose :where(h2):not(:where(.not-prose, .not-prose *)) {
-  font-size: 1.5rem;
+/* Adjacent sibling spacing after headings */
+.kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) + * {
+  margin-top: 0;
 }
 
-.kumo-prose :where(h3):not(:where(.not-prose, .not-prose *)) {
-  font-size: 1.25rem;
-}
-
+/* Paragraphs — base size with relaxed line-height */
 .kumo-prose :where(p):not(:where(.not-prose, .not-prose *)) {
-  margin: 0.5rem 0;
+  @apply text-base leading-relaxed;
 }
 
-.kumo-prose :where(ul):not(:where(.not-prose, .not-prose *)) {
+/* Adjacent sibling spacing between paragraphs */
+.kumo-prose :where(p + p):not(:where(.not-prose, .not-prose *)) {
+  margin-top: 0.75rem;
+}
+
+/* Unordered and ordered lists */
+.kumo-prose :where(ul, ol):not(:where(.not-prose, .not-prose *)) {
+  @apply text-base leading-relaxed;
   margin: 0;
   margin-bottom: 1rem;
+}
+
+/* List items */
+.kumo-prose :where(li):not(:where(.not-prose, .not-prose *)) {
+  @apply text-base leading-relaxed;
 }
 
 /* Divider styling */
@@ -159,19 +195,21 @@ html {
   width: 100%;
 }
 
+/* Table header border */
 .kumo-prose :where(thead) {
   border-bottom-color: var(--color-kumo-hairline);
 }
 
+/* Table header cells — use strong text color */
 .kumo-prose :where(thead th) {
-  color: var(--color-kumo-default);
+  color: var(--text-color-kumo-strong);
   font-weight: 600;
 }
 
-/* Blockquote */
+/* Blockquote — branded left border with default text */
 .kumo-prose :where(blockquote) {
   border-left-color: var(--color-kumo-brand);
-  color: var(--color-kumo-strong);
+  color: var(--text-color-kumo-default);
   font-style: normal;
 }
 
@@ -223,11 +261,12 @@ pre.astro-code {
    Code block copy button
    ========================================================================== */
 
+/* Copy button — positioned over code blocks */
 .code-block-copy-btn {
   @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);
   color: var(--text-color-kumo-subtle);
-  ring-color: var(--color-kumo-hairline);
+  --tw-ring-color: var(--color-kumo-hairline);
 
   &:hover {
     background: var(--color-kumo-tint);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -76,7 +76,7 @@ html {
   /* Table cell borders */
   --tw-prose-td-borders: var(--color-kumo-hairline);
 
-  /* Dark/invert mode — same tokens, they auto-adapt via light-dark() */
+  /* Dark mode — same tokens, they auto-adapt via light-dark() */
   --tw-prose-invert-body: var(--text-color-kumo-default);
   --tw-prose-invert-headings: var(--text-color-kumo-strong);
   --tw-prose-invert-lead: var(--text-color-kumo-default);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -108,6 +108,7 @@ html {
   font-family:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     "Courier New", monospace;
+  letter-spacing: normal;
 }
 
 /* Remove backtick decoration from inline code */
@@ -185,6 +186,7 @@ html {
 /* Pre / code blocks — don't interfere with our CodeBlock component */
 .kumo-prose :where(pre) {
   border-radius: 0.5rem;
+  letter-spacing: normal;
 }
 
 /* Table styling */

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -145,7 +145,7 @@ html {
   margin-top: 0;
 }
 
-/* Paragraphs — base size with relaxed line-height */
+/* Paragraphs */
 .kumo-prose :where(p):not(:where(.not-prose, .not-prose *)) {
   @apply text-base leading-relaxed;
 }
@@ -200,13 +200,13 @@ html {
   border-bottom-color: var(--color-kumo-hairline);
 }
 
-/* Table header cells — use strong text color */
+/* Table header cells */
 .kumo-prose :where(thead th) {
   color: var(--text-color-kumo-strong);
   font-weight: 600;
 }
 
-/* Blockquote — branded left border with default text */
+/* Blockquote */
 .kumo-prose :where(blockquote) {
   border-left-color: var(--color-kumo-brand);
   color: var(--text-color-kumo-default);
@@ -261,7 +261,6 @@ pre.astro-code {
    Code block copy button
    ========================================================================== */
 
-/* Copy button — positioned over code blocks */
 .code-block-copy-btn {
   @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -39,9 +39,9 @@ html {
   /* Base letter-spacing for prose content */
   letter-spacing: -0.01em;
 
-  /* Body text — use default weight, not strong */
+  /* Body text */
   --tw-prose-body: var(--text-color-kumo-default);
-  /* Headings — use default (near-black), not strong (medium gray) */
+  /* Headings */
   --tw-prose-headings: var(--text-color-kumo-default);
   /* Lead paragraphs */
   --tw-prose-lead: var(--text-color-kumo-default);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -167,12 +167,9 @@ html {
   @apply text-base leading-relaxed;
 }
 
-/* Divider styling */
-.kumo-prose :where(hr) {
-  justify-self: center;
-  width: 100%;
-  margin: 4rem 0;
-  padding: 0;
+/* Horizontal rule */
+.kumo-prose :where(hr):not(:where(.not-prose, .not-prose *)) {
+  margin: 1.5rem 0;
 }
 
 /* kbd styling */

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -41,8 +41,8 @@ html {
 
   /* Body text — use default weight, not strong */
   --tw-prose-body: var(--text-color-kumo-default);
-  /* Headings — strong emphasis */
-  --tw-prose-headings: var(--text-color-kumo-strong);
+  /* Headings — use default (near-black), not strong (medium gray) */
+  --tw-prose-headings: var(--text-color-kumo-default);
   /* Lead paragraphs */
   --tw-prose-lead: var(--text-color-kumo-default);
   /* Link color */
@@ -78,7 +78,7 @@ html {
 
   /* Dark mode — same tokens, they auto-adapt via light-dark() */
   --tw-prose-invert-body: var(--text-color-kumo-default);
-  --tw-prose-invert-headings: var(--text-color-kumo-strong);
+  --tw-prose-invert-headings: var(--text-color-kumo-default);
   --tw-prose-invert-lead: var(--text-color-kumo-default);
   --tw-prose-invert-links: var(--text-color-kumo-link);
   --tw-prose-invert-bold: var(--text-color-kumo-strong);


### PR DESCRIPTION
## Summary

The .astro → .mdx migration introduced `.kumo-prose` overrides that referenced non-existent `--color-kumo-*` CSS variables for text colors. The correct namespace is `--text-color-kumo-*`. This caused all prose text (headings, body, links, lists) to fall back to browser-default `#000` across all MDX doc pages.

## Changes

- Fix 28 CSS variable references in `.kumo-prose` token overrides (`--color-kumo-*` → `--text-color-kumo-*`) for both light and dark modes
- Align prose `<p>` / `<ul>` / `<ol>` / `<li>` to `text-base leading-relaxed` (matching kumo `<Text>` component)
- Add letter-spacing (`-0.02em` headings, `-0.01em` body content)
- Add `text-kumo-default` to `<html>` as a root text color safety net
- Fix heading anchors inheriting prose link color and font-weight → `inherit`
- Fix invalid `ring-color` CSS property → `--tw-ring-color`
- Fix `margin-bottom: 1rem 0` → split into base + adjacent-sibling margin rules
- Standardize `ComponentSection` spacing to `mb-8`
- Fix `ChangelogEntry` code block font size (`[&_pre]:text-base`) to match paragraph sizing
- Fix prose heading color: use `text-kumo-default` (near-black) instead of `text-kumo-strong` (gray) for `--tw-prose-headings`
- Reduce `<hr>` margin from `3em` to `1.5rem` (24px)

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only CSS changes, no component library code modified
- Tests
  - [x] Additional testing not necessary because: docs-site-only styling changes — build passes, all 59 pages render correctly
