### PR TITLE
ci(changeset): skip validation on Changesets release PRs

### DIFF
--- a/ci/scripts/validate-kumo-changeset.ts
+++ b/ci/scripts/validate-kumo-changeset.ts
@@ -42,6 +42,21 @@ function main() {
     return;
   }
 
+  // Skip validation on Changesets release PRs. The `changesets/action` bot
+  // opens these PRs from a `changeset-release/<target>` branch and, by
+  // design, their diff modifies `packages/kumo/` (version bump + CHANGELOG)
+  // while removing — not adding — `.changeset/*.md` files. Running the
+  // "must add a new changeset" rule here would always fail. See
+  // https://github.com/changesets/action for the branch-name convention.
+  const headRef =
+    process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME || "";
+  if (headRef.startsWith("changeset-release/")) {
+    console.log(
+      `Detected Changesets release PR (branch: ${headRef}); skipping validation.`,
+    );
+    return;
+  }
+
   console.log("Validating changesets...");
 
   // Check if kumo files have been modified

--- a/ci/scripts/validate-kumo-changeset.ts
+++ b/ci/scripts/validate-kumo-changeset.ts
@@ -48,8 +48,11 @@ function main() {
   // while removing — not adding — `.changeset/*.md` files. Running the
   // "must add a new changeset" rule here would always fail. See
   // https://github.com/changesets/action for the branch-name convention.
-  const headRef =
-    process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME || "";
+  //
+  // GITHUB_HEAD_REF is the PR's source branch name and is always set on
+  // pull_request workflow runs — the only CI path that reaches this code,
+  // per the isPullRequestContext() guard above.
+  const headRef = process.env.GITHUB_HEAD_REF ?? "";
   if (headRef.startsWith("changeset-release/")) {
     console.log(
       `Detected Changesets release PR (branch: ${headRef}); skipping validation.`,


### PR DESCRIPTION
## Summary

The `ci/scripts/validate-kumo-changeset.ts` script enforces *"if `packages/kumo/` changed, a new `.changeset/*.md` file must exist."* Correct rule for feature PRs — but **guaranteed to fail** on the Changesets release PR itself, because by construction the release PR:

- Modifies `packages/kumo/package.json` (version bump) and `packages/kumo/CHANGELOG.md` (entries).
- **Deletes** all `.changeset/*.md` files it consumed.
- **Never adds** new changesets.

## Why this is only hitting us now

Prior "Version Packages" PRs didn't trigger the failure — but not because they were healthy. Bot-authored PRs require a maintainer to click **"Approve and run"** before the `pull_request` workflow actually executes. That approval was never granted on prior release PRs, so the Pull Request workflow sat in `action_required` forever and the validation never ran. [PR #428](https://github.com/cloudflare/kumo/pull/428) is the first release PR where the workflow was approved to run, exposing the latent false-positive.

Reference — same error on an earlier release PR when its workflow was briefly approved before a force-push:
https://github.com/cloudflare/kumo/actions/runs/24518655574/job/71669853648

## The fix

Five lines in `validate-kumo-changeset.ts`: if the PR's head branch is `changeset-release/*` (the hardcoded naming convention from [`changesets/action`](https://github.com/changesets/action)), log and exit early. All other PRs — feature branches, Renovate/Dependabot bumps, human contributions — continue through full validation unchanged.

## Alternatives considered

- **Detect by PR author (`github-actions[bot]`)** — fragile if the release token ever changes.
- **Detect "deleted .changeset files but no new ones"** — more semantic but more code, and you'd still want a branch check as a sanity gate anyway.
- **Add a `skip-changeset-validation` label** — requires a human action every release; self-healing > self-disciplining.
- **Drop the CI validation entirely and rely on pre-push** — pre-push can be bypassed with `--no-verify`; the CI check is the belt-and-suspenders layer and worth keeping.

## Expected behavior after this lands

- **Feature PR missing a changeset** → still fails loudly (unchanged).
- **Release PR (`changeset-release/*`)** → logs `Detected Changesets release PR (branch: changeset-release/main); skipping validation.` and exits 0 → green check.

After merge, re-run the latest Release workflow to regenerate PR #428:

```bash
gh run rerun 24792409741
```

Red X on #428 should clear on the next workflow run.

## Checklist

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: single-file CI script change with well-scoped blast radius
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [x] Additional testing not necessary because: the change is a narrow early-exit in a CI validation script; behavior is directly observable on the next release PR workflow run, and the non-release-PR path is unchanged