### PR TITLE
fix(sidebar): remove z-50 from mobile Dialog backdrop and panel

### DIFF
--- a/.changeset/fix-sidebar-z-index.md
+++ b/.changeset/fix-sidebar-z-index.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Remove z-50 from mobile Sidebar Dialog backdrop and panel. The z-50 caused portaled floating elements (Popover, DropdownMenu, Select, Combobox) opened from inside the Sidebar to render behind the Dialog backdrop. Matches the pattern used by Kumo's own Dialog component, which relies on DOM order for stacking with no explicit z-index. Also adds `data-sidebar-backdrop` and `data-sidebar-popup` attributes as stable CSS hooks.

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -406,10 +406,11 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       return (
         <DialogBase.Root open={openMobile} onOpenChange={setOpenMobile}>
           <DialogBase.Portal>
-            <DialogBase.Backdrop className="fixed inset-0 z-50 bg-black/50 transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+            <DialogBase.Backdrop data-sidebar-backdrop="" className="fixed inset-0 bg-black/50 transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
             <DialogBase.Popup
+              data-sidebar-popup=""
               className={cn(
-                "fixed inset-y-0 z-50 flex w-[--sidebar-width] flex-col bg-kumo-base p-0",
+                "fixed inset-y-0 flex w-[--sidebar-width] flex-col bg-kumo-base p-0",
                 "duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
                 side === "left" &&
                   "left-0 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full",


### PR DESCRIPTION
Fixes portaled floating elements (Popover, DropdownMenu, Select, Combobox) rendering behind the mobile Sidebar Dialog backdrop.

## Problem

The Sidebar's mobile Dialog applies `z-50` to both its backdrop and popup panel. Any portaled floating element opened from inside the Sidebar renders behind the Dialog backdrop — their positioners have no explicit z-index, so `z-50` beats `z-auto` regardless of DOM order.

## Fix

Remove `z-50` from both elements, matching Kumo's own `Dialog` component which uses no z-index at all. The backdrop renders before the popup in DOM order (popup paints on top), and later portals (e.g. a Popover triggered from inside the sidebar) render after the Dialog portal in DOM order (Popover paints on top). No explicit z-index is needed.

Also adds `data-sidebar-backdrop` and `data-sidebar-popup` attributes as stable CSS hooks so consumers can target these elements with scoped overrides if needed.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: two-line CSS-only change removing Tailwind utility classes, no logic to review
- Tests
  - [x] Additional testing not necessary because: this removes z-50 from two elements to match the pattern already used by Kumo's own Dialog component (which ships with no z-index). The existing sidebar test suite covers open/close behavior. Visual verification: render a Sidebar on mobile viewport, open a DropdownMenu/Popover/Select from inside it, confirm the floating element renders above the backdrop.