### PR TITLE
feat(layer-card): accept HTML div props on Primary and Secondary

### DIFF
--- a/.changeset/layer-card-html-props.md
+++ b/.changeset/layer-card-html-props.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Allow `LayerCard.Primary` and `LayerCard.Secondary` to accept all standard HTML div attributes, including `data-testid` for testing.

--- a/packages/kumo-docs-astro/src/components/demos/LayerCardDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerCardDemo.tsx
@@ -42,6 +42,22 @@ export function LayerCardSurfaceDemo() {
   );
 }
 
+/** Pass HTML attributes like `data-testid` to `Primary` and `Secondary` for testing. */
+export function LayerCardTestIdDemo() {
+  return (
+    <LayerCard className="w-[250px]">
+      <LayerCard.Secondary data-testid="card-header">
+        Getting Started
+      </LayerCard.Secondary>
+      <LayerCard.Primary data-testid="card-body">
+        <p className="text-sm text-kumo-subtle">
+          Quick start guide for new users
+        </p>
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
 export function LayerCardMultipleDemo() {
   return (
     <div className="flex gap-4">

--- a/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
@@ -13,6 +13,7 @@ import {
   LayerCardBasicDemo,
   LayerCardSurfaceDemo,
   LayerCardMultipleDemo,
+  LayerCardTestIdDemo,
 } from "~/components/demos/LayerCardDemo";
 
 {/* Hero Demo */}
@@ -109,6 +110,17 @@ export default function Example() {
 
 <ComponentExample demo="LayerCardMultipleDemo">
   <LayerCardMultipleDemo client:visible />
+</ComponentExample>
+
+### Test IDs
+
+<p>
+  <code>LayerCard.Primary</code> and <code>LayerCard.Secondary</code> accept all
+  standard HTML attributes, including <code>data-testid</code> for testing.
+</p>
+
+<ComponentExample demo="LayerCardTestIdDemo">
+  <LayerCardTestIdDemo client:visible />
 </ComponentExample>
 
 </ComponentSection>

--- a/packages/kumo/src/components/layer-card/layer-card.test.tsx
+++ b/packages/kumo/src/components/layer-card/layer-card.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { LayerCard } from "./layer-card";
+
+describe("LayerCard", () => {
+  describe("HTML attribute pass-through", () => {
+    it("passes data-testid to LayerCard.Primary", () => {
+      const { container } = render(
+        <LayerCard>
+          <LayerCard.Secondary>Header</LayerCard.Secondary>
+          <LayerCard.Primary data-testid="primary-card">
+            Content
+          </LayerCard.Primary>
+        </LayerCard>,
+      );
+
+      const primary = container.querySelector('[data-testid="primary-card"]');
+      expect(primary).toBeTruthy();
+      expect(primary!.textContent).toBe("Content");
+    });
+
+    it("passes data-testid to LayerCard.Secondary", () => {
+      const { container } = render(
+        <LayerCard>
+          <LayerCard.Secondary data-testid="secondary-card">
+            Header
+          </LayerCard.Secondary>
+          <LayerCard.Primary>Content</LayerCard.Primary>
+        </LayerCard>,
+      );
+
+      const secondary = container.querySelector(
+        '[data-testid="secondary-card"]',
+      );
+      expect(secondary).toBeTruthy();
+      expect(secondary!.textContent).toBe("Header");
+    });
+
+    it("passes aria attributes to sections", () => {
+      const { container } = render(
+        <LayerCard>
+          <LayerCard.Secondary aria-label="secondary section">
+            Header
+          </LayerCard.Secondary>
+          <LayerCard.Primary aria-label="primary section">
+            Content
+          </LayerCard.Primary>
+        </LayerCard>,
+      );
+
+      expect(
+        container.querySelector('[aria-label="secondary section"]'),
+      ).toBeTruthy();
+      expect(
+        container.querySelector('[aria-label="primary section"]'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/packages/kumo/src/components/layer-card/layer-card.tsx
+++ b/packages/kumo/src/components/layer-card/layer-card.tsx
@@ -3,7 +3,7 @@ import {
   Fragment,
   forwardRef,
   isValidElement,
-  type PropsWithChildren,
+  type ComponentPropsWithoutRef,
   type ReactElement,
   type ReactNode,
 } from "react";
@@ -71,10 +71,7 @@ function hasLayerCardSections(children: ReactNode): boolean {
 export type LayerCardProps = useRender.ComponentProps<"div"> &
   KumoLayerCardVariantsProps;
 
-export type LayerCardSectionProps = PropsWithChildren<{
-  /** Additional CSS classes merged via `cn()`. */
-  className?: string;
-}>;
+export type LayerCardSectionProps = ComponentPropsWithoutRef<"div">;
 
 /**
  * Card container for both simple surfaces and layered layouts.
@@ -119,12 +116,13 @@ const LayerCardRoot = forwardRef<HTMLDivElement, LayerCardProps>(function LayerC
 function LayerCardSecondary({
   children,
   className,
+  ...props
 }: LayerCardSectionProps) {
-  return <div className={cn(LAYER_CARD_SECONDARY_CLASSES, className)}>{children}</div>;
+  return <div className={cn(LAYER_CARD_SECONDARY_CLASSES, className)} {...props}>{children}</div>;
 }
 
-function LayerCardPrimary({ children, className }: LayerCardSectionProps) {
-  return <div className={cn(LAYER_CARD_PRIMARY_CLASSES, className)}>{children}</div>;
+function LayerCardPrimary({ children, className, ...props }: LayerCardSectionProps) {
+  return <div className={cn(LAYER_CARD_PRIMARY_CLASSES, className)} {...props}>{children}</div>;
 }
 
 LayerCardRoot.displayName = "LayerCard";


### PR DESCRIPTION
## Summary

- `LayerCard.Primary` and `LayerCard.Secondary` now accept all standard HTML div attributes (`data-testid`, `aria-*`, etc.) instead of only `children` and `className`
- Eliminates the need for downstream consumers to mock `LayerCard` just to test content inside it
- Adds tests and docs example demonstrating `data-testid` usage

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: small API surface change, needs human review
- Tests
- [x] Tests included/updated