### PR TITLE
[Docs] Fix broken links and remove internal section on Contributing page

### DIFF
--- a/.changeset/contributing-docs-cleanup.md
+++ b/.changeset/contributing-docs-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Clean up the Contributing page: remove the "Questions?" section that referenced an internal channel, and fix the "Related Docs" links to point to absolute GitHub URLs instead of relative paths that 404'd.

--- a/packages/kumo-docs-astro/src/pages/contributing.mdx
+++ b/packages/kumo-docs-astro/src/pages/contributing.mdx
@@ -196,12 +196,6 @@ Common pitfalls to avoid:
 
 ---
 
-## Questions?
-If you have any questions for Kumo, please reach out to the team in our Kumo channel.
-
----
-
 ## Related Docs
 
-- Changeset guidance: [`.changeset/README.md`](../../../.changeset/README.md)
-- Kumo package architecture: [`packages/kumo/AGENTS.md`](../../kumo/AGENTS.md)
+Follow the [changeset guide](https://github.com/cloudflare/kumo/blob/main/.changeset/README.md) to document releasable library changes and see the [AGENTS.md](https://github.com/cloudflare/kumo/blob/main/packages/kumo/AGENTS.md) for conventions and patterns.


### PR DESCRIPTION
The Contributing page referenced an internal Kumo channel that isn't useful now that the docs are public, so the "Questions?" section is gone. The "Related Docs" links also pointed to relative paths that 404'd on the deployed site and now point to the corresponding files on GitHub.

| Before | After |
|--------|--------|
|<img width="1781" height="1195" alt="Screenshot 2026-04-23 at 02 49 03" src="https://github.com/user-attachments/assets/0491338a-b8a2-4db4-915b-8f0adceedbc4" />|<img width="1781" height="1195" alt="Screenshot 2026-04-23 at 02 49 10" src="https://github.com/user-attachments/assets/51c96ffb-eeb3-4f97-8360-304ffd5ffad3" />|

---

- Reviews
- [x] automated review not possible because: docs-only content change
- Tests
- [x] Additional testing not necessary because: MDX content change with no functional behavior; lint passes