### PR TITLE
feat(tabs): add size="sm" variant

### DIFF
--- a/.changeset/tabs-sm-size.md
+++ b/.changeset/tabs-sm-size.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `size="sm"` variant to Tabs component (h-6.5 / 26px, matching Input sm)

--- a/packages/kumo-docs-astro/src/components/demos/LayerCardFilterMockupDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerCardFilterMockupDemo.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Badge, Input, LayerCard, Tabs } from "@cloudflare/kumo";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+
+// ─── Data ────────────────────────────────────────────────────────────
+
+const ORIGINS = [
+	{ origin: "challenges.cloudflare.com", s2xx: 1, s4xx: 0, duration: "95.4ms" },
+	{ origin: "Unknown", s2xx: 19, s4xx: 7, duration: "463.7ms" },
+	{ origin: "api.example.com", s2xx: 42, s4xx: 3, duration: "128.1ms" },
+];
+
+type StatusFilter = "all" | "2xx" | "3xx" | "4xx" | "5xx";
+
+// ─── Mockup: Segmented filter + search ───────────────────────────────
+
+/** Subrequests card with inline filter toolbar inside Primary. */
+export function LayerCardFilterSubrequestsDemo() {
+	const [filter, setFilter] = useState<StatusFilter>("all");
+	const [search, setSearch] = useState("");
+
+	const filtered = ORIGINS.filter((o) => {
+		if (filter === "2xx" && o.s2xx === 0) return false;
+		if (filter === "4xx" && o.s4xx === 0) return false;
+		if (search && !o.origin.toLowerCase().includes(search.toLowerCase())) return false;
+		return true;
+	});
+
+	return (
+		<LayerCard className="w-full max-w-[540px]">
+			<LayerCard.Secondary>Subrequests</LayerCard.Secondary>
+
+			<LayerCard.Primary>
+				{/* Toolbar: tabs + search on one line */}
+				<div className="mb-2 flex items-center gap-3">
+					<Input
+						size="sm"
+						placeholder="Filter origins…"
+						aria-label="Filter origins"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						prefix={<MagnifyingGlassIcon size={12} />}
+						className="min-w-0 flex-1"
+					/>
+					<Tabs
+						variant="segmented"
+						size="sm"
+						className="shrink-0"
+						tabs={[
+							{ value: "all", label: "All" },
+							{ value: "2xx", label: "2xx" },
+							{ value: "3xx", label: "3xx" },
+							{ value: "4xx", label: "4xx" },
+							{ value: "5xx", label: "5xx" },
+						]}
+						value={filter}
+						onValueChange={(v) => setFilter(v as StatusFilter)}
+					/>
+				</div>
+
+				{/* Custom lightweight table — no banding, uniform bg */}
+				<div className="-mx-1 text-sm">
+					{/* Header */}
+					<div className="grid grid-cols-[1fr_auto_auto] gap-x-4 border-b border-kumo-fill px-1 pb-2 text-xs font-medium text-kumo-subtle">
+						<span>Origin</span>
+						<span className="w-28 text-right">Requests</span>
+						<span className="w-20 text-right">Duration</span>
+					</div>
+
+					{/* Rows */}
+					{filtered.map((row, i) => (
+						<div
+							key={row.origin}
+							className={`grid grid-cols-[1fr_auto_auto] items-center gap-x-4 px-1 py-2.5 ${i < filtered.length - 1 ? "border-b border-kumo-hairline" : ""}`}
+						>
+							<span className="truncate font-medium text-kumo-default">{row.origin}</span>
+							<div className="flex w-28 items-center justify-end gap-1.5">
+								{row.s2xx > 0 && <Badge variant="success">{`2xx ${row.s2xx}`}</Badge>}
+								{row.s4xx > 0 && <Badge variant="error">{`4xx ${row.s4xx}`}</Badge>}
+							</div>
+							<span className="w-20 text-right text-kumo-subtle">{row.duration}</span>
+						</div>
+					))}
+				</div>
+
+				{/* Footer */}
+				<div className="-mx-1 border-t border-kumo-fill pt-2 text-xs text-kumo-subtle">
+					Showing {filtered.length} of {ORIGINS.length}
+				</div>
+			</LayerCard.Primary>
+		</LayerCard>
+	);
+}

--- a/packages/kumo-docs-astro/src/components/demos/LayerCardFilterMockupDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerCardFilterMockupDemo.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Badge, Input, LayerCard, Tabs } from "@cloudflare/kumo";
-import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 
 // ─── Data ────────────────────────────────────────────────────────────
 
