### PR TITLE
feat(radio): accept ReactNode label and honor controlPosition on card appearance

### DIFF
--- a/.changeset/radio-reactnode-label-card-control-position.md
+++ b/.changeset/radio-reactnode-label-card-control-position.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(radio): accept ReactNode for `Radio.Item` label and honor `controlPosition` on card appearance
+
+- `Radio.Item`'s `label` prop now accepts `ReactNode`, allowing icons, badges, or other markup alongside text.
+- `Radio.Group`'s `controlPosition` prop now takes effect on `appearance="card"`. Card appearance continues to default to `"end"` (radio on the right); pass `controlPosition="start"` to render the radio on the left of the label and description.

--- a/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Radio } from "@cloudflare/kumo";
+import { Badge, Radio } from "@cloudflare/kumo";
 
 /** Shows a basic controlled radio group */
 export function RadioBasicDemo() {
@@ -256,9 +256,7 @@ export function RadioRichLabelDemo() {
         label={
           <span className="flex items-center gap-2">
             Free
-            <span className="rounded-sm bg-kumo-tint px-1.5 py-0.5 text-xs text-kumo-subtle">
-              $0
-            </span>
+            <Badge variant="neutral">$0</Badge>
           </span>
         }
         description="For personal or hobby projects."
@@ -268,9 +266,7 @@ export function RadioRichLabelDemo() {
         label={
           <span className="flex items-center gap-2">
             Pro
-            <span className="rounded-sm bg-kumo-brand px-1.5 py-0.5 text-xs text-white">
-              Popular
-            </span>
+            <Badge variant="primary">Popular</Badge>
           </span>
         }
         description="For professional websites."

--- a/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
@@ -217,6 +217,69 @@ export function RadioLegendCustomDemo() {
   );
 }
 
+/** Shows radio card appearance with the control positioned on the left via controlPosition="start" */
+export function RadioCardControlStartDemo() {
+  const [value, setValue] = useState("free");
+  return (
+    <Radio.Group
+      legend="Choose a plan"
+      appearance="card"
+      controlPosition="start"
+      value={value}
+      onValueChange={setValue}
+    >
+      <Radio.Item
+        label="Free"
+        description="For personal or hobby projects that aren't business-critical."
+        value="free"
+      />
+      <Radio.Item
+        label="Pro"
+        description="For professional websites that aren't business-critical."
+        value="pro"
+      />
+    </Radio.Group>
+  );
+}
+
+/** Shows Radio.Item labels with rich ReactNode content (icons, badges, or additional markup) */
+export function RadioRichLabelDemo() {
+  const [value, setValue] = useState("pro");
+  return (
+    <Radio.Group
+      legend="Choose a plan"
+      appearance="card"
+      value={value}
+      onValueChange={setValue}
+    >
+      <Radio.Item
+        label={
+          <span className="flex items-center gap-2">
+            Free
+            <span className="rounded-sm bg-kumo-tint px-1.5 py-0.5 text-xs text-kumo-subtle">
+              $0
+            </span>
+          </span>
+        }
+        description="For personal or hobby projects."
+        value="free"
+      />
+      <Radio.Item
+        label={
+          <span className="flex items-center gap-2">
+            Pro
+            <span className="rounded-sm bg-kumo-brand px-1.5 py-0.5 text-xs text-white">
+              Popular
+            </span>
+          </span>
+        }
+        description="For professional websites."
+        value="pro"
+      />
+    </Radio.Group>
+  );
+}
+
 /** Shows radio card appearance in horizontal layout */
 export function RadioCardHorizontalDemo() {
   const [value, setValue] = useState("free");

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -18,7 +18,9 @@ import {
   RadioDisabledDemo,
   RadioControlPositionDemo,
   RadioCardDemo,
+  RadioCardControlStartDemo,
   RadioCardHorizontalDemo,
+  RadioRichLabelDemo,
   RadioLegendSrOnlyDemo,
   RadioLegendCustomDemo,
 } from "~/components/demos/RadioDemo";
@@ -120,6 +122,26 @@ export default function Example() {
 </p>
 <ComponentExample demo="RadioCardDemo">
   <RadioCardDemo client:visible />
+</ComponentExample>
+
+### Radio Card (Control on the Left)
+
+<p>
+  Use `controlPosition="start"` on a card radio group to place the radio control
+  on the left of the label and description.
+</p>
+<ComponentExample demo="RadioCardControlStartDemo">
+  <RadioCardControlStartDemo client:visible />
+</ComponentExample>
+
+### Rich Label Content
+
+<p>
+  The `label` prop on `Radio.Item` accepts React nodes, so you can embed icons,
+  badges, or other markup alongside the text.
+</p>
+<ComponentExample demo="RadioRichLabelDemo">
+  <RadioRichLabelDemo client:visible />
 </ComponentExample>
 
 ### Radio Card (Horizontal)

--- a/packages/kumo/src/components/radio/radio.test.tsx
+++ b/packages/kumo/src/components/radio/radio.test.tsx
@@ -62,6 +62,42 @@ describe("Radio", () => {
     expect(screen.getByText("Pick one")).toBeTruthy();
   });
 
+  it("accepts ReactNode content for Radio.Item label", () => {
+    render(
+      <Radio.Group legend="Plans" appearance="card" defaultValue="pro">
+        <Radio.Item
+          label={
+            <span>
+              Pro <span data-testid="badge">Popular</span>
+            </span>
+          }
+          description="For professional websites."
+          value="pro"
+        />
+      </Radio.Group>,
+    );
+
+    expect(screen.getByText("Popular")).toBeTruthy();
+    expect(screen.getByTestId("badge")).toBeTruthy();
+  });
+
+  it("supports controlPosition='start' on card appearance", () => {
+    const { container } = render(
+      <Radio.Group
+        legend="Plan"
+        appearance="card"
+        controlPosition="start"
+        defaultValue="free"
+      >
+        <Radio.Item label="Free" description="Hobby" value="free" />
+      </Radio.Group>,
+    );
+
+    // The card label wrapper uses flex-row-reverse to place the control at start.
+    const label = container.querySelector("label");
+    expect(label?.className).toContain("flex-row-reverse");
+  });
+
   it("exports KUMO_RADIO_VARIANTS with appearance axis", () => {
     expect(KUMO_RADIO_VARIANTS.appearance.default).toBeDefined();
     expect(KUMO_RADIO_VARIANTS.appearance.card).toBeDefined();

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -72,12 +72,14 @@ export type RadioVariant = KumoRadioVariant;
 /** Position of the radio control relative to its label */
 export type RadioControlPosition = "start" | "end";
 
-// Context for passing controlPosition and appearance from Group to Items
+// Context for passing controlPosition and appearance from Group to Items.
+// `controlPosition` may be undefined so each item can fall back to an
+// appearance-appropriate default (start for default, end for card).
 const RadioGroupContext = createContext<{
-  controlPosition: RadioControlPosition;
+  controlPosition: RadioControlPosition | undefined;
   appearance: KumoRadioAppearance;
 }>({
-  controlPosition: "start",
+  controlPosition: undefined,
   appearance: "default",
 });
 
@@ -188,7 +190,7 @@ export interface RadioGroupProps {
   onValueChange?: (value: string) => void;
   /** Whether all radios in the group are disabled */
   disabled?: boolean;
-  /** Position of radio control relative to label: "start" (default) puts radio before label, "end" puts label before radio. Note: In card appearance, the control is always positioned at the end. */
+  /** Position of radio control relative to label: "start" puts radio before label, "end" puts label before radio. Defaults to "start" for default appearance and "end" for card appearance. */
   controlPosition?: RadioControlPosition;
   /** Form submission name for the radio group */
   name?: string;
@@ -222,8 +224,8 @@ export type RadioItemProps = {
    * @default "default"
    */
   appearance?: KumoRadioAppearance;
-  /** Label text displayed next to radio (required) */
-  label: string;
+  /** Label content displayed next to radio (required). Accepts strings or React nodes for rich content. */
+  label: ReactNode;
   /** Description text displayed below the label (only visible in card appearance) */
   description?: ReactNode;
   /** Value of the radio (required) */
@@ -253,14 +255,19 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
     const appearance = appearanceProp ?? groupAppearance;
     const isCard = appearance === "card";
 
-    // In card mode, default to "end" (radio on the right); otherwise follow group setting
-    const effectiveControlPosition = isCard ? "end" : controlPosition;
+    // Fall back to an appearance-appropriate default when controlPosition is
+    // not provided: card defaults to "end" (radio on the right), default
+    // appearance defaults to "start" (radio on the left).
+    const effectiveControlPosition: RadioControlPosition =
+      controlPosition ?? (isCard ? "end" : "start");
 
     if (isCard) {
+      const controlAtStart = effectiveControlPosition === "start";
       return (
         <label
           className={cn(
             "m-0 group relative flex items-start gap-3 rounded-lg border border-kumo-hairline bg-kumo-base p-3 transition-colors has-[[data-checked]]:border-kumo-interact has-[[data-checked]]:bg-kumo-tint",
+            controlAtStart && "flex-row-reverse",
             variant === "error" &&
               "border-kumo-danger has-[[data-checked]]:border-kumo-danger has-[[data-checked]]:bg-kumo-base",
             disabled
@@ -375,7 +382,7 @@ function RadioGroup({
   value,
   onValueChange,
   disabled,
-  controlPosition = "start",
+  controlPosition,
   name,
   className,
 }: RadioGroupProps) {


### PR DESCRIPTION
## Summary

Addresses two pieces of feedback on `Radio.Group`:

1. **`Radio.Item`'s `label` prop now accepts `ReactNode`.** Previously typed as `string`, so passing JSX (e.g. a label with an inline `<Badge>`) worked at runtime but raised `Type 'Element' is not assignable to type 'string'`. Users were having to cast or ignore the error.
2. **`controlPosition` now takes effect on `appearance="card"`.** Previously hardcoded to `"end"` regardless of the prop, so `controlPosition="start"` silently did nothing on cards. Card appearance still defaults to `"end"` (radio on the right, matching existing behavior); pass `controlPosition="start"` to render the radio on the left of the label and description.

## Changes

- `packages/kumo/src/components/radio/radio.tsx`
  - `label: string` → `label: ReactNode`
  - Card branch now applies `flex-row-reverse` when `effectiveControlPosition === "start"`
  - `RadioGroupContext.controlPosition` is now `RadioControlPosition | undefined`; each item picks an appearance-appropriate default (`start` for default, `end` for card) when the group doesn't specify one
  - Updated JSDoc on `controlPosition` (removed the outdated "card always at end" note)
- `packages/kumo/src/components/radio/radio.test.tsx` — 2 new tests (ReactNode label + card `controlPosition="start"`)
- `packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx` — `RadioCardControlStartDemo` and `RadioRichLabelDemo`
- `packages/kumo-docs-astro/src/pages/components/radio.mdx` — registers the two new demo sections

## Backwards compatibility

Additive only. Existing usage (`label="Email"`, card without `controlPosition`) behaves identically.

## Checklist

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: waiting on bonk
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because: