### PR TITLE
feat(combobox): export Trigger, Value, and Icon primitives for custom triggers

### DIFF
--- a/.changeset/combobox-trigger-render.md
+++ b/.changeset/combobox-trigger-render.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Export `Combobox.Trigger`, `Combobox.Value`, and `Combobox.Icon` — the raw Base UI primitives for building custom combobox triggers. Use these when you need full control over the trigger's visual treatment (e.g. a sidebar account switcher that renders as a plain button instead of an input-like control).

--- a/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CaretUpDownIcon } from "@phosphor-icons/react";
 import { Combobox, Text, Button } from "@cloudflare/kumo";
 
 // Basic fruits list for simple demos (expanded to test scrolling)
@@ -606,5 +607,41 @@ export function ComboboxSizesSearchableInsideDemo() {
         </Combobox.Content>
       </Combobox>
     </div>
+  );
+}
+
+export function ComboboxCustomTriggerDemo() {
+  const [value, setValue] = useState<Language>(languages[0]);
+
+  return (
+    <Combobox
+      value={value}
+      onValueChange={(v) => setValue(v as Language)}
+      items={languages}
+    >
+      <Combobox.Trigger
+        render={
+          <Button variant="ghost" size="sm" />
+        }
+      >
+        <Combobox.Value>
+          <span className="truncate">
+            {value.emoji} {value.label}
+          </span>
+        </Combobox.Value>
+        <CaretUpDownIcon size={14} className="text-kumo-subtle shrink-0" />
+      </Combobox.Trigger>
+      <Combobox.Content>
+        <Combobox.Input placeholder="Search languages" />
+        <Combobox.Empty />
+        <Combobox.List>
+          {(item: Language) => (
+            <Combobox.Item key={item.value} value={item}>
+              {item.emoji} {item.label}
+            </Combobox.Item>
+          )}
+        </Combobox.List>
+      </Combobox.Content>
+    </Combobox>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -22,6 +22,7 @@ import {
   ComboboxErrorDemo,
   ComboboxSizesDemo,
   ComboboxSizesSearchableInsideDemo,
+  ComboboxCustomTriggerDemo,
 } from "~/components/demos/ComboboxDemo";
 
 {/* Hero Demo */}
@@ -133,6 +134,17 @@ export default function Example() {
   <ComponentExample demo="ComboboxSearchableSelectDemo">
     <ComboboxSearchableSelectDemo client:load />
   </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+### Custom Trigger
+
+<p>Use <code>Combobox.Trigger</code> with a <code>render</code> prop to replace the default input-like trigger with your own element. Pair with <code>Combobox.Value</code> to display the selected value. Useful for account switchers, sidebar navigation, or anywhere the default chrome doesn't fit.</p>
+<ComponentExample demo="ComboboxCustomTriggerDemo">
+  <ComboboxCustomTriggerDemo client:load />
+</ComponentExample>
+
 </ComponentSection>
 
 <ComponentSection>

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -617,4 +617,8 @@ export const Combobox = Object.assign(Root, {
 
   // BaseUI
   Collection: ComboboxBase.Collection,
+
+  Trigger: ComboboxBase.Trigger,
+  Value: ComboboxBase.Value,
+  Icon: ComboboxBase.Icon,
 });


### PR DESCRIPTION
Export `Combobox.Trigger`, `Combobox.Value`, and `Combobox.Icon` on the Combobox namespace — the raw Base UI primitives for building custom combobox triggers without reaching for the primitives package directly.

Use these when you need full control over the trigger's visual treatment (e.g. a sidebar account switcher that renders as a plain button instead of an input-like control).

```tsx
<Combobox.Trigger render={<button className="my-custom-trigger" />}>
  <Combobox.Value>{selected.label}</Combobox.Value>
</Combobox.Trigger>
```

Adds a "Custom Trigger" demo to the Combobox docs page.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: additive export of existing Base UI primitives, no logic changes
- Tests
  - [x] Additional testing not necessary because: purely re-exporting existing Base UI components that are already tested upstream. The docs demo serves as a visual integration test.