### PR TITLE
fix(collapsible): forward all Panel props through DefaultPanel

### DIFF
--- a/.changeset/collapsible-default-panel-props.md
+++ b/.changeset/collapsible-default-panel-props.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Forward all Base UI Panel props (including `keepMounted` and `hiddenUntilFound`) through `Collapsible.DefaultPanel`. Previously these were silently dropped because `DefaultPanel` used a standalone props interface instead of extending `BasePanelProps`.

--- a/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
@@ -1,4 +1,4 @@
-import { Button, Collapsible, Text } from "@cloudflare/kumo";
+import { Button, Collapsible, Input, Text } from "@cloudflare/kumo";
 import { useState } from "react";
 
 /**
@@ -85,6 +85,27 @@ export function CollapsibleCustomTriggerDemo() {
             This panel uses custom styling instead of the default border-left accent.
           </Text>
         </Collapsible.Panel>
+      </Collapsible.Root>
+    </div>
+  );
+}
+
+/**
+ * Keep the panel mounted in the DOM when closed to preserve internal state like form inputs.
+ */
+export function CollapsibleKeepMountedDemo() {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <div className="w-full space-y-4">
+      <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Collapsible.DefaultTrigger>Edit details</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel keepMounted>
+          <Text>
+            Type something below, then collapse and re-open — your input is
+            preserved because the panel stays mounted.
+          </Text>
+          <Input label="Name" placeholder="Type here…" />
+        </Collapsible.DefaultPanel>
       </Collapsible.Root>
     </div>
   );

--- a/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
@@ -14,6 +14,7 @@ import {
   CollapsibleBasicDemo,
   CollapsibleMultipleDemo,
   CollapsibleCustomTriggerDemo,
+  CollapsibleKeepMountedDemo,
   CollapsibleAccordionDemo,
 } from "~/components/demos/CollapsibleDemo";
 
@@ -117,6 +118,14 @@ Use `Collapsible.Trigger` with the `render` prop for full control:
   <CollapsibleCustomTriggerDemo client:load />
 </ComponentExample>
 
+### Keep Mounted
+
+Use `keepMounted` on `DefaultPanel` (or `Panel`) to preserve internal state — such as form inputs — when the panel is collapsed:
+
+<ComponentExample demo="CollapsibleKeepMountedDemo">
+  <CollapsibleKeepMountedDemo client:load />
+</ComponentExample>
+
 ### Accordion Pattern
 
 Control which item is open to create an accordion where only one item can be expanded at a time:
@@ -181,9 +190,12 @@ Control which item is open to create an accordion where only one item can be exp
 
 ### Collapsible.DefaultPanel
 
+Accepts all `Collapsible.Panel` props in addition to the ones listed below.
+
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `children` | `ReactNode` | — | Panel content. |
 | `className` | `string` | — | Additional CSS classes. |
+| `keepMounted` | `boolean` | `false` | Whether to keep the panel in the DOM when closed. |
 
 </ComponentSection>

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -178,7 +178,7 @@ CollapsibleDefaultTrigger.displayName = "Collapsible.DefaultTrigger";
 // Default Panel (Migration Affordance)
 // =============================================================================
 
-export interface CollapsibleDefaultPanelProps {
+export interface CollapsibleDefaultPanelProps extends BasePanelProps {
   /** Panel content */
   children: ReactNode;
   /** Additional CSS classes */
@@ -202,11 +202,12 @@ export interface CollapsibleDefaultPanelProps {
 const CollapsibleDefaultPanel = forwardRef<
   HTMLDivElement,
   CollapsibleDefaultPanelProps
->(({ children, className }, ref) => {
+>(({ children, className, ...props }, ref) => {
   return (
     <CollapsibleBase.Panel
       ref={ref}
       className={cn("my-2 space-y-4 border-l-2 border-kumo-fill pl-4", className)}
+      {...props}
     >
       {children}
     </CollapsibleBase.Panel>


### PR DESCRIPTION
## Summary

- `Collapsible.DefaultPanel` had a standalone props interface (`children` + `className` only), silently dropping props like `keepMounted` and `hiddenUntilFound` that `Collapsible.Panel` supports
- Extended `CollapsibleDefaultPanelProps` from `BasePanelProps` and spread remaining props through to the underlying Base UI `Panel`, bringing it to parity with `Collapsible.Panel`
- Added a `keepMounted` demo to the docs showing state preservation across collapse/expand
- Updated the DefaultPanel API reference table

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: straightforward prop forwarding fix
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: typecheck passes, no existing component tests to update, and the change is a mechanical props passthrough