### PR TITLE
fix(buttons): white border around secondary buttons in pagination

### DIFF
--- a/.changeset/button-secondary-hover-border-cleanup.md
+++ b/.changeset/button-secondary-hover-border-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Remove invalid hover border utility from secondary button variants to keep hover styling consistent and avoid unintended class output.

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -53,7 +53,7 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     secondary: {
       classes:
-        "bg-kumo-base !text-kumo-default ring not-disabled:hover:border-secondary! not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
+        "bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
       description: "Default button style for most actions",
     },
     ghost: {
@@ -66,7 +66,7 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     "secondary-destructive": {
       classes:
-        "bg-kumo-base !text-kumo-danger ring not-disabled:hover:border-secondary! not-disabled:hover:bg-kumo-base disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
+        "bg-kumo-base !text-kumo-danger ring not-disabled:hover:bg-kumo-base disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
       description:
         "Secondary button with destructive text for less prominent dangerous actions",
     },


### PR DESCRIPTION
This fixes unwanted white borders around the next and previous buttons in `Pagination` with the new `InputGroup` replacement in stratus by removing `not-disabled:hover:border-secondary!`

### Before
<img width="263" height="108" alt="Screenshot 2026-04-29 at 8 46 44 AM" src="https://github.com/user-attachments/assets/0164c604-2e32-47b1-9b14-c8f4d9da0019" />

### After
<img width="263" height="107" alt="Screenshot 2026-04-29 at 8 45 54 AM" src="https://github.com/user-attachments/assets/b31eccb4-b27c-43b8-9518-462dcdf249e2" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: no access to bonk
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: `pnpm lint`, `pnpm typecheck` and visual QA
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
