### PR TITLE
kumo-screenshot-worker: teach ci to write to r2 through the worker

### DIFF
--- a/ci/visual-regression/run-visual-regression.ts
+++ b/ci/visual-regression/run-visual-regression.ts
@@ -36,7 +36,9 @@ const API_KEY = process.env.SCREENSHOT_API_KEY ?? "";
 interface ScreenshotResult {
   url: string;
   /** Base64-encoded PNG image */
-  image: string;
+  image?: string;
+  /** Worker-served URL for the stored PNG */
+  imageUrl?: string;
   error?: string;
   /** Unique identifier for this demo section, from data-vr-section attribute */
   sectionId?: string;
@@ -92,113 +94,60 @@ function ensureDir(dir: string): void {
   }
 }
 
-async function uploadImageToGitHub(
-  imageBuffer: Buffer,
-  filename: string,
-): Promise<string> {
-  const token = process.env.GITHUB_TOKEN;
-  const repo = process.env.GITHUB_REPOSITORY ?? "cloudflare/kumo";
-  const prNumber = process.env.GITHUB_PR_NUMBER ?? process.env.PR_NUMBER;
+function sanitizeKeyPart(value: string): string {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return sanitized || "visual-regression";
+}
+
+function encodeScreenshotKey(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function getRunStoragePrefix(): string {
+  const prNumber =
+    process.env.GITHUB_PR_NUMBER ?? process.env.PR_NUMBER ?? "local";
   const runId = process.env.GITHUB_RUN_ID ?? Date.now().toString();
+  const headSha = process.env.PR_HEAD_SHA ?? process.env.GITHUB_SHA ?? "unknown";
 
-  if (!token) {
-    throw new Error("GITHUB_TOKEN required for image upload");
+  return [
+    "runs",
+    `pr-${sanitizeKeyPart(prNumber)}`,
+    `run-${sanitizeKeyPart(runId)}`,
+    sanitizeKeyPart(headSha.substring(0, 12)),
+  ].join("/");
+}
+
+async function uploadScreenshotToWorker(
+  imageBuffer: Buffer,
+  key: string,
+): Promise<string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "image/png",
+  };
+  if (API_KEY) {
+    headers["X-API-Key"] = API_KEY;
   }
 
-  const [owner, repoName] = repo.split("/");
-  const branch = `vr-screenshots-${prNumber}-${runId}`;
-  const path = `screenshots/${filename}`;
-
-  const mainRef = await fetch(
-    `https://api.github.com/repos/${owner}/${repoName}/git/ref/heads/main`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.v3+json",
-      },
-    },
-  );
-  if (!mainRef.ok) {
-    throw new Error(
-      `Failed to get main ref: ${mainRef.status} ${await mainRef.text()}`,
-    );
-  }
-  const mainData = (await mainRef.json()) as { object: { sha: string } };
-  const baseSha = mainData.object.sha;
-
-  const refCheck = await fetch(
-    `https://api.github.com/repos/${owner}/${repoName}/git/ref/heads/${branch}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.v3+json",
-      },
-    },
-  );
-
-  if (refCheck.status === 404) {
-    const createRef = await fetch(
-      `https://api.github.com/repos/${owner}/${repoName}/git/refs`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github.v3+json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          ref: `refs/heads/${branch}`,
-          sha: baseSha,
-        }),
-      },
-    );
-    if (!createRef.ok) {
-      throw new Error(
-        `Failed to create branch ${branch}: ${createRef.status} ${await createRef.text()}`,
-      );
-    }
-  }
-
-  const content = imageBuffer.toString("base64");
-
-  const existingFile = await fetch(
-    `https://api.github.com/repos/${owner}/${repoName}/contents/${path}?ref=${branch}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.v3+json",
-      },
-    },
-  );
-
-  const existingData = existingFile.ok
-    ? ((await existingFile.json()) as { sha?: string })
-    : null;
-
-  const upload = await fetch(
-    `https://api.github.com/repos/${owner}/${repoName}/contents/${path}`,
+  const response = await fetch(
+    `${WORKER_URL}/screenshots/${encodeScreenshotKey(key)}`,
     {
       method: "PUT",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.v3+json",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        message: `Visual regression: ${filename}`,
-        content,
-        branch,
-        ...(existingData?.sha ? { sha: existingData.sha } : {}),
-      }),
+      headers,
+      body: imageBuffer,
     },
   );
