### PR TITLE
Fix Table font size mismatch

### DIFF
--- a/.changeset/fix-table-font-size.md
+++ b/.changeset/fix-table-font-size.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Table body cells rendering at 16px. The Table root now sets text-base (14px) so <td> cells match Kumo's default body font-size instead of inheriting the browser default. Also replaces an arbitrary text-[14px] in Empty with text-base.

--- a/packages/kumo/src/components/empty/empty.tsx
+++ b/packages/kumo/src/components/empty/empty.tsx
@@ -113,7 +113,7 @@ export function Empty({
           )}
         >
           <span className="text-xs text-kumo-inactive select-none">$</span>
-          <span className="no-scrollbar overflow-scroll text-[14px] whitespace-nowrap text-kumo-brand">
+          <span className="no-scrollbar overflow-scroll text-base whitespace-nowrap text-kumo-brand">
             {commandLine}
           </span>
           <Button

--- a/packages/kumo/src/components/table/table.tsx
+++ b/packages/kumo/src/components/table/table.tsx
@@ -132,7 +132,7 @@ const TableRoot = forwardRef<
     "[&_td]:p-3", // Cell padding
     "[&_th]:border-b [&_th]:border-kumo-fill [&_th]:p-3 [&_th]:font-semibold [&_th]:text-base", // Header styles
     "[&_th]:bg-kumo-base", // Header background color
-    "text-left text-kumo-default",
+    "text-base text-left text-kumo-default",
     props.className,
   );
 


### PR DESCRIPTION
The Table root didn't set a font-size, so `<td>` body cells inherited the browser's 16px default while headers already used Kumo's 14px. This PR adds `text-base` to the Table root so cells render at the correct 14px. Also replaces an arbitrary `text-[14px]` in `Empty` with the semantic `text-base`.

| Before | After |
|--------|--------|
|<img width="1781" height="1195" alt="Screenshot 2026-04-23 at 02 07 59" src="https://github.com/user-attachments/assets/4d708602-9569-43ba-9985-e65afc446b32" />|<img width="1781" height="1195" alt="Screenshot 2026-04-23 at 02 08 18" src="https://github.com/user-attachments/assets/2d22a1aa-854a-43d0-8059-ac4aca637d53" />|

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: small, mechanical font-size fix
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: pure className change; typecheck and lint pass
