### PR TITLE
Deprecate Link `to` prop — standardize on `href` + LinkProvider

### DIFF
--- a/.changeset/deprecate-link-to-prop.md
+++ b/.changeset/deprecate-link-to-prop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Deprecate `to` prop on Link in favor of `href`. The `to` prop is a routing-framework concept that doesn't belong on a presentational component. Use `href` for all link destinations and configure a `LinkProvider` wrapper to bridge to your router. `to` continues to work but emits a dev-mode deprecation warning.

--- a/packages/kumo-docs-astro/src/pages/components/link.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/link.mdx
@@ -90,11 +90,52 @@ export default function Example() {
 }
 ```
 
-### Framework Integration (render prop)
+### Framework Integration (LinkProvider)
 
 <p>
-  Use the `render` prop to compose Link styles onto framework-specific routing
-  components like React Router's Link or Next.js Link.
+  For app-wide router integration, configure a `LinkProvider` at your app root.
+  Your wrapper component receives `href` and is responsible for bridging to your
+  router's API. This lets engineers use `<Link href="...">` everywhere without
+  thinking about routing internals.
+</p>
+
+```tsx
+import { forwardRef } from "react";
+import { LinkProvider } from "@cloudflare/kumo";
+import { Link as RouterLink } from "react-router-dom";
+
+// Your app's wrapper maps href to the router's navigation prop
+// and handles external URLs with a plain <a>
+const AppLink = forwardRef(({ href, to, ...rest }, ref) => {
+  const destination = href ?? to;
+  const isExternal =
+    destination?.startsWith("http") &&
+    new URL(destination).origin !== window.location.origin;
+
+  if (isExternal) {
+    return <a ref={ref} href={destination} {...rest} />;
+  }
+  return <RouterLink ref={ref} to={destination} {...rest} />;
+});
+
+// Wrap your app once
+export function App() {
+  return (
+    <LinkProvider component={AppLink}>
+      {/* All <Link href="..."> calls go through AppLink */}
+      <YourApp />
+    </LinkProvider>
+  );
+}
+```
+
+### Composition with render prop
+
+<p>
+  For exceptional cases where you need direct control over the rendered element,
+  use the `render` prop. This bypasses the `LinkProvider` entirely — all other
+  props (`href`, `target`, `className`, etc.) are merged onto the provided element
+  automatically.
 </p>
 
 ```tsx
@@ -103,9 +144,17 @@ import { Link as RouterLink } from "react-router-dom";
 
 export default function Example() {
   return (
-    <Link render={<RouterLink to="/dashboard" />} variant="inline">
-      Dashboard
-    </Link>
+    <>
+      {/* Force a specific router link (bypasses LinkProvider) */}
+      <Link render={<RouterLink to="/dashboard" />} variant="inline">
+        Dashboard
+      </Link>
+
+      {/* Force a plain anchor (bypasses LinkProvider) */}
+      <Link render={<a />} href="https://example.com" target="_blank" rel="noopener noreferrer">
+        External Site <Link.ExternalIcon />
+      </Link>
+    </>
   );
 }
 ```
@@ -197,7 +246,20 @@ export default function Example() {
         <td class="px-4 py-3 font-mono text-xs">href</td>
         <td class="px-4 py-3 font-mono text-xs">string</td>
         <td class="px-4 py-3 font-mono text-xs">-</td>
-        <td class="px-4 py-3 text-xs">Link destination URL</td>
+        <td class="px-4 py-3 text-xs">
+          Link destination URL. Use this for all links — both internal and
+          external. Configure a `LinkProvider` to bridge `href` to your
+          router.
+        </td>
+      </tr>
+      <tr class="border-b border-kumo-hairline">
+        <td class="px-4 py-3 font-mono text-xs">to</td>
+        <td class="px-4 py-3 font-mono text-xs">string</td>
+        <td class="px-4 py-3 font-mono text-xs">-</td>
+        <td class="px-4 py-3 text-xs">
+          <strong>Deprecated.</strong> Use `href` instead. This prop will
+          be removed in a future major version.
+        </td>
       </tr>
       <tr class="border-b border-kumo-hairline">
         <td class="px-4 py-3 font-mono text-xs">className</td>
@@ -310,16 +372,23 @@ export default function Example() {
 
       <ul class="ml-4 list-disc space-y-1">
         <li>
-          Use the `render` prop with React Router, Next.js, or other framework
-          links
-        </li>
-        <li>Pass your framework's Link component as the render prop value</li>
-        <li>
-          This preserves client-side navigation while applying Kumo styling
+          Configure a `LinkProvider` at your app root to integrate with your
+          client-side router
         </li>
         <li>
-          Alternatively, configure a global LinkProvider for automatic
-          integration
+          Your wrapper receives `href` and maps it to your router's
+          navigation prop (e.g. React Router's `to`)
+        </li>
+        <li>
+          The wrapper should handle external URLs by rendering a plain
+          `&lt;a&gt;` instead of routing them
+        </li>
+        <li>
+          Use the `render` prop as an escape hatch for exceptional cases
+          that need direct control over the rendered element
+        </li>
+        <li>
+          The `to` prop is deprecated — use `href` for all link destinations
         </li>
       </ul>
     </div>

--- a/packages/kumo-docs-astro/src/pages/installation.mdx
+++ b/packages/kumo-docs-astro/src/pages/installation.mdx
@@ -235,6 +235,6 @@ const className = cn("base-class", condition && "conditional-class");
 // Generate safe random IDs
 const id = safeRandomId();
 
-// Configure link component for your framework
-<LinkProvider component={YourLinkComponent}>{/* Your app */}</LinkProvider>;
+// Configure link component for your framework (maps href to your router)
+<LinkProvider component={YourAppLink}>{/* Your app */}</LinkProvider>;
 ```

