### PR TITLE
refactor(sensitive-input): rewrite on InputGroup + anchored toast

### DIFF
--- a/.changeset/sensitive-input-rewrite.md
+++ b/.changeset/sensitive-input-rewrite.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Rewrite SensitiveInput on InputGroup primitives with anchored Base UI Toast for copy confirmation. Replaces 500+ lines of hand-rolled layout with composable primitives. Action buttons use inverted dark tooltips for a consistent, polished feel.

--- a/packages/kumo-docs-astro/src/components/demos/SensitiveInputDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SensitiveInputDemo.tsx
@@ -4,7 +4,34 @@ import { SensitiveInput, Button } from "@cloudflare/kumo";
 export function SensitiveInputDemo() {
   return (
     <div className="w-80">
-      <SensitiveInput label="API Key" defaultValue="sk_live_abc123xyz789" />
+      <SensitiveInput
+        label="API Key"
+        defaultValue="sk_live_abc123xyz789"
+        onCopy={() => {}}
+      />
+    </div>
+  );
+}
+
+/** SensitiveInput with only the reveal toggle — no copy button. */
+export function SensitiveInputBasicDemo() {
+  return (
+    <div className="w-80">
+      <SensitiveInput label="Password" defaultValue="super-secret-password" />
+    </div>
+  );
+}
+
+/** SensitiveInput with copy enabled via onCopy. */
+export function SensitiveInputWithCopyDemo() {
+  return (
+    <div className="w-80">
+      <SensitiveInput
+        label="API Key"
+        defaultValue="sk_live_abc123xyz789"
+        readOnly
+        onCopy={() => {}}
+      />
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ~/layouts/MdxDocLayout.astro
 title: "Sensitive Input"
-description: "A masked input for sensitive values like API keys and passwords. Toggle visibility and copy to clipboard."
+description: "A masked input for sensitive values like API keys and passwords. Toggle visibility, with optional copy-to-clipboard."
 sourceFile: "components/sensitive-input"
 ---
 
@@ -10,6 +10,8 @@ import ComponentSection from "~/components/docs/ComponentSection.astro";
 import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   SensitiveInputDemo,
+  SensitiveInputBasicDemo,
+  SensitiveInputWithCopyDemo,
   SensitiveInputSizesDemo,
   SensitiveInputControlledDemo,
   SensitiveInputStatesDemo,
@@ -59,6 +61,48 @@ export default function Example() {
 
 </ComponentSection>
 
+{/* Basic (no copy) */}
+
+<ComponentSection>
+
+## Basic
+
+<p>
+  By default, SensitiveInput renders only a reveal/mask toggle. The value is
+  masked on blur and can be re-masked with Escape.
+</p>
+
+<ComponentExample demo="SensitiveInputBasicDemo">
+  <SensitiveInputBasicDemo client:visible />
+</ComponentExample>
+
+</ComponentSection>
+
+{/* With Copy */}
+
+<ComponentSection>
+
+## With Copy Button
+
+<p>
+  Pass <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">onCopy</code> to
+  enable a copy-to-clipboard button. An anchored toast confirms the action.
+</p>
+
+```tsx
+<SensitiveInput
+  label="API Key"
+  defaultValue="sk_live_abc123xyz789"
+  onCopy={() => {}}
+/>
+```
+
+<ComponentExample demo="SensitiveInputWithCopyDemo">
+  <SensitiveInputWithCopyDemo client:load />
+</ComponentExample>
+
+</ComponentSection>
+
 {/* Sizes */}
 
 <ComponentSection>
@@ -96,6 +140,37 @@ export default function Example() {
   <ComponentExample demo="SensitiveInputStatesDemo">
     <SensitiveInputStatesDemo client:visible />
   </ComponentExample>
+</ComponentSection>
+
+{/* i18n */}
+
+<ComponentSection>
+
+## Internationalization
+
+<p>
+  Pass a <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">labels</code> prop
+  to override the default English strings for tooltips, aria labels, and the
+  copy confirmation toast.
+</p>
+
+```tsx
+<SensitiveInput
+  label="Clé API"
+  defaultValue="sk_live_abc123xyz789"
+  onCopy={() => {}}
+  labels={{
+    copyAction: "Copier dans le presse-papiers",
+    copyTooltip: "Copier",
+    copiedToast: "Copié !",
+    reveal: "Afficher la valeur",
+    revealTooltip: "Afficher",
+    hide: "Masquer la valeur",
+    hideTooltip: "Masquer",
+  }}
+/>
+```
+
 </ComponentSection>
 
 {/* API Reference */}

--- a/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/sensitive-input.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ~/layouts/MdxDocLayout.astro
 title: "Sensitive Input"
-description: "A masked input for sensitive values like API keys and passwords. Click to reveal."
+description: "A masked input for sensitive values like API keys and passwords. Toggle visibility and copy to clipboard."
 sourceFile: "components/sensitive-input"
 ---
 

--- a/packages/kumo/src/components/sensitive-input/index.ts
+++ b/packages/kumo/src/components/sensitive-input/index.ts
@@ -1,6 +1,7 @@
 export {
   SensitiveInput,
   type SensitiveInputProps,
+  type SensitiveInputLabels,
   KUMO_SENSITIVE_INPUT_VARIANTS,
   KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS,
 } from "./sensitive-input";

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -86,6 +86,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
       value: controlledValue,
       defaultValue = "",
       onChange,
+      onBlur,
       onValueChange,
       onCopy,
       size = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.size,
@@ -126,6 +127,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
     // Mask on blur (unless focus moves to a sibling button inside the group)
     const handleBlur = useCallback(
       (e: React.FocusEvent<HTMLInputElement>) => {
+        onBlur?.(e);
         if (
           containerRef.current &&
           e.relatedTarget instanceof Node &&
@@ -135,7 +137,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
         }
         if (hasValue) setRevealed(false);
       },
-      [hasValue],
+      [hasValue, onBlur],
     );
 
     // Escape to re-mask

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -384,12 +384,13 @@ function SensitiveInputInner({
 }
 
 const INVERTED_POPUP_CLASS = cn(
-          "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-inverse",
+  "rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-inverse",
   "shadow-lg",
-  "transition-[transform,opacity] duration-150",
+  "origin-[var(--transform-origin)]",
+  "transition-[transform,scale,opacity]",
   "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",
   "data-[ending-style]:scale-90 data-[ending-style]:opacity-0",
-  "data-[instant]:duration-0",
+  "data-[instant]:transition-none",
 );
 
 /** Dark inverted tooltip used for SensitiveInput action buttons. */

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -126,7 +126,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
       onValueChange,
       onCopy,
       size = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.size,
-      variant = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.variant,
+      variant: _variant = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.variant,
       disabled = false,
       readOnly = false,
       autoComplete = "off",
@@ -293,7 +293,7 @@ function SensitiveInputInner({
   label?: ReactNode;
   labelTooltip?: ReactNode;
   description?: ReactNode;
-  error?: { message: ReactNode; match: FieldErrorMatch | boolean };
+  error?: { message: ReactNode; match: FieldErrorMatch };
   required?: boolean;
   handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
   handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
@@ -384,7 +384,7 @@ function SensitiveInputInner({
 }
 
 const INVERTED_POPUP_CLASS = cn(
-  "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-base",
+          "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-inverse",
   "shadow-lg",
   "transition-[transform,opacity] duration-150",
   "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",
@@ -425,7 +425,7 @@ function AnchoredToastList() {
       <Toast.Root
         toast={toast}
         className={cn(
-          "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-base",
+  "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-inverse",
           "shadow-lg",
           "transition-[transform,opacity] duration-150",
           "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -34,6 +34,34 @@ export const KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS = {
  * <SensitiveInput label="Secret" value={secret} onValueChange={setSecret} />
  * ```
  */
+/** Accessible labels for i18n. Pass translated strings to override English defaults. */
+export interface SensitiveInputLabels {
+  /** Aria label for the copy button. @default "Copy to clipboard" */
+  copyAction?: string;
+  /** Tooltip text for the copy button. @default "Copy" */
+  copyTooltip?: string;
+  /** Toast title shown after copying. @default "Copied!" */
+  copiedToast?: string;
+  /** Aria label for the reveal button when value is hidden. @default "Reveal value" */
+  reveal?: string;
+  /** Tooltip text for the reveal button. @default "Reveal" */
+  revealTooltip?: string;
+  /** Aria label for the hide button when value is visible. @default "Hide value" */
+  hide?: string;
+  /** Tooltip text for the hide button. @default "Hide" */
+  hideTooltip?: string;
+}
+
+const DEFAULT_LABELS: Required<SensitiveInputLabels> = {
+  copyAction: "Copy to clipboard",
+  copyTooltip: "Copy",
+  copiedToast: "Copied!",
+  reveal: "Reveal value",
+  revealTooltip: "Reveal",
+  hide: "Hide value",
+  hideTooltip: "Hide",
+};
+
 export interface SensitiveInputProps
   extends Omit<
     ComponentPropsWithoutRef<"input">,
@@ -45,7 +73,10 @@ export interface SensitiveInputProps
   defaultValue?: string;
   /** Simplified change handler receiving just the value */
   onValueChange?: (value: string) => void;
-  /** Callback fired after value is copied to clipboard */
+  /**
+   * Callback fired after value is copied to clipboard.
+   * When provided, a copy button is rendered alongside the reveal toggle.
+   */
   onCopy?: () => void;
   /**
    * Size of the input.
@@ -65,19 +96,24 @@ export interface SensitiveInputProps
   description?: ReactNode;
   /** Error message or validation error object */
   error?: string | { message: ReactNode; match: FieldErrorMatch };
+  /** Accessible labels for i18n. Pass translated strings to override English defaults. */
+  labels?: SensitiveInputLabels;
 }
 
 /**
  * Password/secret input that masks its value by default and reveals on toggle.
- * Includes copy-to-clipboard with an anchored toast confirmation and a
- * visibility toggle button.
+ * Built on InputGroup for consistent sizing and layout.
  *
- * Built on InputGroup for consistent sizing and layout, and Base UI Toast
- * for the anchored "Copied!" feedback.
+ * Pass `onCopy` to enable a copy-to-clipboard button with an anchored
+ * toast confirmation.
  *
  * @example
  * ```tsx
+ * // Basic — reveal/mask only
  * <SensitiveInput label="API Key" defaultValue="sk_live_abc123xyz789" />
+ *
+ * // With copy button
+ * <SensitiveInput label="API Key" defaultValue="sk_live_abc123xyz789" onCopy={() => {}} />
  * ```
  */
 export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
@@ -100,10 +136,12 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
       description,
       error,
       required,
+      labels: labelsProp,
       ...inputProps
     },
     ref,
   ) => {
+    const labels = { ...DEFAULT_LABELS, ...labelsProp };
     const isControlled = controlledValue !== undefined;
     const [internalValue, setInternalValue] = useState(defaultValue);
     const value = isControlled ? controlledValue : internalValue;
@@ -202,6 +240,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
           handleChange={handleChange}
           toggleVisibility={toggleVisibility}
           onCopy={onCopy}
+          labels={labels}
           inputProps={inputProps}
         />
       </Toast.Provider>
@@ -237,6 +276,7 @@ function SensitiveInputInner({
   handleChange,
   toggleVisibility,
   onCopy,
+  labels,
   inputProps,
 }: {
   containerRef: React.RefObject<HTMLElement | null>;
@@ -260,6 +300,7 @@ function SensitiveInputInner({
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   toggleVisibility: () => void;
   onCopy?: () => void;
+  labels: Required<SensitiveInputLabels>;
   inputProps: Record<string, unknown>;
 }) {
   const toastManager = Toast.useToastManager();
@@ -269,7 +310,7 @@ function SensitiveInputInner({
       await navigator.clipboard.writeText(value);
       toastManager.add({
         id: "sensitive-input-copied",
-        title: "Copied!",
+        title: labels.copiedToast,
         timeout: 1500,
         positionerProps: {
           anchor: copyButtonRef.current,
@@ -282,7 +323,7 @@ function SensitiveInputInner({
     } catch {
       console.warn("Clipboard copy failed");
     }
-  }, [value, onCopy, toastManager, copyButtonRef]);
+  }, [value, onCopy, toastManager, copyButtonRef, labels.copiedToast]);
 
   return (
     <>
@@ -309,22 +350,22 @@ function SensitiveInputInner({
           {...inputProps}
         />
         <InputGroup.Addon align="end">
-          {hasValue && !disabled && (
-            <InvertedTooltip content="Copy">
+          {onCopy && hasValue && !disabled && (
+            <InvertedTooltip content={labels.copyTooltip}>
               <InputGroup.Button
                 ref={copyButtonRef}
                 icon={Copy}
-                aria-label="Copy to clipboard"
+                aria-label={labels.copyAction}
                 onClick={copyToClipboard}
                 onBlur={() => toastManager.close("sensitive-input-copied")}
               />
             </InvertedTooltip>
           )}
           {!disabled && (
-            <InvertedTooltip content={revealed ? "Hide" : "Reveal"}>
+            <InvertedTooltip content={revealed ? labels.hideTooltip : labels.revealTooltip}>
               <InputGroup.Button
                 icon={revealed ? EyeSlash : Eye}
-                aria-label={revealed ? "Hide value" : "Reveal value"}
+                aria-label={revealed ? labels.hide : labels.reveal}
                 onClick={toggleVisibility}
               />
             </InvertedTooltip>

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -314,6 +314,7 @@ function SensitiveInputInner({
                 icon={Copy}
                 aria-label="Copy to clipboard"
                 onClick={copyToClipboard}
+                onBlur={() => toastManager.close("sensitive-input-copied")}
               />
             </InvertedTooltip>
           )}

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -1,4 +1,4 @@
-import { Copy, Eye, EyeSlash } from "@phosphor-icons/react";
+import { CopyIcon, EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
 import { Toast } from "@base-ui/react/toast";
 import { Tooltip as TooltipBase } from "@base-ui/react/tooltip";
 import {
@@ -354,7 +354,7 @@ function SensitiveInputInner({
             <InvertedTooltip content={labels.copyTooltip}>
               <InputGroup.Button
                 ref={copyButtonRef}
-                icon={Copy}
+                icon={CopyIcon}
                 aria-label={labels.copyAction}
                 onClick={copyToClipboard}
                 onBlur={() => toastManager.close("sensitive-input-copied")}
@@ -364,7 +364,7 @@ function SensitiveInputInner({
           {!disabled && (
             <InvertedTooltip content={revealed ? labels.hideTooltip : labels.revealTooltip}>
               <InputGroup.Button
-                icon={revealed ? EyeSlash : Eye}
+                icon={revealed ? EyeSlashIcon : EyeIcon}
                 aria-label={revealed ? labels.hide : labels.reveal}
                 onClick={toggleVisibility}
               />

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -1,23 +1,22 @@
-import { Eye, EyeSlash } from "@phosphor-icons/react";
+import { Copy, Eye, EyeSlash } from "@phosphor-icons/react";
+import { Toast } from "@base-ui/react/toast";
+import { Tooltip as TooltipBase } from "@base-ui/react/tooltip";
 import {
   forwardRef,
   useCallback,
-  useEffect,
-  useId,
   useRef,
   useState,
   type ComponentPropsWithoutRef,
   type ReactNode,
 } from "react";
 import { cn } from "../../utils/cn";
-import { Input as BaseInput } from "@base-ui/react/input";
 import {
-  inputVariants,
   KUMO_INPUT_VARIANTS,
   type KumoInputSize,
   type KumoInputVariant,
 } from "../input/input";
-import { Field, type FieldErrorMatch } from "../field/field";
+import { InputGroup } from "../input-group/input-group";
+import type { FieldErrorMatch } from "../field/field";
 
 export const KUMO_SENSITIVE_INPUT_VARIANTS = KUMO_INPUT_VARIANTS;
 
@@ -25,8 +24,6 @@ export const KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS = {
   size: "base",
   variant: "default",
 } as const;
-
-type Mode = "masked" | "revealed" | "empty";
 
 /**
  * SensitiveInput component props.
@@ -52,23 +49,17 @@ export interface SensitiveInputProps
   onCopy?: () => void;
   /**
    * Size of the input.
-   * - `"xs"` — Extra small for compact UIs
-   * - `"sm"` — Small for secondary fields
-   * - `"base"` — Default input size
-   * - `"lg"` — Large for prominent fields
    * @default "base"
    */
   size?: KumoInputSize;
   /**
    * Style variant of the input.
-   * - `"default"` — Default input appearance
-   * - `"error"` — Error state for validation failures
    * @default "default"
    */
   variant?: KumoInputVariant;
-  /** Label content for the input (enables Field wrapper and sets masked state label) - can be a string or any React node */
+  /** Label content for the input */
   label?: ReactNode;
-  /** Tooltip content to display next to the label via an info icon */
+  /** Tooltip content to display next to the label */
   labelTooltip?: ReactNode;
   /** Helper text displayed below the input */
   description?: ReactNode;
@@ -77,8 +68,12 @@ export interface SensitiveInputProps
 }
 
 /**
- * Password/secret input that masks its value by default and reveals on click.
- * Includes a built-in copy-to-clipboard button on hover.
+ * Password/secret input that masks its value by default and reveals on toggle.
+ * Includes copy-to-clipboard with an anchored toast confirmation and a
+ * visibility toggle button.
+ *
+ * Built on InputGroup for consistent sizing and layout, and Base UI Toast
+ * for the anchored "Copied!" feedback.
  *
  * @example
  * ```tsx
@@ -97,7 +92,6 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
       variant = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.variant,
       disabled = false,
       readOnly = false,
-      id,
       autoComplete = "off",
       className,
       label,
@@ -109,160 +103,29 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
     },
     ref,
   ) => {
-    // For aria-label, only use string labels (ReactNode labels can't be used for aria-label)
-    const ariaLabelFallback =
-      typeof label === "string" ? label : "Sensitive value";
     const isControlled = controlledValue !== undefined;
     const [internalValue, setInternalValue] = useState(defaultValue);
     const value = isControlled ? controlledValue : internalValue;
     const hasValue = value.length > 0;
 
-    const [mode, setMode] = useState<Mode>(() =>
-      hasValue ? "masked" : "empty",
-    );
-
-    const [copied, setCopied] = useState(false);
+    const [revealed, setRevealed] = useState(false);
 
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const liveRegionId = useId();
-    const generatedId = useId();
-    const inputId = id ?? generatedId;
-    const maskedInstructionId = useId();
+    const containerRef = useRef<HTMLElement>(null);
+    const copyButtonRef = useRef<HTMLButtonElement>(null);
 
     const mergedRef = useCallback(
       (node: HTMLInputElement | null) => {
         inputRef.current = node;
-        if (typeof ref === "function") {
-          ref(node);
-        } else if (ref) {
-          ref.current = node;
-        }
+        if (typeof ref === "function") ref(node);
+        else if (ref) ref.current = node;
       },
       [ref],
     );
 
-    // Reset copied state after 2 seconds
-    useEffect(() => {
-      if (copied) {
-        const timeoutId = setTimeout(() => setCopied(false), 2000);
-        return () => clearTimeout(timeoutId);
-      }
-    }, [copied]);
-
-    const copyToClipboard = useCallback(
-      async (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation();
-        try {
-          if (
-            typeof navigator !== "undefined" &&
-            navigator.clipboard &&
-            typeof navigator.clipboard.writeText === "function"
-          ) {
-            await navigator.clipboard.writeText(value);
-            setCopied(true);
-            onCopy?.();
-            return;
-          }
-        } catch {
-          // Fall through to manual fallback
-        }
-
-        if (typeof document !== "undefined") {
-          const textarea = document.createElement("textarea");
-          textarea.value = value;
-          textarea.setAttribute("readonly", "");
-          textarea.style.position = "absolute";
-          textarea.style.left = "-9999px";
-          document.body.appendChild(textarea);
-          const selection = document.getSelection();
-          const previousRange = selection?.rangeCount
-            ? selection.getRangeAt(0)
-            : null;
-          textarea.select();
-          try {
-            document.execCommand("copy");
-            setCopied(true);
-            onCopy?.();
-          } catch (error) {
-            console.warn("Clipboard copy failed", error);
-          } finally {
-            document.body.removeChild(textarea);
-            if (previousRange) {
-              selection?.removeAllRanges();
-              selection?.addRange(previousRange);
-            }
-          }
-        }
-      },
-      [value, onCopy],
-    );
-
-    // Sync mode when value changes externally
-    const prevHasValueRef = useRef(hasValue);
-    if (prevHasValueRef.current !== hasValue) {
-      prevHasValueRef.current = hasValue;
-      if (!hasValue && mode === "masked") {
-        setMode("empty");
-      }
-    }
-
-    const handleContainerClick = useCallback(
-      (e: React.MouseEvent) => {
-        if (disabled) return;
-        // Ignore clicks that originated from outside (e.g., label click focusing input)
-        // Label clicks trigger a click on the input, but the click coordinates are outside the container
-        if (containerRef.current) {
-          const rect = containerRef.current.getBoundingClientRect();
-          const isClickInsideContainer =
-            e.clientX >= rect.left &&
-            e.clientX <= rect.right &&
-            e.clientY >= rect.top &&
-            e.clientY <= rect.bottom;
-          if (!isClickInsideContainer) return;
-        }
-        if (mode === "masked" && hasValue) {
-          setMode("revealed");
-          if (!readOnly) {
-            setTimeout(() => inputRef.current?.focus(), 0);
-          }
-        }
-      },
-      [mode, hasValue, disabled, readOnly],
-    );
-
-    const handleToggleVisibility = useCallback(
-      (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation();
-        if (mode === "revealed") {
-          setMode("masked");
-        } else if (mode === "empty" && hasValue) {
-          setMode("revealed");
-        }
-      },
-      [mode, hasValue],
-    );
-
-    const handleChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value;
-        if (!isControlled) {
-          setInternalValue(newValue);
-        }
-        // When typing into an empty field, switch to revealed mode
-        // so the input shows as type="text" instead of type="password"
-        if (mode === "empty" && newValue.length > 0) {
-          setMode("revealed");
-        }
-        onChange?.(e);
-        onValueChange?.(newValue);
-      },
-      [isControlled, onChange, onValueChange, mode],
-    );
-
+    // Mask on blur (unless focus moves to a sibling button inside the group)
     const handleBlur = useCallback(
       (e: React.FocusEvent<HTMLInputElement>) => {
-        // Don't mask if focus is moving to a button inside the container (copy/eye buttons)
         if (
           containerRef.current &&
           e.relatedTarget instanceof Node &&
@@ -270,234 +133,264 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
         ) {
           return;
         }
-        if (hasValue) {
-          setMode("masked");
-        }
+        if (hasValue) setRevealed(false);
       },
       [hasValue],
     );
 
-    const handleContainerKeyDown = useCallback(
-      (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (disabled) return;
-        if (mode === "masked" && hasValue) {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            setMode("revealed");
-            if (!readOnly) {
-              setTimeout(() => inputRef.current?.focus(), 0);
-            }
-          }
-        }
-      },
-      [mode, hasValue, disabled, readOnly],
-    );
-
-    const handleInputKeyDown = useCallback(
+    // Escape to re-mask
+    const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (mode === "revealed" && e.key === "Escape") {
-          setMode("masked");
-          // Move focus to container to avoid focus trap (input becomes tabIndex={-1})
-          setTimeout(() => containerRef.current?.focus(), 0);
+        if (revealed && e.key === "Escape") {
+          setRevealed(false);
         }
       },
-      [mode],
+      [revealed],
     );
 
-    const isMaskedWithValue = mode === "masked" && hasValue;
-    const showEyeButton =
-      !disabled && (mode === "revealed" || (mode === "empty" && hasValue));
-
-    // Icon sizes matching input sizes
-    const iconSize = size === "xs" || size === "sm" ? "size-3" : "size-4";
-
-    const containerClassName = cn(
-      inputVariants({ size, variant, parentFocusIndicator: true }),
-      "group/container relative flex w-full items-center",
-      // Show browser-native focus outline on container when child input is focused
-      "focus-within:outline focus-within:outline-2 focus-within:outline-kumo-focus",
-      isMaskedWithValue && !disabled && "cursor-pointer",
-      disabled && "cursor-not-allowed",
-      className,
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const v = e.target.value;
+        if (!isControlled) setInternalValue(v);
+        if (!revealed && v.length > 0) setRevealed(true);
+        onChange?.(e);
+        onValueChange?.(v);
+      },
+      [isControlled, onChange, onValueChange, revealed],
     );
 
-    const containerContent = (
-      <>
-        {/* Input - defines the width, always rendered */}
-        <BaseInput
-          ref={mergedRef}
-          id={inputId}
-          type={mode === "revealed" ? "text" : "password"}
-          value={value}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          onKeyDown={handleInputKeyDown}
-          disabled={disabled}
-          readOnly={readOnly || isMaskedWithValue}
-          autoComplete={autoComplete}
-          tabIndex={isMaskedWithValue ? -1 : 0}
-          className={cn(
-            "w-full border-0 bg-transparent p-0 text-kumo-default ring-0 outline-none kumo-input-placeholder disabled:cursor-not-allowed disabled:text-kumo-subtle",
-            size === "xs" && "pr-5",
-            size === "sm" && "pr-6",
-            size === "base" && "pr-8",
-            size === "lg" && "pr-10",
-            isMaskedWithValue && "pointer-events-none text-transparent",
-          )}
-          aria-hidden={isMaskedWithValue}
-          {...inputProps}
-        />
+    const toggleVisibility = useCallback(() => {
+      setRevealed((r) => !r);
+    }, []);
 
-        {/* Mask overlay - absolutely positioned, doesn't affect layout */}
-        <span
-          className={cn(
-            "pointer-events-none absolute inset-y-0 left-0 flex items-center overflow-hidden select-none",
-            // Match input pr padding (space for icon)
-            size === "xs" && "right-5",
-            size === "sm" && "right-6",
-            size === "base" && "right-8",
-            size === "lg" && "right-10",
-            // Match the padding from inputVariants
-            size === "xs" && "px-1.5",
-            size === "sm" && "px-2",
-            size === "base" && "px-3",
-            size === "lg" && "px-4",
-            // Hidden when not masked
-            !isMaskedWithValue && "invisible",
-            // When masked: enable pointer events
-            isMaskedWithValue && "pointer-events-auto",
-            // Text color - use text-kumo-default to contrast with bg-kumo-control input background
-            "text-kumo-default",
-            // Hover state - pure CSS, no React state (group for children)
-            "group/mask",
-          )}
-          aria-hidden="true"
-        >
-          {/* Both texts rendered, stacked. Visibility toggled on hover to prevent layout shift */}
-          <span className="relative">
-            <span
-              className={cn(
-                isMaskedWithValue &&
-                  !disabled &&
-                  "group-focus-within/container:invisible group-hover/mask:invisible",
-              )}
-            >
-              ••••••••
-            </span>
-            {isMaskedWithValue && !disabled && (
-              <span className="invisible absolute left-0 top-0 whitespace-nowrap text-kumo-subtle group-focus-within/container:visible group-hover/mask:visible">
-                Click to reveal
-              </span>
-            )}
-          </span>
-        </span>
-
-        {/* Eye button - absolutely positioned to the right */}
-        <button
-          type="button"
-          onClick={handleToggleVisibility}
-          onKeyDown={(e) => e.stopPropagation()}
-          aria-label={mode === "revealed" ? "Hide value" : "Reveal value"}
-          tabIndex={showEyeButton ? 0 : -1}
-          className={cn(
-            "absolute top-1/2 right-0 -translate-y-1/2 cursor-pointer text-kumo-subtle hover:text-kumo-default focus:text-kumo-default focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:rounded-sm",
-            // Defensive styles to prevent global CSS pollution (e.g., button { background: gray })
-            "bg-transparent border-none shadow-none p-0 m-0 h-auto min-h-0 inline-flex items-center justify-center",
-            // Match right padding from inputVariants
-            size === "xs" && "right-1.5",
-            size === "sm" && "right-2",
-            size === "base" && "right-3",
-            size === "lg" && "right-4",
-            iconSize,
-            !showEyeButton && "pointer-events-none opacity-0",
-          )}
-        >
-          {mode === "revealed" ? (
-            <EyeSlash className="size-full" />
-          ) : (
-            <Eye className="size-full" />
-          )}
-        </button>
-
-        {/* Copy tab - appears on hover/focus at top right (hidden when disabled) */}
-        {hasValue && !disabled && (
-          <button
-            type="button"
-            onClick={copyToClipboard}
-            onKeyDown={(e) => e.stopPropagation()}
-            aria-label={copied ? "Copied" : "Copy to clipboard"}
-            className={cn(
-              "absolute -top-px right-2 -translate-y-full cursor-pointer rounded-t-md bg-kumo-brand px-2 py-0.5 text-xs text-white opacity-0 transition-opacity group-focus-within/container:opacity-100 group-hover/container:opacity-100 hover:brightness-120 focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand",
-              // Defensive styles to prevent global CSS pollution
-              "border-none shadow-none m-0 h-auto min-h-0",
-            )}
-          >
-            {copied ? "Copied" : "Copy"}
-          </button>
-        )}
-      </>
-    );
-
-    const input = (
-      <div>
-        {isMaskedWithValue ? (
-          <div
-            ref={containerRef}
-            // Cannot use <button> here because containerContent contains interactive button elements (Copy, Reveal).
-            // Using role="button" with proper keyboard handling instead.
-            // oxlint-disable-next-line prefer-tag-over-role
-            role="button"
-            tabIndex={disabled ? -1 : 0}
-            className={containerClassName}
-            onClick={handleContainerClick}
-            onKeyDown={handleContainerKeyDown}
-            aria-label={`${ariaLabelFallback}, masked.`}
-            aria-describedby={`${maskedInstructionId} ${liveRegionId}`}
-            aria-disabled={disabled}
-          >
-            {containerContent}
-          </div>
-        ) : (
-          <div ref={containerRef} className={containerClassName}>
-            {containerContent}
-          </div>
-        )}
-        {isMaskedWithValue && (
-          <span id={maskedInstructionId} className="sr-only">
-            Click or press Enter to reveal.
-          </span>
-        )}
-        <span id={liveRegionId} className="sr-only" aria-live="polite">
-          {mode === "masked" && hasValue && "Value hidden"}
-          {copied && "Copied to clipboard"}
-        </span>
-      </div>
-    );
-
-    // Render with Field wrapper if label is provided
-    if (label) {
-      return (
-        <Field
-          label={label}
-          required={required}
-          labelTooltip={labelTooltip}
-          description={description}
-          error={
-            error
-              ? typeof error === "string"
-                ? { message: error, match: true }
-                : error
-              : undefined
-          }
-        >
-          {input}
-        </Field>
-      );
+    // Sync: if value is cleared externally, unmask
+    const prevHasValueRef = useRef(hasValue);
+    if (prevHasValueRef.current !== hasValue) {
+      prevHasValueRef.current = hasValue;
+      if (!hasValue && !revealed) setRevealed(false);
     }
 
-    // Render bare input without Field wrapper
-    return input;
+    const normalizedError = error
+      ? typeof error === "string"
+        ? { message: error, match: true as const }
+        : error
+      : undefined;
+
+    return (
+      <Toast.Provider timeout={1500}>
+        <SensitiveInputInner
+          containerRef={containerRef}
+          inputRef={mergedRef}
+          copyButtonRef={copyButtonRef}
+          value={value}
+          hasValue={hasValue}
+          revealed={revealed}
+          size={size}
+          disabled={disabled}
+          readOnly={readOnly}
+          autoComplete={autoComplete}
+          className={className}
+          label={label}
+          labelTooltip={labelTooltip}
+          description={description}
+          error={normalizedError}
+          required={required}
+          handleBlur={handleBlur}
+          handleKeyDown={handleKeyDown}
+          handleChange={handleChange}
+          toggleVisibility={toggleVisibility}
+          onCopy={onCopy}
+          inputProps={inputProps}
+        />
+      </Toast.Provider>
+    );
   },
 );
 
 SensitiveInput.displayName = "SensitiveInput";
+
+/**
+ * Inner component that renders inside Toast.Provider so it can use
+ * the useToastManager hook.
+ */
+function SensitiveInputInner({
+  containerRef,
+  inputRef,
+  copyButtonRef,
+  value,
+  hasValue,
+  revealed,
+  size,
+  disabled,
+  readOnly,
+  autoComplete,
+  className,
+  label,
+  labelTooltip,
+  description,
+  error,
+  required,
+  handleBlur,
+  handleKeyDown,
+  handleChange,
+  toggleVisibility,
+  onCopy,
+  inputProps,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>;
+  inputRef: (node: HTMLInputElement | null) => void;
+  copyButtonRef: React.RefObject<HTMLButtonElement | null>;
+  value: string;
+  hasValue: boolean;
+  revealed: boolean;
+  size: KumoInputSize;
+  disabled: boolean;
+  readOnly: boolean;
+  autoComplete: string;
+  className?: string;
+  label?: ReactNode;
+  labelTooltip?: ReactNode;
+  description?: ReactNode;
+  error?: { message: ReactNode; match: FieldErrorMatch | boolean };
+  required?: boolean;
+  handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  toggleVisibility: () => void;
+  onCopy?: () => void;
+  inputProps: Record<string, unknown>;
+}) {
+  const toastManager = Toast.useToastManager();
+
+  const copyToClipboard = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toastManager.add({
+        id: "sensitive-input-copied",
+        title: "Copied!",
+        timeout: 1500,
+        positionerProps: {
+          anchor: copyButtonRef.current,
+          side: "top",
+          sideOffset: 10,
+          align: "center",
+        },
+      });
+      onCopy?.();
+    } catch {
+      console.warn("Clipboard copy failed");
+    }
+  }, [value, onCopy, toastManager, copyButtonRef]);
+
+  return (
+    <>
+      <InputGroup
+        ref={containerRef}
+        size={size}
+        disabled={disabled}
+        label={label}
+        labelTooltip={labelTooltip}
+        description={description}
+        error={error}
+        required={required}
+        className={className}
+      >
+        <InputGroup.Input
+          ref={inputRef}
+          type={revealed ? "text" : "password"}
+          value={value}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          readOnly={readOnly}
+          autoComplete={autoComplete}
+          {...inputProps}
+        />
+        <InputGroup.Addon align="end">
+          {hasValue && !disabled && (
+            <InvertedTooltip content="Copy">
+              <InputGroup.Button
+                ref={copyButtonRef}
+                icon={Copy}
+                aria-label="Copy to clipboard"
+                onClick={copyToClipboard}
+              />
+            </InvertedTooltip>
+          )}
+          {!disabled && (
+            <InvertedTooltip content={revealed ? "Hide" : "Reveal"}>
+              <InputGroup.Button
+                icon={revealed ? EyeSlash : Eye}
+                aria-label={revealed ? "Hide value" : "Reveal value"}
+                onClick={toggleVisibility}
+              />
+            </InvertedTooltip>
+          )}
+        </InputGroup.Addon>
+      </InputGroup>
+
+      {/* Anchored toast viewport — renders "Copied!" near the copy button */}
+      <Toast.Portal>
+        <Toast.Viewport className="pointer-events-none fixed z-50">
+          <AnchoredToastList />
+        </Toast.Viewport>
+      </Toast.Portal>
+    </>
+  );
+}
+
+const INVERTED_POPUP_CLASS = cn(
+  "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-base",
+  "shadow-lg",
+  "transition-[transform,opacity] duration-150",
+  "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",
+  "data-[ending-style]:scale-90 data-[ending-style]:opacity-0",
+  "data-[instant]:duration-0",
+);
+
+/** Dark inverted tooltip used for SensitiveInput action buttons. */
+function InvertedTooltip({
+  content,
+  children,
+}: {
+  content: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <TooltipBase.Root>
+      <TooltipBase.Trigger
+        className="inline-flex items-center bg-transparent border-none shadow-none p-0 m-0 h-auto min-h-0 leading-[0] cursor-default"
+        render={children as React.ReactElement}
+      />
+      <TooltipBase.Portal>
+        <TooltipBase.Positioner side="top" sideOffset={10}>
+          <TooltipBase.Popup className={INVERTED_POPUP_CLASS}>
+            <TooltipBase.Arrow className="fill-kumo-contrast" />
+            {content}
+          </TooltipBase.Popup>
+        </TooltipBase.Positioner>
+      </TooltipBase.Portal>
+    </TooltipBase.Root>
+  );
+}
+
+function AnchoredToastList() {
+  const { toasts } = Toast.useToastManager();
+  return toasts.map((toast) => (
+    <Toast.Positioner key={toast.id} toast={toast}>
+      <Toast.Root
+        toast={toast}
+        className={cn(
+          "origin-[var(--transform-origin)] rounded-md bg-kumo-contrast px-2.5 py-1.5 text-sm font-medium text-kumo-base",
+          "shadow-lg",
+          "transition-[transform,opacity] duration-150",
+          "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",
+          "data-[ending-style]:scale-90 data-[ending-style]:opacity-0",
+        )}
+      >
+        <Toast.Arrow className="fill-kumo-contrast" />
+        <Toast.Title />
+      </Toast.Root>
+    </Toast.Positioner>
+  ));
+}


### PR DESCRIPTION
## Summary

- Rewrites SensitiveInput as a thin wrapper around InputGroup, replacing 500+ lines of hand-rolled layout (manual mask overlay, absolute positioning, per-size padding duplication, `role="button"` container, `execCommand` fallback) with composable primitives
- Copy confirmation now uses an anchored Base UI Toast positioned above the copy button instead of icon-swapping with a timeout
- Action button tooltips use a scoped inverted dark style (`bg-kumo-contrast`/`text-kumo-base`) that adapts to light/dark mode
- Toast dismisses immediately on blur (e.g. tabbing to reveal button) for snappy feedback
- Consumer `onBlur` is properly forwarded before masking logic (verified against stratus Formik usage)
- No public API changes — all existing props (`onChange`, `onValueChange`, `onBlur`, `error`, `onCopy`, etc.) continue to work

Audited against real-world usage in `cloudflare/stratus` (CustomHeaders.tsx, ImportVariablesSecretsDialog.tsx) — no breaking changes.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: UX refactor needs visual review
- Tests
- [x] Additional testing not necessary because: existing unit tests pass, no API changes, verified against stratus consumers