### PR TITLE
docs: add select placeholder to home grid

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -154,6 +154,7 @@ export function HomeGrid() {
         <Select
           aria-label="Select version"
           className="w-[200px]"
+          placeholder="Select version"
           renderValue={(v) => {
             const labels: Record<string, string> = {
               all: "All deployed versions",


### PR DESCRIPTION
## Summary
- Adds a placeholder to the Select example in the homepage component grid.

**Before**
<img width="393" height="398" alt="Screenshot 2026-04-27 at 12 16 53 PM" src="https://github.com/user-attachments/assets/f4103977-a570-4ae9-885b-c30c8234ca21" />

**After**
<img width="368" height="368" alt="Screenshot 2026-04-27 at 12 17 04 PM" src="https://github.com/user-attachments/assets/fbd8c58c-5f27-4909-a5cc-e55be276ae97" />


## Validation
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`
- `pnpm --filter @cloudflare/kumo-docs-astro lint` currently fails on existing unrelated docs lint errors.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: docs-only one-line placeholder update
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [x] Additional testing not necessary because: docs-only one-line placeholder update; package typecheck passes