### PR TITLE
fix: add font smoothing (antialiased) to base styles

### DIFF
--- a/.changeset/add-font-smoothing.md
+++ b/.changeset/add-font-smoothing.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add font smoothing (antialiased) to base styles

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -44,6 +44,11 @@
   [data-mode="dark"] {
     color-scheme: dark;
   }
+
+  html, body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary

Adds `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` to the `html, body` selector in the library's base styles (`kumo-binding.css`).

Previously, font smoothing was only applied in the docs site's `global.css`. Now all consumers of `@cloudflare/kumo` get antialiased font rendering automatically when they import the library's CSS.

## Changes

- `packages/kumo/src/styles/kumo-binding.css` — added font smoothing to `@layer base`
- `.changeset/add-font-smoothing.md` — patch changeset

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: trivial CSS-only change
- Tests
- [x] Additional testing not necessary because: CSS property addition with no logic changes