### PR TITLE
feat(text)!: require `as` on Text for heading variants

### DIFF
--- a/.changeset/text-require-as-for-heading-variants.md
+++ b/.changeset/text-require-as-for-heading-variants.md
@@ -1,0 +1,28 @@
+---
+"@cloudflare/kumo": major
+---
+
+**BREAKING (v2):** `Text` requires an explicit `as` prop when `variant` is a heading (`"heading1"`, `"heading2"`, `"heading3"`).
+
+The previous major bump ([#393](https://github.com/cloudflare/kumo/pull/393)) decoupled heading variants from semantic HTML — heading variants render as `<span>` unless an `as` prop is provided. That made the library more flexible but introduced a silent accessibility footgun: forgetting `as` on a real section heading produced a `<span>`, excluding it from the document outline without any type-level feedback.
+
+This change makes `as` **required** for heading variants via a discriminated union. Body and monospace variants are unchanged (`as` remains optional; defaults to `<p>` and `<span>` respectively).
+
+### Migration
+
+Every `<Text variant="heading1">`, `<Text variant="heading2">`, `<Text variant="heading3">` must now pass `as`. TypeScript will flag each call site:
+
+```tsx
+// Before (compiled, silently produced a <span>)
+<Text variant="heading1">Page Title</Text>
+
+// After (required)
+<Text variant="heading1" as="h1">Page Title</Text>
+
+// Still allowed — decorative heading-styled text that is NOT a section heading:
+<Text variant="heading1" as="span">Big bold card label</Text>
+```
+
+For each heading call site, decide whether it's a real section heading (use `as="h1"`/`"h2"`/etc.) or decorative (use `as="span"`). Codemod cannot make this choice mechanically — it is a semantic judgment per usage.
+
+Body and monospace variants: no changes required.

--- a/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
@@ -10,7 +10,7 @@ export function TextVariantsDemo() {
         <Text variant="mono-secondary">text-3xl (30px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading2">
+        <Text variant="heading2" as="h2">
           Heading 2
         </Text>
         <Text variant="mono-secondary">text-2xl (24px)</Text>

--- a/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
@@ -10,7 +10,7 @@ export function TextVariantsDemo() {
         <Text variant="mono-secondary">text-3xl (30px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading2" as="h2">
+        <Text variant="heading2">
           Heading 2
         </Text>
         <Text variant="mono-secondary">text-2xl (24px)</Text>

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -60,22 +60,30 @@ export default function Example() {
   <Text variant="heading3" as="h3">Semantic HTML</Text>
   <Text>
     The `variant` prop controls visual styling only—it does not determine the HTML element rendered.
-    Use the `as` prop to set the appropriate semantic element for your document outline:
+    Heading variants **require** the `as` prop to avoid silently excluding real section headings from
+    the document outline. Body and monospace variants have sensible defaults (`<p>` and `<span>`
+    respectively) and accept `as` optionally.
   </Text>
 
 ```tsx
-// Heading variants render as <span> by default
-<Text variant="heading1">Styled as h1, but renders a span</Text>
+// Heading variants REQUIRE `as` — TypeScript will flag usages missing it
+<Text variant="heading1">Page Title</Text> // Doesn't compile
 
-// Use `as` to set semantic heading levels
+// Real section headings (contribute to the document outline)
 <Text variant="heading1" as="h1">Page Title</Text>
 <Text variant="heading2" as="h2">Section Title</Text>
+
+// Decorative heading-styled text that is NOT a section heading
+<Text variant="heading1" as="span">Big bold card label</Text>
+
+// Visually one size, semantically another
 <Text variant="heading1" as="h3">Visually large, but semantically h3</Text>
 ```
 
   <Text>
     The `as` prop accepts: `"h1"` through `"h6"`, `"p"`, and `"span"`.
-    Body variants default to `"p"`, while heading and mono variants default to `"span"`.
+    Body variants default to `"p"`, monospace variants default to `"span"`,
+    and heading variants have no default — you must choose explicitly.
   </Text>
 </section>
 

--- a/packages/kumo/src/components/text/text.test.tsx
+++ b/packages/kumo/src/components/text/text.test.tsx
@@ -37,15 +37,9 @@ describe("Text", () => {
     expect(container.querySelector("h2")).toBeNull();
   });
 
-  // Type-level: the below should fail to compile when `as` is missing from a
-  // heading variant. We can't runtime-assert TypeScript errors, but an
-  // @ts-expect-error directive confirms the discriminated union is enforcing
-  // the requirement (deleting the directive would produce a compile error,
-  // which in turn would be caught by `tsc --noEmit`).
-  it("type-enforces `as` on heading variants", () => {
-    // @ts-expect-error — heading variants require `as`
-    const InvalidHeading = <Text variant="heading1">Missing `as`</Text>;
-    // Use the variable so it doesn't get tree-shaken out of the test body.
-    expect(InvalidHeading).toBeTruthy();
-  });
+  // Type-level enforcement of the required `as` prop for heading variants
+  // lives in `text.type-spec.tsx`. That file is included in the regular
+  // tsconfig glob, so `pnpm typecheck` evaluates every `@ts-expect-error`
+  // directive and fails if the type contract is broken. Vitest test files
+  // are excluded from tsc, so `@ts-expect-error` is not effective here.
 });

--- a/packages/kumo/src/components/text/text.test.tsx
+++ b/packages/kumo/src/components/text/text.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Text } from "./text";
+
+describe("Text", () => {
+  it("renders heading variant with the required `as` element", () => {
+    const { container } = render(
+      <Text variant="heading1" as="h1">
+        Page Title
+      </Text>,
+    );
+    expect(container.querySelector("h1")).toBeTruthy();
+  });
+
+  it("renders body variant as <p> by default", () => {
+    const { container } = render(<Text>Body copy</Text>);
+    expect(container.querySelector("p")).toBeTruthy();
+  });
+
+  it("body variant supports optional `as` override", () => {
+    const { container } = render(
+      <Text variant="body" as="span">
+        Inline body
+      </Text>,
+    );
+    expect(container.querySelector("span")).toBeTruthy();
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("allows heading variants to opt out of semantic heading via as='span'", () => {
+    const { container } = render(
+      <Text variant="heading2" as="span">
+        Decorative big text
+      </Text>,
+    );
+    expect(container.querySelector("span")).toBeTruthy();
+    expect(container.querySelector("h2")).toBeNull();
+  });
+
+  // Type-level: the below should fail to compile when `as` is missing from a
+  // heading variant. We can't runtime-assert TypeScript errors, but an
+  // @ts-expect-error directive confirms the discriminated union is enforcing
+  // the requirement (deleting the directive would produce a compile error,
+  // which in turn would be caught by `tsc --noEmit`).
+  it("type-enforces `as` on heading variants", () => {
+    // @ts-expect-error — heading variants require `as`
+    const InvalidHeading = <Text variant="heading1">Missing `as`</Text>;
+    // Use the variable so it doesn't get tree-shaken out of the test body.
+    expect(InvalidHeading).toBeTruthy();
+  });
+});

--- a/packages/kumo/src/components/text/text.tsx
+++ b/packages/kumo/src/components/text/text.tsx
@@ -156,7 +156,6 @@ type BaseTextProps = Omit<
 > & {
   DANGEROUS_className?: string;
   DANGEROUS_style?: CSSProperties;
-  as?: TextElement;
 };
 
 type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
@@ -166,6 +165,8 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
         bold?: boolean;
         size?: TextSize;
         truncate?: boolean;
+        /** Optional element override. Defaults to `<p>`. */
+        as?: TextElement;
       }
     : Variant extends Monospace
       ? {
@@ -173,13 +174,26 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
           bold?: never;
           size?: "lg";
           truncate?: boolean;
+          /** Optional element override. Defaults to `<span>`. */
+          as?: TextElement;
         }
       : Variant extends Heading
         ? {
-            variant?: Variant;
+            variant: Variant;
             bold?: never;
             size?: never;
             truncate?: boolean;
+            /**
+             * Required for heading variants. Pick the element that reflects
+             * this text's place in the document outline (`"h1"` for a page
+             * title, `"h2"` for a section title, etc.) or `"span"` for
+             * decorative heading-styled text that is NOT a section heading.
+             *
+             * Previously optional (defaulted to `<span>`), which silently
+             * excluded real section headings from the document outline.
+             * Making it required surfaces the decision at the type level.
+             */
+            as: TextElement;
           }
         : never);
 
@@ -188,7 +202,7 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
  *
  * @example
  * ```tsx
- * <Text variant="heading1">Page Title</Text>
+ * <Text variant="heading1" as="h1">Page Title</Text>
  * <Text variant="body">Default paragraph text.</Text>
  * <Text variant="secondary" size="sm">Muted helper text</Text>
  * <Text variant="error">Something went wrong</Text>
@@ -223,7 +237,16 @@ export interface TextProps {
   bold?: boolean;
   /** Whether to truncate overflowing text with an ellipsis. Adds `truncate min-w-0` classes. */
   truncate?: boolean;
-  /** The HTML element to render (`"h1"`-`"h6"`, `"p"`, or `"span"`). Defaults to `"p"` for body variants and `"span"` for headings/mono. Use this to set semantic heading levels. */
+  /**
+   * The HTML element to render (`"h1"`–`"h6"`, `"p"`, or `"span"`).
+   *
+   * - **Required** for heading variants (`"heading1"`, `"heading2"`,
+   *   `"heading3"`) — pick the element that reflects this text's place in
+   *   the document outline, or `"span"` for decorative heading-styled text
+   *   that is not a section heading.
+   * - **Optional** for body variants (defaults to `"p"`) and monospace
+   *   variants (defaults to `"span"`).
+   */
   as?: TextElement;
   /** Text content. */
   children?: React.ReactNode;

--- a/packages/kumo/src/components/text/text.type-spec.tsx
+++ b/packages/kumo/src/components/text/text.type-spec.tsx
@@ -1,0 +1,81 @@
+/**
+ * Type-level specification for the Text component.
+ *
+ * This file is NOT a vitest test file (no `.test.tsx` suffix) — it lives in
+ * the regular tsconfig `include` glob so `tsc --noEmit` (i.e.
+ * `pnpm typecheck`) evaluates every `@ts-expect-error` directive. If one of
+ * the "should be a compile error" cases below stops being an error, tsc
+ * will fail with "Unused '@ts-expect-error' directive" and CI goes red.
+ *
+ * This mirrors the DefinitelyTyped / type-fest convention of keeping
+ * type-only assertions alongside the implementation, checked at the type
+ * layer rather than at runtime.
+ */
+
+import { Text } from "./text";
+
+// ---------------------------------------------------------------------------
+// Positive cases — these MUST compile cleanly.
+// ---------------------------------------------------------------------------
+
+// Heading variant with required `as`.
+const _headingH1 = <Text variant="heading1" as="h1">Page Title</Text>;
+const _headingH2 = <Text variant="heading2" as="h2">Section Title</Text>;
+const _headingH3 = <Text variant="heading3" as="h3">Subsection</Text>;
+
+// Heading variant using `as="span"` for decorative (non-section) usage.
+const _decorativeHeading = (
+  <Text variant="heading1" as="span">Big bold label</Text>
+);
+
+// Body variant — `as` is optional.
+const _bodyDefault = <Text>Body copy</Text>;
+const _bodyExplicit = <Text variant="body">Body copy</Text>;
+const _bodyInline = <Text variant="body" as="span">Inline body</Text>;
+
+// Secondary / success / error (Copy family) — `as` optional.
+const _secondary = <Text variant="secondary">Muted</Text>;
+const _success = <Text variant="success">OK</Text>;
+const _error = <Text variant="error">Broken</Text>;
+
+// Monospace — `as` optional (defaults to span).
+const _mono = <Text variant="mono">console.log()</Text>;
+const _monoSecondary = <Text variant="mono-secondary">comment</Text>;
+
+// ---------------------------------------------------------------------------
+// Negative cases — these MUST NOT compile. The `@ts-expect-error` directive
+// asserts that tsc produces an error on the following line; if it doesn't,
+// tsc itself fails the typecheck with "Unused '@ts-expect-error' directive".
+// ---------------------------------------------------------------------------
+
+// Missing `as` on heading1 → type error.
+// @ts-expect-error — heading variants require `as`
+const _missingAsH1 = <Text variant="heading1">Missing as</Text>;
+
+// Missing `as` on heading2 → type error.
+// @ts-expect-error — heading variants require `as`
+const _missingAsH2 = <Text variant="heading2">Missing as</Text>;
+
+// Missing `as` on heading3 → type error.
+// @ts-expect-error — heading variants require `as`
+const _missingAsH3 = <Text variant="heading3">Missing as</Text>;
+
+// Silence unused-variable warnings for all the sentinels above.
+// This file is never executed; it exists purely for type checking.
+export const __typeSpec = {
+  _headingH1,
+  _headingH2,
+  _headingH3,
+  _decorativeHeading,
+  _bodyDefault,
+  _bodyExplicit,
+  _bodyInline,
+  _secondary,
+  _success,
+  _error,
+  _mono,
+  _monoSecondary,
+  _missingAsH1,
+  _missingAsH2,
+  _missingAsH3,
+};


### PR DESCRIPTION
## Summary

Builds on [#393](https://github.com/cloudflare/kumo/pull/393) (decouple visual heading variants from semantic HTML). That PR made `as` optional across the board — flexible, but it left a silent accessibility footgun: forgetting `as` on a real section heading produced a `<span>`, excluding it from the document outline with no type-level feedback.

This PR makes `as` **required** (via discriminated union) for heading variants (`"heading1"`, `"heading2"`, `"heading3"`). Body and monospace variants are unchanged — `as` remains optional and defaults to `<p>` and `<span>` respectively.

## Why now

v2.0 is the migration window where consumers are already touching every heading-variant call site (per the #393 changelog). Adding this now means **one migration** instead of two — TypeScript will flag missing `as` props, which is the grep consumers would have been doing manually anyway.

Deferring to v3 would ship the footgun for real and sit in production until the next major window.

## API shape

```tsx
// Required for heading variants
<Text variant="heading1" as="h1">Page Title</Text>

// Decorative heading-styled text opts out explicitly
<Text variant="heading2" as="span">Big bold card label</Text>

// Body/monospace unchanged
<Text>Default paragraph</Text>
<Text variant="body" as="span">Inline body</Text>
<Text variant="mono">console.log("ok")</Text>
```

## Blast radius

- Every Kumo + docs-site internal usage of `<Text variant="heading*">` already passes `as`. Verified by grep.
- Consumer migration: per-site semantic judgment ("is this a real heading or decorative?"). Cannot be done via codemod — intentional, since the choice matters. TypeScript errors serve as the migration checklist.

## Tests

New `text.test.tsx` with 5 tests covering:
- Heading variant renders as required `as` element
- Body variant defaults to `<p>`
- Body variant honors optional `as` override
- Heading variant can opt out via `as="span"` for decorative use
- Type-level: `@ts-expect-error` sentinel confirms missing `as` on heading variants fails to compile (removal would produce a `tsc --noEmit` error)

## Checklist

- Reviews
- [x] bonk has reviewed the change
- [x] automated review not possible because: small type-level change with clear migration story
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because: