### PR TITLE
fix(combobox): render visible disabled state on Combobox.Item

### DIFF
--- a/.changeset/combobox-item-disabled-styles.md
+++ b/.changeset/combobox-item-disabled-styles.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+`Combobox.Item` now renders a visible disabled state when the `disabled` prop is set. Previously the prop was forwarded to Base UI (so click/keyboard selection were correctly blocked) but the row looked identical to an enabled one. Adds `data-[disabled]:*` Tailwind classes for muted text, `cursor-not-allowed`, reduced opacity, and suppresses the highlight background on disabled rows during keyboard navigation. Also fixes `className` passthrough — user-supplied classes are now merged via `cn()` instead of being overridden.

--- a/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
@@ -396,6 +396,65 @@ export function ComboboxDisabledDemo() {
   );
 }
 
+/** Demonstrates disabled individual items. The `disabled` prop on
+ * `Combobox.Item` blocks click and keyboard selection, and renders the row
+ * with muted text + a not-allowed cursor. Useful for surfacing options that
+ * exist but the user can't pick (e.g. permission-gated, read-only, or
+ * already in use elsewhere). */
+export function ComboboxDisabledItemsDemo() {
+  type DatabaseItemWithDisabled = DatabaseItem & {
+    disabled?: boolean;
+    reason?: string;
+  };
+
+  const items: DatabaseItemWithDisabled[] = [
+    { value: "postgres", label: "PostgreSQL" },
+    { value: "mysql", label: "MySQL" },
+    { value: "mariadb", label: "MariaDB", disabled: true, reason: "Beta" },
+    { value: "mongodb", label: "MongoDB" },
+    {
+      value: "cassandra",
+      label: "Apache Cassandra",
+      disabled: true,
+      reason: "Coming soon",
+    },
+    { value: "redis", label: "Redis" },
+    { value: "d1", label: "Cloudflare D1" },
+  ];
+
+  const [value, setValue] = useState<DatabaseItemWithDisabled | null>(null);
+
+  return (
+    <div className="w-80">
+      <Combobox value={value} onValueChange={setValue} items={items}>
+        <Combobox.TriggerInput placeholder="Select database" />
+        <Combobox.Content>
+          <Combobox.Empty />
+          <Combobox.List>
+            {(item: DatabaseItemWithDisabled) => (
+              <Combobox.Item
+                key={item.value}
+                value={item}
+                disabled={item.disabled}
+              >
+                <span>
+                  {item.label}
+                  {item.reason && (
+                    <Text variant="secondary" size="xs" as="span">
+                      {" — "}
+                      {item.reason}
+                    </Text>
+                  )}
+                </span>
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Content>
+      </Combobox>
+    </div>
+  );
+}
+
 export function ComboboxErrorDemo() {
   const [value, setValue] = useState<DatabaseItem | null>(null);
 

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -17,6 +17,7 @@ import {
   ComboboxMultipleDemo,
   ComboboxWithFieldDemo,
   ComboboxDisabledDemo,
+  ComboboxDisabledItemsDemo,
   ComboboxErrorDemo,
   ComboboxSizesDemo,
   ComboboxSizesSearchableInsideDemo,
@@ -157,6 +158,16 @@ export default function Example() {
   <p>Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` and `TriggerValue`.</p>
   <ComponentExample demo="ComboboxDisabledDemo">
     <ComboboxDisabledDemo client:load />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+### Disabled Items
+
+  <p>Pass the `disabled` prop to an individual `Combobox.Item` to make it non-selectable. Disabled rows are rendered with a muted style and skipped during keyboard navigation selection.</p>
+  <ComponentExample demo="ComboboxDisabledItemsDemo">
+    <ComboboxDisabledItemsDemo client:load />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -370,11 +370,23 @@ function TriggerInput({
   );
 }
 
-function Item({ children, ...props }: ComboboxBase.Item.Props) {
+function Item({
+  children,
+  className,
+  ...props
+}: ComboboxBase.Item.Props & { className?: string }) {
   return (
     <ComboboxBase.Item
       {...props}
-      className="group mx-1.5 grid cursor-pointer grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-base data-highlighted:bg-kumo-tint"
+      className={cn(
+        "group mx-1.5 grid grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-base",
+        "cursor-pointer data-highlighted:bg-kumo-tint",
+        // Disabled rows: muted text, no pointer, suppress highlight bg even
+        // when keyboard nav lands on them. Base UI sets `data-disabled` on
+        // the element when the `disabled` prop is true.
+        "data-[disabled]:cursor-not-allowed data-[disabled]:text-kumo-subtle data-[disabled]:opacity-60 data-[disabled]:data-highlighted:bg-transparent",
+        className,
+      )}
     >
       <div className="col-start-1">{children}</div>
       <ComboboxBase.ItemIndicator className="col-start-2 flex items-center">


### PR DESCRIPTION
## Summary

- `Combobox.Item` now renders a visible disabled state when the `disabled` prop is set. Previously the prop was forwarded to Base UI (so click and keyboard selection were correctly blocked) but the row looked identical to an enabled one — there were no `data-[disabled]:*` styles on the wrapper.
- Adds muted text, `cursor-not-allowed`, reduced opacity, and suppresses the `data-highlighted:bg-kumo-tint` background on disabled rows so keyboard nav doesn't make them appear interactive.
- Fixes `className` passthrough as a drive-by: user-supplied classes were being dropped because the spread came before a static `className` literal. Now composed via `cn()`, matching the rest of the library.
- Adds a `ComboboxDisabledItemsDemo` and a "Disabled Items" section in `combobox.mdx` so the new state is visible in the docs site and feeds the registry.

## Why

Surfaced while building an OAuth account-grant prototype that needs to gate certain accounts behind permission reasons (e.g. "Read-only", "Insufficient permissions"). The `disabled` prop already worked behaviorally but the row was indistinguishable visually, so users had no way to know why their click did nothing.

## Test plan

- `pnpm --filter @cloudflare/kumo test` — all 899 tests pass.
- `pnpm --filter @cloudflare/kumo typecheck` — clean.
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck` — clean.
- Visually verified the new demo renders with muted "Beta" / "Coming soon" rows that are non-clickable and skipped by keyboard navigation.

- Reviews
- [x] bonk has reviewed the change
- Tests
- [x] Additional testing not necessary because: this is a styling-only change to an already-functional `disabled` prop; visual regression tests cover the rendered output via the new demo.