### PR TITLE
fix(combobox): pass through TriggerValue props including placeholder

### DIFF
--- a/.changeset/combobox-trigger-value-placeholder.md
+++ b/.changeset/combobox-trigger-value-placeholder.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(combobox): forward all props from TriggerValue to ComboboxBase.Value, enabling placeholder support and styled placeholder text via data-[placeholder]:text-kumo-placeholder

--- a/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
@@ -225,6 +225,36 @@ export function ComboboxSearchableInsideDemo() {
   );
 }
 
+/** Demonstrates using TriggerValue with a placeholder, behaving like a
+ * searchable Select field. The placeholder is shown until a value is selected. */
+export function ComboboxSearchableSelectDemo() {
+  const [value, setValue] = useState<Language | null>(null);
+
+  return (
+    <Combobox
+      value={value}
+      onValueChange={(v) => setValue(v as Language | null)}
+      items={languages}
+    >
+      <Combobox.TriggerValue
+        className="w-[200px]"
+        placeholder="Select a language"
+      />
+      <Combobox.Content>
+        <Combobox.Input placeholder="Search languages" />
+        <Combobox.Empty />
+        <Combobox.List>
+          {(item: Language) => (
+            <Combobox.Item key={item.value} value={item}>
+              {item.emoji} {item.label}
+            </Combobox.Item>
+          )}
+        </Combobox.List>
+      </Combobox.Content>
+    </Combobox>
+  );
+}
+
 // Grouped items demo
 export function ComboboxGroupedDemo() {
   const [value, setValue] = useState<ServerLocation | null>(null);

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -13,6 +13,7 @@ import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   ComboboxDemo,
   ComboboxSearchableInsideDemo,
+  ComboboxSearchableSelectDemo,
   ComboboxGroupedDemo,
   ComboboxMultipleDemo,
   ComboboxWithFieldDemo,
@@ -118,6 +119,19 @@ export default function Example() {
   </p>
   <ComponentExample demo="ComboboxSearchableInsideDemo">
     <ComboboxSearchableInsideDemo client:load />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+### Searchable Select with Placeholder
+
+  <p>
+    Use `TriggerValue` with a `placeholder` prop to create a searchable Select-style field.
+    The placeholder is displayed until a value is selected.
+  </p>
+  <ComponentExample demo="ComboboxSearchableSelectDemo">
+    <ComboboxSearchableSelectDemo client:load />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -261,11 +261,12 @@ function TriggerValue({
         inputVariants({ size }),
         "relative flex items-center",
         "data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed",
+        "data-[placeholder]:text-kumo-placeholder",
         iconStyles.padding,
         className,
       )}
     >
-      <ComboboxBase.Value>{props.children}</ComboboxBase.Value>
+      <ComboboxBase.Value {...props} />
       <ComboboxBase.Icon
         className={cn(
           "absolute top-1/2 -translate-y-1/2 flex items-center text-kumo-subtle",


### PR DESCRIPTION
## Summary

- **Fix:** `Combobox.TriggerValue` was only passing `children` to the underlying `ComboboxBase.Value`, silently dropping `placeholder` and other props. Now spreads all props through.
- **Style:** Adds `data-[placeholder]:text-kumo-placeholder` on the trigger element to match Select's placeholder styling, using the `data-placeholder` attribute that Base UI's `ComboboxBase.Trigger` already provides.
- **Docs:** Adds `ComboboxSearchableSelectDemo` showing the searchable Select pattern with a placeholder.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: bug fix needs visual verification
- Tests
  - [x] Additional testing not necessary because: existing tests pass, fix is a prop forwarding correction with no logic change