### PR TITLE
feat(chart): dim non-hovered series rows in tooltip

### DIFF
--- a/.changeset/two-numbers-throw.md
+++ b/.changeset/two-numbers-throw.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(chart): dim non-hovered series rows in tooltip

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -450,6 +450,46 @@ export function BarChartDemo() {
   );
 }
 
+/** Bar chart with many series and a scrollable tooltip via `tooltipCss`. */
+export function TooltipCssDemo() {
+  const isDarkMode = useIsDarkMode();
+
+  const colors = [
+    ChartPalette.categorical(0, isDarkMode),
+    ChartPalette.categorical(1, isDarkMode),
+    ChartPalette.categorical(2, isDarkMode),
+    ChartPalette.categorical(3, isDarkMode),
+    ChartPalette.categorical(4, isDarkMode),
+    ChartPalette.categorical(5, isDarkMode),
+    ChartPalette.categorical(6, isDarkMode),
+    ChartPalette.categorical(7, isDarkMode),
+  ];
+
+  const data = useMemo(
+    () =>
+      Array.from({ length: 8 }, (_, i) => ({
+        name: `Series ${String.fromCharCode(65 + i)}`,
+        data: buildSeriesData(i, 20, 3_600_000, 0.3 + i * 0.1),
+        color: colors[i],
+      })),
+    [isDarkMode],
+  );
+
+  return (
+    <TimeseriesChart
+      echarts={echarts}
+      isDarkMode={isDarkMode}
+      type="bar"
+      data={data}
+      xAxisName="Time (UTC)"
+      yAxisName="Count"
+      tooltipValueFormat={(r) => r.toFixed(2)}
+      tooltipCss="max-height:180px;overflow-y:auto;"
+      tooltipEnterable
+    />
+  );
+}
+
 /**
  * Timeseries chart in loading state, showing the animated sine-wave skeleton.
  * Loads for 5 seconds then reveals the real chart. A button restarts the cycle.

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -15,6 +15,7 @@ import {
   IncompleteDataChartDemo,
   LoadingChartDemo,
   TimeRangeSelectionChartDemo,
+  TooltipCssDemo,
 } from "~/components/demos/Chart/ChartDemo";
 
 <p>
@@ -103,6 +104,22 @@ import {
 
   <ComponentExample demo="BarChartDemo">
     <BarChartDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+### Tooltip CSS
+
+<p>
+  Use the <code>tooltipCss</code> prop to append custom CSS to the tooltip
+  container. This is useful for constraining tooltip height when there are many
+  series, or adding scroll behavior. The string is passed directly to ECharts'
+  <code>extraCssText</code> option.
+</p>
+
+  <ComponentExample demo="TooltipCssDemo">
+    <TooltipCssDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/chart/EChart.tsx
+++ b/packages/kumo/src/components/chart/EChart.tsx
@@ -107,26 +107,6 @@ export interface ChartEvents {
 
   axisareaselected: (params: any) => void;
 
-  /**
-   * Fired whenever the axis pointer moves to a new position.
-   * Includes the series index closest to the pointer, which is useful
-   * for determining which series the user is interacting with when
-   * the tooltip uses `trigger: "axis"`.
-   */
-  updateAxisPointer: (params: {
-    seriesDataByAxis: Array<{
-      axisDim: string;
-      axisIndex: number;
-      value: number;
-      seriesDataIndices: Array<{
-        seriesIndex: number;
-        dataIndex: number;
-      }>;
-    }>;
-    dataIndex?: number;
-    seriesIndex?: number;
-  }) => void;
-
   // Brush / selection events
   brush: (params: any) => void;
   brushselected: (params: any) => void;

