### PR TITLE
fix(command-palette): prevent Footer from clipping List ring border

### DIFF
--- a/.changeset/command-palette-ring-clipping.md
+++ b/.changeset/command-palette-ring-clipping.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix CommandPalette List bottom ring being clipped by Footer background. Add scroll padding to prevent items from clipping behind rounded corners.

--- a/packages/kumo/src/components/command-palette/command-palette.tsx
+++ b/packages/kumo/src/components/command-palette/command-palette.tsx
@@ -279,7 +279,7 @@ const List = forwardRef<
     <div
       ref={ref}
       className={cn(
-        "min-h-0 flex-1 overflow-y-auto rounded-b-lg bg-kumo-base px-2 py-2 ring-1 ring-kumo-hairline",
+        "relative min-h-0 flex-1 overflow-y-auto rounded-b-lg bg-kumo-base px-2 py-2 scroll-py-2 ring-1 ring-kumo-hairline",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Add `relative` to CommandPalette List so its `ring-1` border renders above the Footer's background (same pattern as `LayerCard.Primary`)
- Add `scroll-py-2` so keyboard-navigated items don't clip behind rounded corners when scrolling

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: single CSS class change
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: visual-only fix, existing tests pass, manually verified scrolling and ring visibility