### PR TITLE
Add "New" badge to docs sidebar

### DIFF
--- a/.changeset/docs-new-sidebar-badge.md
+++ b/.changeset/docs-new-sidebar-badge.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Add "New" badge to docs sidebar for recently added components, blocks, and chart pages

--- a/packages/kumo-docs-astro/astro.config.mjs
+++ b/packages/kumo-docs-astro/astro.config.mjs
@@ -12,6 +12,7 @@ import { kumoRegistryPlugin } from "./src/lib/vite-plugin-kumo-registry.js";
 import { kumoHmrPlugin } from "./src/lib/vite-plugin-kumo-hmr.js";
 import { markdownPages } from "./src/lib/astro-markdown-pages.js";
 import { remarkHeadingComponents } from "./src/lib/remark-heading-components.js";
+import { getComponentBirthDates } from "./src/lib/component-birth-dates.js";
 
 import sitemap from "@astrojs/sitemap";
 
@@ -63,6 +64,8 @@ function getBuildInfo() {
 }
 
 const buildInfo = getBuildInfo();
+
+const newItems = getComponentBirthDates();
 
 // Detect dev mode: `astro dev` sets this in process.argv
 const isDev = process.argv.includes("dev");
@@ -133,6 +136,7 @@ export default defineConfig({
       __BUILD_COMMIT_DATE__: JSON.stringify(buildInfo.commitDate),
       __BUILD_BRANCH__: JSON.stringify(buildInfo.branch),
       __BUILD_DATE__: JSON.stringify(buildInfo.buildDate),
+      __KUMO_NEW_ITEMS__: JSON.stringify(newItems),
     },
   },
 });

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { cn, Button } from "@cloudflare/kumo";
+import { cn, Button, Badge } from "@cloudflare/kumo";
 import {
   CaretDownIcon,
   MagnifyingGlassIcon,
@@ -8,6 +8,7 @@ import {
 import { KumoMenuIcon } from "./KumoMenuIcon";
 import { SearchDialog } from "./SearchDialog";
 import { ThemeToggle } from "./ThemeToggle";
+import { isNewItem, type NewItems } from "../lib/is-new-item";
 
 interface NavItem {
   label: string;
@@ -98,9 +99,10 @@ const blockItems: NavItem[] = [
 declare const __DOCS_VERSION__: string;
 declare const __BUILD_COMMIT__: string;
 declare const __BUILD_DATE__: string;
+declare const __KUMO_NEW_ITEMS__: NewItems;
 
 const LI_STYLE =
-  "block rounded-lg text-kumo-strong hover:text-kumo-default hover:bg-kumo-tint p-2 my-[.05rem] cursor-pointer transition-colors no-underline relative z-10";
+  "flex items-center justify-between rounded-lg text-kumo-strong hover:text-kumo-default hover:bg-kumo-tint p-2 my-[.05rem] cursor-pointer transition-colors no-underline relative z-10";
 const LI_ACTIVE_STYLE = "font-semibold text-kumo-default bg-kumo-tint";
 
 interface SidebarNavProps {
@@ -249,7 +251,10 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
                     LI_ACTIVE_STYLE,
                 )}
               >
-                {item.label}
+                <span>{item.label}</span>
+                {isNewItem(item.href, __KUMO_NEW_ITEMS__) && (
+                  <Badge variant="secondary">New</Badge>
+                )}
               </a>
             </li>
           ))}
@@ -287,7 +292,10 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
                   currentPath === item.href && LI_ACTIVE_STYLE,
                 )}
               >
-                {item.label}
+                <span>{item.label}</span>
+                {isNewItem(item.href, __KUMO_NEW_ITEMS__) && (
+                  <Badge variant="secondary">New</Badge>
+                )}
               </a>
             </li>
           ))}
@@ -327,7 +335,10 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
                     LI_ACTIVE_STYLE,
                 )}
               >
-                {item.label}
+                <span>{item.label}</span>
+                {isNewItem(item.href, __KUMO_NEW_ITEMS__) && (
+                  <Badge variant="secondary">New</Badge>
+                )}
               </a>
             </li>
           ))}

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
@@ -15,12 +15,13 @@ import { getComponentBirthDates } from "./component-birth-dates";
 const mockedExecSync = vi.mocked(execSync);
 const mockedReaddirSync = vi.mocked(readdirSync);
 
-// Returns an ISO timestamp `daysAgo` days before now, with an explicit timezone offset
-// so it matches the shape of `git log --format=%aI` output.
+const pad = (n: number) => String(n).padStart(2, "0");
+
+// Returns an ISO timestamp `daysAgo` days before now, with an explicit timezone offset so it matches the shape of `git log --format=%aI` output.
 function daysAgoISO(daysAgo: number): string {
   const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+
   // Format as YYYY-MM-DDTHH:mm:ss+00:00
-  const pad = (n: number) => String(n).padStart(2, "0");
   return (
     `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
     `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}+00:00`
@@ -43,18 +44,24 @@ function setupExecSyncMock(opts: {
   gitLogThrows?: boolean;
 }) {
   const { isShallow = false, gitLogOutput = "", gitLogThrows = false } = opts;
+
   mockedExecSync.mockImplementation((cmd) => {
     const cmdStr = String(cmd);
+
     if (cmdStr.includes("--is-shallow-repository")) {
       return (isShallow ? "true\n" : "false\n") as never;
     }
+
     if (cmdStr.includes("--show-toplevel")) {
       return "/repo-root\n" as never;
     }
+
     if (cmdStr.includes("--diff-filter=A")) {
       if (gitLogThrows) throw new Error("git log failed");
+
       return gitLogOutput as never;
     }
+
     return "" as never;
   });
 }
@@ -118,6 +125,7 @@ describe("getComponentBirthDates", () => {
     setupExecSyncMock({ gitLogThrows: true });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     expect(getComponentBirthDates()).toEqual({
       components: {},
       blocks: {},
@@ -189,6 +197,7 @@ describe("getComponentBirthDates", () => {
           direntFor("notes.txt", "file"),
         ] as never;
       }
+
       return [] as never;
     });
 

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
@@ -15,19 +15,48 @@ import { getComponentBirthDates } from "./component-birth-dates";
 const mockedExecSync = vi.mocked(execSync);
 const mockedReaddirSync = vi.mocked(readdirSync);
 
-// Returns an ISO timestamp `daysAgo` days before now.
+// Returns an ISO timestamp `daysAgo` days before now, with an explicit timezone offset
+// so it matches the shape of `git log --format=%aI` output.
 function daysAgoISO(daysAgo: number): string {
-  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+  const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  // Format as YYYY-MM-DDTHH:mm:ss+00:00
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}+00:00`
+  );
 }
 
 // Build a minimal Dirent-like object for readdirSync with withFileTypes.
