### PR TITLE
Add global letter-spacing and typography defaults

### DIFF
--- a/.changeset/global-typography-defaults.md
+++ b/.changeset/global-typography-defaults.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Add global letter-spacing and typography defaults
+
+- Set global `letter-spacing: -0.01em`, `line-height: 1.5`, and OpenType font features (`cv02`, `cv03`, `cv04`, `calt`) on `html`
+- Reset `letter-spacing: normal` on `pre`, `code`, `kbd`, and `.font-mono` elements
+- Replace hardcoded `tracking-[-0.02em]` with `tracking-tight` utility across headings
+- Switch prose paragraphs and lists from `leading-relaxed` to `leading-normal`

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -656,7 +656,7 @@ export function HomeGrid() {
                 {c.name}
               </span>
             )}
-            <div className="flex w-full items-center justify-center p-8">
+            <div className="flex w-full items-center justify-center p-8 tracking-normal leading-normal">
               {c.Component ?? (
                 <p className="text-base font-medium text-kumo-subtle">TBD</p>
               )}

--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -35,7 +35,7 @@ const baseStyles = levelStyles[level];
 
 <Element
   id={slug}
-  class:list={["group relative scroll-mt-24 tracking-[-0.02em]", baseStyles, className]}
+  class:list={["group relative scroll-mt-24 tracking-tight", baseStyles, className]}
 >
   <a
     href={`#${slug}`}

