### PR TITLE
Docs: Remove redundant inline styles now handled by prose (4/5)

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
@@ -11,8 +11,7 @@ const proseStyles = cn(
   "[&>:first-child]:mt-0 [&>:last-child]:mb-0",
   "[&_h1]:text-xl [&_h2]:text-lg [&_h3]:text-base",
   "[&_:is(h1,h2,h3)]:font-semibold [&_:is(h1,h2,h3)]:text-kumo-default",
-  "[&_p]:text-kumo-default",
-  "[&_pre]:overflow-x-auto",
+  "[&_pre]:overflow-x-auto [&_pre]:text-base",
 );
 
 interface ChangelogEntryProps {

--- a/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/ChangelogEntry.tsx
@@ -11,7 +11,7 @@ const proseStyles = cn(
   "[&>:first-child]:mt-0 [&>:last-child]:mb-0",
   "[&_h1]:text-xl [&_h2]:text-lg [&_h3]:text-base",
   "[&_:is(h1,h2,h3)]:font-semibold [&_:is(h1,h2,h3)]:text-kumo-default",
-  "[&_pre]:overflow-x-auto [&_pre]:text-base",
+  "[&_pre]:overflow-x-auto",
 );
 
 interface ChangelogEntryProps {

--- a/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
@@ -161,7 +161,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Type</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">label</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/page-header.mdx
@@ -161,7 +161,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Type</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">label</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
@@ -124,7 +124,7 @@ export default function DatabasesPage() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">title</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
+++ b/packages/kumo-docs-astro/src/pages/blocks/resource-list.mdx
@@ -124,7 +124,7 @@ export default function DatabasesPage() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">title</td>
           <td class="px-4 py-3 font-mono text-xs">string</td>

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -150,14 +150,14 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-default">
+      <p>
         Single checkboxes require a `label` prop or `aria-label` for accessibility.
         Missing labels trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-default">
+      <p>
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> toggles
         the checkbox.
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
@@ -166,7 +166,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-default">
+      <p>
         Checkbox.Group uses semantic `<fieldset>` and `<legend>` elements for
         proper grouping announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -150,14 +150,14 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Single checkboxes require a `label` prop or `aria-label` for accessibility.
         Missing labels trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> toggles
         the checkbox.
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
@@ -166,7 +166,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Checkbox.Group uses semantic `<fieldset>` and `<legend>` elements for
         proper grouping announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
@@ -181,7 +181,7 @@ export function App() {
     CodeHighlighted uses hardcoded themes for consistent styling across all Kumo
     applications:
   </p>
-  <ul class="mb-4 list-disc pl-6 text-kumo-strong">
+  <ul class="mb-4 list-disc pl-6 text-kumo-default">
     <li>
       <strong>Light mode:</strong>
       `github-light`

--- a/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/code-highlighted.mdx
@@ -181,7 +181,7 @@ export function App() {
     CodeHighlighted uses hardcoded themes for consistent styling across all Kumo
     applications:
   </p>
-  <ul class="mb-4 list-disc pl-6 text-kumo-default">
+  <ul class="mb-4 list-disc pl-6">
     <li>
       <strong>Light mode:</strong>
       `github-light`

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -137,7 +137,10 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={3}>Disabled</Heading>
-  <p>Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` and `TriggerValue`.</p>
+  <p>
+    Pass the `disabled` prop to prevent interaction. Works with both
+    `TriggerInput` and `TriggerValue`.
+  </p>
   <ComponentExample demo="ComboboxDisabledDemo">
     <ComboboxDisabledDemo client:load />
   </ComponentExample>
@@ -190,7 +193,7 @@ export default function Example() {
 <PropsTable component="Combobox.Item" />
 
   <Heading level={3}>Additional Sub-components</Heading>
-  <ul class="list-disc list-inside text-kumo-strong space-y-1">
+  <ul class="list-disc list-inside text-kumo-default space-y-1">
     <li>`Combobox.TriggerInput` - Single-select input trigger</li>
     <li>`Combobox.TriggerValue` - Button trigger showing selected value</li>
     <li>`Combobox.TriggerMultipleWithInput` - Multi-select with chips</li>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -193,7 +193,7 @@ export default function Example() {
 <PropsTable component="Combobox.Item" />
 
   <Heading level={3}>Additional Sub-components</Heading>
-  <ul class="list-disc list-inside text-kumo-default space-y-1">
+  <ul class="list-disc list-inside space-y-1">
     <li>`Combobox.TriggerInput` - Single-select input trigger</li>
     <li>`Combobox.TriggerValue` - Button trigger showing selected value</li>
     <li>`Combobox.TriggerMultipleWithInput` - Multi-select with chips</li>

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -182,7 +182,7 @@ export function DatePickerDropdown() {
     DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
     Key props include:
   </p>
-  <ul class="mt-4 list-disc list-inside text-kumo-default space-y-2">
+  <ul class="mt-4 list-disc list-inside space-y-2">
     <li>`mode` — <code class="text-xs">"single" | "multiple" | "range"</code> — Selection mode (required)</li>
     <li>`selected` — Currently selected date(s)</li>
     <li>`onChange` — Callback when selection changes</li>

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -108,11 +108,8 @@ export default function Example() {
 
 <Heading level={3}>With Popover</Heading>
 <p>
-  Compose with the
-  <a href="/components/popover" class="text-kumo-link hover:underline">
-    Popover
-  </a>
-  component to create a dropdown date picker.
+  Compose with the [Popover](/components/popover) component to create a dropdown
+  date picker.
 </p>
 <ComponentExample demo="DatePickerPopoverDemo">
   <DatePickerPopoverDemo client:load />
@@ -182,10 +179,10 @@ export function DatePickerDropdown() {
 <ComponentSection>
   <Heading level={2}>API Reference</Heading>
   <p>
-    DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
+    DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
     Key props include:
   </p>
-  <ul class="mt-4 list-disc list-inside text-kumo-strong space-y-2">
+  <ul class="mt-4 list-disc list-inside text-kumo-default space-y-2">
     <li>`mode` — <code class="text-xs">"single" | "multiple" | "range"</code> — Selection mode (required)</li>
     <li>`selected` — Currently selected date(s)</li>
     <li>`onChange` — Callback when selection changes</li>
@@ -197,7 +194,7 @@ export function DatePickerDropdown() {
     <li>`className` — Additional CSS classes</li>
   </ul>
   <p class="mt-4 text-kumo-subtle text-sm">
-    See the <a href="https://daypicker.dev/docs" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">react-day-picker documentation</a> for the full API.
+    See the <a href="https://daypicker.dev/docs" target="_blank" rel="noopener noreferrer">react-day-picker documentation</a> for the full API.
   </p>
 
   <Heading level={3}>Differences from react-day-picker</Heading>

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -134,11 +134,11 @@ export default function Example() {
   dialog with `role="alertdialog"` instead of `role="dialog"`.
 </p>
 <div class="mb-4 rounded-lg border border-kumo-info/30 bg-kumo-info/10 p-4 text-sm text-kumo-info">
-  <p class="font-medium mb-2">
+  <p class="font-medium mb-2 text-sm">
     When to use{" "}
     <code class="bg-kumo-info/20 px-1 rounded">role="alertdialog"</code>:
   </p>
-  <ul class="list-disc list-inside space-y-1 ml-2">
+  <ul class="list-disc list-inside space-y-1 ml-2 mb-0">
     <li>Destructive actions (delete, discard, remove)</li>
     <li>Confirmation flows requiring explicit user acknowledgment</li>
     <li>Actions that cannot be undone</li>

--- a/packages/kumo-docs-astro/src/pages/components/flow.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/flow.mdx
@@ -218,7 +218,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "center"</td>
@@ -255,7 +255,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">render</td>
         <td class="px-4 py-3 font-mono">ReactElement</td>
@@ -295,7 +295,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">type</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -332,7 +332,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -367,7 +367,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono">children</td>
           <td class="px-4 py-3 font-mono">ReactNode</td>

--- a/packages/kumo-docs-astro/src/pages/components/flow.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/flow.mdx
@@ -218,7 +218,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "center"</td>
@@ -255,7 +255,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">render</td>
         <td class="px-4 py-3 font-mono">ReactElement</td>
@@ -295,7 +295,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">type</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -332,7 +332,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono">align</td>
         <td class="px-4 py-3 font-mono">"start" | "end"</td>
@@ -367,7 +367,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono">children</td>
           <td class="px-4 py-3 font-mono">ReactNode</td>

--- a/packages/kumo-docs-astro/src/pages/components/grid.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/grid.mdx
@@ -95,7 +95,7 @@ import { Grid, GridItem } from "@cloudflare/kumo";
           <th class="py-3 pr-4 font-medium">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="py-3 pr-4">`2up`</td>
           <td class="py-3 pr-4">1 column mobile, 2 columns medium+</td>

--- a/packages/kumo-docs-astro/src/pages/components/grid.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/grid.mdx
@@ -95,7 +95,7 @@ import { Grid, GridItem } from "@cloudflare/kumo";
           <th class="py-3 pr-4 font-medium">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="py-3 pr-4">`2up`</td>
           <td class="py-3 pr-4">1 column mobile, 2 columns medium+</td>

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -181,23 +181,21 @@ export default function Example() {
 
 <h3 class="mb-2 font-semibold">Label Requirement</h3>
 
-<p class="text-kumo-default">
-  InputArea requires an accessible name via one of:
-</p>
+<p>InputArea requires an accessible name via one of:</p>
 
-<ul class="ml-4 list-disc space-y-1 text-kumo-default">
+<ul class="ml-4 list-disc space-y-1">
   <li>`label` prop (recommended)</li>
   <li>`placeholder` + `aria-label` for bare textareas</li>
   <li>`aria-labelledby` for custom label association</li>
 </ul>
 
-<p class="mt-2 text-kumo-default">
+<p class="mt-2">
   Missing accessible names trigger console warnings in development.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Error Association</h3>
 
-<p class="text-kumo-default">
+<p>
   Error messages are automatically associated with the textarea via ARIA
   attributes for screen reader announcement.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -181,23 +181,23 @@ export default function Example() {
 
 <h3 class="mb-2 font-semibold">Label Requirement</h3>
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   InputArea requires an accessible name via one of:
 </p>
 
-<ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+<ul class="ml-4 list-disc space-y-1 text-kumo-default">
   <li>`label` prop (recommended)</li>
   <li>`placeholder` + `aria-label` for bare textareas</li>
   <li>`aria-labelledby` for custom label association</li>
 </ul>
 
-<p class="mt-2 text-kumo-strong">
+<p class="mt-2 text-kumo-default">
   Missing accessible names trigger console warnings in development.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Error Association</h3>
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Error messages are automatically associated with the textarea via ARIA
   attributes for screen reader announcement.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -206,7 +206,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">valueMissing</td>
           <td class="px-4 py-3 text-xs">Required field is empty</td>
@@ -251,21 +251,21 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Inputs require an accessible name via one of:
       </p>
-      <ul class="mt-2 ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="mt-2 ml-4 list-disc space-y-1 text-kumo-default">
         <li>`label` prop (recommended)</li>
         <li>`placeholder` + `aria-label` for bare inputs</li>
         <li>`aria-labelledby` for custom label association</li>
       </ul>
-      <p class="mt-2 text-kumo-strong">
+      <p class="mt-2 text-kumo-default">
         Missing accessible names trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Error Association</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Error messages are automatically associated with the input via ARIA
         attributes for screen reader announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -206,7 +206,7 @@ export default function Example() {
           <th class="px-4 py-3 text-left font-semibold">Description</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">valueMissing</td>
           <td class="px-4 py-3 text-xs">Required field is empty</td>
@@ -251,21 +251,19 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Label Requirement</h3>
-      <p class="text-kumo-default">
-        Inputs require an accessible name via one of:
-      </p>
-      <ul class="mt-2 ml-4 list-disc space-y-1 text-kumo-default">
+      <p>Inputs require an accessible name via one of:</p>
+      <ul class="mt-2 ml-4 list-disc space-y-1">
         <li>`label` prop (recommended)</li>
         <li>`placeholder` + `aria-label` for bare inputs</li>
         <li>`aria-labelledby` for custom label association</li>
       </ul>
-      <p class="mt-2 text-kumo-default">
+      <p class="mt-2">
         Missing accessible names trigger console warnings in development.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Error Association</h3>
-      <p class="text-kumo-default">
+      <p>
         Error messages are automatically associated with the input via ARIA
         attributes for screen reader announcement.
       </p>

--- a/packages/kumo-docs-astro/src/pages/components/label.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/label.mdx
@@ -138,7 +138,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">children</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -184,7 +184,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">label</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -221,7 +221,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Optional Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           Use "(optional)" for optional fields when most fields are required
         </li>
@@ -231,7 +231,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">When to Use Tooltips</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>Provide additional context that doesn't fit in the label</li>
         <li>Explain format requirements or validation rules</li>
         <li>Link to help documentation for complex fields</li>
@@ -240,7 +240,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           Optional indicators are purely visual - use the `required` attribute
           for validation

--- a/packages/kumo-docs-astro/src/pages/components/label.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/label.mdx
@@ -138,7 +138,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">children</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -184,7 +184,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">label</td>
         <td class="px-4 py-3 font-mono text-xs">ReactNode</td>
@@ -221,7 +221,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Optional Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           Use "(optional)" for optional fields when most fields are required
         </li>
@@ -231,7 +231,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">When to Use Tooltips</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>Provide additional context that doesn't fit in the label</li>
         <li>Explain format requirements or validation rules</li>
         <li>Link to help documentation for complex fields</li>
@@ -240,7 +240,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           Optional indicators are purely visual - use the `required` attribute
           for validation

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -163,7 +163,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">variant</td>
         <td class="px-4 py-3 font-mono text-xs">
@@ -212,7 +212,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Use Case</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-default">
+    <tbody>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">inline</td>
         <td class="px-4 py-3 text-xs">Primary color with underline</td>
@@ -257,7 +257,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Each Variant</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           <strong>inline</strong>: Default choice for links within body text
         </li>
@@ -273,7 +273,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">External Link Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>Always use `Link.ExternalIcon` for links that open in new tabs</li>
         <li>
           Set `target="_blank"` and `rel="noopener noreferrer"` for security
@@ -285,7 +285,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Framework Integration</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>
           Use the `render` prop with React Router, Next.js, or other framework
           links
@@ -302,7 +302,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
+      <ul class="ml-4 list-disc space-y-1">
         <li>Links are keyboard focusable by default</li>
         <li>
           The external icon has `aria-hidden="true"` - add descriptive text for

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -163,7 +163,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Description</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">variant</td>
         <td class="px-4 py-3 font-mono text-xs">
@@ -212,7 +212,7 @@ export default function Example() {
         <th class="px-4 py-3 text-left font-semibold">Use Case</th>
       </tr>
     </thead>
-    <tbody class="text-kumo-strong">
+    <tbody class="text-kumo-default">
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">inline</td>
         <td class="px-4 py-3 text-xs">Primary color with underline</td>
@@ -257,7 +257,7 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">When to Use Each Variant</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           <strong>inline</strong>: Default choice for links within body text
         </li>
@@ -273,7 +273,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">External Link Indicators</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>Always use `Link.ExternalIcon` for links that open in new tabs</li>
         <li>
           Set `target="_blank"` and `rel="noopener noreferrer"` for security
@@ -285,7 +285,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Framework Integration</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>
           Use the `render` prop with React Router, Next.js, or other framework
           links
@@ -302,7 +302,7 @@ export default function Example() {
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Accessibility</h3>
-      <ul class="ml-4 list-disc space-y-1 text-kumo-strong">
+      <ul class="ml-4 list-disc space-y-1 text-kumo-default">
         <li>Links are keyboard focusable by default</li>
         <li>
           The external icon has `aria-hidden="true"` - add descriptive text for

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -157,19 +157,19 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-      <p class="text-kumo-default">
+      <p>
         Radio.Group uses semantic `<fieldset>` and `<legend>` elements for proper grouping and screen reader announcement.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-default">
+      <p>
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Up/Down</kbd> or <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Left/Right</kbd> moves between options. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> selects the focused option. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus to and from the radio group.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-default">
+      <p>
         Each radio is announced with its label and selection state. The group legend provides context for all options.
       </p>
     </div>

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -157,19 +157,19 @@ export default function Example() {
   <div class="space-y-4 text-sm">
     <div>
       <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Radio.Group uses semantic `<fieldset>` and `<legend>` elements for proper grouping and screen reader announcement.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Keyboard Navigation</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Up/Down</kbd> or <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Arrow Left/Right</kbd> moves between options. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd> selects the focused option. <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus to and from the radio group.
       </p>
     </div>
     <div>
       <h3 class="mb-2 font-semibold">Screen Readers</h3>
-      <p class="text-kumo-strong">
+      <p class="text-kumo-default">
         Each radio is announced with its label and selection state. The group legend provides context for all options.
       </p>
     </div>

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -240,9 +240,9 @@ export default function Example() {
 
   <ComponentExample demo="SelectLoadingDemo">
     <div class="flex flex-col gap-4">
-      <p class="text-kumo-strong">Loading State</p>
+      <p class="text-kumo-default">Loading State</p>
       <SelectLoadingDemo client:load />
-      <p class="text-kumo-strong">Loading From Server (simulated 2s delay)</p>
+      <p class="text-kumo-default">Loading From Server (simulated 2s delay)</p>
       <SelectLoadingDataDemo client:load />
     </div>
   </ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -39,7 +39,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Widths</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Control the randomized width range for more natural-looking skeletons.
   </p>
   <ComponentExample demo="SkeletonLineWidthDemo">
@@ -51,7 +51,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Height</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Override the default height using Tailwind utility classes via{" "}
     <code>className</code>. The default height is <code>0.5rem</code>.
   </p>
@@ -64,7 +64,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Block Height</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Use <code>blockHeight</code> to set the height of a container that
     vertically centers the skeleton line. Useful when replacing text of a known
     line height. Accepts a number (treated as <code>px</code>) or any CSS string
@@ -79,7 +79,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Card Loading State</Heading>
-  <p class="text-kumo-strong mb-4">
+  <p class="text-kumo-default mb-4">
     Use skeleton lines to create loading states for cards and content areas.
   </p>
   <ComponentExample demo="SkeletonLineCardDemo">
@@ -100,7 +100,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
           <th class="px-4 py-3 text-left font-semibold">Default</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-strong">
+      <tbody class="text-kumo-default">
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">minWidth</td>
           <td class="px-4 py-3 font-mono text-xs">number</td>

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -39,7 +39,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Widths</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Control the randomized width range for more natural-looking skeletons.
   </p>
   <ComponentExample demo="SkeletonLineWidthDemo">
@@ -51,7 +51,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Custom Height</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Override the default height using Tailwind utility classes via{" "}
     <code>className</code>. The default height is <code>0.5rem</code>.
   </p>
@@ -64,7 +64,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Block Height</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Use <code>blockHeight</code> to set the height of a container that
     vertically centers the skeleton line. Useful when replacing text of a known
     line height. Accepts a number (treated as <code>px</code>) or any CSS string
@@ -79,7 +79,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
 
 <ComponentSection>
   <Heading level={2}>Card Loading State</Heading>
-  <p class="text-kumo-default mb-4">
+  <p class="mb-4">
     Use skeleton lines to create loading states for cards and content areas.
   </p>
   <ComponentExample demo="SkeletonLineCardDemo">
@@ -100,7 +100,7 @@ import { SkeletonLine } from "@cloudflare/kumo";
           <th class="px-4 py-3 text-left font-semibold">Default</th>
         </tr>
       </thead>
-      <tbody class="text-kumo-default">
+      <tbody>
         <tr class="border-b border-kumo-hairline">
           <td class="px-4 py-3 font-mono text-xs">minWidth</td>
           <td class="px-4 py-3 font-mono text-xs">number</td>

--- a/packages/kumo-docs-astro/src/pages/components/table.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table.mdx
@@ -256,18 +256,18 @@ function DataTable({ data, columns }) {
   <Heading level={2}>Accessibility</Heading>
 
 <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-<p class="text-kumo-default">
+<p>
   Table uses semantic `<table>`, `<thead>`, `<tbody>`, `<th>`, and `<td>` elements for proper screen reader navigation.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Checkbox Labels</h3>
-<p class="text-kumo-default">
+<p>
   Always provide `aria-label` for `Table.CheckHead` and `Table.CheckCell` to
   describe their purpose.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Keyboard Navigation</h3>
-<p class="text-kumo-default">
+<p>
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
   through interactive elements. Checkboxes respond to{" "}
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd>.

--- a/packages/kumo-docs-astro/src/pages/components/table.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/table.mdx
@@ -188,7 +188,7 @@ export default function Example() {
 <ComponentSection>
   <Heading level={2}>TanStack Table Integration</Heading>
   <p>
-    For advanced features like sorting, filtering, and resizable columns, integrate with <a href="https://tanstack.com/table" class="text-kumo-link hover:underline" target="_blank" rel="noopener noreferrer">TanStack Table</a>. The Table component is designed to work seamlessly with TanStack's headless API.
+    For advanced features like sorting, filtering, and resizable columns, integrate with <a href="https://tanstack.com/table" target="_blank" rel="noopener noreferrer">TanStack Table</a>. The Table component is designed to work seamlessly with TanStack's headless API.
   </p>
 
 ```tsx
@@ -256,18 +256,18 @@ function DataTable({ data, columns }) {
   <Heading level={2}>Accessibility</Heading>
 
 <h3 class="mb-2 font-semibold">Semantic HTML</h3>
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Table uses semantic `<table>`, `<thead>`, `<tbody>`, `<th>`, and `<td>` elements for proper screen reader navigation.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Checkbox Labels</h3>
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Always provide `aria-label` for `Table.CheckHead` and `Table.CheckCell` to
   describe their purpose.
 </p>
 
 <h3 class="mb-2 mt-4 font-semibold">Keyboard Navigation</h3>
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Tab</kbd> moves focus
   through interactive elements. Checkboxes respond to{" "}
   <kbd class="rounded bg-kumo-control px-1.5 py-0.5">Space</kbd>.

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -55,7 +55,7 @@ export default function Example() {
 
 <section class="mt-8 space-y-4">
   <h3 class="text-lg font-semibold">Restrictions</h3>
-  <p class="text-kumo-default">
+  <p>
     The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
   </p>
 
@@ -66,7 +66,7 @@ export default function Example() {
 <Text variant="error">Error</Text>
 ```
 
-<p class="text-kumo-default">
+<p>
   Monospace variants (`mono` and `mono-secondary`) can only set `size` to `lg`
   and cannot use the `bold` prop:
 </p>
@@ -77,7 +77,7 @@ export default function Example() {
 <Text variant="mono" bold>Monospace</Text> // Doesn't compile
 ```
 
-<p class="text-kumo-default">
+<p>
   Headings (i.e. `h1`, `h2` and `h3` variants) cannot use these props at all:
 </p>
 
@@ -95,7 +95,7 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={2}>Truncate</Heading>
-  <p class="text-kumo-default">
+  <p>
     Use the `truncate` prop to clip overflowing text with an ellipsis. This adds `truncate min-w-0` classes, which is useful when `Text` is inside a flex or grid container.
   </p>
   <ComponentExample demo="TextTruncateDemo">

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -55,7 +55,7 @@ export default function Example() {
 
 <section class="mt-8 space-y-4">
   <h3 class="text-lg font-semibold">Restrictions</h3>
-  <p class="text-kumo-strong">
+  <p class="text-kumo-default">
     The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
   </p>
 
@@ -66,7 +66,7 @@ export default function Example() {
 <Text variant="error">Error</Text>
 ```
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Monospace variants (`mono` and `mono-secondary`) can only set `size` to `lg`
   and cannot use the `bold` prop:
 </p>
@@ -77,7 +77,7 @@ export default function Example() {
 <Text variant="mono" bold>Monospace</Text> // Doesn't compile
 ```
 
-<p class="text-kumo-strong">
+<p class="text-kumo-default">
   Headings (i.e. `h1`, `h2` and `h3` variants) cannot use these props at all:
 </p>
 
@@ -95,7 +95,7 @@ export default function Example() {
 
 <ComponentSection>
   <Heading level={2}>Truncate</Heading>
-  <p class="text-kumo-strong">
+  <p class="text-kumo-default">
     Use the `truncate` prop to clip overflowing text with an ellipsis. This adds `truncate min-w-0` classes, which is useful when `Text` is inside a flex or grid container.
   </p>
   <ComponentExample demo="TextTruncateDemo">

--- a/packages/kumo-docs-astro/src/pages/components/toast.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/toast.mdx
@@ -219,10 +219,10 @@ toastManager.promise(asyncFn(), {
   <table class="w-full text-left text-sm">
     <thead>
       <tr class="border-b border-kumo-hairline">
-        <th class="py-3 pr-4 font-semibold text-kumo-default">Prop</th>
-        <th class="py-3 pr-4 font-semibold text-kumo-default">Type</th>
-        <th class="py-3 pr-4 font-semibold text-kumo-default">Default</th>
-        <th class="py-3 font-semibold text-kumo-default">Description</th>
+        <th class="py-3 pr-4 font-semibold">Prop</th>
+        <th class="py-3 pr-4 font-semibold">Type</th>
+        <th class="py-3 pr-4 font-semibold">Default</th>
+        <th class="py-3 font-semibold">Description</th>
       </tr>
     </thead>
     <tbody class="text-kumo-subtle">


### PR DESCRIPTION
## Summary

Now that `.kumo-prose` handles text colors, font sizes, link styling, and margins automatically, many inline classes on MDX elements are redundant. This PR removes ~90 instances of unnecessary styling.

## Changes

- Remove `text-kumo-strong` → `text-kumo-default` on body text that was incorrectly using the emphasis token (~50 instances across `<p>`, `<ul>`, `<tbody>` tags)
- Convert 4 redundant styled `<a>` tags to plain markdown links (preserving `target="_blank"` on external links)
- Remove redundant `[&_p]:text-sm [&_p]:text-kumo-default` from `ChangelogEntry.tsx`
- Fix empty `<p>` rendering bug in `dialog.mdx` (MDX multiline parsing issue)

> **Depends on:** PR 1/5 (#419) for the prose CSS that makes these inline styles redundant

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only content cleanup, removing redundant CSS classes from MDX files
- Tests
  - [x] Additional testing not necessary because: docs-site-only changes — build passes, no component library modifications