### PR TITLE
fix(tooltip): set cursor-default on disclosure triggers

### DIFF
--- a/.changeset/tooltip-cursor-default.md
+++ b/.changeset/tooltip-cursor-default.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Set `cursor-default` on Tooltip triggers so disclosure buttons don't appear clickable. Overridable via `className`.

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -168,6 +168,10 @@ export function Tooltip({
           // Consumer styles passed via className will override these (tailwind-merge)
           !shouldUseRender &&
             "inline-flex items-center bg-transparent border-none shadow-none p-0 m-0 h-auto min-h-0 leading-[0]",
+          // Tooltip triggers are disclosure elements, not actions — override
+          // cursor: pointer (e.g. from Button used via render prop) so the
+          // trigger doesn't appear clickable
+          "cursor-default",
           className,
         )}
         render={resolvedRender}


### PR DESCRIPTION
## Summary
- Tooltip triggers are disclosure elements, not actions — they shouldn't show `cursor: pointer`
- Add `cursor-default` to `TooltipBase.Trigger` className so Button-based triggers don't appear clickable
- Consumers can override via `className="cursor-pointer"` if the trigger is genuinely actionable

Fixes feedback that tooltip disclosure buttons looked clickable but clicking dismissed the tooltip (Base UI's default `closeOnClick` behavior).

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: single CSS class addition
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: visual-only fix, manually verified cursor behavior on docs site