### PR TITLE
feat(sankey): add loading state and transparent background to SankeyC…

### DIFF
--- a/.changeset/clever-bikes-find.md
+++ b/.changeset/clever-bikes-find.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add transparent background to SankeyChart component

--- a/packages/kumo/src/components/chart/SankeyChart.test.tsx
+++ b/packages/kumo/src/components/chart/SankeyChart.test.tsx
@@ -72,8 +72,9 @@ describe("SankeyChart", () => {
           className="custom-class"
         />,
       );
-      const div = container.firstChild as HTMLElement;
-      expect(div.classList.contains("custom-class")).toBe(true);
+      // className is passed to the inner Chart component, not the wrapper div
+      const chartDiv = container.querySelector(".custom-class");
+      expect(chartDiv).toBeTruthy();
     });
 
     it("handles empty nodes array", () => {

--- a/packages/kumo/src/components/chart/SankeyChart.tsx
+++ b/packages/kumo/src/components/chart/SankeyChart.tsx
@@ -201,6 +201,7 @@ export function SankeyChart({
     }));
 
     return {
+      backgroundColor: "transparent",
       animation: true,
       animationDuration: 500,
       animationDurationUpdate: 300,


### PR DESCRIPTION
### Changes
- Set `backgroundColor: "transparent"` to match TimeseriesChart behavior

Background change (Most apparent on dark mode) BEFORE/ AFTER

<img width="855" height="464" alt="image" src="https://github.com/user-attachments/assets/b23284fb-1222-4620-bd68-c237c15f37ee" />

<img width="932" height="510" alt="image" src="https://github.com/user-attachments/assets/5e188841-93f9-4790-9412-007d5d32421f" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
