### PR TITLE
fix(input-group): added mb-0 to prevent layout shifts in stratus

### DIFF
--- a/.changeset/input-group-label-margin-reset.md
+++ b/.changeset/input-group-label-margin-reset.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix `InputGroup` label wrappers to enforce `mb-0`, preventing inherited label margins from shifting layout and click-target overlays.

--- a/packages/kumo/src/components/input-group/input-group.tsx
+++ b/packages/kumo/src/components/input-group/input-group.tsx
@@ -220,7 +220,7 @@ const Root = forwardRef<
                 <label
                   htmlFor={inputId}
                   // Positioned behind children (z-0) so it catches clicks on empty space
-                  className="absolute inset-0 z-0 cursor-text"
+                  className="absolute inset-0 z-0 cursor-text !mb-0"
                   aria-hidden="true"
                 />
               )}
@@ -283,7 +283,7 @@ const Root = forwardRef<
             <label
               htmlFor={inputId}
               // Positioned behind children (z-0) so it catches clicks on empty space
-              className="absolute inset-0 z-0"
+              className="absolute inset-0 z-0 !mb-0"
               aria-hidden="true"
             />
             {children}
@@ -293,7 +293,7 @@ const Root = forwardRef<
           <label
             ref={forwardedRef as React.Ref<HTMLLabelElement>}
             {...dataProps}
-            className={containerClassName}
+            className={cn(containerClassName, "!mb-0")}
             {...rest}
           >
             {children}


### PR DESCRIPTION
Fixes a margin issues in stratus when `InputGroup` renders as a `label` by adding `mb-0`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: no access to bonk
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: ran `pnpm typecheck`, `pnpm test` and `pnpm build`, verified through browser devtools
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