--- a/packages/kumo/src/components/link/link.test.tsx
+++ b/packages/kumo/src/components/link/link.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { createElement } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createElement, forwardRef } from "react";
+import { render, screen } from "@testing-library/react";
 import { Link, KUMO_LINK_VARIANTS, linkVariants } from "./link";
+import { LinkProvider } from "../../utils/link-provider";
 
 describe("Link", () => {
   it("should be defined", () => {
@@ -112,5 +114,252 @@ describe("Link", () => {
       children: "Dashboard",
     };
     expect(() => createElement(Link, props)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// href behavior — the standard, framework-agnostic prop
+// ---------------------------------------------------------------------------
+describe("Link with href (standard usage)", () => {
+  it("renders an anchor with the correct href", () => {
+    render(<Link href="/docs">Docs</Link>);
+    const anchor = screen.getByRole("link", { name: "Docs" });
+    expect(anchor.getAttribute("href")).toBe("/docs");
+  });
+
+  it("renders external URLs correctly with the default LinkProvider", () => {
+    render(
+      <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+        External
+      </Link>,
+    );
+    const anchor = screen.getByRole("link", { name: "External" });
+    expect(anchor.getAttribute("href")).toBe("https://example.com");
+    expect(anchor.getAttribute("target")).toBe("_blank");
+  });
+
+  it("passes href through to a custom LinkProvider component", () => {
+    const CustomLink = forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >(({ href, ...rest }, ref) => (
+      <a ref={ref} href={href} data-testid="custom-link" {...rest} />
+    ));
+    CustomLink.displayName = "CustomLink";
+
+    render(
+      <LinkProvider component={CustomLink}>
+        <Link href="https://example.com">External</Link>
+      </LinkProvider>,
+    );
+
+    const anchor = screen.getByTestId("custom-link");
+    expect(anchor.getAttribute("href")).toBe("https://example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LinkProvider — application-layer routing integration
+// ---------------------------------------------------------------------------
+describe("LinkProvider", () => {
+  it("uses the default <a> element when no provider is configured", () => {
+    render(<Link href="/about">About</Link>);
+    const el = screen.getByRole("link", { name: "About" });
+    expect(el.tagName).toBe("A");
+    expect(el.getAttribute("href")).toBe("/about");
+  });
+
+  it("renders the custom component from LinkProvider", () => {
+    const RouterLink = forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >(({ href, children, ...rest }, ref) => (
+      <a ref={ref} href={href} data-router="true" {...rest}>
+        {children}
+      </a>
+    ));
+    RouterLink.displayName = "RouterLink";
+
+    render(
+      <LinkProvider component={RouterLink}>
+        <Link href="/dashboard">Dashboard</Link>
+      </LinkProvider>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Dashboard" });
+    expect(anchor.getAttribute("data-router")).toBe("true");
+    expect(anchor.getAttribute("href")).toBe("/dashboard");
+  });
+
+  it("the custom LinkProvider component receives href for external URLs", () => {
+    /**
+     * This test documents the correct integration pattern: the LinkProvider
+     * component should handle href correctly for both internal and external URLs.
+     * If the consumer's router mishandles external URLs via href, the fix belongs
+     * in the LinkProvider wrapper — not in Kumo's Link component.
+     */
+    const AppLink = forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >(({ href, ...rest }, ref) => {
+      // A well-written LinkProvider wrapper detects external URLs
+      // and renders a plain <a> for them.
+      const isExternal = href?.startsWith("http");
+      if (isExternal) {
+        return <a ref={ref} href={href} {...rest} />;
+      }
+      // Internal URLs get routed via the framework
+      return <a ref={ref} href={href} data-routed="true" {...rest} />;
+    });
+    AppLink.displayName = "AppLink";
+
+    render(
+      <LinkProvider component={AppLink}>
+        <Link href="https://example.com">External</Link>
+        <Link href="/internal">Internal</Link>
+      </LinkProvider>,
+    );
+
+    const external = screen.getByRole("link", { name: "External" });
+    expect(external.getAttribute("href")).toBe("https://example.com");
+    expect(external.getAttribute("data-routed")).toBeNull();
+
+    const internal = screen.getByRole("link", { name: "Internal" });
+    expect(internal.getAttribute("href")).toBe("/internal");
+    expect(internal.getAttribute("data-routed")).toBe("true");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// render prop — bypasses LinkProvider entirely
+// ---------------------------------------------------------------------------
+describe("Link with render prop", () => {
+  it("bypasses LinkProvider when render is provided", () => {
+    const SpyLink = forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >((props, ref) => (
+      <a ref={ref} data-spy="true" {...props} />
+    ));
+    SpyLink.displayName = "SpyLink";
+
+    render(
+      <LinkProvider component={SpyLink}>
+        <Link render={<a href="/direct" />}>Direct</Link>
+      </LinkProvider>,
+    );
+
+    const anchor = screen.getByRole("link", { name: "Direct" });
+    // render prop element is used instead of LinkProvider's component
+    expect(anchor.getAttribute("data-spy")).toBeNull();
+    expect(anchor.getAttribute("href")).toBe("/direct");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `to` prop deprecation
+// ---------------------------------------------------------------------------
+describe("Link `to` prop deprecation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("still renders when `to` is used (backwards compatibility)", () => {
+    // Suppress the expected deprecation warning
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<Link to="/legacy">Legacy</Link>);
+    const anchor = screen.getByRole("link", { name: "Legacy" });
+    // DefaultLinkComponent resolves href ?? to, so `to` still works
+    expect(anchor.getAttribute("href")).toBe("/legacy");
+  });
+
+  it("emits a deprecation warning in development when `to` is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<Link to="/old-style">Old</Link>);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("The `to` prop is deprecated"),
+    );
+  });
+
+  it("does not emit a deprecation warning when only `href` is used", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<Link href="/new-style">New</Link>);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Documents the recommended LinkProvider integration pattern
+// ---------------------------------------------------------------------------
+describe("LinkProvider integration patterns", () => {
+  it("a well-written wrapper maps href to the router's navigation prop", () => {
+    /**
+     * The correct pattern: the LinkProvider wrapper receives `href` (the
+     * web-standard prop) and maps it to whatever the router expects.
+     * This keeps Kumo framework-agnostic — routing logic stays in the app.
+     */
+    const AppRouterLink = forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >(({ href, to, children, ...rest }, ref) => (
+      <a ref={ref} href={href ?? to} data-routed="true" {...rest}>
+        {children}
+      </a>
+    ));
+    AppRouterLink.displayName = "AppRouterLink";
+
+    render(
+      <LinkProvider component={AppRouterLink}>
+        <Link href="https://example.com">External</Link>
+        <Link href="/internal">Internal</Link>
+      </LinkProvider>,
+    );
+
+    const external = screen.getByRole("link", { name: "External" });
+    expect(external.getAttribute("href")).toBe("https://example.com");
+
+    const internal = screen.getByRole("link", { name: "Internal" });
+    expect(internal.getAttribute("href")).toBe("/internal");
+    expect(internal.getAttribute("data-routed")).toBe("true");
+  });
+
+  it("a wrapper that only reads `to` will not receive the destination from href", () => {
+    /**
+     * This test documents the footgun: if a LinkProvider component only
+     * destructures `to` and ignores `href`, then <Link href="..."> will
+     * not navigate correctly. Router components (e.g. React Router's <Link>)
+     * typically read `to` for navigation and ignore `href`.
+     *
+     * The solution is NOT to add `to` to Kumo's Link API. Instead, the
+     * LinkProvider wrapper must map `href` → `to` at the application layer.
+     */
+    const ToOnlyLink = forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
+    >(({ to, children, ...rest }, ref) => (
+      // Simulates a router component that only reads `to` for navigation.
+      // `href` falls through via ...rest here, but a real router component
+      // would not pass unknown props to the DOM — it would be silently lost.
+      <a ref={ref} data-navigated-to={to ?? "none"} {...rest}>
+        {children}
+      </a>
+    ));
+    ToOnlyLink.displayName = "ToOnlyLink";
+
+    render(
+      <LinkProvider component={ToOnlyLink}>
+        <Link href="https://example.com">Test Link</Link>
+      </LinkProvider>,
+    );
+
+    const anchor = screen.getByText("Test Link");
+    // The wrapper never saw the URL via `to` — it was passed as `href`
+    // which the wrapper ignores for navigation purposes.
+    expect(anchor.getAttribute("data-navigated-to")).toBe("none");
   });
 });

--- a/packages/kumo/src/components/link/link.test.tsx
+++ b/packages/kumo/src/components/link/link.test.tsx
@@ -143,6 +143,7 @@ describe("Link with href (standard usage)", () => {
       HTMLAnchorElement,
       React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
     >(({ href, ...rest }, ref) => (
+      // oxlint-disable-next-line anchor-has-content, control-has-associated-label
       <a ref={ref} href={href} data-testid="custom-link" {...rest} />
     ));
     CustomLink.displayName = "CustomLink";
@@ -206,9 +207,11 @@ describe("LinkProvider", () => {
       // and renders a plain <a> for them.
       const isExternal = href?.startsWith("http");
       if (isExternal) {
+        // oxlint-disable-next-line anchor-has-content, control-has-associated-label
         return <a ref={ref} href={href} {...rest} />;
       }
       // Internal URLs get routed via the framework
+      // oxlint-disable-next-line anchor-has-content, control-has-associated-label
       return <a ref={ref} href={href} data-routed="true" {...rest} />;
     });
     AppLink.displayName = "AppLink";
@@ -239,13 +242,16 @@ describe("Link with render prop", () => {
       HTMLAnchorElement,
       React.AnchorHTMLAttributes<HTMLAnchorElement> & { to?: string }
     >((props, ref) => (
+      // oxlint-disable-next-line anchor-has-content, control-has-associated-label
       <a ref={ref} data-spy="true" {...props} />
     ));
     SpyLink.displayName = "SpyLink";
 
     render(
       <LinkProvider component={SpyLink}>
+        {/* oxlint-disable anchor-has-content, control-has-associated-label */}
         <Link render={<a href="/direct" />}>Direct</Link>
+        {/* oxlint-enable anchor-has-content, control-has-associated-label */}
       </LinkProvider>,
     );
 

--- a/packages/kumo/src/components/link/link.tsx
+++ b/packages/kumo/src/components/link/link.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type SVGProps } from "react";
+import { forwardRef, useEffect, type SVGProps } from "react";
 import { useRender } from "@base-ui/react/use-render";
 import { mergeProps } from "@base-ui/react/merge-props";
 import { cn } from "../../utils/cn";
@@ -87,12 +87,23 @@ export function linkVariants({
 /**
  * Link component props.
  *
- * @example
+ * Use `href` for the link destination. For framework-specific routing, use the
+ * `render` prop or configure a `LinkProvider` at the app root.
+ *
+ * @example Internal link
  * ```tsx
  * <Link href="/docs">Learn more</Link>
+ * ```
+ *
+ * @example External link
+ * ```tsx
  * <Link href="https://cloudflare.com" target="_blank" rel="noopener noreferrer">
  *   Visit Cloudflare <Link.ExternalIcon />
  * </Link>
+ * ```
+ *
+ * @example Composition with render prop
+ * ```tsx
  * <Link render={<RouterLink to="/dashboard" />}>Dashboard</Link>
  * ```
  */
@@ -103,9 +114,12 @@ export type LinkProps = useRender.ComponentProps<"a"> &
 /**
  * Link component for consistent inline text links.
  *
- * Supports composition via `render` prop for framework-specific routing:
- * - Without render: renders via LinkProvider (default anchor or configured component)
- * - With render: merges props onto the provided element with proper ref/event handling
+ * Link is a **presentational component** — it handles visual styling and
+ * accessibility. Routing behavior belongs in the application layer, via
+ * either the `render` prop or a `LinkProvider`.
+ *
+ * - Without `render`: renders via LinkProvider (default `<a>` or configured component)
+ * - With `render`: merges props onto the provided element with proper ref/event handling
  *
  * @example Basic usage
  * ```tsx
@@ -119,11 +133,23 @@ export type LinkProps = useRender.ComponentProps<"a"> &
  * </Link>
  * ```
  *
- * @example Composition with React Router
+ * @example Composition with React Router via render prop
  * ```tsx
  * <Link render={<RouterLink to="/dashboard" />} variant="inline">
  *   Dashboard
  * </Link>
+ * ```
+ *
+ * @example Composition via LinkProvider (recommended for app-wide routing)
+ * ```tsx
+ * // App root:
+ * <LinkProvider component={AppLink}>
+ *   <App />
+ * </LinkProvider>
+ *
+ * // Then use href everywhere:
+ * <Link href="/dashboard">Dashboard</Link>
+ * <Link href="https://example.com" target="_blank">External</Link>
  * ```
  */
 const LinkBase = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
@@ -131,6 +157,23 @@ const LinkBase = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   ref,
 ) {
   const LinkComponent = useLinkComponent();
+
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- dev-only, conditional is stable
+    useEffect(() => {
+      if ("to" in props && props.to !== undefined) {
+        console.warn(
+          '[kumo] Link: The `to` prop is deprecated. Use `href` instead.\n\n' +
+            'If your app uses a client-side router, configure a LinkProvider that\n' +
+            'maps `href` to your router\'s navigation prop. See:\n' +
+            'https://kumo.cfops.it/utilities/link-provider\n\n' +
+            'Migration example:\n' +
+            '  Before: <Link to="/page">…</Link>\n' +
+            '  After:  <Link href="/page">…</Link>',
+        );
+      }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps -- one-time warning
+  }
 
   const defaultProps: useRender.ElementProps<"a"> = {
     className: cn(

--- a/packages/kumo/src/utils/link-provider.tsx
+++ b/packages/kumo/src/utils/link-provider.tsx
@@ -9,6 +9,23 @@ import {
 } from "react";
 
 type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  /**
+   * @deprecated Use `href` instead. The `to` prop is a routing-framework concept
+   * (e.g. React Router) that does not belong on a presentational component.
+   *
+   * If your application uses a client-side router, configure the `LinkProvider`
+   * with a wrapper component that maps `href` to your router's navigation prop:
+   *
+   * ```tsx
+   * const AppLink = forwardRef(({ href, ...rest }, ref) => (
+   *   <ReactRouterLink ref={ref} to={href} {...rest} />
+   * ));
+   *
+   * <LinkProvider component={AppLink}>
+   *   <App />
+   * </LinkProvider>
+   * ```
+   */
   to?: string;
 };
 
@@ -31,6 +48,43 @@ export function useLinkComponent() {
   return useContext(LinkComponentContext);
 }
 
+/**
+ * Provides a custom link component for all Kumo Link instances in the tree.
+ *
+ * Use this to integrate framework-specific routing (React Router, Next.js, etc.)
+ * while keeping Kumo's Link component framework-agnostic.
+ *
+ * Your custom component receives standard anchor props (including `href`) and
+ * is responsible for bridging to your router's API:
+ *
+ * @example React Router integration
+ * ```tsx
+ * import { Link as ReactRouterLink } from "react-router-dom";
+ *
+ * const AppLink = forwardRef<HTMLAnchorElement, LinkComponentProps>(
+ *   ({ href, ...rest }, ref) => (
+ *     <ReactRouterLink ref={ref} to={href ?? ""} {...rest} />
+ *   ),
+ * );
+ *
+ * <LinkProvider component={AppLink}>
+ *   <App />
+ * </LinkProvider>
+ * ```
+ *
+ * @example Next.js integration
+ * ```tsx
+ * import NextLink from "next/link";
+ *
+ * const AppLink = forwardRef<HTMLAnchorElement, LinkComponentProps>(
+ *   (props, ref) => <NextLink ref={ref} {...props} />,
+ * );
+ *
+ * <LinkProvider component={AppLink}>
+ *   <App />
+ * </LinkProvider>
+ * ```
+ */
 export function LinkProvider({
   component,
   children,


### PR DESCRIPTION
## Summary

- Deprecates the `to` prop on `Link` and `LinkComponentProps` in favor of `href`
- Adds a dev-mode deprecation warning when `to` is used
- Documents the correct `LinkProvider` integration pattern for framework routers
- Adds comprehensive tests covering `href`, `LinkProvider`, `render` prop, and the deprecation

## Problem

Kumo's `Link` component accepts both `href` and `to` for specifying the destination URL. This causes a real-world bug when applications configure a `LinkProvider` with a client-side router:

1. Developer writes `<Link href="https://example.com">` (the natural, platform-standard prop)
2. The `LinkProvider` wraps a router component (e.g. React Router's `<Link>`) that reads `to` for navigation
3. The router component ignores `href` — the external link silently breaks, navigating to a broken internal route instead

The workaround has been to use `<Link to="https://example.com">` instead, but **this doesn't actually work either** — React Router's `<Link to>` does not support fully qualified URLs. It resolves everything as a path within the app.

### The full matrix

**With a LinkProvider wrapping React Router:**

| URL | Prop | Result |
|---|---|---|
| `/dashboard` | `href` | Broken — RR ignores `href`, reads `to` (undefined) |
| `/dashboard` | `to` | Works — RR reads `to`, client-side nav |
| `https://example.com` | `href` | Broken — RR ignores `href` |
| `https://example.com` | `to` | **Also broken** — RR resolves it as a relative path |

No single prop solves external links without the wrapper being explicit about it.

### Why `to` exists today

`to` is a React Router-ism that was added to `LinkComponentProps` so the `DefaultLinkComponent` could accept either prop. This leaked a routing-framework concept into a presentational component's API.

### The scope of the workaround inside Kumo

Five places inside Kumo itself defensively pass `to={href}` to work around this:

| Component | Pattern |
|---|---|
| `LinkButton` | `to={typeof href === "string" ? href : undefined}` |
| `Sidebar.MenuButton` (2 sites) | `to={href}` |
| `DropdownMenu.LinkItem` | `to={href}` |
| `Breadcrumbs.Link` | `to={href}` |

## Solution

### 1. Deprecate `to`, standardize on `href` (this PR)

**Link should only speak `href`** (the platform primitive). Routing integration is the application's responsibility via `LinkProvider`. This is [inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control): Kumo defines the interface, the application injects the routing implementation.

This PR:
- **Deprecates `to`** with `@deprecated` JSDoc and a dev-mode `console.warn`
- **Documents `LinkProvider`** with concrete examples for React Router and Next.js
- **Adds tests** covering `href`, `LinkProvider`, `render` prop, backwards compatibility, and the deprecation warning

`to` is **not removed** — it continues to work for backwards compatibility. Consumers get a dev-mode warning guiding them to migrate.

### 2. Consumer apps build a smart `LinkProvider` wrapper (downstream follow-up)

The recommended pattern is for consumer apps to provide a `LinkProvider` component that:
- Maps `href` to the router's navigation prop for internal links
- Renders a plain `<a>` for external links
- Handles `target`, `rel`, etc. as appropriate

```tsx
const AppLink = forwardRef(({ href, to, ...rest }, ref) => {
  const destination = href ?? to;
  const isExternal = destination?.startsWith("http") &&
    new URL(destination).origin !== window.location.origin;

  if (isExternal) {
    return <a ref={ref} href={destination} {...rest} />;
  }
  return <RouterLink ref={ref} to={destination} {...rest} />;
});

<LinkProvider component={AppLink}>
  <App />
</LinkProvider>
```

Engineers then just use `href` everywhere — the wrapper handles the rest:

```tsx
<Link href="/dashboard">Dashboard</Link>
<Link href="https://example.com" target="_blank" rel="noopener noreferrer">
  Cloudflare Docs <Link.ExternalIcon />
</Link>
```

For exceptional cases where direct router control is needed, the `render` prop remains as an escape hatch:

```tsx
<Link render={<RouterLink to="/special" />}>Special case</Link>
```

## Breaking change?

**Soft deprecation only.** `to` continues to work — consumers just get a dev-mode warning guiding them to migrate. A future major version could remove `to` entirely.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: RFC for team discussion, requesting feedback on approach
- Tests
  - [x] Tests included/updated