### PR TITLE
fix(select): replace Field label with Select.Label from Base UI

### DIFF
--- a/.changeset/select-api-updates.md
+++ b/.changeset/select-api-updates.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/kumo": patch
+---
+Updates `Select` label API to use Base UI's `Select.Label` for better accessibility and hover coupling issues.
+
+- Switch `Select` over to Base UI’s `Select.Label` so the trigger gets its accessible name without relying on a native `<label>`—fixes the hover coupling bug and silences the dev warning while preserving tooltips/optional badges via our `Label` component.  
+- Inline the Field wrapper behavior (error normalization, helper text toggling, `aria-describedby` wiring) so the label, description, and error props keep working exactly as before.  
+- Allow `Label` to accept an `id`, and document the updated compound pieces (`Select.Label`, `Select.Group`, `Select.GroupLabel`, `Select.Separator`) so manual composition stays clear.

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -91,8 +91,9 @@ export default function Example() {
 <p>
   A select with a visible label. When you provide the{" "}
   <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code> prop,
-  the select automatically renders inside a Field wrapper with the label
-  displayed above it.
+  the component mounts Base UI’s <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Label</code>
+  internally, so the trigger is accessible without coupling hover or focus
+  states to the text.
 </p>
 
   <ComponentExample demo="SelectBasicDemo">
@@ -138,9 +139,11 @@ export default function Example() {
 
 ### With Description and Error
 
-  <p>
-    Select integrates with the Field wrapper to show description text and validation errors.
-  </p>
+<p>
+  Description and error text are rendered directly by the Select component:
+  helper copy appears when there is no validation error, and validation
+  messages are linked to the trigger via <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">aria-describedby</code>.
+</p>
 
   <ComponentExample demo="SelectWithFieldDemo">
     <SelectWithFieldDemo client:load />
@@ -179,10 +182,16 @@ export default function Example() {
 
 ### Label with Tooltip
 
-  <p>
-    Add a tooltip icon next to the label for additional context using <code
+<p>
+  Add a tooltip icon next to the label for additional context using <code
       class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
-  </p>
+</p>
+
+<p class="mt-2 text-sm text-kumo-subtle">
+  Under the hood the tooltip sits inside <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Label</code>,
+  so the trigger continues to be labelled correctly while the icon remains
+  outside of the hover/focus hit area.
+</p>
 
   <ComponentExample demo="SelectWithTooltipDemo">
     <SelectWithTooltipDemo client:load />
@@ -403,6 +412,13 @@ export default function Example() {
 
   <PropsTable component="Select" />
 
+### Select.Label
+
+<p>
+  Mounts a context-aware label inside the select. Use when composing the
+  compound API manually; the top-level <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code> prop renders it automatically.
+</p>
+
 ### Select.Option
 
 <PropsTable component="Select.Option" />
@@ -410,24 +426,23 @@ export default function Example() {
 ### Select.Group
 
 <p>
-  Groups related options together with an accessible{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>.
-  Use with{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
-    Select.GroupLabel
-  </code>{" "}
-  to provide a visible heading.
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code> wraps a
+  related set of options and exposes <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code> for screen readers. Pair it with
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.GroupLabel</code> and
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Separator</code> when creating grouped menus.
 </p>
 
 ### Select.GroupLabel
 
 <p>
-  A visible heading for a{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>.
-  Automatically associated with its parent group for accessibility.
+  Displays a heading for the nearest <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code> and links it via
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">aria-labelledby</code>.
 </p>
 
 ### Select.Separator
 
-  <p>A visual divider line between option groups. Renders with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="separator"</code>.</p>
+  <p>
+    A visual divider line between option groups. Renders with
+    <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="separator"</code>.
+  </p>
 </ComponentSection>

--- a/packages/kumo/src/components/label/label.tsx
+++ b/packages/kumo/src/components/label/label.tsx
@@ -50,6 +50,8 @@ export interface LabelProps extends KumoLabelVariantsProps {
   className?: string;
   /** The id of the form element this label is associated with */
   htmlFor?: string;
+  /** Optional id so other components can reference this label directly. */
+  id?: string;
   /**
    * When true, only renders the inline content (indicators, tooltip) without
    * the outer label element with font styling. Useful when composed inside another
@@ -90,6 +92,7 @@ export function Label({
   tooltip,
   className,
   htmlFor,
+  id,
   asContent = false,
 }: LabelProps) {
   const content = (
@@ -119,13 +122,16 @@ export function Label({
   // When used as content inside another styled element, just render inline
   if (asContent) {
     return (
-      <span className={cn(labelContentVariants(), className)}>{content}</span>
+      <span id={id} className={cn(labelContentVariants(), className)}>
+        {content}
+      </span>
     );
   }
 
   // When used standalone, render as <label> for accessibility
   return (
     <label
+      id={id}
       htmlFor={htmlFor}
       className={cn(labelVariants(), labelContentVariants(), className)}
     >

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -6,7 +6,8 @@ import { cn } from "../../utils/cn";
 import { buttonVariants } from "../button";
 import { KUMO_INPUT_VARIANTS, type KumoInputSize } from "../input/input";
 import { SkeletonLine } from "../loader";
-import { Field, type FieldErrorMatch } from "../field/field";
+import { Label } from "../label";
+import type { FieldErrorMatch } from "../field/field";
 import {
   usePortalContainer,
   type PortalContainer,
@@ -280,8 +281,7 @@ export interface SelectProps {
   /** Size of the select trigger. Matches Input component sizes. */
   size?: KumoSelectSize;
   /**
-   * Label content for the select.
-   * When provided, enables the Field wrapper with a visible label above the select.
+   * Label content for the select. Rendered above the trigger.
    * For accessibility without a visible label, use `aria-label` instead.
    */
   label?: ReactNode;
@@ -333,7 +333,7 @@ export interface SelectOptionProps {
 
 /**
  * Dropdown for selecting a value from a list of options.
- * Wraps Base UI Select with Kumo styling and optional Field integration.
+ * Wraps Base UI Select with Kumo styling.
  *
  * @example
  * ```tsx
@@ -360,6 +360,8 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   ...props
 }: SelectPropsGeneric<T, Multiple> & { required?: boolean }) {
   const labelId = useId();
+  const descriptionId = useId();
+  const errorId = useId();
   const contextContainer = usePortalContainer();
   const container = containerProp ?? contextContainer ?? undefined;
   const propLookup = props as Record<string, unknown>;
@@ -378,14 +380,10 @@ export function Select<T, Multiple extends boolean | undefined = false>({
     );
   }
 
-  // New behavior: label presence determines Field wrapper visibility (like Input)
-  // hideLabel is only respected for backward compatibility when explicitly set to true
-  const useFieldWrapper = label && hideLabel !== true;
-  const triggerLabelledBy = useFieldWrapper
-    ? undefined
-    : (ariaLabelledby ?? (label ? labelId : undefined));
+  const triggerLabelledBy =
+    ariaLabelledby ?? (label ? labelId : undefined);
   const triggerAriaLabel =
-    ariaLabel ?? (!triggerLabelledBy ? fallbackLabel : undefined);
+    ariaLabel ?? (!label ? fallbackLabel : undefined);
 
   // Normalize items to array format for Base UI compatibility
   // This fixes placeholder not showing with object map items
@@ -417,7 +415,60 @@ export function Select<T, Multiple extends boolean | undefined = false>({
     : undefined;
 
   // Exclude Kumo-extended `items` from Base UI spread — we pass `normalizedItems` instead
+  // Strip out the high-level items API; we pass Base UI the normalized array instead.
   const { items: _items, ...baseProps } = props;
+
+  /**
+   * Recreate the Field wrapper's accessibility wiring inline—error normalization, helper toggling,
+   * and aria links since Select is now using the Select.Label from Base UI and no longer mounts
+   * Field around the control.
+   */
+
+  // Resolve the error message once so we can reuse it for aria-invalid and helper text.
+  const resolvedError = error
+    ? typeof error === "string"
+      ? error
+      : error.message
+    : null;
+
+  // Only surface helper copy when there isn't an error message showing.
+  const helperDescription = !resolvedError && description ? description : null;
+
+  // Build the aria-describedby string that points to helper or error content.
+  const describedBy = [
+    helperDescription ? descriptionId : null,
+    resolvedError ? errorId : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // Avoid empty aria-describedby attributes when there's nothing to announce.
+  const describedByAttr = describedBy.length > 0 ? describedBy : undefined;
+
+  // Select shows "(optional)" when required is explicitly false (matches Input).
+  const showOptional = required === false;
+
+  /**
+   * Wrap the visual label in Base UI's context-aware label so we get
+   * accessible naming without native <label> hover/focus coupling.
+   */
+  const labelNode = label ? (
+    <SelectBase.Label
+      className={cn(
+        "text-base font-medium text-kumo-default",
+        hideLabel && "sr-only",
+      )}
+    >
+      <Label
+        id={labelId}
+        showOptional={showOptional}
+        tooltip={!hideLabel ? labelTooltip : undefined}
+        asContent
+      >
+        {label}
+      </Label>
+    </SelectBase.Label>
+  ) : null;
 
   const selectControl = (
     <SelectBase.Root
@@ -425,6 +476,7 @@ export function Select<T, Multiple extends boolean | undefined = false>({
       items={normalizedItems}
       disabled={loading || props.disabled}
     >
+      {labelNode}
       <SelectBase.Trigger
         className={cn(
           selectVariants({ size }),
@@ -433,6 +485,8 @@ export function Select<T, Multiple extends boolean | undefined = false>({
         )}
         aria-label={triggerAriaLabel}
         aria-labelledby={triggerLabelledBy}
+        aria-describedby={describedByAttr}
+        aria-invalid={resolvedError ? true : undefined}
       >
         {loading ? (
           <SkeletonLine className="w-32" />
@@ -478,55 +532,21 @@ export function Select<T, Multiple extends boolean | undefined = false>({
       </SelectBase.Portal>
     </SelectBase.Root>
   );
-
-  // Use Field wrapper when label is provided and not hidden
-  if (useFieldWrapper) {
-    return (
-      <Field
-        label={label}
-        required={required}
-        labelTooltip={labelTooltip}
-        description={description}
-        error={
-          error
-            ? typeof error === "string"
-              ? { message: error, match: true }
-              : error
-            : undefined
-        }
-      >
-        {selectControl}
-      </Field>
-    );
-  }
-
-  // Render with standalone label when label is hidden (sr-only)
-  // Still show description/error for accessibility and UX
-  const normalizedError = error
-    ? typeof error === "string"
-      ? { message: error, match: true as const }
-      : error
-    : undefined;
-
   return (
     <div className="grid gap-2">
-      {label && (
-        <span id={labelId} className="sr-only">
-          {label}
-        </span>
-      )}
       {selectControl}
-      {normalizedError ? (
-        <span className="text-sm text-kumo-danger">
-          {normalizedError.message}
-        </span>
-      ) : (
-        description && (
-          <span className="text-sm leading-snug text-kumo-subtle">
-            {description}
-          </span>
-        )
-      )}
+      {resolvedError ? (
+        <div id={errorId} className="text-sm leading-snug text-kumo-danger">
+          {resolvedError}
+        </div>
+      ) : helperDescription ? (
+        <div
+          id={descriptionId}
+          className="text-sm leading-snug text-kumo-subtle"
+        >
+          {helperDescription}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Updates `Select` label API to use Base UI's `Select.Label` for better accessibility and hover coupling issues.

- Switch `Select` over to Base UI’s `Select.Label` so the trigger gets its accessible name without relying on a native `<label>`—fixes the hover coupling bug and silences the dev warning while preserving tooltips/optional badges via our `Label` component.  
- Inline the Field wrapper behavior (error normalization, helper text toggling, `aria-describedby` wiring) so the label, description, and error props keep working exactly as before.  
- Allow `Label` to accept an `id`, and document the updated compound pieces (`Select.Label`, `Select.Group`, `Select.GroupLabel`, `Select.Separator`) so manual composition stays clear.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: no access to bonk
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: ran pnpm checks locally
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
