### PR TITLE
feat(Collapsible)!: refactor to compound component API

### DIFF
--- a/.changeset/collapsible-compound-api.md
+++ b/.changeset/collapsible-compound-api.md
@@ -1,0 +1,45 @@
+---
+"@cloudflare/kumo": major
+---
+
+feat(Collapsible)!: refactor to compound component API
+
+**Breaking change:** Collapsible now uses a compound component pattern matching other Kumo components like Popover and Dialog.
+
+### Before
+
+```tsx
+<Collapsible label="Show details" open={open} onOpenChange={setOpen}>
+  Content here
+</Collapsible>
+```
+
+### After
+
+```tsx
+<Collapsible.Root open={open} onOpenChange={setOpen}>
+  <Collapsible.Trigger>Show details</Collapsible.Trigger>
+  <Collapsible.Panel>Content here</Collapsible.Panel>
+</Collapsible.Root>
+```
+
+### Migration
+
+For the quickest migration, use the new `DefaultTrigger` and `DefaultPanel` components which preserve the previous styling:
+
+```tsx
+<Collapsible.Root open={open} onOpenChange={setOpen}>
+  <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
+  <Collapsible.DefaultPanel>Content here</Collapsible.DefaultPanel>
+</Collapsible.Root>
+```
+
+### New Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `Collapsible.Root` | Manages open state |
+| `Collapsible.Trigger` | Composable trigger with `render` prop support |
+| `Collapsible.Panel` | Content container |
+| `Collapsible.DefaultTrigger` | Pre-styled trigger with caret icon (migration helper) |
+| `Collapsible.DefaultPanel` | Pre-styled panel with border-left accent (migration helper) |

--- a/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
@@ -1,28 +1,43 @@
-import { Collapsible } from "@cloudflare/kumo";
+import { Button, Collapsible, Text } from "@cloudflare/kumo";
 import { useState } from "react";
 
+/**
+ * Hero demo using DefaultTrigger and DefaultPanel for classic Kumo styling.
+ */
 export function CollapsibleHeroDemo() {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <div className="w-full">
-      <Collapsible label="What is Kumo?" open={isOpen} onOpenChange={setIsOpen}>
-        Kumo is Cloudflare's new design system.
-      </Collapsible>
+      <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel>
+          <Text>Kumo is Cloudflare's new design system.</Text>
+        </Collapsible.DefaultPanel>
+      </Collapsible.Root>
     </div>
   );
 }
 
+/**
+ * Basic usage with default styling components.
+ */
 export function CollapsibleBasicDemo() {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div className="w-full">
-      <Collapsible label="What is Kumo?" open={isOpen} onOpenChange={setIsOpen}>
-        Kumo is Cloudflare's new design system.
-      </Collapsible>
+      <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel>
+          <Text>Kumo is Cloudflare's new design system.</Text>
+        </Collapsible.DefaultPanel>
+      </Collapsible.Root>
     </div>
   );
 }
 
