### PR TITLE
fix(input-group): add !mb-0 to container className

### DIFF
--- a/.changeset/input-group-container-mb-0.md
+++ b/.changeset/input-group-container-mb-0.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix `InputGroup` container className to enforce `mb-0`, ensuring all container variants (not just the standalone `<label>` mode) reset inherited bottom margin.

--- a/packages/kumo/src/components/input-group/input-group.tsx
+++ b/packages/kumo/src/components/input-group/input-group.tsx
@@ -151,6 +151,8 @@ const Root = forwardRef<
       "has-[[data-slot=input-group-suffix]]:[&_input]:pr-0",
       // Size-specific padding adjustments when addons or suffixes are present
       INPUT_GROUP_HAS_CLASSES[size],
+      // Reset bottom margin to avoid inherited spacing from parent <label> styles
+      "!mb-0",
       className,
     );
 


### PR DESCRIPTION
## Summary

We missed adding an instance of `!mb-0` to the `InputGroup` container className in `packages/kumo/src/components/input-group/input-group.tsx`. Currently only the standalone `<label>` container variant (line 296) explicitly applies `!mb-0`; the `<div>`-based container variants (used when a `label` prop is provided, in hybrid mode, and in individual mode) inherit margin from parent label styles.

This adds `!mb-0` to `containerClassName` itself so all container variants reset bottom margin consistently.

- Reviews
- [x] automated review not possible because: trivial single-line CSS class addition
- Tests
- [x] Additional testing not necessary because: visual-only change matching existing `!mb-0` usage on the standalone `<label>` container variant