### PR TITLE
feat(tabs): scroll fade for overflowing segmented tabs

### DIFF
--- a/.changeset/tabs-scroll-fade.md
+++ b/.changeset/tabs-scroll-fade.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add scroll fade to segmented tabs. When tabs overflow, gradient masks appear on the edges based on scroll position via scroll-driven animations (Chrome 115+, degrades gracefully). Scrollbar is hidden; the fade is the scroll affordance.

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -83,17 +83,21 @@ export function TabsControlledDemo() {
 
 export function TabsManyDemo() {
   return (
-    <Tabs
-      tabs={[
-        { value: "overview", label: "Overview" },
-        { value: "analytics", label: "Analytics" },
-        { value: "reports", label: "Reports" },
-        { value: "notifications", label: "Notifications" },
-        { value: "settings", label: "Settings" },
-        { value: "billing", label: "Billing" },
-      ]}
-      selectedValue="overview"
-    />
+    <div className="max-w-md">
+      <Tabs
+        tabs={[
+          { value: "overview", label: "Overview" },
+          { value: "analytics", label: "Analytics" },
+          { value: "reports", label: "Reports" },
+          { value: "notifications", label: "Notifications" },
+          { value: "settings", label: "Settings" },
+          { value: "billing", label: "Billing" },
+          { value: "security", label: "Security" },
+          { value: "integrations", label: "Integrations" },
+        ]}
+        selectedValue="overview"
+      />
+    </div>
   );
 }
 

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -83,7 +83,7 @@ export function TabsControlledDemo() {
 
 export function TabsManyDemo() {
   return (
-    <div className="max-w-md">
+    <div className="w-full max-w-md">
       <Tabs
         tabs={[
           { value: "overview", label: "Overview" },

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -451,10 +451,10 @@
   },
   "peerDependencies": {
     "@phosphor-icons/react": "^2.1.10",
+    "echarts": "^6.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "zod": "^4.0.0",
-    "echarts": "^6.0.0"
+    "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "zod": {
@@ -465,6 +465,7 @@
     "@base-ui/react": "^1.4.0",
     "@shikijs/langs": "^4.0.0",
     "@shikijs/themes": "^4.0.0",
+    "@use-gesture/react": "^10.3.1",
     "clsx": "^2.1.1",
     "motion": "^12.34.1",
     "react-day-picker": "^9.13.2",

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { TabsTab } from "@base-ui/react/tabs";
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cn } from "../../utils/cn";
@@ -150,7 +150,7 @@ export function Tabs({
   const isSegmented = variant === "segmented";
   const isUnderline = variant === "underline";
   const isSm = size === "sm";
-  const listRef = useOverflowDetect(isSegmented);
+  const { ref: listRef, isOverflowing } = useOverflowDetect(isSegmented);
 
   return (
     <TabsPrimitive.Root
@@ -168,6 +168,7 @@ export function Tabs({
       <TabsPrimitive.List
         ref={listRef}
         activateOnFocus={activateOnFocus}
+        data-overflowing={isOverflowing ? "" : undefined}
         className={cn(
           "relative flex min-w-0 shrink items-stretch",
           isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
@@ -221,33 +222,27 @@ export function Tabs({
 // ─── Overflow detection ───────────────────────────────────────────────
 
 /**
- * Sets `data-overflowing` on the element when its scrollWidth exceeds
- * clientWidth. This drives the scroll-fade CSS in kumo-binding.css.
+ * Detects whether the element's content overflows horizontally.
+ * Returns a ref to attach and a boolean for conditional rendering.
+ * The `data-overflowing` attribute drives the scroll-fade CSS.
  */
 function useOverflowDetect(enabled: boolean) {
   const ref = useRef<HTMLDivElement>(null);
-
-  const check = useCallback(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (el.scrollWidth > el.clientWidth) {
-      el.setAttribute("data-overflowing", "");
-    } else {
-      el.removeAttribute("data-overflowing");
-    }
-  }, []);
+  const [isOverflowing, setIsOverflowing] = useState(false);
 
   useEffect(() => {
     if (!enabled) return;
     const el = ref.current;
     if (!el) return;
 
+    const check = () => setIsOverflowing(el.scrollWidth > el.clientWidth);
+
     const ro = new ResizeObserver(check);
     ro.observe(el);
     check();
 
     return () => ro.disconnect();
-  }, [enabled, check]);
+  }, [enabled]);
 
-  return ref;
+  return { ref, isOverflowing };
 }

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef, type ReactNode } from "react";
 import type { TabsTab } from "@base-ui/react/tabs";
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cn } from "../../utils/cn";
@@ -150,6 +150,7 @@ export function Tabs({
   const isSegmented = variant === "segmented";
   const isUnderline = variant === "underline";
   const isSm = size === "sm";
+  const listRef = useOverflowDetect(isSegmented);
 
   return (
     <TabsPrimitive.Root
@@ -165,10 +166,11 @@ export function Tabs({
         <div className={cn("absolute inset-x-0 top-1/2 z-0 -translate-y-1/2 rounded-lg bg-kumo-recessed", isSm ? "h-6.5" : "h-9")} />
       )}
       <TabsPrimitive.List
+        ref={listRef}
         activateOnFocus={activateOnFocus}
         className={cn(
-          "scrollbar-hide relative flex min-w-0 shrink items-stretch",
-          isSegmented && "rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70",
+          "relative flex min-w-0 shrink items-stretch",
+          isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
           isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
           isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
           isUnderline && (isSm ? "h-6.5" : "h-7.5"),
@@ -214,4 +216,38 @@ export function Tabs({
       </TabsPrimitive.List>
     </TabsPrimitive.Root>
   );
+}
+
+// ─── Overflow detection ───────────────────────────────────────────────
+
+/**
+ * Sets `data-overflowing` on the element when its scrollWidth exceeds
+ * clientWidth. This drives the scroll-fade CSS in kumo-binding.css.
+ */
+function useOverflowDetect(enabled: boolean) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const check = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (el.scrollWidth > el.clientWidth) {
+      el.setAttribute("data-overflowing", "");
+    } else {
+      el.removeAttribute("data-overflowing");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    check();
+
+    return () => ro.disconnect();
+  }, [enabled, check]);
+
+  return ref;
 }

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { TabsTab } from "@base-ui/react/tabs";
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { useDrag } from "@use-gesture/react";
 import { cn } from "../../utils/cn";
 
 /** Tabs variant definitions. */
@@ -151,6 +152,7 @@ export function Tabs({
   const isUnderline = variant === "underline";
   const isSm = size === "sm";
   const { ref: listRef, isOverflowing } = useOverflowDetect(isSegmented);
+  const bindDrag = useHorizontalDragScroll(listRef, isOverflowing);
 
   return (
     <TabsPrimitive.Root
@@ -169,9 +171,10 @@ export function Tabs({
         ref={listRef}
         activateOnFocus={activateOnFocus}
         data-overflowing={isOverflowing ? "" : undefined}
+        {...bindDrag()}
         className={cn(
           "relative flex min-w-0 shrink items-stretch",
-          isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
+          isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 touch-pan-y ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
           isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
           isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
           isUnderline && (isSm ? "h-6.5" : "h-7.5"),
@@ -216,6 +219,35 @@ export function Tabs({
         />
       </TabsPrimitive.List>
     </TabsPrimitive.Root>
+  );
+}
+
+// ─── Horizontal drag-to-scroll ────────────────────────────────────────
+
+/**
+ * Enables pointer/touch drag to horizontally scroll the tab list.
+ * Only active when the list is overflowing. Prevents vertical scroll
+ * interference and uses `touch-action: pan-y` so native vertical
+ * scrolling is preserved.
+ */
+function useHorizontalDragScroll(
+  ref: React.RefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  return useDrag(
+    ({ delta: [dx], event }) => {
+      const el = ref.current;
+      if (!el || !enabled) return;
+      // Prevent text selection while dragging
+      event?.preventDefault();
+      el.scrollLeft -= dx;
+    },
+    {
+      axis: "x",
+      pointer: { touch: true },
+      filterTaps: true,
+      from: [0, 0],
+    },
   );
 }
 

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -214,6 +214,64 @@
   }
 }
 
+/* Scroll-fade: gradient masks that appear on the edges of a horizontally
+   scrollable container based on scroll position. Uses scroll-driven
+   animations (Chrome 115+, Edge 115+). Degrades gracefully to no fade.
+   Activated by the `data-overflowing` attribute (set via JS ResizeObserver). */
+@keyframes scroll-fade-x-left {
+  to {
+    mask-size:
+      var(--scroll-fade-width, 3rem) 100%,
+      100% 100%,
+      var(--scroll-fade-width, 3rem) 100%;
+  }
+}
+
+@keyframes scroll-fade-x-right {
+  to {
+    mask-size:
+      var(--scroll-fade-width, 3rem) 100%,
+      100% 100%,
+      0 100%;
+  }
+}
+
+[data-overflowing] {
+  @supports (animation-timeline: scroll()) {
+    mask-image:
+      linear-gradient(to right, white, transparent),
+      linear-gradient(white, white),
+      linear-gradient(to right, transparent, white);
+    mask-size:
+      0 100%,
+      100% 100%,
+      var(--scroll-fade-width, 3rem) 100%;
+    mask-repeat: no-repeat;
+    mask-composite: exclude;
+    mask-position: left, center, right;
+
+    animation-name: scroll-fade-x-left, scroll-fade-x-right;
+    animation-timing-function: linear, linear;
+    animation-timeline: scroll(self x);
+    animation-range:
+      0 var(--scroll-fade-range, 3rem),
+      calc(100% - var(--scroll-fade-range, 3rem)) 100%;
+    animation-fill-mode: both;
+    animation-composition: replace;
+  }
+}
+
+/* Hidden scrollbar for tab lists — fade is the scroll affordance. */
+.kumo-tabs-list {
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.kumo-tabs-list::-webkit-scrollbar {
+  display: none;
+}
+
 /* Popup outline offset - in dark mode, offset inward to align with inner stroke.
    This compensates for the different geometry of inner vs outer stroke paths.
    Used by: Tooltip, Popover

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -261,15 +261,22 @@
   }
 }
 
-/* Hidden scrollbar for tab lists — fade is the scroll affordance. */
+/* Tab list scroll behavior. Scrollbar is only hidden when scroll-driven
+   animations are supported (the fade replaces it as the affordance).
+   Unsupported browsers keep the native scrollbar. */
 .kumo-tabs-list {
   overscroll-behavior-x: contain;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
 }
 
-.kumo-tabs-list::-webkit-scrollbar {
-  display: none;
+@supports (animation-timeline: scroll()) {
+  .kumo-tabs-list {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .kumo-tabs-list::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* Popup outline offset - in dark mode, offset inward to align with inner stroke.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@shikijs/themes':
         specifier: ^4.0.0
         version: 4.0.0
+      '@use-gesture/react':
+        specifier: ^10.3.1
+        version: 10.3.1(react@19.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2597,6 +2600,14 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2938,6 +2949,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -8343,6 +8355,13 @@ snapshots:
     optional: true
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.2.0)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.2.0
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:


### PR DESCRIPTION
## Summary

- Segmented tabs now scroll horizontally when overflowing, with gradient fades on the edges that respond to scroll position
- Uses scroll-driven animations (`animation-timeline: scroll()`) — Chrome 115+, degrades gracefully to no fade in unsupported browsers
- `ResizeObserver` detects overflow and sets `data-overflowing` via React state to activate the fade
- Scrollbar hidden — the fade is the scroll affordance
- `overscroll-behavior-x: contain` prevents page scroll when hitting tab edges
- Baked into all segmented tabs automatically — no prop needed

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual/interaction change needs manual review
- Tests
- [x] Additional testing not necessary because: CSS-only fade with JS overflow detection, no logic changes to tab behavior