### PR TITLE
Fix Google Translate DOM mutation crash in Button

### DIFF
--- a/.changeset/fix-google-translate-button.md
+++ b/.changeset/fix-google-translate-button.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Google Translate DOM mutation crash in Button

--- a/packages/kumo/AGENTS.md
+++ b/packages/kumo/AGENTS.md
@@ -83,7 +83,7 @@ Output: ai/component-registry.{json,md} + ai/schemas.ts
 - **Vitest** with `happy-dom`, globals enabled
 - **Path aliases**: `@/` → `src/`, `@cloudflare/kumo` → `src/index.ts`
 - **Structural tests** in `tests/imports/`: validate all export paths resolve, package.json matches vite entries
-- **Sparse component tests**: Only ~6 components have unit tests; emphasis on infrastructure testing
+- **Component tests**: ~14 components have unit tests (`*.test.tsx`), plus 2 browser tests (`*.browser.test.tsx`). Coverage is growing but not comprehensive across all 39 components
 - **`describe.skipIf(!isBuilt)`**: Export validation tests skip gracefully when `dist/` missing
 
 ## ANTI-PATTERNS

--- a/packages/kumo/src/components/AGENTS.md
+++ b/packages/kumo/src/components/AGENTS.md
@@ -160,13 +160,15 @@ classes: "bg-kumo-elevated hover:bg-kumo-base focus:ring-kumo-hairline disabled:
 
 ## ANTI-PATTERNS
 