@@ -39,7 +38,6 @@ export function LayerCardFilterSubrequestsDemo() {
 						aria-label="Filter origins"
 						value={search}
 						onChange={(e) => setSearch(e.target.value)}
-						prefix={<MagnifyingGlassIcon size={12} />}
 						className="min-w-0 flex-1"
 					/>
 					<Tabs

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -97,6 +97,39 @@ export function TabsManyDemo() {
   );
 }
 
+export function TabsSmDemo() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="mb-2 text-sm text-kumo-subtle">Segmented sm</p>
+        <Tabs
+          variant="segmented"
+          size="sm"
+          tabs={[
+            { value: "tab1", label: "Tab 1" },
+            { value: "tab2", label: "Tab 2" },
+            { value: "tab3", label: "Tab 3" },
+          ]}
+          selectedValue="tab1"
+        />
+      </div>
+      <div>
+        <p className="mb-2 text-sm text-kumo-subtle">Underline sm</p>
+        <Tabs
+          variant="underline"
+          size="sm"
+          tabs={[
+            { value: "tab1", label: "Tab 1" },
+            { value: "tab2", label: "Tab 2" },
+            { value: "tab3", label: "Tab 3" },
+          ]}
+          selectedValue="tab1"
+        />
+      </div>
+    </div>
+  );
+}
+
 export function TabsRenderPropDemo() {
   return (
     <Tabs

--- a/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-card.mdx
@@ -15,6 +15,9 @@ import {
   LayerCardMultipleDemo,
   LayerCardTestIdDemo,
 } from "~/components/demos/LayerCardDemo";
+import {
+  LayerCardFilterSubrequestsDemo,
+} from "~/components/demos/LayerCardFilterMockupDemo";
 
 {/* Hero Demo */}
 
@@ -110,6 +113,17 @@ export default function Example() {
 
 <ComponentExample demo="LayerCardMultipleDemo">
   <LayerCardMultipleDemo client:visible />
+</ComponentExample>
+
+### Filter Toolbar with Small Tabs
+
+<p>
+  Combine <code>Tabs size="sm"</code> with <code>Input size="sm"</code> inside a
+  LayerCard for compact filter toolbars. Both share the same <code>h-6.5</code> (26px) height.
+</p>
+
+<ComponentExample demo="LayerCardFilterSubrequestsDemo">
+  <LayerCardFilterSubrequestsDemo client:visible />
 </ComponentExample>
 
 ### Test IDs

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -12,6 +12,7 @@ import {
   TabsDefaultDemo,
   TabsSegmentedDemo,
   TabsUnderlineDemo,
+  TabsSmDemo,
   TabsControlledDemo,
   TabsManyDemo,
 } from "~/components/demos/TabsDemo";
@@ -91,6 +92,16 @@ export default function Example() {
 </p>
 <ComponentExample demo="TabsUnderlineDemo">
   <TabsUnderlineDemo client:visible />
+</ComponentExample>
+
+### Small Size
+
+<p>
+  Use `size="sm"` for a compact tab bar that matches `Input size="sm"` height (h-6.5 / 26px).
+  Useful inside toolbars and filter rows.
+</p>
+<ComponentExample demo="TabsSmDemo">
+  <TabsSmDemo client:visible />
 </ComponentExample>
 
 ### Controlled

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -6,10 +6,12 @@ import { cn } from "../../utils/cn";
 /** Tabs variant definitions. */
 export const KUMO_TABS_VARIANTS = {
   variant: ["segmented", "underline"],
+  size: ["base", "sm"],
 } as const;
 
 export const KUMO_TABS_DEFAULT_VARIANTS = {
   variant: "segmented",
+  size: "base",
 } as const;
 
 export const KUMO_TABS_STYLING = {
@@ -45,6 +47,13 @@ export interface KumoTabsVariantsProps {
    * @default "segmented"
    */
   variant?: (typeof KUMO_TABS_VARIANTS.variant)[number];
+  /**
+   * Tab size.
+   * - `"base"` — Default size (h-9, text-base)
+   * - `"sm"` — Compact size (h-6.5, text-xs) — matches Input size="sm"
+   * @default "base"
+   */
+  size?: (typeof KUMO_TABS_VARIANTS.size)[number];
 }
 
 /** Configuration for a single tab within the Tabs component. */
@@ -123,6 +132,7 @@ export function Tabs({
   listClassName,
   indicatorClassName,
   variant = KUMO_TABS_DEFAULT_VARIANTS.variant,
+  size = KUMO_TABS_DEFAULT_VARIANTS.size,
 }: TabsProps) {
   const items: TabsItem[] = tabs ?? [];
 
@@ -139,6 +149,7 @@ export function Tabs({
 
   const isSegmented = variant === "segmented";
   const isUnderline = variant === "underline";
+  const isSm = size === "sm";
 
   return (
     <TabsPrimitive.Root
@@ -151,14 +162,16 @@ export function Tabs({
     >
       {/* Background element for segmented variant */}
       {isSegmented && (
-        <div className="absolute inset-x-0 top-1/2 z-0 h-9 -translate-y-1/2 rounded-lg bg-kumo-recessed" />
+        <div className={cn("absolute inset-x-0 top-1/2 z-0 -translate-y-1/2 rounded-lg bg-kumo-recessed", isSm ? "h-6.5" : "h-9")} />
       )}
       <TabsPrimitive.List
         activateOnFocus={activateOnFocus}
         className={cn(
           "scrollbar-hide relative flex min-w-0 shrink items-stretch",
-          isSegmented && "h-9 rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70",
-          isUnderline && "h-7 gap-4 border-b border-kumo-hairline pb-2",
+          isSegmented && "rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70",
+          isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
+          isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
+          isUnderline && (isSm ? "h-6.5" : "h-7"),
           listClassName,
         )}
       >
@@ -168,11 +181,14 @@ export function Tabs({
             value={tab.value}
             render={tab.render}
             className={cn(
-              "relative z-2 flex cursor-pointer items-center rounded bg-transparent text-base whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand",
+              "relative z-2 flex cursor-pointer items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand",
+              isSm ? "text-xs" : "text-base",
               isSegmented &&
-                "my-0.5 rounded-md px-2.5 text-kumo-subtle hover:text-kumo-default aria-selected:text-kumo-default focus-visible:ring-inset",
+                "my-0.5 rounded-md text-kumo-subtle hover:text-kumo-default aria-selected:text-kumo-default focus-visible:ring-inset",
+              isSegmented && (isSm ? "px-2" : "px-2.5"),
               isUnderline &&
-                "px-2 py-2.5 text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default aria-selected:hover:bg-kumo-tint aria-selected:font-medium aria-selected:text-kumo-default",
+                "text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default aria-selected:hover:bg-kumo-tint aria-selected:font-medium aria-selected:text-kumo-default",
+              isUnderline && (isSm ? "px-1.5 py-2" : "px-2 py-2.5"),
               tab.className,
             )}
           >
@@ -188,7 +204,7 @@ export function Tabs({
                 "w-(--active-tab-width) translate-x-(--active-tab-left) transition-all duration-200",
                 "data-[rendered=false]:scale-90 data-[rendered=false]:opacity-0",
                 isSegmented &&
-                  "top-(--active-tab-top) h-(--active-tab-height) rounded-md bg-kumo-base shadow-sm ring ring-kumo-line",
+                  cn("top-(--active-tab-top) h-(--active-tab-height) bg-kumo-base shadow-sm ring ring-kumo-line", isSm ? "rounded" : "rounded-md"),
                 isUnderline && "bottom-0 h-0.5 bg-kumo-brand",
                 indicatorClassName,
               )}

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -171,7 +171,7 @@ export function Tabs({
           isSegmented && "rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70",
           isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
           isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
-          isUnderline && (isSm ? "h-6.5" : "h-7"),
+          isUnderline && (isSm ? "h-6.5" : "h-7.5"),
           listClassName,
         )}
       >
@@ -188,7 +188,7 @@ export function Tabs({
               isSegmented && (isSm ? "px-2" : "px-2.5"),
               isUnderline &&
                 "text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default aria-selected:hover:bg-kumo-tint aria-selected:font-medium aria-selected:text-kumo-default",
-              isUnderline && (isSm ? "px-1.5 py-2" : "px-2 py-2.5"),
+              isUnderline && (isSm ? "px-1.5 py-2.5" : "px-2 py-3"),
               tab.className,
             )}
           >


### PR DESCRIPTION
## Summary

- Adds `size` prop to `Tabs` with `"base"` (default) and `"sm"` options
- `size="sm"` uses `h-6.5` (26px) for both segmented and underline variants, matching `Input size="sm"` for aligned toolbars
- Adds `TabsSmDemo` to Tabs doc page and `LayerCardFilterSubrequestsDemo` to LayerCard doc page showing Tabs sm + Input sm side-by-side in a filter toolbar

<img width="512" height="281" alt="image" src="https://github.com/user-attachments/assets/eda231e0-bac0-4ad0-8db6-96bc70b7736c" />


- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: new feature needs visual review
- Tests
- [x] Additional testing not necessary because: additive prop with no logic changes to existing behavior