--- a/packages/kumo-docs-astro/src/components/docs/StickyDocHeader.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/StickyDocHeader.tsx
@@ -77,7 +77,7 @@ export function StickyDocHeader({
         >
           <span className="pointer-events-auto flex items-center gap-2 text-base">
             <span className="text-kumo-subtle">/ </span>
-            <span className="font-semibold">{title}</span>
+            <span className="font-semibold tracking-tight">{title}</span>
             {githubSourceUrl && (
               <a
                 href={githubSourceUrl}
@@ -122,7 +122,7 @@ export function StickyDocHeader({
                 : "pointer-events-none opacity-0",
             )}
           >
-            <span className="text-lg font-semibold text-kumo-default">
+            <span className="text-lg font-semibold tracking-tight text-kumo-default">
               {title}
             </span>
             {githubSourceUrl && (

--- a/packages/kumo-docs-astro/src/components/kumo/page-header/page-header.tsx
+++ b/packages/kumo-docs-astro/src/components/kumo/page-header/page-header.tsx
@@ -69,7 +69,7 @@ export function PageHeader({
       {(title || description) && (
         <div className="flex flex-col gap-2 py-3 pl-3">
           {title && (
-            <h1 className="font-heading text-3xl font-semibold text-kumo-default">
+            <h1 className="font-heading text-3xl font-semibold tracking-tight text-kumo-default">
               {title}
             </h1>
           )}

--- a/packages/kumo-docs-astro/src/layouts/DocLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/DocLayout.astro
@@ -64,7 +64,7 @@ const githubSourceUrl = sourceFile
             <CopyPageButton align="center" client:idle />
           </div>
           <div class="mb-3 flex items-center gap-3">
-            <h1 class="text-4xl font-bold text-kumo-default">{title}</h1>
+            <h1 class="text-4xl font-bold tracking-tight text-kumo-default">{title}</h1>
             {
               githubSourceUrl && (
                 <a

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -20,8 +20,10 @@
 
 /* Prevent CLS from font loading */
 html {
-  font-display: optional;
   scroll-behavior: smooth;
+  letter-spacing: -0.01em;
+  line-height: 1.5;
+  font-feature-settings: "cv02", "cv03", "cv04", "calt";
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -30,15 +32,20 @@ html {
   }
 }
 
+/* Reset tracking for monospace/code elements and kumo component areas */
+pre,
+code,
+kbd,
+.font-mono {
+  letter-spacing: normal;
+}
+
 /* ==========================================================================
    Kumo Prose — Tailwind Typography overrides using kumo semantic tokens
    Used on .kumo-prose wrapper in DocLayout and MdxDocLayout
    ========================================================================== */
 
 .kumo-prose {
-  /* Base letter-spacing for prose content */
-  letter-spacing: -0.01em;
-
   /* Body text */
   --tw-prose-body: var(--text-color-kumo-default);
   /* Headings */
@@ -141,10 +148,10 @@ html {
 
 /* Headings — shared spacing and tracking */
 .kumo-prose :where(h2, h3, h4):not(:where(.not-prose, .not-prose *)) {
+  @apply tracking-tight;
   scroll-margin-top: 6rem;
   margin-bottom: 1rem;
   font-weight: 600;
-  letter-spacing: -0.02em;
 }
 
 /* Adjacent sibling spacing after headings */
@@ -154,7 +161,7 @@ html {
 
 /* Paragraphs */
 .kumo-prose :where(p):not(:where(.not-prose, .not-prose *)) {
-  @apply text-base leading-relaxed;
+  @apply text-base leading-normal;
 }
 
 /* Adjacent sibling spacing between paragraphs */
@@ -164,14 +171,14 @@ html {
 
 /* Unordered and ordered lists */
 .kumo-prose :where(ul, ol):not(:where(.not-prose, .not-prose *)) {
-  @apply text-base leading-relaxed;
+  @apply text-base;
   margin: 0;
   margin-bottom: 1rem;
 }
 
 /* List items */
 .kumo-prose :where(li):not(:where(.not-prose, .not-prose *)) {
-  @apply text-base leading-relaxed;
+  @apply text-base leading-normal;
 }
 
 /* Horizontal rule */
@@ -189,8 +196,7 @@ html {
   box-shadow: none;
 }
 
-/* Pre / code blocks — better defaults for changelog <pre> without affecting
-   CodeBlock (wrapped in .not-prose) or Shiki blocks (inline styles override) */
+/* Pre / code blocks — better defaults for changelog <pre> without affecting CodeBlock (wrapped in .not-prose) or Shiki blocks (inline styles override) */
 .kumo-prose :where(pre):not(:where(.not-prose, .not-prose *)) {
   @apply text-base;
   background-color: var(--tw-prose-pre-bg);


### PR DESCRIPTION
Aligns the docs site's base typography with the Dashboard's global defaults:

- Add `letter-spacing: -0.01em` globally on `html` (matches Dashboard)
- Add `line-height: 1.5` globally on `html`
- Add `font-feature-settings: 'cv02', 'cv03', 'cv04', 'calt'` for Inter's open numerals and contextual alternates
- Remove invalid `font-display: optional` from `html` (only works inside `@font-face`)
- Add `tracking-tight` to page titles (`DocLayout`, `PageHeader`, `StickyDocHeader`, `Heading`)
- Reset `letter-spacing` and `line-height` in HomeGrid demo tiles so kumo components render with their own spacing
- Add monospace tracking reset (`letter-spacing: normal`) for `pre`, `code`, `kbd`, `.font-mono`

| Before | After |
|--------|--------|
|<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 13 58 16" src="https://github.com/user-attachments/assets/9df7b51d-86fb-4e4c-b228-ff3e6b2dabe5" />|<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 13 58 19" src="https://github.com/user-attachments/assets/4a1e87e3-137f-4c58-89ea-e4f8dda89975" />|
|<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 13 59 08" src="https://github.com/user-attachments/assets/3376b188-cb7d-42b9-be53-a6459cd6acbf" />|<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 13 59 09" src="https://github.com/user-attachments/assets/ce116317-d64a-4bb6-9217-17c622a51b7c" />|
|<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 13 58 52" src="https://github.com/user-attachments/assets/d3a2b351-9a68-4141-bcb8-c6026065c738" />|<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 13 58 53" src="https://github.com/user-attachments/assets/7ed5ecec-8aed-4bdd-9ea3-0e704cca14e7" />|

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: typography/styling changes require visual review
- Tests
- [x] Additional testing not necessary because: CSS-only changes with no logic, verified visually in dev server