--- a/packages/kumo/src/components/chart/EChart.tsx
+++ b/packages/kumo/src/components/chart/EChart.tsx
@@ -107,6 +107,26 @@ export interface ChartEvents {
 
   axisareaselected: (params: any) => void;
 
+  /**
+   * Fired whenever the axis pointer moves to a new position.
+   * Includes the series index closest to the pointer, which is useful
+   * for determining which series the user is interacting with when
+   * the tooltip uses `trigger: "axis"`.
+   */
+  updateAxisPointer: (params: {
+    seriesDataByAxis: Array<{
+      axisDim: string;
+      axisIndex: number;
+      value: number;
+      seriesDataIndices: Array<{
+        seriesIndex: number;
+        dataIndex: number;
+      }>;
+    }>;
+    dataIndex?: number;
+    seriesIndex?: number;
+  }) => void;
+
   // Brush / selection events
   brush: (params: any) => void;
   brushselected: (params: any) => void;

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -162,10 +162,9 @@ export function TimeseriesChart({
   tooltipEnterable,
 }: TimeseriesChartProps) {
   const chartRef = useRef<echarts.ECharts | null>(null);
-  // Tracks which bar series the user is hovering over so the tooltip
+  // Tracks which series the user is hovering over so the tooltip
   // formatter can dim the rows of non-hovered series, matching the
-  // emphasis dimming on the bars. Only used for bar charts — line charts
-  // with showSymbol: false lack hover targets for mouseover events.
+  // emphasis dimming on the chart.
   const hoveredSeriesRef = useRef<string | null>(null);
   // Stable ref to the tooltip value formatter so the dangerousHtmlFormatter
   // closure (captured by useMemo) always calls the latest function without
@@ -396,25 +395,19 @@ export function TimeseriesChart({
     }
 
     // Track which series is hovered so the tooltip formatter can dim
-    // non-hovered rows, matching the emphasis dimming on the bars.
-    // Only enabled for bar charts — each stacked segment is a distinct
-    // graphical element so mouseover/mouseout fire reliably. Line charts
-    // with showSymbol: false lack hover targets, so tooltip dimming is
-    // not supported for them.
-    if (type === "bar") {
-      handlers.mouseover = (params) => {
-        hoveredSeriesRef.current = params.seriesName ?? null;
-      };
-      handlers.mouseout = () => {
-        hoveredSeriesRef.current = null;
-      };
-      handlers.globalout = () => {
-        hoveredSeriesRef.current = null;
-      };
-    }
+    // non-hovered rows, matching the emphasis dimming on the chart.
+    handlers.mouseover = (params) => {
+      hoveredSeriesRef.current = params.seriesName ?? null;
+    };
+    handlers.mouseout = () => {
+      hoveredSeriesRef.current = null;
+    };
+    handlers.globalout = () => {
+      hoveredSeriesRef.current = null;
+    };
 
     return handlers;
-  }, [onTimeRangeChange, type]);
+  }, [onTimeRangeChange]);
 
   // Activate the lineX brush cursor when a time-range callback is provided,
   // and deactivate it on cleanup so the cursor resets when the prop is removed.

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -364,28 +364,44 @@ export function TimeseriesChart({
       };
     }
 