-  if (!upload.ok) {
+
+  if (!response.ok) {
     throw new Error(
-      `Failed to upload ${filename}: ${upload.status} ${await upload.text()}`,
+      `Worker upload failed: ${response.status} - ${await response.text()}`,
     );
   }
 
-  return `https://raw.githubusercontent.com/${owner}/${repoName}/${branch}/${path}`;
+  return `${WORKER_URL}/screenshots/${encodeScreenshotKey(key)}`;
 }
 
 /**
@@ -229,6 +178,7 @@ async function captureScreenshots(
   components: DiscoveredComponent[],
   outputDir: string,
   prefix: string,
+  storagePrefix: string,
 ): Promise<CapturedScreenshot[]> {
   ensureDir(outputDir);
   const screenshots: CapturedScreenshot[] = [];
@@ -271,6 +221,10 @@ async function captureScreenshots(
       pages: requests,
       viewport: { width: 1440, height: 900 },
       hideSidebar: true,
+      storage: {
+        prefix: storagePrefix,
+        includeImage: true,
+      },
     }),
   });
 
@@ -322,18 +276,12 @@ async function captureScreenshots(
     const imageBuffer = Buffer.from(result.image, "base64");
     writeFileSync(filepath, imageBuffer);
 
-    let imageUrl: string | null = null;
-    try {
-      imageUrl = await uploadImageToGitHub(imageBuffer, filename);
-      console.log(`  OK: ${screenshotName} -> ${imageUrl}`);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("GITHUB_TOKEN required")) {
-        console.log(`  OK: ${screenshotName} (local only, no GITHUB_TOKEN)`);
-      } else {
-        console.error(`  Upload failed for ${screenshotName}: ${msg}`);
-      }
-    }
+    const imageUrl = result.imageUrl ?? null;
+    console.log(
+      imageUrl
+        ? `  OK: ${screenshotName} -> ${imageUrl}`
+        : `  OK: ${screenshotName} (local only, no worker URL)`,
+    );
 
     screenshots.push({
       id: screenshotId,
@@ -606,6 +554,7 @@ async function main(): Promise<void> {
 
   const beforeDir = join(SCREENSHOTS_DIR, "before");
   const afterDir = join(SCREENSHOTS_DIR, "after");
+  const storagePrefix = getRunStoragePrefix();
 
   console.log("=== Capturing BEFORE screenshots ===");
   const beforeScreenshots = await captureScreenshots(
@@ -613,6 +562,7 @@ async function main(): Promise<void> {
     components,
     beforeDir,
     "before",
+    `${storagePrefix}/before`,
   );
 
   console.log("\n=== Capturing AFTER screenshots ===");
@@ -621,6 +571,7 @@ async function main(): Promise<void> {
     components,
     afterDir,
     "after",
+    `${storagePrefix}/after`,
   );
 
   console.log("\n=== Comparing screenshots ===");
@@ -655,7 +606,10 @@ async function main(): Promise<void> {
       writeFileSync(diffPath, diff.diffImage);
 
       try {
-        diffUrl = await uploadImageToGitHub(diff.diffImage, diffFilename);
+        diffUrl = await uploadScreenshotToWorker(
+          diff.diffImage,
+          `${storagePrefix}/diff/${diffFilename}`,
+        );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`  Diff upload failed for ${before.name}: ${msg}`);

--- a/packages/kumo-screenshot-worker/src/index.ts
+++ b/packages/kumo-screenshot-worker/src/index.ts
@@ -6,6 +6,7 @@ import { cors } from "hono/cors";
 
 const MAX_PAGES = 50;
 const MAX_ACTION_PAYLOAD_BYTES = 64_000; // 64 KB per css action payload
+const MAX_SCREENSHOT_UPLOAD_BYTES = 10_000_000; // 10 MB per uploaded PNG
 
 const HIDE_SIDEBAR_CSS = `
   aside[data-sidebar-open] { display: none !important; }
@@ -187,6 +188,26 @@ function getScreenshotUrl(requestUrl: string, key: string): string {
   return url.toString();
 }
 
+function validateScreenshotKey(
+  key: string,
+): { ok: true; key: string } | { ok: false; error: string } {
+  const normalized = key.replace(/^\/+/, "");
+
+  if (!normalized) {
+    return { ok: false, error: "Screenshot key must not be empty" };
+  }
+
+  if (normalized.split("/").some((part) => part === ".." || part === "")) {
+    return { ok: false, error: "Screenshot key contains invalid path parts" };
+  }
+
+  if (!normalized.endsWith(".png")) {
+    return { ok: false, error: "Screenshot key must end with .png" };
+  }
+
+  return { ok: true, key: normalized };
+}
+
 async function appendScreenshotResult(options: {
   env: Env;
   requestUrl: string;
@@ -236,19 +257,18 @@ app.use(
   "*",
   cors({
     origin: getCorsOrigin,
-    allowMethods: ["POST", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PUT", "OPTIONS"],
     allowHeaders: ["Content-Type", "X-API-Key"],
   }),
 );
 
 app.get("/screenshots/*", async (c) => {
-  const key = c.req.path.slice("/screenshots/".length);
-
-  if (!key || key.split("/").some((part) => part === ".." || part === "")) {
-    return c.json({ error: "Invalid screenshot key" }, 400);
+  const keyCheck = validateScreenshotKey(c.req.path.slice("/screenshots/".length));
+  if (!keyCheck.ok) {
+    return c.json({ error: keyCheck.error }, 400);
   }
 
-  const object = await c.env.SCREENSHOTS.get(key);
+  const object = await c.env.SCREENSHOTS.get(keyCheck.key);
   if (!object) {
     return c.json({ error: "Screenshot not found" }, 404);
   }
@@ -268,6 +288,35 @@ app.use("*", async (c, next) => {
   }
 
   await next();
+});
+
+app.put("/screenshots/*", async (c) => {
+  const keyCheck = validateScreenshotKey(c.req.path.slice("/screenshots/".length));
+  if (!keyCheck.ok) {
+    return c.json({ error: keyCheck.error }, 400);
+  }
+
+  const contentType = c.req.header("Content-Type") ?? "";
+  if (!contentType.startsWith("image/png")) {
+    return c.json({ error: "Content-Type must be image/png" }, 415);
+  }
+
+  const contentLength = c.req.header("Content-Length");
+  const parsedLength = contentLength ? Number(contentLength) : null;
+  if (parsedLength !== null && parsedLength > MAX_SCREENSHOT_UPLOAD_BYTES) {
+    return c.json({ error: "Screenshot upload exceeds 10 MB limit" }, 413);
+  }
+
+  const image = await c.req.arrayBuffer();
+  if (image.byteLength > MAX_SCREENSHOT_UPLOAD_BYTES) {
+    return c.json({ error: "Screenshot upload exceeds 10 MB limit" }, 413);
+  }
+
+  await c.env.SCREENSHOTS.put(keyCheck.key, image, {
+    httpMetadata: { contentType: "image/png" },
+  });
+
+  return c.json({ key: keyCheck.key, url: getScreenshotUrl(c.req.url, keyCheck.key) });
 });
 
 app.post("/batch", (c) => handleBatch(c.req.raw, c.env, {}));


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

- Added authenticated PUT /screenshots/* to worker for PNG uploads.
- Switched VR CI image storage from GitHub branches to worker/R2 URLs.
- Before/after screenshots use /batch with storage.
- Diff screenshots upload to worker via PUT /screenshots/*.
- Removed GitHub branch image upload path from VR runner.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: testing in prod lol <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