-// `kind` lets the same helper stand in for directories (component/block scan) or files (chart page scan).
 function direntFor(name: string, kind: "dir" | "file") {
   return {
     name,
     isDirectory: () => kind === "dir",
     isFile: () => kind === "file",
   } as unknown as ReturnType<typeof readdirSync>[number];
+}
+
+// Configure the execSync mock to handle both the shallow-clone probe and the git log call.
+function setupExecSyncMock(opts: {
+  isShallow?: boolean;
+  gitLogOutput?: string;
+  gitLogThrows?: boolean;
+}) {
+  const { isShallow = false, gitLogOutput = "", gitLogThrows = false } = opts;
+  mockedExecSync.mockImplementation((cmd) => {
+    const cmdStr = String(cmd);
+    if (cmdStr.includes("--is-shallow-repository")) {
+      return (isShallow ? "true\n" : "false\n") as never;
+    }
+    if (cmdStr.includes("--show-toplevel")) {
+      return "/repo-root\n" as never;
+    }
+    if (cmdStr.includes("--diff-filter=A")) {
+      if (gitLogThrows) throw new Error("git log failed");
+      return gitLogOutput as never;
+    }
+    return "" as never;
+  });
 }
 
 describe("getComponentBirthDates", () => {
@@ -42,19 +71,14 @@ describe("getComponentBirthDates", () => {
   });
 
   it("returns empty maps on shallow clone", () => {
-    mockedExecSync.mockImplementation((cmd) => {
-      if (String(cmd).includes("--is-shallow-repository")) {
-        return "true\n" as never;
-      }
-      return "" as never;
-    });
+    setupExecSyncMock({ isShallow: true });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const result = getComponentBirthDates();
 
     expect(result).toEqual({ components: {}, blocks: {}, charts: {} });
-    // Only the shallow-repo probe should have been invoked — no further git calls.
+    // Only the shallow-repo probe should have been invoked — no git log call.
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
     expect(String(mockedExecSync.mock.calls[0][0])).toContain(
       "--is-shallow-repository",
@@ -69,22 +93,18 @@ describe("getComponentBirthDates", () => {
     const recent = daysAgoISO(30);
     const old = daysAgoISO(90);
 
-    mockedReaddirSync.mockImplementation((dir) => {
-      if (String(dir).endsWith("/components")) {
-        return [
-          direntFor("recent-component", "dir"),
-          direntFor("old-component", "dir"),
-        ] as never;
-      }
-      return [] as never;
-    });
+    const gitLogOutput = [
+      recent,
+      "",
+      "packages/kumo/src/components/recent-component/RecentComponent.tsx",
+      "",
+      old,
+      "",
+      "packages/kumo/src/components/old-component/OldComponent.tsx",
+      "",
+    ].join("\n");
 
-    mockedExecSync.mockImplementation((cmd) => {
-      const cmdStr = String(cmd);
-      if (cmdStr.includes("recent-component")) return recent as never;
-      if (cmdStr.includes("old-component")) return old as never;
-      return "" as never;
-    });
+    setupExecSyncMock({ gitLogOutput });
 
     const result = getComponentBirthDates();
 
@@ -94,11 +114,8 @@ describe("getComponentBirthDates", () => {
     expect(result.charts).toEqual({});
   });
 
-  it("swallows per-entry git failures without poisoning the result", () => {
-    mockedReaddirSync.mockReturnValue([direntFor("some-dir", "dir")] as never);
-    mockedExecSync.mockImplementation(() => {
-      throw new Error("git not available");
-    });
+  it("returns empty maps when git log throws", () => {
+    setupExecSyncMock({ gitLogThrows: true });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(getComponentBirthDates()).toEqual({
@@ -109,109 +126,65 @@ describe("getComponentBirthDates", () => {
     warnSpy.mockRestore();
   });
 
-  it("returns empty maps when readdirSync throws", () => {
-    mockedReaddirSync.mockImplementation(() => {
-      throw new Error("read failure");
-    });
+  it("returns empty maps when git log output is empty", () => {
+    setupExecSyncMock({ gitLogOutput: "" });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(getComponentBirthDates()).toEqual({
-      components: {},
-      blocks: {},
-      charts: {},
-    });
-    warnSpy.mockRestore();
+    const result = getComponentBirthDates();
+
+    expect(result).toEqual({ components: {}, blocks: {}, charts: {} });
   });
 
-  it("skips non-directory entries", () => {
+  it("parses components and blocks correctly from a single git log output", () => {
     const recent = daysAgoISO(10);
 
-    mockedReaddirSync.mockImplementation((dir) => {
-      if (String(dir).endsWith("/components")) {
-        return [
-          direntFor("README.md", "file"),
-          direntFor("my-component", "dir"),
-        ] as never;
-      }
-      return [] as never;
-    });
+    const gitLogOutput = [
+      recent,
+      "",
+      "packages/kumo/src/components/my-component/MyComponent.tsx",
+      "packages/kumo/src/components/my-component/index.ts",
+      "packages/kumo/src/blocks/my-block/MyBlock.tsx",
+      "",
+    ].join("\n");
 
-    mockedExecSync.mockImplementation((cmd) => {
-      if (String(cmd).includes("my-component")) return recent as never;
-      return "" as never;
-    });
+    setupExecSyncMock({ gitLogOutput });
 
     const result = getComponentBirthDates();
 
     expect(result.components).toEqual({ "my-component": recent });
-    const gitCallsForFile = mockedExecSync.mock.calls.filter((c) =>
-      String(c[0]).includes("README.md"),
-    );
-    expect(gitCallsForFile).toHaveLength(0);
+    expect(result.blocks).toEqual({ "my-block": recent });
   });
 
-  it("skips entries with empty git output", () => {
-    const recent = daysAgoISO(5);
+  it("uses the oldest (first-added) date when multiple commits touch the same component", () => {
+    // git log is newest-first; the last (oldest) date written to the map should win.
+    const newer = daysAgoISO(10);
+    const older = daysAgoISO(40);
 
-    mockedReaddirSync.mockImplementation((dir) => {
-      if (String(dir).endsWith("/components")) {
-        return [
-          direntFor("with-history", "dir"),
-          direntFor("no-history", "dir"),
-        ] as never;
-      }
-      return [] as never;
-    });
+    const gitLogOutput = [
+      newer,
+      "",
+      "packages/kumo/src/components/shared/new-file.tsx",
+      "",
+      older,
+      "",
+      "packages/kumo/src/components/shared/original.tsx",
+      "",
+    ].join("\n");
 
-    mockedExecSync.mockImplementation((cmd) => {
-      const cmdStr = String(cmd);
-      if (cmdStr.includes("with-history")) return recent as never;
-      return "" as never;
-    });
+    setupExecSyncMock({ gitLogOutput });
 
     const result = getComponentBirthDates();
 
-    expect(result.components).toEqual({ "with-history": recent });
-    expect(result.components).not.toHaveProperty("no-history");
+    expect(result.components).toEqual({ shared: older });
   });
 
-  it("skips entries with invalid date strings without crashing", () => {
-    const recent = daysAgoISO(5);
-
-    mockedReaddirSync.mockImplementation((dir) => {
-      if (String(dir).endsWith("/components")) {
-        return [
-          direntFor("ok-component", "dir"),
-          direntFor("broken-component", "dir"),
-        ] as never;
-      }
-      return [] as never;
-    });
-
-    mockedExecSync.mockImplementation((cmd) => {
-      const cmdStr = String(cmd);
-      if (cmdStr.includes("broken-component")) return "not-a-date" as never;
-      if (cmdStr.includes("ok-component")) return recent as never;
-      return "" as never;
-    });
-
-    const result = getComponentBirthDates();
-
-    expect(result.components).toEqual({ "ok-component": recent });
-    expect(result.components).not.toHaveProperty("broken-component");
-  });
-
-  it("scans chart page files and keys them by filename without extension", () => {
+  it("only includes chart pages that currently exist on disk", () => {
     const recent = daysAgoISO(10);
-    const old = daysAgoISO(120);
 
+    // The allowlist only has `timeseries` — `deleted` is in git log but no longer on disk.
     mockedReaddirSync.mockImplementation((dir) => {
       if (String(dir).endsWith("/pages/charts")) {
         return [
-          direntFor("index.mdx", "file"),
           direntFor("timeseries.mdx", "file"),
-          direntFor("custom.mdx", "file"),
-          // A subdirectory and unrelated file should both be ignored.
           direntFor("assets", "dir"),
           direntFor("notes.txt", "file"),
         ] as never;
@@ -219,23 +192,88 @@ describe("getComponentBirthDates", () => {
       return [] as never;
     });
 
-    mockedExecSync.mockImplementation((cmd) => {
-      const cmdStr = String(cmd);
-      if (cmdStr.includes("timeseries.mdx")) return recent as never;
-      if (cmdStr.includes("index.mdx")) return recent as never;
-      if (cmdStr.includes("custom.mdx")) return old as never;
-      return "" as never;
-    });
+    const gitLogOutput = [
+      recent,
+      "",
+      "packages/kumo-docs-astro/src/pages/charts/timeseries.mdx",
+      "packages/kumo-docs-astro/src/pages/charts/deleted.astro",
+      "",
+    ].join("\n");
+
+    setupExecSyncMock({ gitLogOutput });
 
     const result = getComponentBirthDates();
 
-    expect(result.charts).toEqual({
-      index: recent,
-      timeseries: recent,
-    });
-    expect(result.charts).not.toHaveProperty("custom");
-    // Subdirectories and non-.mdx/.astro files must not be scanned.
-    expect(result.charts).not.toHaveProperty("assets");
-    expect(result.charts).not.toHaveProperty("notes");
+    expect(result.charts).toEqual({ timeseries: recent });
+    expect(result.charts).not.toHaveProperty("deleted");
+  });
+
+  it("skips malformed date lines without crashing", () => {
+    const recent = daysAgoISO(5);
+
+    // "not-a-date" doesn't match the ISO regex, so it shouldn't become currentDate
+    // and the file line that follows should be ignored (no active date).
+    // Then a valid date + file pair should still be picked up.
+    const gitLogOutput = [
+      "not-a-date",
+      "",
+      "packages/kumo/src/components/orphaned/orphan.tsx",
+      "",
+      recent,
+      "",
+      "packages/kumo/src/components/ok-component/OkComponent.tsx",
+      "",
+    ].join("\n");
+
+    setupExecSyncMock({ gitLogOutput });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ "ok-component": recent });
+    expect(result.components).not.toHaveProperty("orphaned");
+  });
+
+  it("ignores flat files inside the components and blocks directories", () => {
+    const recent = daysAgoISO(10);
+
+    const gitLogOutput = [
+      recent,
+      "",
+      "packages/kumo/src/components/AGENTS.md",
+      "packages/kumo/src/components/real/real.tsx",
+      "packages/kumo/src/blocks/README.md",
+      "packages/kumo/src/blocks/my-block/Block.tsx",
+      "",
+    ].join("\n");
+
+    setupExecSyncMock({ gitLogOutput });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ real: recent });
+    expect(result.components).not.toHaveProperty("AGENTS.md");
+    expect(result.blocks).toEqual({ "my-block": recent });
+    expect(result.blocks).not.toHaveProperty("README.md");
+  });
+
+  it("ignores paths outside the tracked prefixes", () => {
+    const recent = daysAgoISO(10);
+
+    const gitLogOutput = [
+      recent,
+      "",
+      "packages/kumo/src/components/real/real.tsx",
+      "packages/other/unrelated.ts",
+      "README.md",
+      "",
+    ].join("\n");
+
+    setupExecSyncMock({ gitLogOutput });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ real: recent });
+    expect(result.blocks).toEqual({});
+    expect(result.charts).toEqual({});
   });
 });

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
@@ -1,4 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { getComponentBirthDates } from "./component-birth-dates";
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
@@ -7,10 +10,6 @@ vi.mock("node:child_process", () => ({
 vi.mock("node:fs", () => ({
   readdirSync: vi.fn(),
 }));
-
-import { execSync } from "node:child_process";
-import { readdirSync } from "node:fs";
-import { getComponentBirthDates } from "./component-birth-dates";
 
 const mockedExecSync = vi.mocked(execSync);
 const mockedReaddirSync = vi.mocked(readdirSync);

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
@@ -41,6 +41,30 @@ describe("getComponentBirthDates", () => {
     vi.restoreAllMocks();
   });
 
+  it("returns empty maps on shallow clone", () => {
+    mockedExecSync.mockImplementation((cmd) => {
+      if (String(cmd).includes("--is-shallow-repository")) {
+        return "true\n" as never;
+      }
+      return "" as never;
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = getComponentBirthDates();
+
+    expect(result).toEqual({ components: {}, blocks: {}, charts: {} });
+    // Only the shallow-repo probe should have been invoked — no further git calls.
+    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(String(mockedExecSync.mock.calls[0][0])).toContain(
+      "--is-shallow-repository",
+    );
+    // And we should not have scanned any directories.
+    expect(mockedReaddirSync).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it("includes entries within the cutoff and excludes older ones", () => {
     const recent = daysAgoISO(30);
     const old = daysAgoISO(90);
@@ -76,7 +100,7 @@ describe("getComponentBirthDates", () => {
       throw new Error("git not available");
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(getComponentBirthDates()).toEqual({
       components: {},
       blocks: {},
@@ -90,7 +114,7 @@ describe("getComponentBirthDates", () => {
       throw new Error("read failure");
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(getComponentBirthDates()).toEqual({
       components: {},
       blocks: {},

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.test.ts
@@ -1,0 +1,217 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  readdirSync: vi.fn(),
+}));
+
+import { execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { getComponentBirthDates } from "./component-birth-dates";
+
+const mockedExecSync = vi.mocked(execSync);
+const mockedReaddirSync = vi.mocked(readdirSync);
+
+// Returns an ISO timestamp `daysAgo` days before now.
+function daysAgoISO(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// Build a minimal Dirent-like object for readdirSync with withFileTypes.
+// `kind` lets the same helper stand in for directories (component/block scan) or files (chart page scan).
+function direntFor(name: string, kind: "dir" | "file") {
+  return {
+    name,
+    isDirectory: () => kind === "dir",
+    isFile: () => kind === "file",
+  } as unknown as ReturnType<typeof readdirSync>[number];
+}
+
+describe("getComponentBirthDates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedReaddirSync.mockReturnValue([] as never);
+    mockedExecSync.mockReturnValue("" as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("includes entries within the cutoff and excludes older ones", () => {
+    const recent = daysAgoISO(30);
+    const old = daysAgoISO(90);
+
+    mockedReaddirSync.mockImplementation((dir) => {
+      if (String(dir).endsWith("/components")) {
+        return [
+          direntFor("recent-component", "dir"),
+          direntFor("old-component", "dir"),
+        ] as never;
+      }
+      return [] as never;
+    });
+
+    mockedExecSync.mockImplementation((cmd) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes("recent-component")) return recent as never;
+      if (cmdStr.includes("old-component")) return old as never;
+      return "" as never;
+    });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ "recent-component": recent });
+    expect(result.components).not.toHaveProperty("old-component");
+    expect(result.blocks).toEqual({});
+    expect(result.charts).toEqual({});
+  });
+
+  it("swallows per-entry git failures without poisoning the result", () => {
+    mockedReaddirSync.mockReturnValue([direntFor("some-dir", "dir")] as never);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("git not available");
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+    expect(getComponentBirthDates()).toEqual({
+      components: {},
+      blocks: {},
+      charts: {},
+    });
+    warnSpy.mockRestore();
+  });
+
+  it("returns empty maps when readdirSync throws", () => {
+    mockedReaddirSync.mockImplementation(() => {
+      throw new Error("read failure");
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+    expect(getComponentBirthDates()).toEqual({
+      components: {},
+      blocks: {},
+      charts: {},
+    });
+    warnSpy.mockRestore();
+  });
+
+  it("skips non-directory entries", () => {
+    const recent = daysAgoISO(10);
+
+    mockedReaddirSync.mockImplementation((dir) => {
+      if (String(dir).endsWith("/components")) {
+        return [
+          direntFor("README.md", "file"),
+          direntFor("my-component", "dir"),
+        ] as never;
+      }
+      return [] as never;
+    });
+
+    mockedExecSync.mockImplementation((cmd) => {
+      if (String(cmd).includes("my-component")) return recent as never;
+      return "" as never;
+    });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ "my-component": recent });
+    const gitCallsForFile = mockedExecSync.mock.calls.filter((c) =>
+      String(c[0]).includes("README.md"),
+    );
+    expect(gitCallsForFile).toHaveLength(0);
+  });
+
+  it("skips entries with empty git output", () => {
+    const recent = daysAgoISO(5);
+
+    mockedReaddirSync.mockImplementation((dir) => {
+      if (String(dir).endsWith("/components")) {
+        return [
+          direntFor("with-history", "dir"),
+          direntFor("no-history", "dir"),
+        ] as never;
+      }
+      return [] as never;
+    });
+
+    mockedExecSync.mockImplementation((cmd) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes("with-history")) return recent as never;
+      return "" as never;
+    });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ "with-history": recent });
+    expect(result.components).not.toHaveProperty("no-history");
+  });
+
+  it("skips entries with invalid date strings without crashing", () => {
+    const recent = daysAgoISO(5);
+
+    mockedReaddirSync.mockImplementation((dir) => {
+      if (String(dir).endsWith("/components")) {
+        return [
+          direntFor("ok-component", "dir"),
+          direntFor("broken-component", "dir"),
+        ] as never;
+      }
+      return [] as never;
+    });
+
+    mockedExecSync.mockImplementation((cmd) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes("broken-component")) return "not-a-date" as never;
+      if (cmdStr.includes("ok-component")) return recent as never;
+      return "" as never;
+    });
+
+    const result = getComponentBirthDates();
+
+    expect(result.components).toEqual({ "ok-component": recent });
+    expect(result.components).not.toHaveProperty("broken-component");
+  });
+
+  it("scans chart page files and keys them by filename without extension", () => {
+    const recent = daysAgoISO(10);
+    const old = daysAgoISO(120);
+
+    mockedReaddirSync.mockImplementation((dir) => {
+      if (String(dir).endsWith("/pages/charts")) {
+        return [
+          direntFor("index.mdx", "file"),
+          direntFor("timeseries.mdx", "file"),
+          direntFor("custom.mdx", "file"),
+          // A subdirectory and unrelated file should both be ignored.
+          direntFor("assets", "dir"),
+          direntFor("notes.txt", "file"),
+        ] as never;
+      }
+      return [] as never;
+    });
+
+    mockedExecSync.mockImplementation((cmd) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes("timeseries.mdx")) return recent as never;
+      if (cmdStr.includes("index.mdx")) return recent as never;
+      if (cmdStr.includes("custom.mdx")) return old as never;
+      return "" as never;
+    });
+
+    const result = getComponentBirthDates();
+
+    expect(result.charts).toEqual({
+      index: recent,
+      timeseries: recent,
+    });
+    expect(result.charts).not.toHaveProperty("custom");
+    // Subdirectories and non-.mdx/.astro files must not be scanned.
+    expect(result.charts).not.toHaveProperty("assets");
+    expect(result.charts).not.toHaveProperty("notes");
+  });
+});

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
@@ -30,15 +30,19 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/;
 // that have since been deleted or renamed (e.g. an old `.astro` file replaced by `.mdx`).
 function getPresentChartPages(): Set<string> {
   const chartPagesDir = resolve(PACKAGE_ROOT, "src/pages/charts");
+
   try {
     const entries = readdirSync(chartPagesDir, { withFileTypes: true });
     const names = new Set<string>();
+
     for (const entry of entries) {
       if (!entry.isFile()) continue;
       const ext = CHART_PAGE_EXTENSIONS.find((e) => entry.name.endsWith(e));
+
       if (!ext) continue;
       names.add(entry.name.slice(0, -ext.length));
     }
+
     return names;
   } catch {
     return new Set();
@@ -52,18 +56,18 @@ export function getComponentBirthDates(): NewItems {
       execSync("git rev-parse --is-shallow-repository", {
         encoding: "utf-8",
       }).trim() === "true";
+
     if (isShallow) {
       console.warn(
         '[kumo-docs-astro] Shallow clone detected — skipping "New" badge detection.',
       );
+
       return { components: {}, blocks: {}, charts: {} };
     }
 
     const presentChartPages = getPresentChartPages();
 
-    // Resolve repo root so the git log path arguments (which are relative to the
-    // working directory) are interpreted correctly regardless of where the build
-    // is invoked from.
+    // Resolve repo root so the git log path arguments (which are relative to the working directory) are interpreted correctly regardless of where the build is invoked from.
     const repoRoot = execSync("git rev-parse --show-toplevel", {
       encoding: "utf-8",
     }).trim();
@@ -82,8 +86,10 @@ export function getComponentBirthDates(): NewItems {
     const charts = new Map<string, string>();
 
     let currentDate: string | null = null;
+
     for (const rawLine of gitOutput.split("\n")) {
       const line = rawLine.trim();
+
       if (!line) continue;
 
       if (ISO_DATE_RE.test(line)) {
@@ -98,22 +104,29 @@ export function getComponentBirthDates(): NewItems {
         // Only accept files inside a component subdirectory (must contain a "/").
         // Flat files like `components/AGENTS.md` are not component entries.
         const slashIdx = rest.indexOf("/");
+
         if (slashIdx <= 0) continue; // skip flat files (no slash) and edge cases
         const key = rest.slice(0, slashIdx);
+
         components.set(key, currentDate);
       } else if (line.startsWith(BLOCKS_REL_PATH)) {
         const rest = line.slice(BLOCKS_REL_PATH.length);
         const slashIdx = rest.indexOf("/");
+
         if (slashIdx <= 0) continue; // skip flat files (no slash) and edge cases
         const key = rest.slice(0, slashIdx);
+
         blocks.set(key, currentDate);
       } else if (line.startsWith(CHART_PAGES_REL_PATH)) {
         const filename = line.slice(CHART_PAGES_REL_PATH.length);
+
         // Chart pages are flat files at the top of the charts dir — ignore anything nested.
         if (filename.includes("/")) continue;
         const ext = CHART_PAGE_EXTENSIONS.find((e) => filename.endsWith(e));
+
         if (!ext) continue;
         const key = filename.slice(0, -ext.length);
+
         if (!presentChartPages.has(key)) continue;
         charts.set(key, currentDate);
       }
@@ -125,11 +138,14 @@ export function getComponentBirthDates(): NewItems {
 
     const withinCutoff = (map: Map<string, string>): Record<string, string> => {
       const out: Record<string, string> = {};
+
       for (const [key, iso] of map) {
         const parsed = new Date(iso);
+
         if (Number.isNaN(parsed.getTime())) continue;
         if (parsed >= cutoff) out[key] = iso;
       }
+
       return out;
     };
 

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
@@ -15,83 +15,34 @@ export interface NewItems {
   charts: Record<string, string>;
 }
 
-// Returns the first-commit ISO date for the given absolute path, or null if there is no git history or the output cannot be parsed.
-function getFirstCommitDate(absolutePath: string): string | null {
+// Paths relative to repo root — passed as cwd to git log below.
+const COMPONENTS_REL_PATH = "packages/kumo/src/components/";
+const BLOCKS_REL_PATH = "packages/kumo/src/blocks/";
+const CHART_PAGES_REL_PATH = "packages/kumo-docs-astro/src/pages/charts/";
+
+const CHART_PAGE_EXTENSIONS = [".mdx", ".astro"] as const;
+
+// Matches lines like "2026-04-15T10:00:00+01:00".
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/;
+
+// Build the set of chart page basenames (without extension) that currently exist on disk.
+// Used as an allowlist when parsing git log output, so we don't surface dates for files
+// that have since been deleted or renamed (e.g. an old `.astro` file replaced by `.mdx`).
+function getPresentChartPages(): Set<string> {
+  const chartPagesDir = resolve(PACKAGE_ROOT, "src/pages/charts");
   try {
-    const output = execSync(
-      `git log --reverse --format=%aI -- "${absolutePath}" | head -1`,
-      { encoding: "utf-8" },
-    ).trim();
-
-    if (!output) return null;
-
-    const firstCommitDate = new Date(output);
-    if (Number.isNaN(firstCommitDate.getTime())) return null;
-
-    return output;
-  } catch {
-    return null;
-  }
-}
-
-function scanDir(relativeDir: string, cutoff: Date): Record<string, string> {
-  const result: Record<string, string> = {};
-  const absoluteDir = resolve(PACKAGE_ROOT, relativeDir);
-
-  let entries;
-  try {
-    entries = readdirSync(absoluteDir, { withFileTypes: true });
-  } catch {
-    return result;
-  }
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const fullPath = resolve(absoluteDir, entry.name);
-    const firstCommit = getFirstCommitDate(fullPath);
-    if (!firstCommit) continue;
-
-    if (new Date(firstCommit) >= cutoff) {
-      result[entry.name] = firstCommit;
+    const entries = readdirSync(chartPagesDir, { withFileTypes: true });
+    const names = new Set<string>();
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const ext = CHART_PAGE_EXTENSIONS.find((e) => entry.name.endsWith(e));
+      if (!ext) continue;
+      names.add(entry.name.slice(0, -ext.length));
     }
-  }
-
-  return result;
-}
-
-// Scan files (not subdirectories) in a single directory, keyed by filename without extension. Used for flat doc-page directories like src/pages/charts/.
-function scanPagesDir(
-  relativeDir: string,
-  cutoff: Date,
-  extensions: readonly string[],
-): Record<string, string> {
-  const result: Record<string, string> = {};
-  const absoluteDir = resolve(PACKAGE_ROOT, relativeDir);
-
-  let entries;
-  try {
-    entries = readdirSync(absoluteDir, { withFileTypes: true });
+    return names;
   } catch {
-    return result;
+    return new Set();
   }
-
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-
-    const match = extensions.find((ext) => entry.name.endsWith(ext));
-    if (!match) continue;
-
-    const key = entry.name.slice(0, -match.length);
-    const fullPath = resolve(absoluteDir, entry.name);
-    const firstCommit = getFirstCommitDate(fullPath);
-    if (!firstCommit) continue;
-
-    if (new Date(firstCommit) >= cutoff) {
-      result[key] = firstCommit;
-    }
-  }
-
-  return result;
 }
 
 // Returns first-commit dates for components, blocks, and chart pages added within NEW_ITEM_CUTOFF_DAYS.
@@ -108,14 +59,84 @@ export function getComponentBirthDates(): NewItems {
       return { components: {}, blocks: {}, charts: {} };
     }
 
+    const presentChartPages = getPresentChartPages();
+
+    // Resolve repo root so the git log path arguments (which are relative to the
+    // working directory) are interpreted correctly regardless of where the build
+    // is invoked from.
+    const repoRoot = execSync("git rev-parse --show-toplevel", {
+      encoding: "utf-8",
+    }).trim();
+
+    // One git log call gets the first-added date for every file under the tracked paths.
+    // --diff-filter=A selects only commits where the file was added.
+    // --name-only prints paths; --format=%aI prints the author ISO date before each commit's files.
+    // Output is newest-first, so by writing into a Map we let the last (oldest) write win.
+    const gitOutput = execSync(
+      `git log --diff-filter=A --name-only --format=%aI -- ${COMPONENTS_REL_PATH} ${BLOCKS_REL_PATH} ${CHART_PAGES_REL_PATH}`,
+      { encoding: "utf-8", cwd: repoRoot },
+    );
+
+    const components = new Map<string, string>();
+    const blocks = new Map<string, string>();
+    const charts = new Map<string, string>();
+
+    let currentDate: string | null = null;
+    for (const rawLine of gitOutput.split("\n")) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      if (ISO_DATE_RE.test(line)) {
+        currentDate = line;
+        continue;
+      }
+
+      if (!currentDate) continue;
+
+      if (line.startsWith(COMPONENTS_REL_PATH)) {
+        const rest = line.slice(COMPONENTS_REL_PATH.length);
+        // Only accept files inside a component subdirectory (must contain a "/").
+        // Flat files like `components/AGENTS.md` are not component entries.
+        const slashIdx = rest.indexOf("/");
+        if (slashIdx <= 0) continue; // skip flat files (no slash) and edge cases
+        const key = rest.slice(0, slashIdx);
+        components.set(key, currentDate);
+      } else if (line.startsWith(BLOCKS_REL_PATH)) {
+        const rest = line.slice(BLOCKS_REL_PATH.length);
+        const slashIdx = rest.indexOf("/");
+        if (slashIdx <= 0) continue; // skip flat files (no slash) and edge cases
+        const key = rest.slice(0, slashIdx);
+        blocks.set(key, currentDate);
+      } else if (line.startsWith(CHART_PAGES_REL_PATH)) {
+        const filename = line.slice(CHART_PAGES_REL_PATH.length);
+        // Chart pages are flat files at the top of the charts dir — ignore anything nested.
+        if (filename.includes("/")) continue;
+        const ext = CHART_PAGE_EXTENSIONS.find((e) => filename.endsWith(e));
+        if (!ext) continue;
+        const key = filename.slice(0, -ext.length);
+        if (!presentChartPages.has(key)) continue;
+        charts.set(key, currentDate);
+      }
+    }
+
     const cutoff = new Date(
       Date.now() - NEW_ITEM_CUTOFF_DAYS * 24 * 60 * 60 * 1000,
     );
 
+    const withinCutoff = (map: Map<string, string>): Record<string, string> => {
+      const out: Record<string, string> = {};
+      for (const [key, iso] of map) {
+        const parsed = new Date(iso);
+        if (Number.isNaN(parsed.getTime())) continue;
+        if (parsed >= cutoff) out[key] = iso;
+      }
+      return out;
+    };
+
     return {
-      components: scanDir("../kumo/src/components", cutoff),
-      blocks: scanDir("../kumo/src/blocks", cutoff),
-      charts: scanPagesDir("src/pages/charts", cutoff, [".mdx", ".astro"]),
+      components: withinCutoff(components),
+      blocks: withinCutoff(blocks),
+      charts: withinCutoff(charts),
     };
   } catch (error) {
     console.warn(

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
@@ -1,0 +1,120 @@
+import { execSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(__dirname, "../..");
+
+// Items added within this window are flagged as "new".
+export const NEW_ITEM_CUTOFF_DAYS = 60;
+
+export interface NewItems {
+  components: Record<string, string>;
+  blocks: Record<string, string>;
+  charts: Record<string, string>;
+}
+
+// Returns the first-commit ISO date for the given absolute path, or null if there is no git history or the output cannot be parsed.
+function getFirstCommitDate(absolutePath: string): string | null {
+  try {
+    const output = execSync(
+      `git log --reverse --format=%aI -- "${absolutePath}" | head -1`,
+      { encoding: "utf-8" },
+    ).trim();
+
+    if (!output) return null;
+
+    const firstCommitDate = new Date(output);
+    if (Number.isNaN(firstCommitDate.getTime())) return null;
+
+    return output;
+  } catch {
+    return null;
+  }
+}
+
+function scanDir(relativeDir: string, cutoff: Date): Record<string, string> {
+  const result: Record<string, string> = {};
+  const absoluteDir = resolve(PACKAGE_ROOT, relativeDir);
+
+  let entries;
+  try {
+    entries = readdirSync(absoluteDir, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const fullPath = resolve(absoluteDir, entry.name);
+    const firstCommit = getFirstCommitDate(fullPath);
+    if (!firstCommit) continue;
+
+    if (new Date(firstCommit) >= cutoff) {
+      result[entry.name] = firstCommit;
+    }
+  }
+
+  return result;
+}
+
+// Scan files (not subdirectories) in a single directory, keyed by filename without extension. Used for flat doc-page directories like src/pages/charts/.
+function scanPagesDir(
+  relativeDir: string,
+  cutoff: Date,
+  extensions: readonly string[],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  const absoluteDir = resolve(PACKAGE_ROOT, relativeDir);
+
+  let entries;
+  try {
+    entries = readdirSync(absoluteDir, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+
+    const match = extensions.find((ext) => entry.name.endsWith(ext));
+    if (!match) continue;
+
+    const key = entry.name.slice(0, -match.length);
+    const fullPath = resolve(absoluteDir, entry.name);
+    const firstCommit = getFirstCommitDate(fullPath);
+    if (!firstCommit) continue;
+
+    if (new Date(firstCommit) >= cutoff) {
+      result[key] = firstCommit;
+    }
+  }
+
+  return result;
+}
+
+// Returns first-commit dates for components, blocks, and chart pages added within NEW_ITEM_CUTOFF_DAYS.
+export function getComponentBirthDates(): NewItems {
+  try {
+    const cutoff = new Date(
+      Date.now() - NEW_ITEM_CUTOFF_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    return {
+      components: scanDir("../kumo/src/components", cutoff),
+      blocks: scanDir("../kumo/src/blocks", cutoff),
+      charts: scanPagesDir("src/pages/charts", cutoff, [".mdx", ".astro"]),
+    };
+  } catch (error) {
+    console.warn(
+      "[kumo-docs-astro] Could not retrieve component birth dates:",
+      error instanceof Error ? error.message : error,
+    );
+    console.warn(
+      "[kumo-docs-astro] This may happen with shallow clones. Set GIT_DEPTH=0 or fetch-depth: 0 in CI.",
+    );
+
+    return { components: {}, blocks: {}, charts: {} };
+  }
+}

--- a/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
+++ b/packages/kumo-docs-astro/src/lib/component-birth-dates.ts
@@ -97,6 +97,17 @@ function scanPagesDir(
 // Returns first-commit dates for components, blocks, and chart pages added within NEW_ITEM_CUTOFF_DAYS.
 export function getComponentBirthDates(): NewItems {
   try {
+    const isShallow =
+      execSync("git rev-parse --is-shallow-repository", {
+        encoding: "utf-8",
+      }).trim() === "true";
+    if (isShallow) {
+      console.warn(
+        '[kumo-docs-astro] Shallow clone detected — skipping "New" badge detection.',
+      );
+      return { components: {}, blocks: {}, charts: {} };
+    }
+
     const cutoff = new Date(
       Date.now() - NEW_ITEM_CUTOFF_DAYS * 24 * 60 * 60 * 1000,
     );

--- a/packages/kumo-docs-astro/src/lib/is-new-item.test.ts
+++ b/packages/kumo-docs-astro/src/lib/is-new-item.test.ts
@@ -8,11 +8,13 @@ describe("isNewItem", () => {
       blocks: {},
       charts: {},
     };
+
     expect(isNewItem("/components/sidebar", newItems)).toBe(true);
   });
 
   it("returns false for a component not in the map", () => {
     const newItems: NewItems = { components: {}, blocks: {}, charts: {} };
+
     expect(isNewItem("/components/badge", newItems)).toBe(false);
   });
 
@@ -22,6 +24,7 @@ describe("isNewItem", () => {
       blocks: { "page-header": "2026-04-01T00:00:00Z" },
       charts: {},
     };
+
     expect(isNewItem("/blocks/page-header", newItems)).toBe(true);
   });
 
@@ -31,6 +34,7 @@ describe("isNewItem", () => {
       blocks: {},
       charts: { timeseries: "2026-04-01T00:00:00Z" },
     };
+
     expect(isNewItem("/charts/timeseries", newItems)).toBe(true);
     expect(isNewItem("/charts/custom", newItems)).toBe(false);
     expect(isNewItem("/charts", newItems)).toBe(false);
@@ -42,12 +46,14 @@ describe("isNewItem", () => {
       blocks: {},
       charts: { index: "2026-04-01T00:00:00Z" },
     };
+
     expect(isNewItem("/charts", newItems)).toBe(true);
     expect(isNewItem("/charts/timeseries", newItems)).toBe(false);
   });
 
   it("returns false for static pages", () => {
     const newItems: NewItems = { components: {}, blocks: {}, charts: {} };
+
     expect(isNewItem("/getting-started", newItems)).toBe(false);
     expect(isNewItem("/", newItems)).toBe(false);
     expect(isNewItem("/installation", newItems)).toBe(false);
@@ -65,6 +71,7 @@ describe("isNewItem", () => {
       blocks: {},
       charts: {},
     };
+
     expect(isNewItem("/components", newItems)).toBe(false);
     expect(isNewItem("/blocks", newItems)).toBe(false);
   });

--- a/packages/kumo-docs-astro/src/lib/is-new-item.test.ts
+++ b/packages/kumo-docs-astro/src/lib/is-new-item.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { isNewItem, type NewItems } from "./is-new-item";
+
+describe("isNewItem", () => {
+  it("returns true for a new component", () => {
+    const newItems: NewItems = {
+      components: { sidebar: "2026-04-01T00:00:00Z" },
+      blocks: {},
+      charts: {},
+    };
+    expect(isNewItem("/components/sidebar", newItems)).toBe(true);
+  });
+
+  it("returns false for a component not in the map", () => {
+    const newItems: NewItems = { components: {}, blocks: {}, charts: {} };
+    expect(isNewItem("/components/badge", newItems)).toBe(false);
+  });
+
+  it("returns true for a new block", () => {
+    const newItems: NewItems = {
+      components: {},
+      blocks: { "page-header": "2026-04-01T00:00:00Z" },
+      charts: {},
+    };
+    expect(isNewItem("/blocks/page-header", newItems)).toBe(true);
+  });
+
+  it("flags only the chart pages that are individually new", () => {
+    const newItems: NewItems = {
+      components: {},
+      blocks: {},
+      charts: { timeseries: "2026-04-01T00:00:00Z" },
+    };
+    expect(isNewItem("/charts/timeseries", newItems)).toBe(true);
+    expect(isNewItem("/charts/custom", newItems)).toBe(false);
+    expect(isNewItem("/charts", newItems)).toBe(false);
+  });
+
+  it("maps /charts (no slug) to the index key", () => {
+    const newItems: NewItems = {
+      components: {},
+      blocks: {},
+      charts: { index: "2026-04-01T00:00:00Z" },
+    };
+    expect(isNewItem("/charts", newItems)).toBe(true);
+    expect(isNewItem("/charts/timeseries", newItems)).toBe(false);
+  });
+
+  it("returns false for static pages", () => {
+    const newItems: NewItems = { components: {}, blocks: {}, charts: {} };
+    expect(isNewItem("/getting-started", newItems)).toBe(false);
+    expect(isNewItem("/", newItems)).toBe(false);
+    expect(isNewItem("/installation", newItems)).toBe(false);
+  });
+
+  it("returns false when newItems is undefined", () => {
+    expect(isNewItem("/components/sidebar", undefined)).toBe(false);
+    expect(isNewItem("/blocks/page-header", undefined)).toBe(false);
+    expect(isNewItem("/charts/timeseries", undefined)).toBe(false);
+  });
+
+  it("returns false for hrefs without a slug segment", () => {
+    const newItems: NewItems = {
+      components: { sidebar: "2026-04-01T00:00:00Z" },
+      blocks: {},
+      charts: {},
+    };
+    expect(isNewItem("/components", newItems)).toBe(false);
+    expect(isNewItem("/blocks", newItems)).toBe(false);
+  });
+});

--- a/packages/kumo-docs-astro/src/lib/is-new-item.ts
+++ b/packages/kumo-docs-astro/src/lib/is-new-item.ts
@@ -1,0 +1,27 @@
+import type { NewItems } from "./component-birth-dates";
+
+// Determines whether a sidebar href points at a recently added component, block, or chart page.
+export function isNewItem(
+  href: string,
+  newItems: NewItems | undefined,
+): boolean {
+  const [section, slug] = href.split("/").filter(Boolean);
+
+  if (section === "components") {
+    return Boolean(newItems?.components?.[slug]);
+  }
+
+  if (section === "blocks") {
+    return Boolean(newItems?.blocks?.[slug]);
+  }
+
+  if (section === "charts") {
+    const key = slug ?? "index";
+
+    return Boolean(newItems?.charts?.[key]);
+  }
+
+  return false;
+}
+
+export type { NewItems };


### PR DESCRIPTION
Automatically shows a "New" badge next to recently added components, blocks, and chart pages in the docs sidebar. Badges appear for items added within the last 60 days, determined from git history at build time. No manual upkeep needed.

### How it works

- At build time, `getComponentBirthDates()` scans git history for first-commit dates of component/block source directories and chart doc pages
- Data is injected via Vite `define` (same pattern as `__KUMO_VERSION__`, `__BUILD_COMMIT__`, etc.)
- `SidebarNav` renders `<Badge variant="secondary">New</Badge>` next to matching items
- Gracefully falls back to no badges on shallow clones

### Files

| File | What |
|---|---|
| `astro.config.mjs` | Imports helper, injects `__KUMO_NEW_ITEMS__` via Vite `define` |
| `src/lib/component-birth-dates.ts` | Scans git history for birth dates within 60-day cutoff |
| `src/lib/is-new-item.ts` | Pure function mapping sidebar hrefs to newness |
| `src/components/SidebarNav.tsx` | Renders badges in components, blocks, and charts sections |

<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 16 24 59" src="https://github.com/user-attachments/assets/fe045e2d-5ef1-4bb2-bbd9-d9f89eb972b9" />
<img width="2032" height="1161" alt="Screenshot 2026-04-17 at 16 24 56" src="https://github.com/user-attachments/assets/cf804ed4-1185-4c62-bc70-2fbd41fb1b62" />

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only UI feature with no bonk integration
- Tests
  - [x] Tests included/updated
  - [x] Additional testing not necessary because: 15 unit tests cover the build-time helpers; visual verification done locally