### PR TITLE
Docs: Fix copy code button appearing above header on scroll

### DIFF
--- a/.changeset/fix-copy-button-zindex.md
+++ b/.changeset/fix-copy-button-zindex.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Fix copy code button z-index so it no longer appears above the sticky header when scrolling

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -279,7 +279,7 @@ pre.astro-code {
    ========================================================================== */
 
 .code-block-copy-btn {
-  @apply absolute top-3 right-3 z-10 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
+  @apply absolute top-3 right-3 z-0 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);
   color: var(--text-color-kumo-subtle);
   --tw-ring-color: var(--color-kumo-hairline);

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -279,7 +279,7 @@ pre.astro-code {
    ========================================================================== */
 
 .code-block-copy-btn {
-  @apply absolute top-3 right-3 z-0 flex items-center justify-center size-[1.625rem] rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
+  @apply absolute top-3 right-3 flex items-center justify-center size-6.5 rounded-md cursor-pointer border-none shadow-none select-none focus-visible:ring-1;
   background: var(--color-kumo-base);
   color: var(--text-color-kumo-subtle);
   --tw-ring-color: var(--color-kumo-hairline);


### PR DESCRIPTION
The copy button inside code blocks was set to `z-10`, the same z-index as the sticky page header. Because the button appeared later in the DOM, it painted on top of the header as users scrolled, causing it to bleed through the nav.

| Before | After |
|--------|--------|
|<img width="2032" height="1161" alt="Screenshot 2026-04-23 at 05 13 25" src="https://github.com/user-attachments/assets/1009e2dd-bfca-4861-b63c-8ae1e2f004e9" />|<img width="2032" height="1161" alt="Screenshot 2026-04-23 at 05 13 12" src="https://github.com/user-attachments/assets/4352527f-b8b8-4841-843a-2149be8c4484" />|

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual/CSS-only fix, no logic changed
- Tests
- [x] Additional testing not necessary because: single CSS value change, verified by manual scroll test