### PR TITLE
Docs: Add automatic heading anchors via remark plugin (2/5)

### DIFF
--- a/packages/kumo-docs-astro/astro.config.mjs
+++ b/packages/kumo-docs-astro/astro.config.mjs
@@ -11,6 +11,7 @@ import { kumoColorsPlugin } from "./src/lib/vite-plugin-kumo-colors.js";
 import { kumoRegistryPlugin } from "./src/lib/vite-plugin-kumo-registry.js";
 import { kumoHmrPlugin } from "./src/lib/vite-plugin-kumo-hmr.js";
 import { markdownPages } from "./src/lib/astro-markdown-pages.js";
+import { remarkHeadingComponents } from "./src/lib/remark-heading-components.js";
 
 import sitemap from "@astrojs/sitemap";
 
@@ -71,7 +72,12 @@ const kumoSrc = resolve(__dirname, "../kumo/src");
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [mdx(), react(), sitemap(), markdownPages()],
+  integrations: [
+    mdx({ remarkPlugins: [remarkHeadingComponents] }),
+    react(),
+    sitemap(),
+    markdownPages(),
+  ],
   site: "https://kumo-ui.com/",
   markdown: {
     shikiConfig: {

--- a/packages/kumo-docs-astro/package.json
+++ b/packages/kumo-docs-astro/package.json
@@ -39,6 +39,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^4.2.1",
     "@tailwindcss/vite": "catalog:",
+    "@types/mdast": "^4.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "oxlint": "catalog:",

--- a/packages/kumo-docs-astro/package.json
+++ b/packages/kumo-docs-astro/package.json
@@ -39,7 +39,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/react": "^4.2.1",
     "@tailwindcss/vite": "catalog:",
-    "@types/mdast": "^4.0.4",
+    "@types/mdast": "4.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "oxlint": "catalog:",

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -35,7 +35,7 @@ const baseStyles = levelStyles[level];
 
 <Element
   id={slug}
-  class:list={["group relative scroll-mt-24", baseStyles, className]}
+  class:list={["group relative scroll-mt-24 tracking-[-0.02em]", baseStyles, className]}
 >
   <a
     href={`#${slug}`}

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -1,5 +1,5 @@
 ---
-import { LinkSimple } from "@phosphor-icons/react";
+import { LinkSimple as LinkSimpleIcon } from "@phosphor-icons/react";
 
 interface Props {
   level: 2 | 3 | 4;
@@ -45,7 +45,7 @@ const baseStyles = levelStyles[level];
       class="absolute -left-6 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100"
       aria-hidden="true"
     >
-      <LinkSimple className="size-4 text-kumo-subtle" />
+      <LinkSimpleIcon className="size-4 text-kumo-subtle" />
     </span>
     <slot />
   </a>

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -23,9 +23,9 @@ const slug =
 
 // Define styles for each heading level
 const levelStyles = {
-  2: "mb-4 text-2xl font-bold",
+  2: "mb-4 text-2xl font-semibold",
   3: "mb-4 text-xl font-semibold",
-  4: "mb-3 text-base font-medium",
+  4: "mb-3 text-base font-semibold",
 };
 
 // Dynamic tag - must be capitalized for Astro

--- a/packages/kumo-docs-astro/src/components/docs/mdx/H2.astro
+++ b/packages/kumo-docs-astro/src/components/docs/mdx/H2.astro
@@ -1,0 +1,7 @@
+---
+import Heading from "../Heading.astro";
+const { id, class: className } = Astro.props;
+---
+<Heading level={2} id={id} class={className}>
+  <slot />
+</Heading>

--- a/packages/kumo-docs-astro/src/components/docs/mdx/H3.astro
+++ b/packages/kumo-docs-astro/src/components/docs/mdx/H3.astro
@@ -1,0 +1,7 @@
+---
+import Heading from "../Heading.astro";
+const { id, class: className } = Astro.props;
+---
+<Heading level={3} id={id} class={className}>
+  <slot />
+</Heading>

--- a/packages/kumo-docs-astro/src/components/docs/mdx/H4.astro
+++ b/packages/kumo-docs-astro/src/components/docs/mdx/H4.astro
@@ -1,0 +1,7 @@
+---
+import Heading from "../Heading.astro";
+const { id, class: className } = Astro.props;
+---
+<Heading level={4} id={id} class={className}>
+  <slot />
+</Heading>

--- a/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
+++ b/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
@@ -12,8 +12,7 @@ import type { Root } from "mdast";
 export function remarkHeadingComponents() {
   return (tree: Root) => {
     // Inject import statements at the top of the MDX AST.
-    // Uses underscore-prefixed names to avoid conflicts with any
-    // existing imports in MDX files.
+    // Uses underscore-prefixed names to avoid conflicts with existing imports in MDX files.
     const importNode = {
       type: "mdxjsEsm",
       value: `import _H2 from '~/components/docs/mdx/H2.astro';

--- a/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
+++ b/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
@@ -1,0 +1,134 @@
+import type { Root } from "mdast";
+
+/**
+ * Remark plugin that injects MDX component overrides for headings.
+ * This makes markdown ## / ### / #### render using the Heading.astro component
+ * instead of plain HTML heading elements.
+ *
+ * Replaces the old rehype-heading-links plugin by delegating heading rendering
+ * entirely to Heading.astro via MDX component overrides, eliminating duplicated
+ * heading logic (slugification, styling, link icon).
+ */
+export function remarkHeadingComponents() {
+  return (tree: Root) => {
+    // Inject import statements at the top of the MDX AST.
+    // Uses underscore-prefixed names to avoid conflicts with any
+    // existing imports in MDX files.
+    const importNode = {
+      type: "mdxjsEsm",
+      value: `import _H2 from '~/components/docs/mdx/H2.astro';
+import _H3 from '~/components/docs/mdx/H3.astro';
+import _H4 from '~/components/docs/mdx/H4.astro';`,
+      data: {
+        estree: {
+          type: "Program",
+          sourceType: "module",
+          body: [
+            {
+              type: "ImportDeclaration",
+              source: {
+                type: "Literal",
+                value: "~/components/docs/mdx/H2.astro",
+              },
+              specifiers: [
+                {
+                  type: "ImportDefaultSpecifier",
+                  local: { type: "Identifier", name: "_H2" },
+                },
+              ],
+            },
+            {
+              type: "ImportDeclaration",
+              source: {
+                type: "Literal",
+                value: "~/components/docs/mdx/H3.astro",
+              },
+              specifiers: [
+                {
+                  type: "ImportDefaultSpecifier",
+                  local: { type: "Identifier", name: "_H3" },
+                },
+              ],
+            },
+            {
+              type: "ImportDeclaration",
+              source: {
+                type: "Literal",
+                value: "~/components/docs/mdx/H4.astro",
+              },
+              specifiers: [
+                {
+                  type: "ImportDefaultSpecifier",
+                  local: { type: "Identifier", name: "_H4" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    // Inject: export const components = { h2: _H2, h3: _H3, h4: _H4 };
+    const exportNode = {
+      type: "mdxjsEsm",
+      value: "export const components = { h2: _H2, h3: _H3, h4: _H4 };",
+      data: {
+        estree: {
+          type: "Program",
+          sourceType: "module",
+          body: [
+            {
+              type: "ExportNamedDeclaration",
+              declaration: {
+                type: "VariableDeclaration",
+                kind: "const" as const,
+                declarations: [
+                  {
+                    type: "VariableDeclarator",
+                    id: { type: "Identifier", name: "components" },
+                    init: {
+                      type: "ObjectExpression",
+                      properties: [
+                        {
+                          type: "Property",
+                          key: { type: "Identifier", name: "h2" },
+                          value: { type: "Identifier", name: "_H2" },
+                          kind: "init" as const,
+                          computed: false,
+                          method: false,
+                          shorthand: false,
+                        },
+                        {
+                          type: "Property",
+                          key: { type: "Identifier", name: "h3" },
+                          value: { type: "Identifier", name: "_H3" },
+                          kind: "init" as const,
+                          computed: false,
+                          method: false,
+                          shorthand: false,
+                        },
+                        {
+                          type: "Property",
+                          key: { type: "Identifier", name: "h4" },
+                          value: { type: "Identifier", name: "_H4" },
+                          kind: "init" as const,
+                          computed: false,
+                          method: false,
+                          shorthand: false,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              specifiers: [],
+            },
+          ],
+        },
+      },
+    };
+
+    // Prepend import and export nodes to the tree
+    tree.children.unshift(importNode as any, exportNode as any);
+  };
+}

--- a/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
+++ b/packages/kumo-docs-astro/src/lib/remark-heading-components.ts
@@ -1,5 +1,18 @@
 import type { Root } from "mdast";
 
+/** MDX ESM node shape used by mdast-util-mdxjs-esm / remark-mdx. */
+interface MdxjsEsmNode {
+  type: "mdxjsEsm";
+  value: string;
+  data: {
+    estree: {
+      type: "Program";
+      sourceType: "module";
+      body: Record<string, unknown>[];
+    };
+  };
+}
+
 /**
  * Remark plugin that injects MDX component overrides for headings.
  * This makes markdown ## / ### / #### render using the Heading.astro component
@@ -13,7 +26,7 @@ export function remarkHeadingComponents() {
   return (tree: Root) => {
     // Inject import statements at the top of the MDX AST.
     // Uses underscore-prefixed names to avoid conflicts with existing imports in MDX files.
-    const importNode = {
+    const importNode: MdxjsEsmNode = {
       type: "mdxjsEsm",
       value: `import _H2 from '~/components/docs/mdx/H2.astro';
 import _H3 from '~/components/docs/mdx/H3.astro';
@@ -68,7 +81,7 @@ import _H4 from '~/components/docs/mdx/H4.astro';`,
     };
 
     // Inject: export const components = { h2: _H2, h3: _H3, h4: _H4 };
-    const exportNode = {
+    const exportNode: MdxjsEsmNode = {
       type: "mdxjsEsm",
       value: "export const components = { h2: _H2, h3: _H3, h4: _H4 };",
       data: {
@@ -127,7 +140,12 @@ import _H4 from '~/components/docs/mdx/H4.astro';`,
       },
     };
 
-    // Prepend import and export nodes to the tree
-    tree.children.unshift(importNode as any, exportNode as any);
+    // Prepend import and export nodes to the tree.
+    // MdxjsEsmNode (from mdx-js/mdx) isn't part of mdast's RootContent union,
+    // so we widen the array type to accept both standard and MDX ESM nodes.
+    (tree.children as (Root["children"][number] | MdxjsEsmNode)[]).unshift(
+      importNode,
+      exportNode,
+    );
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.17(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.4
@@ -1487,89 +1490,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1818,21 +1837,25 @@ packages:
     resolution: {integrity: sha512-j4QzfCM8ks+OyM+KKYWDiBEQsm5RCW50H1Wz16wUyoFsobJ+X5qqcJxq6HvkE07m8euYmZelyB0WqsiDoz1v8g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.42.0':
     resolution: {integrity: sha512-g5b1Uw7zo6yw4Ymzyd1etKzAY7xAaGA3scwB8tAp3QzuY7CYdfTwlhiLKSAKbd7T/JBgxOXAGNcLDorJyVTXcg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.42.0':
     resolution: {integrity: sha512-HnD99GD9qAbpV4q9iQil7mXZUJFpoBdDavfcC2CgGLPlawfcV5COzQPNwOgvPVkr7C0cBx6uNCq3S6r9IIiEIg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.42.0':
     resolution: {integrity: sha512-8NTe8A78HHFn+nBi+8qMwIjgv9oIBh+9zqCPNLH56ah4vKOPvbePLI6NIv9qSkmzrBuu8SB+FJ2TH/G05UzbNA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.42.0':
     resolution: {integrity: sha512-lAPS2YAuu+qFqoTNPFcNsxXjwSV0M+dOgAzzVTAN7Yo2ifj+oLOx0GsntWoM78PvQWI7Q827ZxqtU2ImBmDapA==}
@@ -1873,36 +1896,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -2032,121 +2061,145 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2334,24 +2387,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -4251,24 +4308,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.17(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))
       '@types/mdast':
-        specifier: ^4.0.4
+        specifier: 4.0.4
         version: 4.0.4
       '@types/react':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

Markdown headings (`##`, `###`, `####`) on guide pages lacked anchor links, hover icons, and "On this page" sidebar support — unlike component pages that used the `<Heading>` Astro component directly. This PR adds a remark plugin that auto-injects MDX component overrides, so markdown headings render through the existing `Heading.astro` component — giving them anchor links, hover icons, and sidebar support automatically.

## Changes

- Add `remark-heading-components.ts` — remark plugin that injects `export const components = { h2: H2, h3: H3, h4: H4 }` into every MDX file at compile time
- Create thin wrapper components `H2.astro`, `H3.astro`, `H4.astro` that delegate to `Heading.astro` with the correct `level` prop
- Register the remark plugin in `astro.config.mjs` under the MDX integration
- Add `tracking-[-0.02em]` to `Heading.astro`
- Rename `LinkSimple` → `LinkSimpleIcon` import in `Heading.astro`
- Add `@types/mdast` for plugin type safety

> **Note:** This PR introduces MDX component overrides for headings, which means Astro's built-in heading collection no longer detects `<Heading>` JSX components as headings. This causes the "On this page" sidebar to break on component pages that use explicit `<Heading>` imports. This is resolved in PR 3/5 (#420), which converts all JSX headings to plain markdown.

## How it works

```
## My Heading (in MDX)
       ↓ remark plugin injects component override
<H2>My Heading</H2>
       ↓ H2.astro delegates
<Heading level={2}>My Heading</Heading>
       ↓ renders with anchor link, hover icon, styling
```

> **Depends on:** PR 1/5 (#419) for the prose CSS fixes

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs infrastructure change — remark plugin + Astro wrapper components
- Tests
  - [x] Additional testing not necessary because: build passes with all 59 pages rendering correctly, heading anchors verified in built HTML output