-    // Use updateAxisPointer to track which series is closest to the
-    // pointer. This fires reliably for axis-triggered tooltips (unlike
-    // mouseover which requires hovering directly on a graphical element).
-    // We dispatch highlight/downplay actions so the chart emphasis and
-    // the tooltip dimming stay in sync.
-    handlers.updateAxisPointer = (params) => {
-      const chart = chartRef.current;
-      if (!chart) return;
+    // --- Hover tracking for tooltip row dimming ---
+    // Bar and line charts need different strategies because their hover
+    // targets differ:
+    //
+    // Bar charts: each stacked segment is a distinct graphical element,
+    //   so mouseover/mouseout fire reliably on individual segments.
+    //   updateAxisPointer does NOT provide a useful seriesIndex for bars
+    //   because the axis pointer covers the entire stacked column.
+    //
+    // Line charts: with showSymbol: false there are no hoverable elements,
+    //   so mouseover rarely fires. updateAxisPointer provides seriesIndex
+    //   indicating the nearest line, which is exactly what we need.
+    if (type === "bar") {
+      handlers.mouseover = (params) => {
+        hoveredSeriesRef.current = params.seriesName ?? null;
+      };
+      handlers.mouseout = () => {
+        hoveredSeriesRef.current = null;
+      };
+    } else {
+      handlers.updateAxisPointer = (params) => {
+        const chart = chartRef.current;
+        if (!chart) return;
 
-      const seriesIndex = params.seriesIndex;
-      if (seriesIndex != null) {
-        const option = chart.getOption() as EChartsOption;
-        const series = (option.series as SeriesOption[])?.[seriesIndex];
-        const name =
-          series && "name" in series ? (series.name as string) : null;
+        const seriesIndex = params.seriesIndex;
+        if (seriesIndex != null) {
+          const option = chart.getOption() as EChartsOption;
+          const series = (option.series as SeriesOption[])?.[seriesIndex];
+          const name =
+            series && "name" in series ? (series.name as string) : null;
 
-        if (name && name !== hoveredSeriesRef.current) {
-          hoveredSeriesRef.current = name;
-          chart.dispatchAction({ type: "highlight", seriesName: name });
+          if (name && name !== hoveredSeriesRef.current) {
+            hoveredSeriesRef.current = name;
+            chart.dispatchAction({ type: "highlight", seriesName: name });
+          }
         }
-      }
-    };
+      };
+    }
 
     // Clear hover state when the pointer leaves the chart entirely.
     handlers.globalout = () => {
@@ -394,7 +410,7 @@ export function TimeseriesChart({
     };
 
     return handlers;
-  }, [onTimeRangeChange]);
+  }, [onTimeRangeChange, type]);
 
   // Activate the lineX brush cursor when a time-range callback is provided,
   // and deactivate it on cleanup so the cursor resets when the prop is removed.

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -140,6 +140,9 @@ export function TimeseriesChart({
   ariaDescription,
 }: TimeseriesChartProps) {
   const chartRef = useRef<echarts.ECharts | null>(null);
+  // Tracks which series the user is hovering over so the tooltip formatter
+  // can dim the rows of non-hovered series (mirrors the bar emphasis dimming).
+  const hoveredSeriesRef = useRef<string | null>(null);
   const incompleteBefore = incomplete?.before;
   const incompleteAfter = incomplete?.after;
 
@@ -262,6 +265,8 @@ export function TimeseriesChart({
               ? `<div style="font-weight:600;margin-bottom:4px;">${echarts.format.encodeHTML(formatTimestamp(ts))}</div>`
               : "";
 
+          const hovered = hoveredSeriesRef.current;
+
           const rows = filteredParams
             .map((param: any) => {
               const value = param?.value?.[1];
@@ -270,9 +275,13 @@ export function TimeseriesChart({
                 ? echarts.format.encodeHTML(String(formatFn(value)))
                 : echarts.format.encodeHTML(String(value));
 
-              return `${param.marker} ${echarts.format.encodeHTML(param.seriesName)}: <strong>${formattedValue}</strong>`;
+              const isDimmed =
+                hovered != null && param.seriesName !== hovered;
+              const style = isDimmed ? ' style="opacity:0.5"' : "";
+
+              return `<div${style}>${param.marker} ${echarts.format.encodeHTML(param.seriesName)}: <strong>${formattedValue}</strong></div>`;
             })
-            .join("<br/>");
+            .join("");
 
           return `${header}${rows}`;
         },
@@ -340,15 +349,26 @@ export function TimeseriesChart({
   ]);
 
   const events = useMemo<Partial<ChartEvents>>(() => {
-    if (!onTimeRangeChange) return {};
+    const handlers: Partial<ChartEvents> = {};
 
-    return {
-      brushend: (params) => {
+    if (onTimeRangeChange) {
+      handlers.brushend = (params) => {
         const range = params.areas[0].coordRange;
         onTimeRangeChange(range[0], range[1]);
         chartRef.current?.dispatchAction({ type: "brush", areas: [] });
-      },
+      };
+    }
+
+    // Track which series is hovered so the tooltip formatter can dim
+    // non-hovered rows, matching the emphasis dimming on the chart.
+    handlers.mouseover = (params) => {
+      hoveredSeriesRef.current = params.seriesName ?? null;
     };
+    handlers.mouseout = () => {
+      hoveredSeriesRef.current = null;
+    };
+
+    return handlers;
   }, [onTimeRangeChange]);
 
   // Activate the lineX brush cursor when a time-range callback is provided,

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -87,6 +87,26 @@ export interface TimeseriesChartProps {
    * @see https://echarts.apache.org/handbook/en/best-practices/aria/
    */
   ariaDescription?: string;
+  /**
+   * Extra CSS text appended to the tooltip's inline `style` attribute.
+   * Useful for constraining tooltip size or adding scroll behavior when
+   * there are many series.
+   *
+   * @example
+   * ```tsx
+   * tooltipCss="max-height:200px;overflow-y:auto;"
+   * ```
+   */
+  tooltipCss?: string;
+  /**
+   * When `true`, the tooltip stays visible when the user moves their cursor
+   * into it, allowing interaction with scrollable or selectable content.
+   * Pair with `tooltipCss` to create scrollable tooltips for charts with
+   * many series.
+   *
+   * @default false
+   */
+  tooltipEnterable?: boolean;
 }
 
 /**
@@ -138,6 +158,8 @@ export function TimeseriesChart({
   gradient,
   loading,
   ariaDescription,
+  tooltipCss,
+  tooltipEnterable,
 }: TimeseriesChartProps) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   // Tracks which bar series the user is hovering over so the tooltip
@@ -247,6 +269,13 @@ export function TimeseriesChart({
         trigger: "axis" as const,
         appendTo: "body",
         axisPointer: { type: "shadow" as const },
+        ...(tooltipCss && { extraCssText: tooltipCss }),
+        ...(tooltipEnterable && {
+          enterable: true,
+          // Position the tooltip close to the cursor so the user can
+          // easily move into it (e.g. to scroll overflow content).
+          position: (point: number[]) => [point[0] + 10, point[1] - 10],
+        }),
         dangerousHtmlFormatter: (params) => {
           const items = Array.isArray(params) ? params : [params];
 
@@ -351,6 +380,8 @@ export function TimeseriesChart({
     gradient,
     echarts,
     ariaDescription,
+    tooltipCss,
+    tooltipEnterable,
   ]);
 
   const events = useMemo<Partial<ChartEvents>>(() => {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -141,8 +141,15 @@ export function TimeseriesChart({
 }: TimeseriesChartProps) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   // Tracks which series the user is hovering over so the tooltip formatter
-  // can dim the rows of non-hovered series (mirrors the bar emphasis dimming).
+  // can dim the rows of non-hovered series (mirrors the emphasis dimming).
+  // Updated via the updateAxisPointer event, which fires reliably for
+  // axis-triggered tooltips regardless of chart type.
   const hoveredSeriesRef = useRef<string | null>(null);
+  // Stable ref to the tooltip value formatter so the dangerousHtmlFormatter
+  // closure (captured by useMemo) always calls the latest function without
+  // needing to be a useMemo dependency.
+  const tooltipValueFormatRef = useRef(tooltipValueFormat ?? yAxisTickLabelFormat);
+  tooltipValueFormatRef.current = tooltipValueFormat ?? yAxisTickLabelFormat;
   const incompleteBefore = incomplete?.before;
   const incompleteAfter = incomplete?.after;
 
@@ -266,11 +273,11 @@ export function TimeseriesChart({
               : "";
 
           const hovered = hoveredSeriesRef.current;
+          const formatFn = tooltipValueFormatRef.current;
 
           const rows = filteredParams
             .map((param: any) => {
               const value = param?.value?.[1];
-              const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat;
               const formattedValue = formatFn
                 ? echarts.format.encodeHTML(String(formatFn(value)))
                 : echarts.format.encodeHTML(String(value));
@@ -336,10 +343,8 @@ export function TimeseriesChart({
     xAxisTickCount,
     xAxisTickFormat,
     yAxisTickFormat,
-    yAxisTickLabelFormat,
     yAxisName,
     yAxisTickCount,
-    tooltipValueFormat,
     incompleteBefore,
     incompleteAfter,
     type,
@@ -359,13 +364,33 @@ export function TimeseriesChart({
       };
     }
 
-    // Track which series is hovered so the tooltip formatter can dim
-    // non-hovered rows, matching the emphasis dimming on the chart.
-    handlers.mouseover = (params) => {
-      hoveredSeriesRef.current = params.seriesName ?? null;
+    // Use updateAxisPointer to track which series is closest to the
+    // pointer. This fires reliably for axis-triggered tooltips (unlike
+    // mouseover which requires hovering directly on a graphical element).
+    // We dispatch highlight/downplay actions so the chart emphasis and
+    // the tooltip dimming stay in sync.
+    handlers.updateAxisPointer = (params) => {
+      const chart = chartRef.current;
+      if (!chart) return;
+
+      const seriesIndex = params.seriesIndex;
+      if (seriesIndex != null) {
+        const option = chart.getOption() as EChartsOption;
+        const series = (option.series as SeriesOption[])?.[seriesIndex];
+        const name =
+          series && "name" in series ? (series.name as string) : null;
+
+        if (name && name !== hoveredSeriesRef.current) {
+          hoveredSeriesRef.current = name;
+          chart.dispatchAction({ type: "highlight", seriesName: name });
+        }
+      }
     };
-    handlers.mouseout = () => {
+
+    // Clear hover state when the pointer leaves the chart entirely.
+    handlers.globalout = () => {
       hoveredSeriesRef.current = null;
+      chartRef.current?.dispatchAction({ type: "downplay" });
     };
 
     return handlers;

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -140,10 +140,10 @@ export function TimeseriesChart({
   ariaDescription,
 }: TimeseriesChartProps) {
   const chartRef = useRef<echarts.ECharts | null>(null);
-  // Tracks which series the user is hovering over so the tooltip formatter
-  // can dim the rows of non-hovered series (mirrors the emphasis dimming).
-  // Updated via the updateAxisPointer event, which fires reliably for
-  // axis-triggered tooltips regardless of chart type.
+  // Tracks which bar series the user is hovering over so the tooltip
+  // formatter can dim the rows of non-hovered series, matching the
+  // emphasis dimming on the bars. Only used for bar charts — line charts
+  // with showSymbol: false lack hover targets for mouseover events.
   const hoveredSeriesRef = useRef<string | null>(null);
   // Stable ref to the tooltip value formatter so the dangerousHtmlFormatter
   // closure (captured by useMemo) always calls the latest function without
@@ -364,18 +364,12 @@ export function TimeseriesChart({
       };
     }
 
-    // --- Hover tracking for tooltip row dimming ---
-    // Bar and line charts need different strategies because their hover
-    // targets differ:
-    //
-    // Bar charts: each stacked segment is a distinct graphical element,
-    //   so mouseover/mouseout fire reliably on individual segments.
-    //   updateAxisPointer does NOT provide a useful seriesIndex for bars
-    //   because the axis pointer covers the entire stacked column.
-    //
-    // Line charts: with showSymbol: false there are no hoverable elements,
-    //   so mouseover rarely fires. updateAxisPointer provides seriesIndex
-    //   indicating the nearest line, which is exactly what we need.
+    // Track which series is hovered so the tooltip formatter can dim
+    // non-hovered rows, matching the emphasis dimming on the bars.
+    // Only enabled for bar charts — each stacked segment is a distinct
+    // graphical element so mouseover/mouseout fire reliably. Line charts
+    // with showSymbol: false lack hover targets, so tooltip dimming is
+    // not supported for them.
     if (type === "bar") {
       handlers.mouseover = (params) => {
         hoveredSeriesRef.current = params.seriesName ?? null;
@@ -383,31 +377,10 @@ export function TimeseriesChart({
       handlers.mouseout = () => {
         hoveredSeriesRef.current = null;
       };
-    } else {
-      handlers.updateAxisPointer = (params) => {
-        const chart = chartRef.current;
-        if (!chart) return;
-
-        const seriesIndex = params.seriesIndex;
-        if (seriesIndex != null) {
-          const option = chart.getOption() as EChartsOption;
-          const series = (option.series as SeriesOption[])?.[seriesIndex];
-          const name =
-            series && "name" in series ? (series.name as string) : null;
-
-          if (name && name !== hoveredSeriesRef.current) {
-            hoveredSeriesRef.current = name;
-            chart.dispatchAction({ type: "highlight", seriesName: name });
-          }
-        }
+      handlers.globalout = () => {
+        hoveredSeriesRef.current = null;
       };
     }
-
-    // Clear hover state when the pointer leaves the chart entirely.
-    handlers.globalout = () => {
-      hoveredSeriesRef.current = null;
-      chartRef.current?.dispatchAction({ type: "downplay" });
-    };
 
     return handlers;
   }, [onTimeRangeChange, type]);


### PR DESCRIPTION
When hovering a series on a bar or line chart, the tooltip now dims rows for other series to 50% opacity, matching the emphasis dimming that ECharts already applies to the chart elements themselves.

<img width="877" height="411" alt="Screenshot 2026-04-24 at 1 43 00 PM" src="https://github.com/user-attachments/assets/12db2819-f8a8-4e06-954b-e52f371281c7" />
<img width="865" height="401" alt="Screenshot 2026-04-24 at 1 43 07 PM" src="https://github.com/user-attachments/assets/d2b23265-6b02-4e98-918f-a4aa7b795dfc" />
<img width="861" height="405" alt="Screenshot 2026-04-24 at 1 43 16 PM" src="https://github.com/user-attachments/assets/2713d061-d3ab-4b6c-92ff-5d50e56ea5b2" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:  Verified dimming works for both line and bar charts (see screenshots)
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
