### PR TITLE
fix(docs): use onClick instead of onSelect on DropdownMenu.Item

### DIFF
--- a/.changeset/fix-dropdown-onclick.md
+++ b/.changeset/fix-dropdown-onclick.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix registry codegen to match demo examples when component export name differs from directory name (e.g. DropdownMenu vs dropdown). This restores missing examples for DropdownMenu and other affected components.

--- a/packages/kumo-docs-astro/src/components/demos/CloudflareLogoDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CloudflareLogoDemo.tsx
@@ -82,7 +82,7 @@ export function CloudflareLogoCopyDemo() {
         <DropdownMenu.Content>
           <DropdownMenu.Item
             icon={CloudIcon}
-            onSelect={() =>
+            onClick={() =>
               copyToClipboard(
                 generateCloudflareLogoSvg({ variant: "glyph" }),
                 "glyph",
@@ -93,7 +93,7 @@ export function CloudflareLogoCopyDemo() {
           </DropdownMenu.Item>
           <DropdownMenu.Item
             icon={CodeIcon}
-            onSelect={() =>
+            onClick={() =>
               copyToClipboard(
                 generateCloudflareLogoSvg({ variant: "full" }),
                 "full",
@@ -104,7 +104,7 @@ export function CloudflareLogoCopyDemo() {
           </DropdownMenu.Item>
           <DropdownMenu.Item
             icon={DownloadSimpleIcon}
-            onSelect={() =>
+            onClick={() =>
               window.open(
                 "https://www.cloudflare.com/press-kit/",
                 "_blank",
@@ -117,7 +117,7 @@ export function CloudflareLogoCopyDemo() {
           <DropdownMenu.Separator />
           <DropdownMenu.Item
             icon={ArrowSquareOutIcon}
-            onSelect={() =>
+            onClick={() =>
               window.open(
                 "https://www.cloudflare.com/brand-assets/",
                 "_blank",

--- a/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
@@ -147,6 +147,28 @@ export function DropdownNestedDemo() {
 }
 
 /**
+ * Use `inset` on items without an icon to align their text with items that have one.
+ */
+export function DropdownInsetDemo() {
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger render={<Button>Edit</Button>} />
+      <DropdownMenu.Content>
+        <DropdownMenu.Item icon={PencilSimpleIcon}>Rename</DropdownMenu.Item>
+        <DropdownMenu.Item icon={CopyIcon}>Duplicate</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item inset>Move to folder</DropdownMenu.Item>
+        <DropdownMenu.Item inset>Add to favorites</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item icon={TrashIcon} variant="danger">
+          Delete
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+/**
  * Use `onClick` on `DropdownMenu.Item` to handle item actions.
  * Each item receives a standard React mouse event handler.
  */

--- a/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DropdownDemo.tsx
@@ -9,6 +9,9 @@ import {
   GearIcon,
   BookOpenIcon,
   ArrowSquareOutIcon,
+  CopyIcon,
+  PencilSimpleIcon,
+  TrashIcon,
 } from "@phosphor-icons/react";
 
 export function DropdownBasicDemo() {
@@ -140,6 +143,49 @@ export function DropdownNestedDemo() {
         </DropdownMenu.Item>
       </DropdownMenu.Content>
     </DropdownMenu>
+  );
+}
+
+/**
+ * Use `onClick` on `DropdownMenu.Item` to handle item actions.
+ * Each item receives a standard React mouse event handler.
+ */
+export function DropdownOnClickDemo() {
+  const [lastAction, setLastAction] = useState<string | null>(null);
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <DropdownMenu>
+        <DropdownMenu.Trigger render={<Button>Actions</Button>} />
+        <DropdownMenu.Content>
+          <DropdownMenu.Item
+            icon={CopyIcon}
+            onClick={() => setLastAction("Duplicated")}
+          >
+            Duplicate
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            icon={PencilSimpleIcon}
+            onClick={() => setLastAction("Renamed")}
+          >
+            Rename
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item
+            icon={TrashIcon}
+            variant="danger"
+            onClick={() => setLastAction("Deleted")}
+          >
+            Delete
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+      {lastAction && (
+        <p className="text-sm text-kumo-subtle">
+          Last action: <span className="text-kumo-default">{lastAction}</span>
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
@@ -11,6 +11,7 @@ import ComponentSection from "~/components/docs/ComponentSection.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   DropdownBasicDemo,
+  DropdownOnClickDemo,
   DropdownCheckboxDemo,
   DropdownNestedDemo,
   DropdownAvatarTriggerDemo,
@@ -59,8 +60,19 @@ export default function Example() {
     <DropdownMenu>
       <DropdownMenu.Trigger render={<Button>Menu</Button>} />
       <DropdownMenu.Content>
-        <DropdownMenu.Item>Option 1</DropdownMenu.Item>
-        <DropdownMenu.Item>Option 2</DropdownMenu.Item>
+        <DropdownMenu.Item onClick={() => console.log("edit")}>
+          Edit
+        </DropdownMenu.Item>
+        <DropdownMenu.Item onClick={() => console.log("duplicate")}>
+          Duplicate
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item
+          variant="danger"
+          onClick={() => console.log("delete")}
+        >
+          Delete
+        </DropdownMenu.Item>
       </DropdownMenu.Content>
     </DropdownMenu>
   );
@@ -79,6 +91,15 @@ export default function Example() {
 
 <ComponentExample demo="DropdownBasicDemo">
   <DropdownBasicDemo client:load />
+</ComponentExample>
+
+### Handling Item Clicks
+
+<p>
+  Use `onClick` on `DropdownMenu.Item` to handle actions. Each item receives a standard React mouse event handler.
+</p>
+<ComponentExample demo="DropdownOnClickDemo">
+  <DropdownOnClickDemo client:load />
 </ComponentExample>
 
 ### Checkbox Items

--- a/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dropdown.mdx
@@ -11,6 +11,7 @@ import ComponentSection from "~/components/docs/ComponentSection.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   DropdownBasicDemo,
+  DropdownInsetDemo,
   DropdownOnClickDemo,
   DropdownCheckboxDemo,
   DropdownNestedDemo,
@@ -91,6 +92,15 @@ export default function Example() {
 
 <ComponentExample demo="DropdownBasicDemo">
   <DropdownBasicDemo client:load />
+</ComponentExample>
+
+### Inset Items
+
+<p>
+  Use `inset` on items without an icon to align their text with items that have one.
+</p>
+<ComponentExample demo="DropdownInsetDemo">
+  <DropdownInsetDemo client:load />
 </ComponentExample>
 
 ### Handling Item Clicks

--- a/packages/kumo/scripts/component-registry/index.ts
+++ b/packages/kumo/scripts/component-registry/index.ts
@@ -44,6 +44,7 @@ import {
   createCacheEntry,
 } from "./cache.js";
 import {
+  toPascalCase,
   toScreamingSnakeCase,
   extractSemanticColors,
   extractBlockDependencies,
@@ -586,11 +587,16 @@ async function processComponent(
   const colors = extractSemanticColors(sourcePath);
 
   // Determine examples
+  // Demo metadata keys are derived from file names (e.g. DropdownDemo.tsx → "Dropdown")
+  // which may differ from the component's export name (e.g. "DropdownMenu").
+  // Try the component name first, then fall back to the PascalCase directory name.
   let examples: readonly string[];
   if (config.examples !== undefined) {
     examples = config.examples;
   } else {
-    const extracted = input.storyExamples.get(config.name);
+    const extracted =
+      input.storyExamples.get(config.name) ??
+      input.storyExamples.get(toPascalCase(config.dirName));
     examples = extracted?.aiExamples ?? [];
     if (examples.length > 0 && CLI_FLAGS.verbose) {
       console.log(

--- a/packages/kumo/scripts/component-registry/metadata.ts
+++ b/packages/kumo/scripts/component-registry/metadata.ts
@@ -319,6 +319,161 @@ export const ADDITIONAL_COMPONENT_PROPS: Record<
       description: "Callback when collapsed state changes",
     },
   },
+  "DropdownMenu.Item": {
+    icon: {
+      type: "Icon | ReactNode",
+      description: "Icon displayed before the label.",
+    },
+    variant: {
+      type: '"default" | "danger"',
+      description: "Visual style of the item.",
+      default: '"default"',
+    },
+    selected: {
+      type: "boolean",
+      description: "Shows a check mark indicator when true.",
+    },
+    inset: {
+      type: "boolean",
+      description: "Adds left padding to align with items that have icons.",
+    },
+    onClick: {
+      type: "(event: React.MouseEvent) => void",
+      description: "Callback when the item is clicked.",
+    },
+    closeOnClick: {
+      type: "boolean",
+      description: "Whether the menu closes after clicking this item.",
+      default: "true",
+    },
+    disabled: {
+      type: "boolean",
+      description: "When true, the item cannot be interacted with.",
+    },
+  },
+  "DropdownMenu.LinkItem": {
+    href: {
+      type: "string",
+      description: "URL to navigate to when clicked.",
+    },
+    icon: {
+      type: "Icon | ReactNode",
+      description: "Icon displayed before the label.",
+    },
+    variant: {
+      type: '"default" | "danger"',
+      description: "Visual style of the item.",
+      default: '"default"',
+    },
+    inset: {
+      type: "boolean",
+      description: "Adds left padding to align with items that have icons.",
+    },
+    target: {
+      type: "string",
+      description: 'Link target attribute (e.g. "_blank" for new tab).',
+    },
+    render: {
+      type: "ReactElement | ((props, state) => ReactElement)",
+      description:
+        "Custom element to render as the link. Use to integrate with framework routers (e.g. Next.js Link).",
+    },
+  },
+  "DropdownMenu.Content": {
+    sideOffset: {
+      type: "number",
+      description: "Distance in pixels from the trigger.",
+      default: "8",
+    },
+    container: {
+      type: "PortalContainer",
+      description:
+        "Container element for the portal. Use this to render inside a Shadow DOM or custom container.",
+    },
+  },
+  "DropdownMenu.SubTrigger": {
+    icon: {
+      type: "Icon",
+      description: "Icon displayed before the label.",
+    },
+    inset: {
+      type: "boolean",
+      description: "Adds left padding to align with items that have icons.",
+    },
+  },
+  "DropdownMenu.CheckboxItem": {
+    checked: {
+      type: "boolean",
+      description: "Whether the item is checked.",
+    },
+    defaultChecked: {
+      type: "boolean",
+      description: "Whether the item is initially checked (uncontrolled).",
+      default: "false",
+    },
+    onCheckedChange: {
+      type: "(checked: boolean, event: ChangeEventDetails) => void",
+      description: "Callback when the checked state changes.",
+    },
+    closeOnClick: {
+      type: "boolean",
+      description: "Whether the menu closes after clicking this item.",
+      default: "false",
+    },
+    disabled: {
+      type: "boolean",
+      description: "When true, the item cannot be interacted with.",
+    },
+  },
+  "DropdownMenu.RadioGroup": {
+    value: {
+      type: "any",
+      description:
+        "The controlled value of the currently selected radio item.",
+    },
+    defaultValue: {
+      type: "any",
+      description: "The initially selected value (uncontrolled).",
+    },
+    onValueChange: {
+      type: "(value: any, event: ChangeEventDetails) => void",
+      description: "Callback when the selected value changes.",
+    },
+    disabled: {
+      type: "boolean",
+      description: "When true, all radio items in the group are disabled.",
+    },
+  },
+  "DropdownMenu.RadioItem": {
+    value: {
+      type: "any",
+      required: true,
+      description: "The value of this radio item.",
+    },
+    icon: {
+      type: "Icon | ReactNode",
+      description: "Icon displayed before the label.",
+    },
+    inset: {
+      type: "boolean",
+      description: "Adds left padding to align with items that have icons.",
+    },
+    closeOnClick: {
+      type: "boolean",
+      description: "Whether the menu closes after clicking this item.",
+      default: "false",
+    },
+    disabled: {
+      type: "boolean",
+      description: "When true, the item cannot be interacted with.",
+    },
+  },
+  "DropdownMenu.Label": {
+    inset: {
+      type: "boolean",
+      description: "Adds left padding to align with items that have icons.",
+    },
+  },
   "InputGroup.Addon": {
     align: {
       type: '"start" | "end"',


### PR DESCRIPTION
## Summary

- **Fix incorrect `onSelect` → `onClick`** on `DropdownMenu.Item` in `CloudflareLogoDemo.tsx`. `DropdownMenu.Item` does not have an `onSelect` prop — the only explicitly typed click handler from Base UI's `MenuItem` is `onClick`. `onSelect` only appeared to work because it's a native DOM event (`GlobalEventHandlers.onselect`) that React passes through to the underlying `<div>`.
- **Add `DropdownOnClickDemo`** to the canonical Dropdown demos showing the correct `onClick` pattern, so AI agents and developers have a clear reference.
- **Fix registry codegen demo lookup** to fall back to PascalCase directory name when the component export name differs from the demo file name (e.g. `DropdownMenu` vs `Dropdown`). This was silently dropping all 6 Dropdown demos from the AI registry.

## Details

The `CloudflareLogoDemo` used `onSelect` on 4 `DropdownMenu.Item` instances. Since that demo feeds into the registry codegen pipeline, the bad pattern propagated into `component-registry.md` and `component-registry.json` — the files AI agents consume for API guidance.

The registry codegen also had a name mismatch bug: demo metadata keys are derived from filenames (`DropdownDemo.tsx` → `"Dropdown"`) but the registry looks up by component export name (`"DropdownMenu"`). The fallback to `toPascalCase(config.dirName)` fixes this for all affected components.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: involves codegen pipeline behavior and demo correctness verification
- Tests
  - [x] Additional testing not necessary because: verified by running `codegen:registry --no-cache` and confirming DropdownMenu examples went from 0 → 6, all `onSelect` on dropdown items removed from registry output