+/**
+ * Multiple independent collapsibles.
+ */
 export function CollapsibleMultipleDemo() {
   const [open1, setOpen1] = useState(false);
   const [open2, setOpen2] = useState(false);
@@ -30,23 +45,86 @@ export function CollapsibleMultipleDemo() {
 
   return (
     <div className="w-full space-y-2">
-      <Collapsible label="What is Kumo?" open={open1} onOpenChange={setOpen1}>
-        Kumo is Cloudflare's new design system.
-      </Collapsible>
-      <Collapsible
-        label="How do I use it?"
-        open={open2}
-        onOpenChange={setOpen2}
-      >
-        Install the components and import them into your project.
-      </Collapsible>
-      <Collapsible
-        label="Is it open source?"
-        open={open3}
-        onOpenChange={setOpen3}
-      >
-        Check the repository for license information.
-      </Collapsible>
+      <Collapsible.Root open={open1} onOpenChange={setOpen1}>
+        <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel>
+          <Text>Kumo is Cloudflare's new design system.</Text>
+        </Collapsible.DefaultPanel>
+      </Collapsible.Root>
+      <Collapsible.Root open={open2} onOpenChange={setOpen2}>
+        <Collapsible.DefaultTrigger>How do I use it?</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel>
+          <Text>Install the components and import them into your project.</Text>
+        </Collapsible.DefaultPanel>
+      </Collapsible.Root>
+      <Collapsible.Root open={open3} onOpenChange={setOpen3}>
+        <Collapsible.DefaultTrigger>Is it open source?</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel>
+          <Text>Check the repository for license information.</Text>
+        </Collapsible.DefaultPanel>
+      </Collapsible.Root>
+    </div>
+  );
+}
+
+/**
+ * Custom trigger using the render prop for full control.
+ */
+export function CollapsibleCustomTriggerDemo() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div className="w-full">
+      <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Collapsible.Trigger
+          render={<Button variant="secondary" size="sm" />}
+        >
+          {isOpen ? "Hide details" : "Show details"}
+        </Collapsible.Trigger>
+        <Collapsible.Panel className="mt-3 rounded-lg bg-kumo-tint p-4">
+          <Text>
+            This panel uses custom styling instead of the default border-left accent.
+          </Text>
+        </Collapsible.Panel>
+      </Collapsible.Root>
+    </div>
+  );
+}
+
+/**
+ * Accordion pattern where only one item can be open at a time.
+ */
+export function CollapsibleAccordionDemo() {
+  const [activeIndex, setActiveIndex] = useState<number | null>(0);
+
+  const items = [
+    {
+      title: "What is Kumo?",
+      content: "Kumo is Cloudflare's new design system built on Base UI and Tailwind CSS v4.",
+    },
+    {
+      title: "How do I install it?",
+      content: "Run `npm install @cloudflare/kumo` and import the components you need.",
+    },
+    {
+      title: "Is it accessible?",
+      content: "Yes! Kumo is built on Base UI which provides excellent accessibility out of the box.",
+    },
+  ];
+
+  return (
+    <div className="w-full space-y-2">
+      {items.map((item, i) => (
+        <Collapsible.Root
+          key={i}
+          open={activeIndex === i}
+          onOpenChange={(open) => setActiveIndex(open ? i : null)}
+        >
+          <Collapsible.DefaultTrigger>{item.title}</Collapsible.DefaultTrigger>
+          <Collapsible.DefaultPanel>
+            <Text>{item.content}</Text>
+          </Collapsible.DefaultPanel>
+        </Collapsible.Root>
+      ))}
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -304,13 +304,15 @@ export function HomeGrid() {
       name: "Collapsible",
       id: "collapsible",
       Component: (
-        <Collapsible
-          label="What is Kumo?"
+        <Collapsible.Root
           open={collapsibleOpen}
           onOpenChange={setCollapsibleOpen}
         >
-          Kumo is Cloudflare's component library.
-        </Collapsible>
+          <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+          <Collapsible.DefaultPanel>
+            Kumo is Cloudflare's component library.
+          </Collapsible.DefaultPanel>
+        </Collapsible.Root>
       ),
     },
     {

--- a/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ~/layouts/MdxDocLayout.astro
 title: "Collapsible"
-description: "A vertically stacked set of interactive headings that each reveal a section of content."
+description: "A composable disclosure component for showing and hiding content."
 sourceFile: "components/collapsible"
 baseUIComponent: "collapsible"
 ---
@@ -13,6 +13,8 @@ import {
   CollapsibleHeroDemo,
   CollapsibleBasicDemo,
   CollapsibleMultipleDemo,
+  CollapsibleCustomTriggerDemo,
+  CollapsibleAccordionDemo,
 } from "~/components/demos/CollapsibleDemo";
 
 {/* Hero Demo */}
@@ -49,12 +51,42 @@ import { Collapsible } from "@cloudflare/kumo/components/collapsible";
 
 ## Usage
 
+Collapsible uses a compound component pattern for full composition control.
+
+### With Default Styling
+
+Use `DefaultTrigger` and `DefaultPanel` for the classic Kumo style:
+
 ```tsx
 import { Collapsible } from "@cloudflare/kumo";
 
 export default function Example() {
-  return <Collapsible label="Question">Answer content goes here.</Collapsible>;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen}>
+      <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
+      <Collapsible.DefaultPanel>
+        Content with border-left accent styling.
+      </Collapsible.DefaultPanel>
+    </Collapsible.Root>
+  );
 }
+```
+
+### Custom Trigger
+
+Use the `render` prop on `Trigger` for full control over the trigger element:
+
+```tsx
+<Collapsible.Root open={open} onOpenChange={setOpen}>
+  <Collapsible.Trigger render={<Button variant="ghost" />}>
+    {open ? "Hide" : "Show"} details
+  </Collapsible.Trigger>
+  <Collapsible.Panel className="mt-2 p-4 bg-kumo-tint rounded-lg">
+    Custom styled panel content.
+  </Collapsible.Panel>
+</Collapsible.Root>
 ```
 
 </ComponentSection>
@@ -65,7 +97,7 @@ export default function Example() {
 
 ## Examples
 
-### Single Item
+### Basic
 
 <ComponentExample demo="CollapsibleBasicDemo">
   <CollapsibleBasicDemo client:load />
@@ -77,6 +109,38 @@ export default function Example() {
   <CollapsibleMultipleDemo client:load />
 </ComponentExample>
 
+### Custom Trigger
+
+Use `Collapsible.Trigger` with the `render` prop for full control:
+
+<ComponentExample demo="CollapsibleCustomTriggerDemo">
+  <CollapsibleCustomTriggerDemo client:load />
+</ComponentExample>
+
+### Accordion Pattern
+
+Control which item is open to create an accordion where only one item can be expanded at a time:
+
+<ComponentExample demo="CollapsibleAccordionDemo">
+  <CollapsibleAccordionDemo client:load />
+</ComponentExample>
+
+</ComponentSection>
+
+{/* Sub-components */}
+
+<ComponentSection>
+
+## Sub-components
+
+| Component | Description |
+|-----------|-------------|
+| `Collapsible.Root` | Manages open state. Pass `open` and `onOpenChange` for controlled mode. |
+| `Collapsible.Trigger` | Button that toggles visibility. Use `render` prop for custom elements. |
+| `Collapsible.Panel` | Container for collapsible content. |
+| `Collapsible.DefaultTrigger` | Pre-styled trigger with text label and animated caret icon. |
+| `Collapsible.DefaultPanel` | Pre-styled panel with border-left accent and standard spacing. |
+
 </ComponentSection>
 
 {/* API Reference */}
@@ -85,5 +149,41 @@ export default function Example() {
 
 ## API Reference
 
-  <PropsTable component="Collapsible" />
+### Collapsible.Root
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | — | Whether the panel is visible (controlled). |
+| `defaultOpen` | `boolean` | `false` | Initial open state (uncontrolled). |
+| `onOpenChange` | `(open: boolean) => void` | — | Callback when open state changes. |
+| `disabled` | `boolean` | `false` | Whether the collapsible is disabled. |
+
+### Collapsible.Trigger
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `render` | `ReactElement` | — | Custom element to render as trigger. |
+| `className` | `string` | — | Additional CSS classes. |
+
+### Collapsible.Panel
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `className` | `string` | — | Additional CSS classes. |
+| `keepMounted` | `boolean` | `false` | Whether to keep the panel in the DOM when closed. |
+
+### Collapsible.DefaultTrigger
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Label text displayed in the trigger. |
+| `className` | `string` | — | Additional CSS classes. |
+
+### Collapsible.DefaultPanel
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Panel content. |
+| `className` | `string` | — | Additional CSS classes. |
+
 </ComponentSection>

--- a/packages/kumo-figma/src/generators/collapsible.test.ts
+++ b/packages/kumo-figma/src/generators/collapsible.test.ts
@@ -36,9 +36,9 @@ describe("Collapsible Generator - Registry Validation", () => {
 
   it("should have required props in registry", () => {
     expect(collapsibleComponent.props).toBeDefined();
-    expect(collapsibleComponent.props.label).toBeDefined();
-    expect(collapsibleComponent.props.open).toBeDefined();
-    expect(collapsibleComponent.props.children).toBeDefined();
+    // Compound component API - Root props
+    expect(collapsibleComponent.props.className).toBeDefined();
+    expect(collapsibleComponent.props.onOpenChange).toBeDefined();
   });
 
   it("should have color tokens defined", () => {

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -1,6 +1,15 @@
+import { Collapsible as CollapsibleBase } from "@base-ui/react/collapsible";
 import { CaretDownIcon } from "@phosphor-icons/react";
-import { type PropsWithChildren, forwardRef, useCallback, useId } from "react";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
 import { cn } from "../../utils/cn";
+
+// =============================================================================
+// Variants
+// =============================================================================
 
 export const KUMO_COLLAPSIBLE_VARIANTS = {} as const;
 
@@ -9,106 +18,266 @@ export const KUMO_COLLAPSIBLE_DEFAULT_VARIANTS = {} as const;
 export interface KumoCollapsibleVariantsProps {}
 
 export function collapsibleVariants(_props: KumoCollapsibleVariantsProps = {}) {
-  return cn(
-    // Defensive resets to prevent global button styles from polluting the trigger
-    "bg-transparent border-none shadow-none p-0 m-0",
-    // Base styles for the trigger
-    "flex cursor-pointer items-center gap-1 text-sm text-kumo-link select-none",
-  );
+  return cn();
+}
+
+// =============================================================================
+// Collapsible Root
+// =============================================================================
+
+type BaseRootProps = ComponentPropsWithoutRef<typeof CollapsibleBase.Root>;
+
+export interface CollapsibleRootProps extends BaseRootProps {
+  /** Additional CSS classes */
+  className?: string;
 }
 
 /**
- * Collapsible component props.
+ * Root component that manages collapsible state.
  *
  * @example
  * ```tsx
- * <Collapsible label="Show details" open={open} onOpenChange={setOpen}>
- *   <Text>Hidden content revealed when expanded.</Text>
- * </Collapsible>
+ * <Collapsible.Root open={open} onOpenChange={setOpen}>
+ *   <Collapsible.Trigger>Toggle</Collapsible.Trigger>
+ *   <Collapsible.Panel>Content</Collapsible.Panel>
+ * </Collapsible.Root>
  * ```
  */
-export type CollapsibleProps = PropsWithChildren<
-  KumoCollapsibleVariantsProps & {
-    /** Text label displayed in the trigger button */
-    label: string;
-    /** Whether the collapsible content is visible */
-    open?: boolean;
-    /** Callback fired when the open state changes */
-    onOpenChange?: (open: boolean) => void;
-    /** Additional CSS classes for the content panel */
-    className?: string;
-  }
+function CollapsibleRoot({ className, ...props }: CollapsibleRootProps) {
+  return <CollapsibleBase.Root className={className} {...props} />;
+}
+
+CollapsibleRoot.displayName = "Collapsible.Root";
+
+// =============================================================================
+// Collapsible Trigger
+// =============================================================================
+
+type BaseTriggerProps = ComponentPropsWithoutRef<
+  typeof CollapsibleBase.Trigger
 >;
 
+export interface CollapsibleTriggerProps extends BaseTriggerProps {
+  /** Additional CSS classes */
+  className?: string;
+}
+
 /**
- * Collapsible component for showing/hiding content.
- *
- * Features:
- * - Animated chevron indicator (rotates 180° when open)
- * - Accessible with aria-expanded and aria-controls
- * - Content panel with left border accent
+ * Button that toggles the collapsible panel visibility.
+ * Use the `render` prop to customize the trigger element.
  *
  * @example
  * ```tsx
- * const [open, setOpen] = useState(false);
+ * // Default button
+ * <Collapsible.Trigger>Show more</Collapsible.Trigger>
  *
- * <Collapsible label="Show details" open={open} onOpenChange={setOpen}>
- *   <Text>Hidden content revealed when expanded.</Text>
- * </Collapsible>
- * ```
- *
- * @example Controlled accordion pattern
- * ```tsx
- * const [activeIndex, setActiveIndex] = useState<number | null>(null);
- *
- * {items.map((item, i) => (
- *   <Collapsible
- *     key={i}
- *     label={item.title}
- *     open={activeIndex === i}
- *     onOpenChange={(open) => setActiveIndex(open ? i : null)}
- *   >
- *     {item.content}
- *   </Collapsible>
- * ))}
+ * // Custom trigger element
+ * <Collapsible.Trigger render={<Button variant="ghost" />}>
+ *   Toggle details
+ * </Collapsible.Trigger>
  * ```
  */
-export const Collapsible = forwardRef<HTMLDivElement, CollapsibleProps>(
-  ({ label, open, onOpenChange, children, className }, ref) => {
-    const contentId = useId();
-
-    const handleOpen = useCallback(() => {
-      onOpenChange?.(!open);
-    }, [open, onOpenChange]);
-
+const CollapsibleTrigger = forwardRef<HTMLButtonElement, CollapsibleTriggerProps>(
+  ({ className, ...props }, ref) => {
     return (
-      <div ref={ref}>
-        <button
-          type="button"
-          aria-expanded={open}
-          aria-controls={contentId}
-          className={collapsibleVariants()}
-          onClick={handleOpen}
-        >
-          {label}{" "}
-          <CaretDownIcon
-            className={cn("h-4 w-4 transition-transform", open && "rotate-180")}
-          />
-        </button>
-        {open && (
-          <div
-            id={contentId}
-            className={cn(
-              "my-2 space-y-4 border-l-2 border-kumo-fill pl-4",
-              className,
-            )}
-          >
-            {children}
-          </div>
-        )}
-      </div>
+      <CollapsibleBase.Trigger
+        ref={ref}
+        className={cn("cursor-pointer", className)}
+        {...props}
+      />
     );
   },
 );
 
-Collapsible.displayName = "Collapsible";
+CollapsibleTrigger.displayName = "Collapsible.Trigger";
+
+// =============================================================================
+// Collapsible Panel
+// =============================================================================
+
+type BasePanelProps = ComponentPropsWithoutRef<typeof CollapsibleBase.Panel>;
+
+export interface CollapsiblePanelProps extends BasePanelProps {
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Container for collapsible content. Renders when the collapsible is open.
+ *
+ * @example
+ * ```tsx
+ * <Collapsible.Panel className="mt-2 space-y-4">
+ *   <Text>Revealed content here</Text>
+ * </Collapsible.Panel>
+ * ```
+ */
+const CollapsiblePanel = forwardRef<HTMLDivElement, CollapsiblePanelProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <CollapsibleBase.Panel
+        ref={ref}
+        className={className}
+        {...props}
+      />
+    );
+  },
+);
+
+CollapsiblePanel.displayName = "Collapsible.Panel";
+
+// =============================================================================
+// Default Trigger (Migration Affordance)
+// =============================================================================
+
+export interface CollapsibleDefaultTriggerProps {
+  /** Label text displayed in the trigger */
+  children: ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Pre-styled trigger with text label and animated caret icon.
+ * Provides the same visual style as the previous Collapsible API.
+ *
+ * Use this for quick migration or when you want the default Kumo style.
+ *
+ * @example
+ * ```tsx
+ * <Collapsible.Root>
+ *   <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
+ *   <Collapsible.Panel>Content</Collapsible.Panel>
+ * </Collapsible.Root>
+ * ```
+ */
+function CollapsibleDefaultTrigger({
+  children,
+  className,
+}: CollapsibleDefaultTriggerProps) {
+  return (
+    <CollapsibleBase.Trigger
+      className={cn(
+        // Defensive resets to prevent global button styles from polluting the trigger
+        "bg-transparent border-none shadow-none p-0 m-0",
+        // Base styles for the trigger
+        "flex cursor-pointer items-center gap-1 text-sm text-kumo-link select-none",
+        className,
+      )}
+    >
+      {children}{" "}
+      <CaretDownIcon className="h-4 w-4 transition-transform [[data-panel-open]_&]:rotate-180" />
+    </CollapsibleBase.Trigger>
+  );
+}
+
+CollapsibleDefaultTrigger.displayName = "Collapsible.DefaultTrigger";
+
+// =============================================================================
+// Default Panel (Migration Affordance)
+// =============================================================================
+
+export interface CollapsibleDefaultPanelProps {
+  /** Panel content */
+  children: ReactNode;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Pre-styled panel with left border accent and standard spacing.
+ * Provides the same visual style as the previous Collapsible API.
+ *
+ * @example
+ * ```tsx
+ * <Collapsible.Root>
+ *   <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
+ *   <Collapsible.DefaultPanel>
+ *     <Text>Content with default styling</Text>
+ *   </Collapsible.DefaultPanel>
+ * </Collapsible.Root>
+ * ```
+ */
+const CollapsibleDefaultPanel = forwardRef<
+  HTMLDivElement,
+  CollapsibleDefaultPanelProps
+>(({ children, className }, ref) => {
+  return (
+    <CollapsibleBase.Panel
+      ref={ref}
+      className={cn("my-2 space-y-4 border-l-2 border-kumo-fill pl-4", className)}
+    >
+      {children}
+    </CollapsibleBase.Panel>
+  );
+});
+
+CollapsibleDefaultPanel.displayName = "Collapsible.DefaultPanel";
+
+// =============================================================================
+// Compound Component Export
+// =============================================================================
+
+/**
+ * Collapsible — a composable disclosure component for showing/hiding content.
+ *
+ * Built on Base UI's Collapsible with full composition support.
+ *
+ * ## Basic Usage
+ *
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ *
+ * <Collapsible.Root open={open} onOpenChange={setOpen}>
+ *   <Collapsible.Trigger render={<Button variant="ghost" />}>
+ *     Show details
+ *   </Collapsible.Trigger>
+ *   <Collapsible.Panel className="mt-2">
+ *     <Text>Hidden content revealed when expanded.</Text>
+ *   </Collapsible.Panel>
+ * </Collapsible.Root>
+ * ```
+ *
+ * ## With Default Styling
+ *
+ * Use `DefaultTrigger` and `DefaultPanel` for the classic Kumo style:
+ *
+ * ```tsx
+ * <Collapsible.Root>
+ *   <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
+ *   <Collapsible.DefaultPanel>
+ *     <Text>Content with border-left accent</Text>
+ *   </Collapsible.DefaultPanel>
+ * </Collapsible.Root>
+ * ```
+ *
+ * ## Controlled Accordion Pattern
+ *
+ * ```tsx
+ * const [activeIndex, setActiveIndex] = useState<number | null>(null);
+ *
+ * {items.map((item, i) => (
+ *   <Collapsible.Root
+ *     key={i}
+ *     open={activeIndex === i}
+ *     onOpenChange={(open) => setActiveIndex(open ? i : null)}
+ *   >
+ *     <Collapsible.DefaultTrigger>{item.title}</Collapsible.DefaultTrigger>
+ *     <Collapsible.DefaultPanel>{item.content}</Collapsible.DefaultPanel>
+ *   </Collapsible.Root>
+ * ))}
+ * ```
+ */
+export const Collapsible = Object.assign(CollapsibleRoot, {
+  Root: CollapsibleRoot,
+  Trigger: CollapsibleTrigger,
+  Panel: CollapsiblePanel,
+  DefaultTrigger: CollapsibleDefaultTrigger,
+  DefaultPanel: CollapsibleDefaultPanel,
+});
+
+// =============================================================================
+// Type Exports
+// =============================================================================
+
+export type CollapsibleProps = CollapsibleRootProps;

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -151,12 +151,13 @@ export interface CollapsibleDefaultTriggerProps {
  * </Collapsible.Root>
  * ```
  */
-function CollapsibleDefaultTrigger({
-  children,
-  className,
-}: CollapsibleDefaultTriggerProps) {
+const CollapsibleDefaultTrigger = forwardRef<
+  HTMLButtonElement,
+  CollapsibleDefaultTriggerProps
+>(({ children, className }, ref) => {
   return (
     <CollapsibleBase.Trigger
+      ref={ref}
       className={cn(
         // Defensive resets to prevent global button styles from polluting the trigger
         "bg-transparent border-none shadow-none p-0 m-0",
@@ -169,7 +170,7 @@ function CollapsibleDefaultTrigger({
       <CaretDownIcon className="h-4 w-4 transition-transform [[data-panel-open]_&]:rotate-180" />
     </CollapsibleBase.Trigger>
   );
-}
+});
 
 CollapsibleDefaultTrigger.displayName = "Collapsible.DefaultTrigger";
 

--- a/packages/kumo/src/components/collapsible/index.ts
+++ b/packages/kumo/src/components/collapsible/index.ts
@@ -1,1 +1,9 @@
-export { Collapsible } from "./collapsible";
+export {
+  Collapsible,
+  type CollapsibleProps,
+  type CollapsibleRootProps,
+  type CollapsibleTriggerProps,
+  type CollapsiblePanelProps,
+  type CollapsibleDefaultTriggerProps,
+  type CollapsibleDefaultPanelProps,
+} from "./collapsible";

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -67,7 +67,15 @@ export {
   type DialogCloseProps,
 } from "./components/dialog";
 export { DropdownMenu } from "./components/dropdown";
-export { Collapsible } from "./components/collapsible";
+export {
+  Collapsible,
+  type CollapsibleProps,
+  type CollapsibleRootProps,
+  type CollapsibleTriggerProps,
+  type CollapsiblePanelProps,
+  type CollapsibleDefaultTriggerProps,
+  type CollapsibleDefaultPanelProps,
+} from "./components/collapsible";
 export {
   Field,
   type FieldProps,


### PR DESCRIPTION
## Summary

Refactors Collapsible to use a compound component pattern matching other Kumo components like Popover and Dialog.

**Breaking change:** The old single-component API is removed in favor of composable sub-components.

## Changes

- `Collapsible.Root` - Manages open state
- `Collapsible.Trigger` - Composable trigger with `render` prop support
- `Collapsible.Panel` - Content container
- `Collapsible.DefaultTrigger` - Pre-styled trigger with caret icon (migration helper)
- `Collapsible.DefaultPanel` - Pre-styled panel with border-left accent (migration helper)

## Migration

Before:
```tsx
<Collapsible label="Show details" open={open} onOpenChange={setOpen} className="custom">
  Content here
</Collapsible>
```

After (quick migration with default styling):
```tsx
<Collapsible.Root open={open} onOpenChange={setOpen}>
  <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
  <Collapsible.DefaultPanel className="custom">Content here</Collapsible.DefaultPanel>
</Collapsible.Root>
```

After (full customization):
```tsx
<Collapsible.Root open={open} onOpenChange={setOpen}>
  <Collapsible.Trigger render={<Button variant="ghost" />}>
    Toggle
  </Collapsible.Trigger>
  <Collapsible.Panel className="custom-styles">
    Content here
  </Collapsible.Panel>
</Collapsible.Root>
```

Note: The old `className` prop was applied to the content panel. In the new API, pass `className` directly to `Collapsible.Panel` or `Collapsible.DefaultPanel`.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: API design decision requiring human review
- Tests
  - [x] Tests included/updated