### PR TITLE
docs(layer-card): RFC for first-class composition of Secondary

### DIFF
--- a/.changeset/layer-card-secondary-rfc.md
+++ b/.changeset/layer-card-secondary-rfc.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+docs(layer-card): RFC for first-class composition of `LayerCard.Secondary`
+
+Adds a proposal page documenting a recommended composition pattern for the
+`LayerCard.Secondary` slot — a fixed 56px height, `Title` and `Actions`
+sub-components, and `render` prop support for whole-area linkable headers.
+Prototype components are defined locally in the demo file; this page is the
+design artifact for aligning before promoting the changes onto the real
+`LayerCard`.

--- a/packages/kumo-docs-astro/src/components/demos/LayerCardSecondaryProposalDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerCardSecondaryProposalDemo.tsx
@@ -1,0 +1,615 @@
+/**
+ * PROPOSAL: First-class composition for `LayerCard.Secondary`
+ *
+ * Audit of `LayerCard.Secondary` usage across our largest consumer found
+ * ~360 usages across ~140 files. ~40 of those reimplement `flex items-center
+ * justify-between` with two grouping `<div>`s by hand, plus a long tail of
+ * inline icons, tooltips, badges, switches, tabs, and pagination crammed
+ * into the same slot.
+ *
+ * The recommendation in this file rests on three claims:
+ *
+ *   1. `Secondary` must have a fixed height (56px / `h-14`). Every secondary
+ *      header strip in the product should be the same size, regardless of
+ *      content. Anything that doesn't fit is the child's problem to solve
+ *      (see "Required component tweaks" in the docs page).
+ *
+ *   2. Two new sub-components, `LayerCard.Title` and `LayerCard.Actions`,
+ *      retire the hand-rolled flex layout. Composition only — no slot props.
+ *
+ *   3. The "entire header is a link" case uses the `render` prop pattern
+ *      already idiomatic in kumo (`LayerCard` root, `Tooltip`, etc.). NOT a
+ *      separate `SecondaryLink` component. Hover/focus affordances activate
+ *      automatically via Tailwind attribute selectors when `render={<a/>}`
+ *      is used.
+ *
+ * Until `LayerCard` itself is updated, this file uses a local `Secondary`
+ * stand-in (NOT exported, NOT a public name) that simulates the proposed
+ * defaults. Every demo callsite reads exactly as it will under the proposed
+ * API once promoted, modulo the `LayerCard.` namespace prefix.
+ */
+
+import {
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type ReactElement,
+  type ReactNode,
+  cloneElement,
+  isValidElement,
+} from "react";
+import {
+  ArrowRightIcon,
+  ArrowSquareOutIcon,
+  BookOpenIcon,
+  CodeIcon,
+  InfoIcon,
+} from "@phosphor-icons/react";
+
+import {
+  Badge,
+  Button,
+  LayerCard,
+  LinkButton,
+  Loader,
+  Select,
+  SkeletonLine,
+  Switch,
+  Tabs,
+  Tooltip,
+  TooltipProvider,
+} from "@cloudflare/kumo";
+
+// Tiny local class joiner so this file has no internal-path imports.
+const cn = (...parts: Array<string | false | null | undefined>) =>
+  parts.filter(Boolean).join(" ");
+
+/* -------------------------------------------------------------------------- */
+/*  Stand-in `Secondary` reflecting the proposed defaults                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Proposed base classes for `LayerCard.Secondary`:
+ *
+ *   - `h-14` — fixed 56px height. The single most important change.
+ *   - `px-4 py-0` — vertical sizing comes from `h-14`, not padding, so
+ *     content height variation does NOT affect the strip height.
+ *   - `[&[href]]:cursor-pointer [&[href]]:hover:bg-kumo-fill-hover
+ *      [&[href]]:focus-visible:outline ...` — link affordances baked in,
+ *     scoped with the attribute selector so they only activate when the
+ *     rendered element has an `href` (i.e., when consumers use
+ *     `render={<a />}`). These are no-ops on the default `<div>` rendering.
+ *
+ * Plus the existing base classes (`-my-2 flex items-center gap-2
+ * bg-kumo-elevated text-base font-medium text-kumo-subtle`).
+ */
+const PROPOSED_SECONDARY_CLASSES = cn(
+  "-my-2 flex h-14 items-center gap-2 bg-kumo-elevated px-4 py-0 text-base font-medium text-kumo-subtle",
+  "[&[href]]:cursor-pointer [&[href]]:no-underline [&[href]]:transition-colors",
+  "[&[href]]:hover:bg-kumo-fill-hover",
+  "[&[href]]:focus-visible:outline-2 [&[href]]:focus-visible:-outline-offset-2 [&[href]]:focus-visible:outline-kumo-focus",
+);
+
+/**
+ * File-local stand-in for the proposed `LayerCard.Secondary`. Not exported.
+ * Demo callsites read `<Secondary>` so this code matches the eventual public
+ * API shape (`<LayerCard.Secondary>`) modulo namespace.
+ *
+ * Supports `render` for the polymorphic case — the real `LayerCard.Secondary`
+ * does not yet, and adding it is part of this proposal.
+ */
+type SecondaryProps = {
+  className?: string;
+  children: ReactNode;
+  /**
+   * Render-as element. When passed an `<a>` (or any element with `href`),
+   * the link affordances baked into the base classes activate automatically.
+   */
+  render?: ReactElement;
+};
+
+function Secondary({ className, children, render }: SecondaryProps) {
+  if (render && isValidElement<{ className?: string; children?: ReactNode }>(render)) {
+    return cloneElement(render, {
+      className: cn(PROPOSED_SECONDARY_CLASSES, render.props.className, className),
+      children,
+    });
+  }
+  return (
+    <LayerCard.Secondary className={cn(PROPOSED_SECONDARY_CLASSES, className)}>
+      {children}
+    </LayerCard.Secondary>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Prototype sub-components                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `LayerCard.Title`
+ *
+ * Semantic, styled label for a Secondary section. Inherits the muted label
+ * treatment, but renders a real heading element so screen readers can
+ * navigate the page structure.
+ *
+ * Composition only. No `icon` / `tooltip` / `badge` props — place those as
+ * inline children. This keeps the API one-axis (children) and avoids the
+ * "what wins, prop or child?" broken state.
+ */
+type TitleProps<As extends ElementType = "h3"> = {
+  as?: As;
+  className?: string;
+  children: ReactNode;
+} & Omit<ComponentPropsWithoutRef<As>, "as" | "className" | "children">;
+
+function Title<As extends ElementType = "h3">({
+  as,
+  className,
+  children,
+  ...rest
+}: TitleProps<As>) {
+  const Tag = (as ?? "h3") as ElementType;
+  return (
+    <Tag
+      className={cn(
+        "flex items-center gap-1.5 text-base font-medium text-kumo-subtle",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+/**
+ * `LayerCard.Actions`
+ *
+ * Trailing action group. Uses `ml-auto` so it pushes itself to the right
+ * within Secondary's existing flex container. This deliberately avoids
+ * forcing `justify-between` on `Secondary`, which would break the moment
+ * a third group needs to appear.
+ *
+ * JSX order = visual order.
+ */
+function Actions({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("ml-auto flex items-center gap-2", className)}>
+      {children}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Hero                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Recommended composition: `Title` + `Actions` inside `Secondary`. Replaces
+ * the hand-rolled `flex items-center justify-between` + two grouping divs
+ * pattern that appears ~40 times in production usage.
+ */
+export function LayerCardSecondaryProposalDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary>
+        <Title>Cache Reserve</Title>
+        <Actions>
+          <Button variant="secondary" size="sm">
+            Configure
+          </Button>
+        </Actions>
+      </Secondary>
+      <LayerCard.Primary>
+        <p className="text-sm text-kumo-subtle">
+          Persistent storage on Cloudflare's network for cached assets.
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Archetype demos                                                           */
+/* -------------------------------------------------------------------------- */
+
+/** Label-only — the simplest case. `Title` adds the semantic heading. */
+export function LayerCardSecondaryLabelOnlyDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary>
+        <Title>Documentation</Title>
+      </Secondary>
+      <LayerCard.Primary>
+        <p className="text-sm text-kumo-subtle">
+          Quick start guide for new users.
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Title with a leading icon and inline info tooltip — composed as siblings,
+ * not slot props. The `gap-1.5` on `Title` keeps icon/text/tooltip cohesive.
+ */
+export function LayerCardSecondaryTitleAdornmentsDemo() {
+  return (
+    <TooltipProvider>
+      <LayerCard className="w-[420px]">
+        <Secondary>
+          <Title>
+            <CodeIcon size={16} />
+            Quick start
+            <Tooltip
+              content="Code snippets for common languages."
+              render={
+                <span className="text-kumo-subtle">
+                  <InfoIcon size={14} />
+                </span>
+              }
+            />
+          </Title>
+          <Actions>
+            <LinkButton
+              variant="secondary"
+              size="xs"
+              href="https://developers.cloudflare.com"
+              external
+              aria-label="Open documentation"
+            >
+              <BookOpenIcon size={14} />
+            </LinkButton>
+          </Actions>
+        </Secondary>
+        <LayerCard.Primary>
+          <p className="text-sm text-kumo-subtle">
+            curl https://api.cloudflare.com/...
+          </p>
+        </LayerCard.Primary>
+      </LayerCard>
+    </TooltipProvider>
+  );
+}
+
+/** Status badge alongside title (Beta, New). Just a sibling. */
+export function LayerCardSecondaryWithBadgeDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary>
+        <Title>
+          AI Gateway
+          <Badge variant="beta">Beta</Badge>
+        </Title>
+        <Actions>
+          <LinkButton variant="secondary" size="sm" href="#">
+            View settings
+          </LinkButton>
+        </Actions>
+      </Secondary>
+      <LayerCard.Primary>
+        <p className="text-sm text-kumo-subtle">
+          Gateway requests through Cloudflare for analytics and caching.
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Settings-with-toggle archetype (~30 instances in production usage). Same
+ * composition — no `justify-between`, no two grouping divs.
+ */
+export function LayerCardSecondaryToggleDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary>
+        <Title>
+          Polish
+          <Badge variant="beta">Beta</Badge>
+        </Title>
+        <Actions>
+          <Loader size="sm" />
+          <Switch size="sm" />
+        </Actions>
+      </Secondary>
+      <LayerCard.Primary>
+        <p className="text-sm text-kumo-subtle">
+          Apply lossy or lossless compression to images served from your zone.
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Toolbar / filter chrome — segmented `<Tabs>` as the trailing affordance.
+ * Tabs go in `Actions`. Note: as of today, kumo Tabs do not have a size
+ * variant tuned for the 56px `Secondary` strip. Promoting this proposal
+ * requires adding a small Tabs variant — see "Required component tweaks"
+ * in the docs page.
+ */
+export function LayerCardSecondaryToolbarDemo() {
+  return (
+    <LayerCard className="w-[480px]">
+      <Secondary>
+        <Title as="h2">Operations</Title>
+        <Actions>
+          <Tabs
+            variant="segmented"
+            tabs={[
+              { value: "rps", label: "RPS" },
+              { value: "total", label: "Total" },
+            ]}
+            defaultValue="rps"
+          />
+        </Actions>
+      </Secondary>
+      <LayerCard.Primary>
+        <div className="h-24 rounded bg-kumo-fill" />
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Same toolbar use-case as above, but with a `size="sm"` `Select` instead of
+ * `Tabs`. This is the recommended alternative *today* — `Select` already has
+ * a small variant tuned to fit the 56px `Secondary` strip, whereas `Tabs`
+ * does not. For a binary or small ordinal set, prefer `Tabs` once the small
+ * variant lands; for 3+ options or longer labels, prefer `Select` regardless.
+ */
+export function LayerCardSecondaryToolbarSelectDemo() {
+  return (
+    <LayerCard className="w-[480px]">
+      <Secondary>
+        <Title as="h2">Operations</Title>
+        <Actions>
+          <Select
+            aria-label="Metric"
+            size="sm"
+            defaultValue="rps"
+            items={{ rps: "RPS", total: "Total" }}
+          />
+        </Actions>
+      </Secondary>
+      <LayerCard.Primary>
+        <div className="h-24 rounded bg-kumo-fill" />
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Whole-area linkable header. Pure composition via the `render` prop —
+ * already idiomatic in kumo (`LayerCard` root, `Tooltip`, `Button`, etc.).
+ *
+ * Crucially:
+ *   - `Secondary` IS the `<a>`, not wrapped in one. Valid HTML.
+ *   - Hover, focus-visible, and cursor affordances activate automatically
+ *     via Tailwind attribute selectors (`[&[href]]:...`) baked into
+ *     Secondary's base classes. Nothing inline.
+ *   - Works with React Router: `render={<Link to="/foo" />}`.
+ *
+ * The trailing affordance is a plain icon, NOT an `Actions` block — a
+ * linked Secondary cannot contain interactive children (`<button>` inside
+ * `<a>` is invalid HTML). Lint/runtime guard for this is a follow-up.
+ */
+export function LayerCardSecondaryAsLinkDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary render={<a href="/components/layer-card" aria-label="Browse docs" />}>
+        <Title>Browse docs</Title>
+        <ArrowRightIcon size={16} className="ml-auto" />
+      </Secondary>
+      <LayerCard.Primary>
+        <p className="text-sm text-kumo-subtle">
+          Step-by-step guides for every Cloudflare product.
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Footer pattern — same component, placed below `Primary`. Visually
+ * identical to a header, deliberately. Use `render={<footer />}` to
+ * communicate the semantic role to assistive tech.
+ *
+ * Right-aligned actions: just `<Actions>`. No leading `Title`.
+ */
+export function LayerCardSecondaryFooterDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary>
+        <Title as="h2">Create namespace</Title>
+      </Secondary>
+      <LayerCard.Primary>
+        <div className="h-12 rounded bg-kumo-fill" />
+      </LayerCard.Primary>
+      <Secondary render={<footer />}>
+        <Actions>
+          <LinkButton variant="secondary" size="sm" href="#">
+            Cancel
+          </LinkButton>
+          <Button variant="primary" size="sm">
+            Create
+          </Button>
+        </Actions>
+      </Secondary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Loading state. No `loading` prop — compose `SkeletonLine` in place of the
+ * title content. Replaces the ~10 hand-rolled `animate-pulse` divs in the
+ * audit.
+ */
+export function LayerCardSecondarySkeletonDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <Secondary>
+        <SkeletonLine className="w-28" />
+      </Secondary>
+      <LayerCard.Primary>
+        <div className="space-y-2">
+          <SkeletonLine />
+          <SkeletonLine />
+          <SkeletonLine className="w-3/4" />
+        </div>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
+ * Height consistency proof. Stacks every archetype that should fit in the
+ * fixed-height `Secondary` strip. If any of these rows is visibly taller or
+ * shorter than the others, the recommendation has failed and the offending
+ * child needs a smaller variant in kumo.
+ */
+export function LayerCardSecondaryHeightConsistencyDemo() {
+  return (
+    <TooltipProvider>
+      <div className="flex w-[480px] flex-col gap-3">
+        <LayerCard>
+          <Secondary>
+            <Title>Plain title</Title>
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+
+        <LayerCard>
+          <Secondary>
+            <Title>
+              <CodeIcon size={16} />
+              Adornments
+              <Badge variant="beta">Beta</Badge>
+              <Tooltip
+                content="Help"
+                render={
+                  <span className="text-kumo-subtle">
+                    <InfoIcon size={14} />
+                  </span>
+                }
+              />
+            </Title>
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+
+        <LayerCard>
+          <Secondary>
+            <Title>Trailing button</Title>
+            <Actions>
+              <Button variant="secondary" size="sm">
+                Configure
+              </Button>
+            </Actions>
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+
+        <LayerCard>
+          <Secondary>
+            <Title>Trailing switch</Title>
+            <Actions>
+              <Switch size="sm" />
+            </Actions>
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+
+        <LayerCard>
+          <Secondary>
+            <Title>Trailing select</Title>
+            <Actions>
+              <Select
+                aria-label="Metric"
+                size="sm"
+                defaultValue="rps"
+                items={{ rps: "RPS", total: "Total" }}
+              />
+            </Actions>
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+
+        <LayerCard>
+          <Secondary>
+            <SkeletonLine className="w-28" />
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+
+        <LayerCard>
+          <Secondary render={<a href="/components/layer-card" aria-label="Browse docs" />}>
+            <Title>Linked header</Title>
+            <ArrowRightIcon size={16} className="ml-auto" />
+          </Secondary>
+          <LayerCard.Primary>
+            <p className="text-sm text-kumo-subtle">Body</p>
+          </LayerCard.Primary>
+        </LayerCard>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * Anti-pattern — what we're trying to retire. Shown for contrast in the docs.
+ * ~40 usages in production currently look like this. Note the height of this
+ * Secondary varies with content; in the height-consistency demo above, every
+ * row is exactly 56px.
+ */
+export function LayerCardSecondaryAntiPatternDemo() {
+  return (
+    <LayerCard className="w-[420px]">
+      <LayerCard.Secondary className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span>Cache Reserve</span>
+          <Badge variant="beta">Beta</Badge>
+          <LinkButton
+            className="rounded-full px-2"
+            variant="secondary"
+            size="xs"
+            href="#"
+            external
+            aria-label="Docs"
+          >
+            <ArrowSquareOutIcon size={14} />
+          </LinkButton>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Loader size="sm" />
+          <Switch size="sm" />
+        </div>
+      </LayerCard.Secondary>
+      <LayerCard.Primary>
+        <p className="text-sm text-kumo-subtle">
+          Two grouping divs, an inline override of base styling, and no
+          semantic heading. This file extracts no shared structure.
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/components/layer-card-secondary.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-card-secondary.mdx
@@ -1,0 +1,430 @@
+---
+layout: ~/layouts/MdxDocLayout.astro
+title: "LayerCard.Secondary — composition recommendation"
+description: "A canonical, composable pattern for the LayerCard secondary header that covers the majority of audited usages without prop ambiguity."
+sourceFile: "components/layer-card"
+---
+
+import ComponentExample from "~/components/docs/ComponentExample.astro";
+import ComponentSection from "~/components/docs/ComponentSection.astro";
+import {
+  LayerCardSecondaryProposalDemo,
+  LayerCardSecondaryLabelOnlyDemo,
+  LayerCardSecondaryTitleAdornmentsDemo,
+  LayerCardSecondaryWithBadgeDemo,
+  LayerCardSecondaryToggleDemo,
+  LayerCardSecondaryToolbarDemo,
+  LayerCardSecondaryToolbarSelectDemo,
+  LayerCardSecondaryAsLinkDemo,
+  LayerCardSecondaryFooterDemo,
+  LayerCardSecondarySkeletonDemo,
+  LayerCardSecondaryHeightConsistencyDemo,
+  LayerCardSecondaryAntiPatternDemo,
+} from "~/components/demos/LayerCardSecondaryProposalDemo";
+
+{/* Status banner */}
+
+<ComponentSection>
+
+> **Status:** proposal. The behavior shown below is prototyped locally in the
+> demo file using a stand-in `Secondary` wrapper; this page is the design
+> artifact we'll use to align teams before promoting the changes onto the
+> real `LayerCard` component.
+
+</ComponentSection>
+
+{/* Why */}
+
+<ComponentSection>
+
+## Why this exists
+
+An audit of `LayerCard.Secondary` across our largest consumer found
+**~360 usages in ~140 files**. The current API surface is one slot:
+
+```ts
+type LayerCardSectionProps = PropsWithChildren<{ className?: string }>;
+```
+
+That minimal API has had three predictable consequences:
+
+1. **40+ usages reimplement `flex items-center justify-between`** by hand —
+   each with two grouping `<div>`s — to lay out a title on the left and
+   actions on the right.
+2. **Heights are inconsistent.** `Secondary`'s height comes from `p-4` plus
+   intrinsic content size, so an `h2` heading, a default-size button, a
+   `Switch`, and a `<Tabs>` strip all produce visibly different `Secondary`
+   heights across the product.
+3. **The slot has become a junk drawer.** Tabs, time pickers, switches,
+   tooltips, badges, pagination, skeletons, headings, and link affordances
+   have all been crammed in, each composed differently.
+
+This page proposes the smallest set of changes that fix all three.
+
+</ComponentSection>
+
+{/* Recommendation */}
+
+<ComponentSection>
+
+## Recommendation
+
+Three changes, all to the existing `LayerCard.Secondary`:
+
+1. **Pin the height.** Replace `p-4` with `h-14 px-4` (56px). Vertical
+   sizing comes from `h-14`, not padding, so content height variation does
+   not affect the strip height.
+2. **Add `LayerCard.Title` and `LayerCard.Actions` sub-components.**
+   Composition only — no slot props on `Secondary`.
+3. **Support `render` on `Secondary`** (the same polymorphic pattern
+   already used by `LayerCard` itself, `Tooltip`, `Button`, etc.). This
+   covers the "entire header is a link" case without a separate component.
+   Hover, focus, and cursor affordances activate automatically when the
+   rendered element has an `href`, via Tailwind attribute selectors baked
+   into the base classes.
+
+The recommended composition:
+
+```tsx
+<LayerCard>
+  <LayerCard.Secondary>
+    <LayerCard.Title>Section name</LayerCard.Title>
+    <LayerCard.Actions>
+      <Button size="sm">Configure</Button>
+    </LayerCard.Actions>
+  </LayerCard.Secondary>
+  <LayerCard.Primary>…</LayerCard.Primary>
+</LayerCard>
+```
+
+<ComponentExample demo="LayerCardSecondaryProposalDemo">
+  <LayerCardSecondaryProposalDemo client:visible />
+</ComponentExample>
+
+</ComponentSection>
+
+{/* Height invariant */}
+
+<ComponentSection>
+
+## The height invariant
+
+Every `Secondary` strip in the product is exactly **56px** tall. This is
+non-negotiable. Every demo on this page renders at the same header height —
+if any of the rows below visibly differs from the others, the proposal has
+failed and the offending child needs a smaller variant in kumo (see below).
+
+<ComponentExample demo="LayerCardSecondaryHeightConsistencyDemo">
+  <LayerCardSecondaryHeightConsistencyDemo client:visible />
+</ComponentExample>
+
+The implication: any kumo component that lives in `Actions` must have a
+size variant that fits within 56px (with 12px breathing room top and
+bottom for a 32px control). Anything that doesn't fit is the child's
+problem to solve, not `Secondary`'s.
+
+### Required component tweaks
+
+The audit surfaced children that don't currently have a small-enough
+variant. Promoting this proposal requires the following changes elsewhere
+in kumo. Each is a separate, scoped piece of work.
+
+| Component       | Current state                                   | Tweak needed                                                                  | Audit signal                                                                |
+| --------------- | ----------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `Tabs`          | `underline` and `segmented` variants both ~40px | Add a small variant (`size="sm"` or `compact`) tuned for 32px control height. | Multiple consumers override with `[&_[role=tablist]]:h-9` or similar.        |
+| `Select`        | Default ~40px tall                              | Confirm `size="sm"` fits and is the documented choice for `Actions`.          | ~53 trailing-Select usages in audit.                                         |
+| `TimeframePicker` (block) | App-level block, not a kumo primitive | Calibrate height to match `sm` Button when used as trailing chrome.          | Analytics pages use this in headers.                                         |
+| `Pagination`    | Variable height                                 | Block-level decision: should Pagination ever live in `Secondary`?             | 6 usages — likely belong in `Footer`-style Secondary, not header Secondary.  |
+
+These are tracked separately. The `Title`/`Actions`/`render` proposal can
+ship without all of them — the height invariant simply forecloses the
+problematic combinations until the small variants exist.
+
+</ComponentSection>
+
+{/* Why composition */}
+
+<ComponentSection>
+
+## Why composition (not props)
+
+There was a real temptation to express this as:
+
+```tsx
+{/* DO NOT BUILD THIS */}
+<LayerCard.Secondary
+  title="Section name"
+  icon={<CodeIcon />}
+  badge={<Badge>Beta</Badge>}
+  tooltip="Help text"
+  actions={<Button>Configure</Button>}
+/>
+```
+
+Shorter, but every prop becomes a question:
+
+- What if a consumer passes `title` *and* `children`?
+- What if `actions` is an array vs. a single element vs. a fragment?
+- How do you express two badges, or a leading link plus a trailing menu?
+- How do you control the order of icon, label, and badge inside the title?
+
+Composition answers all of these by construction: JSX order is visual
+order, and there is exactly one way to put something somewhere.
+
+### Why this isn't more verbose than today
+
+The audit's worst offenders look like this today:
+
+```tsx
+<LayerCard.Secondary className="flex items-center justify-between">
+  <div className="flex items-center gap-2">
+    <span>Cache Reserve</span>
+    <Badge variant="beta">Beta</Badge>
+  </div>
+  <div className="flex shrink-0 items-center gap-2">
+    <Loader size="sm" />
+    <Switch size="sm" />
+  </div>
+</LayerCard.Secondary>
+```
+
+Under the recommendation:
+
+```tsx
+<LayerCard.Secondary>
+  <LayerCard.Title>
+    Cache Reserve
+    <Badge variant="beta">Beta</Badge>
+  </LayerCard.Title>
+  <LayerCard.Actions>
+    <Loader size="sm" />
+    <Switch size="sm" />
+  </LayerCard.Actions>
+</LayerCard.Secondary>
+```
+
+Same line count, **fewer concepts** (no className override, no grouping
+divs, no `shrink-0` magic), **more semantics** (real heading element), and
+the layout intent is named instead of inferred from a Tailwind incantation.
+
+</ComponentSection>
+
+{/* Coverage */}
+
+<ComponentSection>
+
+## Coverage of the audited archetypes
+
+The recommendation is only worth adopting if it covers what teams actually
+build today. Each demo below corresponds to a category from the audit.
+
+### 1. Label only
+
+The simplest case. `Title` adds the semantic heading element.
+
+<ComponentExample demo="LayerCardSecondaryLabelOnlyDemo">
+  <LayerCardSecondaryLabelOnlyDemo client:visible />
+</ComponentExample>
+
+### 2. Title with leading icon and inline tooltip
+
+Sibling composition inside `Title` — no slot props. The `gap-1.5` between
+children keeps icon, label, and tooltip mark cohesive.
+
+<ComponentExample demo="LayerCardSecondaryTitleAdornmentsDemo">
+  <LayerCardSecondaryTitleAdornmentsDemo client:visible />
+</ComponentExample>
+
+### 3. Status badge alongside title
+
+Beta / New / status badges live as sibling children inside `Title`.
+
+<ComponentExample demo="LayerCardSecondaryWithBadgeDemo">
+  <LayerCardSecondaryWithBadgeDemo client:visible />
+</ComponentExample>
+
+### 4. Toggle / settings card
+
+The settings-with-toggle archetype (~30 instances in production usage).
+Same shape as the hero — the `Switch` simply lives in `Actions`.
+
+<ComponentExample demo="LayerCardSecondaryToggleDemo">
+  <LayerCardSecondaryToggleDemo client:visible />
+</ComponentExample>
+
+### 5. Toolbar / segmented control
+
+Tabs, segmented controls, time pickers — anything that is the trailing
+affordance of a card header — go in `Actions`. **Note:** kumo's current
+`Tabs` does not yet have a size variant tuned for 56px `Secondary`; this
+is one of the [required component tweaks](#the-height-invariant).
+
+<ComponentExample demo="LayerCardSecondaryToolbarDemo">
+  <LayerCardSecondaryToolbarDemo client:visible />
+</ComponentExample>
+
+#### Alternative: `size="sm"` Select
+
+Until the small `Tabs` variant lands, `Select size="sm"` is the recommended
+trailing control for ordinal pickers. It fits the 56px strip cleanly today
+and is the right choice regardless once the option count exceeds 2–3 or
+labels get long.
+
+<ComponentExample demo="LayerCardSecondaryToolbarSelectDemo">
+  <LayerCardSecondaryToolbarSelectDemo client:visible />
+</ComponentExample>
+
+### 6. The whole header is a link
+
+Use the `render` prop pattern already idiomatic in kumo:
+
+```tsx
+<LayerCard.Secondary render={<a href="/docs/cache-reserve" />}>
+  <LayerCard.Title>Browse docs</LayerCard.Title>
+  <ArrowRightIcon size={16} className="ml-auto" />
+</LayerCard.Secondary>
+```
+
+Why `render` and not a separate `LayerCard.SecondaryLink`:
+
+- **Symmetric.** `LayerCard` itself, `Tooltip`, `Button`, etc. all use
+  `render`. Adding it to `Secondary` is one more place where the same
+  pattern works.
+- **Polymorphic.** `render={<Link to="/x" />}` integrates with React
+  Router, `render={<a download />}` works for downloads, etc. A separate
+  `SecondaryLink` would need its own `as` escape hatch and we're back to
+  polymorphism.
+- **No proliferation.** If we add `SecondaryLink`, why not `PrimaryLink`,
+  `LayerCardLink`? `render` keeps the surface flat.
+- **Affordances are automatic.** `Secondary`'s base classes include
+  Tailwind attribute selectors (`[&[href]]:hover:bg-kumo-fill-hover`,
+  `[&[href]]:focus-visible:outline ...`, `[&[href]]:cursor-pointer`)
+  that activate only when the rendered element has an `href`. The
+  consumer doesn't have to remember to add hover styles.
+- **Valid HTML.** `Secondary` *becomes* the `<a>` rather than wrapping
+  one — no `<a><div>...</div></a>` nesting.
+
+The trailing affordance must be a non-interactive element (icon, text). A
+linked `Secondary` cannot contain `<button>` / `<Switch>` / `<Tabs>` —
+that is invalid HTML and breaks the "click anywhere" contract. A lint
+rule and dev-mode warning are part of the implementation work.
+
+<ComponentExample demo="LayerCardSecondaryAsLinkDemo">
+  <LayerCardSecondaryAsLinkDemo client:visible />
+</ComponentExample>
+
+### 7. Footer pattern (action bar)
+
+`Secondary` placed below `Primary` is a footer. Same component, same
+styling — no `LayerCard.Footer` alias to maintain. Use
+`render={<footer />}` for assistive-tech semantics.
+
+A bare `Actions` block is the canonical Cancel/Submit row.
+
+<ComponentExample demo="LayerCardSecondaryFooterDemo">
+  <LayerCardSecondaryFooterDemo client:visible />
+</ComponentExample>
+
+### 8. Skeleton / loading state
+
+No `loading` prop. Place a `SkeletonLine` where the `Title` would go. This
+replaces ~10 hand-rolled `animate-pulse` divs in the audit.
+
+<ComponentExample demo="LayerCardSecondarySkeletonDemo">
+  <LayerCardSecondarySkeletonDemo client:visible />
+</ComponentExample>
+
+</ComponentSection>
+
+{/* Anti-pattern */}
+
+<ComponentSection>
+
+## What we are retiring
+
+This is the dominant shape `LayerCard.Secondary` takes in production today.
+
+<ComponentExample demo="LayerCardSecondaryAntiPatternDemo">
+  <LayerCardSecondaryAntiPatternDemo client:visible />
+</ComponentExample>
+
+```tsx
+<LayerCard.Secondary className="flex items-center justify-between">
+  <div className="flex items-center gap-2">…</div>
+  <div className="flex shrink-0 items-center gap-2">…</div>
+</LayerCard.Secondary>
+```
+
+Compare its height to any of the recommended demos above — the unpinned
+default `p-4` produces a visibly different strip than a 56px header
+elsewhere in the same product.
+
+</ComponentSection>
+
+{/* Out of scope */}
+
+<ComponentSection>
+
+## Things this proposal deliberately does **not** add
+
+| Considered                                           | Decision | Why                                                                                                                  |
+| ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `icon` / `tooltip` / `badge` props on `Title`        | **No**   | Each prop is a redundant axis next to children → broken-state ambiguity. Compose them inline.                        |
+| `loading` prop on `Secondary` with auto-skeleton     | **No**   | Skeleton dimensions are page-specific. Compose `SkeletonLine` directly.                                              |
+| Explicit `LayerCard.Footer`                          | **No**   | Visually identical to `Secondary`; introducing a second name splits usage without adding meaning.                    |
+| Dedicated `LayerCard.SecondaryLink`                  | **No**   | The `render` prop is the right primitive. A dedicated component would create proliferation and lose RR/Next compat. |
+| `LayerCard.Header.Toolbar` slot                      | **No**   | `Actions` already handles this. Tabs are just children.                                                              |
+| Tabs that switch the *card body*                     | **Out of scope** | Crams content navigation into the header; different concern, different audit.                                        |
+
+</ComponentSection>
+
+{/* Migration */}
+
+<ComponentSection>
+
+## Migration shape
+
+Once promoted, a codemod can handle the mechanical part of the 40+
+`justify-between` cases:
+
+```
+<LayerCard.Secondary className="flex items-center justify-between">
+  <div className="flex items-center gap-2">$LEFT</div>
+  <div className="flex items-center gap-2">$RIGHT</div>
+</LayerCard.Secondary>
+
+  ↓
+
+<LayerCard.Secondary>
+  <LayerCard.Title>$LEFT</LayerCard.Title>
+  <LayerCard.Actions>$RIGHT</LayerCard.Actions>
+</LayerCard.Secondary>
+```
+
+The height change applies automatically (no callsite work). Anything that
+doesn't fit the new fixed height surfaces as visual regression in
+screenshot tests, gets routed to the relevant component-tweak workstream.
+
+</ComponentSection>
+
+{/* Open questions */}
+
+<ComponentSection>
+
+## Open questions
+
+1. **`Title` default tag — `<h3>` or `<h2>`?** Most cards live inside a
+   page that already owns `<h1>` and `<h2>`, so `<h3>` is the safer
+   default; `as` exposes the override. Lean: default `<h3>`.
+2. **Should `Title` get a `variant="prominent"`** for cards that want the
+   muted-label replaced by a real heading style? ~10 production usages
+   currently reach for `<Text variant="heading3">` here. Lean: not yet —
+   wait until there's clear demand after `Title` ships.
+3. **Where does `Pagination` belong?** ~6 usages place it in
+   `Secondary` (footer-style). Likely belongs there, but its variable
+   height is incompatible with the 56px invariant — needs calibration.
+4. **Lint / runtime guard for "no interactive children inside a linked
+   `Secondary`".** `<a>` containing `<button>` is invalid HTML; we should
+   warn at dev time.
+
+</ComponentSection>


### PR DESCRIPTION
## Summary

Proposal page for aligning teams on a recommended composition pattern for `LayerCard.Secondary`. **Not** a code change to `LayerCard` itself — this is a design artifact.

An audit of `LayerCard.Secondary` across our largest consumer found ~360 usages across ~140 files. ~40 of those reimplement `flex items-center justify-between` with two grouping `<div>`s by hand, plus a long tail of inline icons, tooltips, badges, switches, tabs, and pagination crammed into the same slot. Heights drift visibly across the product.

## Proposal (in three parts)

1. **Pin the height.** Replace `p-4` with `h-14 px-4` on `Secondary` (56px). Vertical sizing comes from `h-14`, not padding, so content variation can't change the strip height.
2. **Add `LayerCard.Title` and `LayerCard.Actions` sub-components.** Composition only — no slot props. JSX order = visual order. `Actions` uses `ml-auto` (no `justify-between` parent toggle).
3. **Support `render` on `Secondary`** for the "whole header is a link" case. Already idiomatic in kumo (`LayerCard` root, `Tooltip`, etc.). Hover/focus/cursor affordances activate via `[&[href]]:` attribute selectors baked into the base classes — automatic when consumers do `render={<a/>}`, no-op otherwise.

## What this PR adds

- `packages/kumo-docs-astro/src/pages/components/layer-card-secondary.mdx` — the proposal doc
- `packages/kumo-docs-astro/src/components/demos/LayerCardSecondaryProposalDemo.tsx` — 12 demos covering each archetype from the audit (label-only, title with icon/tooltip/badge, toggle card, toolbar with Tabs, toolbar with `Select size="sm"` as the recommended alternative, linked header, footer, skeleton, height-consistency strip, anti-pattern)
- A changeset for `@cloudflare/kumo-docs-astro`

The prototype `Title` / `Actions` / `render`-aware `Secondary` are defined locally in the demo file as a stand-in. They are **not** exported and the real `LayerCard` is unchanged.

## Required follow-up component tweaks

The 56px height invariant requires a few small changes elsewhere before it can ship for all use cases. Each is scoped and tracked separately:

- `Tabs` — needs a small variant (~32px control height) to fit the Secondary strip. Today consumers override with `[&_[role=tablist]]:h-9`.
- `Select` — confirm `size="sm"` is the documented choice for `Actions`. Already fits today; this proposal uses it as the recommended alternative until small `Tabs` lands.
- `Pagination` — variable height, currently used in ~6 footer-style Secondaries. Calibration needed.

## Why composition (not props)

Considered but rejected: `<LayerCard.Secondary title="…" icon={…} badge={…} actions={…} />`. Every prop introduces a "what wins, prop or children?" broken state, and prop-shaped slots impose an order the consumer can't override. Composition answers all of that by construction.