-| Pattern               | Why                   | Instead                                    |
-| --------------------- | --------------------- | ------------------------------------------ |
-| Missing `displayName` | Breaks React DevTools | Set after forwardRef                       |
-| Raw className string  | Loses passthrough     | Use `cn(base, className)`                  |
-| `as any`              | Type safety           | Model types correctly (3 exist, don't add) |
-| Hardcoded colors      | Breaks theming        | Use semantic tokens                        |
-| `dark:` prefix        | Redundant             | Tokens auto-adapt                          |
+| Pattern                             | Why                            | Instead                                      |
+| ----------------------------------- | ------------------------------ | -------------------------------------------- |
+| Missing `displayName`               | Breaks React DevTools          | Set after forwardRef                         |
+| Raw className string                | Loses passthrough              | Use `cn(base, className)`                    |
+| `as any`                            | Type safety                    | Model types correctly (3 exist, don't add)   |
+| Hardcoded colors                    | Breaks theming                 | Use semantic tokens                          |
+| `dark:` prefix                      | Redundant                      | Tokens auto-adapt                            |
+| `{cond && A}{!cond && B}`           | Unstable child positions       | `{cond ? A : B}` ternary                    |
+| Bare `{children}` with conditionals | Extensions reparent text nodes | Wrap in `<span className="contents">`        |
 
 ## COMPLEXITY HOTSPOTS
 

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Plus } from "@phosphor-icons/react";
+import { Button } from "./button";
+
+describe("Button", () => {
+  describe("children wrapper", () => {
+    it("wraps children in a span with className='contents'", () => {
+      render(<Button>Save</Button>);
+      const button = screen.getByRole("button", { name: "Save" });
+      const span = button.querySelector("span.contents");
+      expect(span).toBeTruthy();
+      expect(span!.textContent).toBe("Save");
+    });
+
+    it("does not render empty span for icon-only button", () => {
+      render(<Button shape="square" icon={Plus} aria-label="Add" />);
+      const button = screen.getByRole("button", { name: "Add" });
+      const span = button.querySelector("span.contents");
+      expect(span).toBeNull();
+    });
+  });
+
+  describe("loading state transitions", () => {
+    it("transitions from non-loading to loading and back", () => {
+      const { rerender } = render(<Button loading={false}>Submit</Button>);
+
+      // Non-loading: children visible, no spinner
+      expect(screen.getByText("Submit")).toBeTruthy();
+      expect(screen.queryByRole("status")).toBeNull();
+
+      // Loading: spinner present
+      rerender(<Button loading={true}>Submit</Button>);
+      expect(screen.getByRole("status")).toBeTruthy();
+
+      // Back to non-loading: spinner gone, children still visible
+      rerender(<Button loading={false}>Submit</Button>);
+      expect(screen.queryByRole("status")).toBeNull();
+      expect(screen.getByText("Submit")).toBeTruthy();
+    });
+  });
+
+  describe("icon rendering", () => {
+    it("renders icon in non-loading state", () => {
+      render(
+        <Button icon={Plus} loading={false}>
+          Add item
+        </Button>,
+      );
+      const button = screen.getByRole("button", { name: "Add item" });
+      // Plus icon renders an SVG element
+      const svg = button.querySelector("svg");
+      expect(svg).toBeTruthy();
+      // Should not be the loader (no role="status")
+      expect(svg!.getAttribute("role")).not.toBe("status");
+    });
+
+    it("renders loader instead of icon in loading state", () => {
+      render(
+        <Button icon={Plus} loading={true}>
+          Add item
+        </Button>,
+      );
+      // When loading, the Loader's aria-label contributes to the button's accessible name
+      const button = screen.getByRole("button");
+      // Loader should be present
+      const loader = screen.getByRole("status");
+      expect(loader).toBeTruthy();
+      expect(loader.getAttribute("aria-label")).toBe("Loading");
+      // The Plus icon should NOT be rendered — only the loader SVG with role="status"
+      const svgs = button.querySelectorAll("svg");
+      expect(svgs).toHaveLength(1);
+      expect(svgs[0].getAttribute("role")).toBe("status");
+    });
+  });
+});

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -1,7 +1,8 @@
+import React from "react";
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Plus } from "@phosphor-icons/react";
-import { Button } from "./button";
+import { Button, RefreshButton, LinkButton } from "./button";
 
 describe("Button", () => {
   describe("children wrapper", () => {
@@ -40,6 +41,30 @@ describe("Button", () => {
     });
   });
 
+  it("type defaults to 'button'", () => {
+    render(<Button>Click</Button>);
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("type")).toBe("button");
+  });
+
+  it("loading={true} sets disabled on the <button>", () => {
+    render(<Button loading>Save</Button>);
+    const button = screen.getByRole("button");
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("disabled prop sets disabled attribute", () => {
+    render(<Button disabled>Save</Button>);
+    const button = screen.getByRole("button");
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("forwards ref to the <button> DOM node", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<Button ref={ref}>Click</Button>);
+    expect(ref.current).toBe(screen.getByRole("button"));
+  });
+
   describe("icon rendering", () => {
     it("renders icon in non-loading state", () => {
       render(
@@ -72,5 +97,61 @@ describe("Button", () => {
       expect(svgs).toHaveLength(1);
       expect(svgs[0].getAttribute("role")).toBe("status");
     });
+
+    it("accepts a React element via icon prop", () => {
+      render(<Button icon={<Plus data-testid="plus-icon" />}>Add</Button>);
+      const button = screen.getByRole("button", { name: "Add" });
+      const svg = button.querySelector("svg");
+      expect(svg).toBeTruthy();
+    });
+  });
+
+  it("title prop wraps in Tooltip and removes native title attribute", () => {
+    render(<Button title="Save changes">Save</Button>);
+    const button = screen.getByRole("button", { name: "Save" });
+    // title is intercepted by Tooltip wrapper, not set as native attribute
+    expect(button.getAttribute("title")).toBeNull();
+  });
+});
+
+describe("RefreshButton", () => {
+  it("renders with default aria-label='Refresh'", () => {
+    render(<RefreshButton />);
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeTruthy();
+  });
+
+  it("allows overriding aria-label", () => {
+    render(<RefreshButton aria-label="Reload workers" />);
+    expect(screen.getByRole("button", { name: "Reload workers" })).toBeTruthy();
+  });
+});
+
+describe("LinkButton", () => {
+  it("renders as an <a> element", () => {
+    render(<LinkButton href="/home">Home</LinkButton>);
+    const link = screen.getByRole("link");
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("/home");
+  });
+
+  it("external sets target='_blank' and rel='noopener noreferrer'", () => {
+    render(
+      <LinkButton href="https://example.com" external>
+        Docs
+      </LinkButton>,
+    );
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("forwards ref to the <a> DOM node", () => {
+    const ref = React.createRef<HTMLAnchorElement>();
+    render(
+      <LinkButton ref={ref} href="/home">
+        Home
+      </LinkButton>,
+    );
+    expect(ref.current).toBe(screen.getByRole("link"));
   });
 });

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -136,10 +136,27 @@ export function buttonVariants({
     // Disabled state
     "disabled:cursor-not-allowed disabled:text-kumo-subtle",
     // Apply variant, size, shape styles from KUMO_BUTTON_VARIANTS
-    resolveVariant(KUMO_BUTTON_VARIANTS.variant, variant, KUMO_BUTTON_DEFAULT_VARIANTS.variant).classes,
-    resolveVariant(KUMO_BUTTON_VARIANTS.size, size, KUMO_BUTTON_DEFAULT_VARIANTS.size).classes,
-    resolveVariant(KUMO_BUTTON_VARIANTS.shape, shape, KUMO_BUTTON_DEFAULT_VARIANTS.shape).classes,
-    isCompactShape && resolveVariant(KUMO_BUTTON_VARIANTS.compactSize, size, KUMO_BUTTON_DEFAULT_VARIANTS.size).classes,
+    resolveVariant(
+      KUMO_BUTTON_VARIANTS.variant,
+      variant,
+      KUMO_BUTTON_DEFAULT_VARIANTS.variant,
+    ).classes,
+    resolveVariant(
+      KUMO_BUTTON_VARIANTS.size,
+      size,
+      KUMO_BUTTON_DEFAULT_VARIANTS.size,
+    ).classes,
+    resolveVariant(
+      KUMO_BUTTON_VARIANTS.shape,
+      shape,
+      KUMO_BUTTON_DEFAULT_VARIANTS.shape,
+    ).classes,
+    isCompactShape &&
+      resolveVariant(
+        KUMO_BUTTON_VARIANTS.compactSize,
+        size,
+        KUMO_BUTTON_DEFAULT_VARIANTS.size,
+      ).classes,
   );
 }
 
@@ -253,10 +270,12 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         type={type ?? "button"}
         {...restProps}
       >
-        {loading && <Loader size={size === "lg" ? 16 : 14} />}
-        {!loading && renderIconNode(IconComponent)}
-
-        {children}
+        {loading ? (
+          <Loader size={size === "lg" ? 16 : 14} />
+        ) : (
+          renderIconNode(IconComponent)
+        )}
+        {children != null && <span className="contents">{children}</span>}
       </button>
     );
 


### PR DESCRIPTION
Google Translate wraps text nodes in `<font>` elements, reparenting them from `<button>`. When Button toggles loading state, React's `insertBefore()` fails with `NotFoundError` because the text node is no longer a direct child.

Fix:
- Wrap `{children}` in `<span className="contents">`, it gives React a stable DOM reference while `display: contents` preserves layout
- Collapse Loader/Icon into a single ternary to eliminate an extra insertion point

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: bugfix validated by unit tests and manual reasoning about DOM behavior
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because: