### PR TITLE
fix(registry): correct Select metadata types and add missing props for object values

### DIFF
--- a/.changeset/fix-select-registry-metadata.md
+++ b/.changeset/fix-select-registry-metadata.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(registry): correct Select component metadata for AI-generated code
+
+The component registry metadata was incorrectly typing Select's `value`, `defaultValue`, and `onValueChange` props as `string`, causing AI agents to produce broken code when implementing Select with object values (e.g., rendering `object.value` in the trigger instead of the label).
+
+Changes:
+- `value` type: `string` → `T` (generic, matches actual component interface)
+- `defaultValue` type: `string` → `T`
+- `onValueChange` type: `(value: string) => void` → `(value: T) => void`
+- Added missing `renderValue` prop: `(value: T) => ReactNode` — required for object values
+- Added missing `items` prop: supports both `Record<string, string>` and `Array<{ label, value }>` forms
+- Added missing `isItemEqualToValue` prop: required for object equality comparison

--- a/packages/kumo/scripts/component-registry/metadata.ts
+++ b/packages/kumo/scripts/component-registry/metadata.ts
@@ -289,12 +289,27 @@ export const ADDITIONAL_COMPONENT_PROPS: Record<
   },
   Select: {
     onValueChange: {
-      type: "(value: string) => void",
+      type: "(value: T) => void",
       description: "Callback when selection changes",
     },
     defaultValue: {
-      type: "string",
+      type: "T",
       description: "Initial value for uncontrolled mode",
+    },
+    renderValue: {
+      type: "(value: T) => ReactNode",
+      description:
+        "A function that returns a ReactNode to format the selected value in the trigger. Required when using object values. Use `placeholder` for the empty state.",
+    },
+    items: {
+      type: 'Record<string, string> | Array<{ label: ReactNode; value: T }>',
+      description:
+        "Data structure of items rendered in the popup. Accepts a plain object map (`{ key: \"Label\" }`) or an array of `{ label, value }` for object/complex values.",
+    },
+    isItemEqualToValue: {
+      type: "(item: T, value: T) => boolean",
+      description:
+        "Custom equality function for comparing items. Required when value is an object, since object identity (`===`) won't match across renders.",
     },
   },
   DateRangePicker: {
@@ -532,7 +547,7 @@ export const PROP_TYPE_OVERRIDES: Record<string, Record<string, string>> = {
     value: "T | T[]",
   },
   Select: {
-    value: "string",
+    value: "T",
   },
 };
 


### PR DESCRIPTION
## Summary

AI agents were producing broken Select implementations when using object values because the component registry metadata was misleading them:

- **`value`, `defaultValue`, `onValueChange`** were all typed as `string` in the registry, but the actual component accepts `unknown` (generic `T`). This caused agents to pass `object.value` (the string key) instead of the full object, making the trigger render the wrong thing.
- **`renderValue`** was completely missing from the documented props, so agents had no way to know how to control what the trigger displays for object values.
- **`items`** (array form `Array<{ label, value }>`) and **`isItemEqualToValue`** were also missing, leaving agents without the tools needed for object-value Selects.

### Changes

In `packages/kumo/scripts/component-registry/metadata.ts`:

**`PROP_TYPE_OVERRIDES`:**
- `Select.value`: `"string"` → `"T"`

**`ADDITIONAL_COMPONENT_PROPS`:**
- `Select.onValueChange`: `"(value: string) => void"` → `"(value: T) => void"`
- `Select.defaultValue`: `"string"` → `"T"`
- Added `renderValue: (value: T) => ReactNode`
- Added `items: Record<string, string> | Array<{ label: ReactNode; value: T }>`
- Added `isItemEqualToValue: (item: T, value: T) => boolean`

These flow through the codegen pipeline to update `component-registry.json`, `component-registry.md`, and `schemas.ts`. Verified by running `pnpm codegen:registry --no-cache` — all three output files now correctly reflect the generic types and include the missing props.

### Comparison with Combobox

The Combobox component already had correct metadata for these patterns (generic `T` types, `isItemEqualToValue` documented). Select was the outlier.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: metadata-only change to codegen config, affects auto-generated AI registry files
- Tests
- [x] Additional testing not necessary because: this changes codegen metadata strings only, verified by running `pnpm codegen:registry --no-cache` and confirming correct output in all three generated files