### PR TITLE
feat(toast): forward toastManager prop on <Toasty>

### DIFF
--- a/.changeset/toasty-manager-prop.md
+++ b/.changeset/toasty-manager-prop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Forward `toastManager` prop on `<Toasty>` so code outside the React tree (timers, query-cache listeners, module-load callbacks) can dispatch toasts via a manager created by `createKumoToastManager()`. Also surface `createKumoToastManager` on the top-level package export (previously only available via the deep `@cloudflare/kumo/components/toast` path).

--- a/packages/kumo/src/components/toast/toast.test.tsx
+++ b/packages/kumo/src/components/toast/toast.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useEffect } from "react";
+import { Toasty, createKumoToastManager, useKumoToastManager } from "./toast";
+
+describe("Toasty", () => {
+  // Regression guard: existing callers that don't pass `toastManager`
+  // must continue to work via the in-tree `useKumoToastManager` hook.
+  it("renders without a toastManager prop and accepts in-tree dispatch", async () => {
+    function TriggerOnMount() {
+      const toasts = useKumoToastManager();
+      useEffect(() => {
+        toasts.add({ title: "from inside" });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return null;
+    }
+
+    render(
+      <Toasty>
+        <TriggerOnMount />
+      </Toasty>,
+    );
+
+    expect(await screen.findByText("from inside")).toBeTruthy();
+  });
+
+  // Headline feature: an external manager passed via the prop allows
+  // dispatch from outside the React tree.
+  it("dispatches toasts via an external manager passed as a prop", async () => {
+    const mgr = createKumoToastManager();
+
+    render(
+      <Toasty toastManager={mgr}>
+        <div />
+      </Toasty>,
+    );
+
+    act(() => {
+      mgr.add({ title: "from outside" });
+    });
+
+    expect(await screen.findByText("from outside")).toBeTruthy();
+  });
+
+  // Duplicate ids dispatched through an external manager must not
+  // produce duplicate DOM nodes. (The exact merge semantics — replace vs
+  // bump — are owned by `wrapManagerMethods` / base-ui and tested
+  // elsewhere; this test only guards against the regression of two
+  // toast roots rendering for the same id.)
+  it("does not render duplicate toast roots for the same id via an external manager", async () => {
+    const mgr = createKumoToastManager();
+
+    render(
+      <Toasty toastManager={mgr}>
+        <div />
+      </Toasty>,
+    );
+
+    act(() => {
+      mgr.add({ id: "dupe", title: "first" });
+      mgr.add({ id: "dupe", title: "second" });
+    });
+
+    // Exactly one toast title rendered — not two.
+    await screen.findByText("second");
+    const titles = document.querySelectorAll("[data-toast-title]");
+    expect(titles).toHaveLength(1);
+  });
+
+  // `useKumoToastManager()` inside a tree wrapped with an external manager
+  // must return that same manager — so in-tree and out-of-tree dispatch
+  // converge on a single instance.
+  it("exposes the same manager instance to useKumoToastManager inside the tree", async () => {
+    const mgr = createKumoToastManager();
+    let inTreeAdd: ((opts: { title: string }) => string) | undefined;
+
+    function CaptureManager() {
+      const toasts = useKumoToastManager();
+      inTreeAdd = toasts.add;
+      return null;
+    }
+
+    render(
+      <Toasty toastManager={mgr}>
+        <CaptureManager />
+      </Toasty>,
+    );
+
+    // External dispatch.
+    act(() => {
+      mgr.add({ title: "external" });
+    });
+    expect(await screen.findByText("external")).toBeTruthy();
+
+    // In-tree dispatch via the hook.
+    act(() => {
+      inTreeAdd?.({ title: "in-tree" });
+    });
+    expect(await screen.findByText("in-tree")).toBeTruthy();
+  });
+});

--- a/packages/kumo/src/components/toast/toast.tsx
+++ b/packages/kumo/src/components/toast/toast.tsx
@@ -148,6 +148,21 @@ export function toastVariants({
  * const toasts = Toast.useToastManager();
  * toasts.notify({ title: "Saved", description: "Changes saved successfully." });
  * ```
+ *
+ * @example Dispatching toasts from non-React-component code
+ * ```tsx
+ * // 1. Create a manager at module scope
+ * import { createKumoToastManager } from "@cloudflare/kumo";
+ * export const appToastManager = createKumoToastManager();
+ *
+ * // 2. Pass it to <Toasty>
+ * <Toasty toastManager={appToastManager}>
+ *   <App />
+ * </Toasty>
+ *
+ * // 3. Dispatch from anywhere — timers, callbacks, query-cache listeners
+ * appToastManager.add({ title: "Saved" });
+ * ```
  */
 export interface ToastyProps extends KumoToastVariantsProps {
   /** Application content. Toasts render via a portal above this. */
@@ -158,6 +173,18 @@ export interface ToastyProps extends KumoToastVariantsProps {
    * @default document.body (or KumoPortalProvider container if set)
    */
   container?: PortalContainer;
+  /**
+   * Optional toast manager created by `createKumoToastManager()`. When
+   * provided, allows code outside the React tree (timers, module-load
+   * callbacks, query-cache listeners) to dispatch toasts via the same
+   * dedupe-aware manager that `useKumoToastManager()` returns inside the
+   * tree.
+   *
+   * Forwarded to the underlying `@base-ui/react/toast` `Toast.Provider`
+   * `toastManager` prop — see
+   * https://base-ui.com/react/components/toast for the upstream primitive.
+   */
+  toastManager?: ReturnType<typeof createKumoToastManager>;
 }
 
 type KumoToastOptionsBase = {
@@ -287,12 +314,16 @@ export const createKumoToastManager = () => {
  * </Toasty>
  * ```
  */
-export function Toasty({ children, container: containerProp }: ToastyProps) {
+export function Toasty({
+  children,
+  container: containerProp,
+  toastManager,
+}: ToastyProps) {
   const contextContainer = usePortalContainer();
   const container = containerProp ?? contextContainer ?? undefined;
 
   return (
-    <Toast.Provider>
+    <Toast.Provider toastManager={toastManager}>
       {children}
       <Toast.Portal container={container}>
         <Toast.Viewport className="fixed top-auto right-4 bottom-4 z-1 mx-auto flex w-[calc(100%-2rem)] sm:right-8 sm:bottom-8 sm:w-[340px]">

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -133,6 +133,7 @@ export {
   ToastProvider,
   Toast,
   useKumoToastManager,
+  createKumoToastManager,
 } from "./components/toast";
 export { Tooltip, TooltipProvider } from "./components/tooltip";
 export {


### PR DESCRIPTION
Fixes internal Cloudflare ticket UI-8298.

## Summary

- Forwards the `toastManager` prop on `<Toasty>` through to the underlying
  `<Toast.Provider>`, enabling toast dispatch from non-React-component code
- Adds `createKumoToastManager` to the top-level `@cloudflare/kumo` barrel
  (already available via the deep `@cloudflare/kumo/components/toast` path)
- Adds tests covering the new prop, no-duplicate-root behavior with an
  external manager, and shared-instance semantics with `useKumoToastManager`

## Problem

`<Toasty>` today only exposes toast dispatch via the `useKumoToastManager`
hook, which is unusable outside React components. Consumers who need to
dispatch toasts from module-load callbacks, timers, web workers, query-cache
listeners, or other non-component code have no canonical path.

`@tanstack/react-query` cache event handlers run outside the
React tree. Wiring "show a toast on every failed mutation" through the
existing API requires a singleton handle pattern (set by a mount-time
component, read by the cache callback) — a workaround that exists in at
least one Cloudflare codebase today and that we'd like to retire.

The underlying `@base-ui/react/toast` already supports this via a
`toastManager` prop on `<Toast.Provider>` — described in their docs as
"A global manager for toasts to use outside of a React component." Kumo's
`<Toasty>` wraps `<Toast.Provider>` but does not forward this prop.

## Solution

Three changes:

1. **`Toasty` accepts an optional `toastManager` prop.** When provided, it
   is forwarded directly to the wrapped `<Toast.Provider>`. The prop type
   is `ReturnType<typeof createKumoToastManager>`, which matches the
   instance kumo's own `wrapManagerMethods()` produces (with dedupe-aware
   `add`/`update`/`promise` behavior).

2. **`createKumoToastManager` is exported from the top-level barrel.**
   Previously only reachable via `@cloudflare/kumo/components/toast`. The
   factory itself is unchanged.

3. **Usage pattern.** Create the manager at module scope, pass it to
   `<Toasty>`, and dispatch from anywhere:

   ```tsx
   // toast-manager.ts
   import { createKumoToastManager } from "@cloudflare/kumo";
   export const appToastManager = createKumoToastManager();

   // app.tsx
   <Toasty toastManager={appToastManager}>
     <App />
   </Toasty>

   // from any non-component code
   appToastManager.add({ title: "Saved" });
   ```

   `useKumoToastManager()` inside the tree returns the same underlying
   manager instance, so in-tree and out-of-tree dispatch converge.

## Breaking change?

No. The prop is optional; existing `<Toasty>` consumers and the existing
top-level barrel exports are unaffected. The `createKumoToastManager`
addition to the top-level export is purely additive (it was already
reachable via the deep path).

---

- Reviews
  - [x] automated review not possible because: additive prop forwarding to a documented base-ui primitive; behavior matches the upstream contract
- Tests
  - [x] Tests included/updated