### PR TITLE
fix(select): added nativeLabel option to Field

### DIFF
--- a/.changeset/select-hover-state.md
+++ b/.changeset/select-hover-state.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add a `labelNative` option to `Field` so consumers can opt out of rendering a native `<label>` wrapper when needed.
+
+Update `Select` to pass `labelNative={false}` to avoid invalid nested label semantics while preserving label rendering.

--- a/packages/kumo/src/components/field/field.tsx
+++ b/packages/kumo/src/components/field/field.tsx
@@ -80,6 +80,8 @@ export interface FieldProps extends KumoFieldVariantsProps {
   children: ReactNode;
   /** The label content — can be a string or any React node. */
   label: ReactNode;
+  /** Whether to render the label as a native `<label>` element. */
+  labelNative?: boolean;
   /**
    * When explicitly `false`, shows gray "(optional)" text after the label.
    * When `true` or `undefined`, no indicator is shown.
@@ -117,13 +119,17 @@ export function Field({
   error,
   description,
   controlFirst = false,
+  labelNative = true,
 }: FieldProps) {
   // Show "(optional)" when required is explicitly false
   const showOptional = required === false;
 
   return (
     <FieldBase.Root className={fieldVariants({ controlFirst })}>
-      <FieldBase.Label className="m-0 text-base font-medium text-kumo-default">
+      <FieldBase.Label
+        nativeLabel={labelNative}
+        className="m-0 text-base font-medium text-kumo-default"
+      >
         <Label showOptional={showOptional} tooltip={labelTooltip} asContent>
           {label}
         </Label>

--- a/packages/kumo/src/components/field/field.tsx
+++ b/packages/kumo/src/components/field/field.tsx
@@ -81,7 +81,7 @@ export interface FieldProps extends KumoFieldVariantsProps {
   /** The label content — can be a string or any React node. */
   label: ReactNode;
   /** Whether to render the label as a native `<label>` element. */
-  labelNative?: boolean;
+  nativeLabel?: boolean;
   /**
    * When explicitly `false`, shows gray "(optional)" text after the label.
    * When `true` or `undefined`, no indicator is shown.
@@ -119,7 +119,7 @@ export function Field({
   error,
   description,
   controlFirst = false,
-  labelNative = true,
+  nativeLabel = true,
 }: FieldProps) {
   // Show "(optional)" when required is explicitly false
   const showOptional = required === false;
@@ -127,7 +127,7 @@ export function Field({
   return (
     <FieldBase.Root className={fieldVariants({ controlFirst })}>
       <FieldBase.Label
-        nativeLabel={labelNative}
+        nativeLabel={nativeLabel}
         className="m-0 text-base font-medium text-kumo-default"
       >
         <Label showOptional={showOptional} tooltip={labelTooltip} asContent>

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -485,6 +485,7 @@ export function Select<T, Multiple extends boolean | undefined = false>({
       <Field
         label={label}
         required={required}
+        labelNative={false}
         labelTooltip={labelTooltip}
         description={description}
         error={

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -485,7 +485,7 @@ export function Select<T, Multiple extends boolean | undefined = false>({
       <Field
         label={label}
         required={required}
-        labelNative={false}
+        nativeLabel={false}
         labelTooltip={labelTooltip}
         description={description}
         error={


### PR DESCRIPTION
## Problem
The existing `Select` component uses a `Field` wrapper to render its label text to have a consistent label/description/error layout. By default, `Field` renders a native `<label>` that's associated with the control, so hovers on the label triggers the input's hover state (i.e. in `Select`).

https://github.com/user-attachments/assets/1c9e347a-58cd-4ad3-a8dd-cbe11dde2877

## Solution
Base UI's `Field.Label` takes a `nativeLabel` prop that defaults to `true`, which renders a native `<label>` element linked to the control. A `nativeLabel` prop was added to `Field` and set `nativeLabel={false}` in `Select` that tells Base UI to render a non-`<label>` element with `aria-labelledby` to avoid hover coupling while still keeping its accessible name.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: no access to bonk
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed: ran `pnpm lint` and `pnpm typecheck` and visual tests across docs
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
