### PR TITLE
fix(tabs): stabilize drag scrolling

### DIFF
--- a/.changeset/tabs-drag-scroll.md
+++ b/.changeset/tabs-drag-scroll.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix overflowing segmented Tabs drag-to-scroll interactions so mouse and touch drags reliably scroll while normal tab clicks still activate tabs.

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -465,7 +465,6 @@
     "@base-ui/react": "^1.4.0",
     "@shikijs/langs": "^4.0.0",
     "@shikijs/themes": "^4.0.0",
-    "@use-gesture/react": "^10.3.1",
     "clsx": "^2.1.1",
     "motion": "^12.34.1",
     "react-day-picker": "^9.13.2",

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type MouseEvent, type PointerEvent, type ReactNode } from "react";
 import type { TabsTab } from "@base-ui/react/tabs";
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
-import { useDrag } from "@use-gesture/react";
 import { cn } from "../../utils/cn";
 
 /** Tabs variant definitions. */
@@ -176,6 +175,7 @@ export function Tabs({
           "relative flex min-w-0 shrink items-stretch",
           isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 touch-pan-y ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
           isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
+          isOverflowing && "cursor-grab active:cursor-grabbing",
           isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
           isUnderline && (isSm ? "h-6.5" : "h-7.5"),
           listClassName,
@@ -187,7 +187,8 @@ export function Tabs({
             value={tab.value}
             render={tab.render}
             className={cn(
-              "relative z-2 flex cursor-pointer items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand",
+              "relative z-2 flex items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand",
+              isOverflowing ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
               isSm ? "text-xs" : "text-base",
               isSegmented &&
                 "my-0.5 rounded-md text-kumo-subtle hover:text-kumo-default aria-selected:text-kumo-default focus-visible:ring-inset",
@@ -234,21 +235,88 @@ function useHorizontalDragScroll(
   ref: React.RefObject<HTMLElement | null>,
   enabled: boolean,
 ) {
-  return useDrag(
-    ({ delta: [dx], event }) => {
+  const dragState = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    scrollLeft: number;
+    dragging: boolean;
+  } | null>(null);
+  const shouldSuppressClick = useRef(false);
+
+  return () => ({
+    onPointerDownCapture: (event: PointerEvent<HTMLElement>) => {
       const el = ref.current;
       if (!el || !enabled) return;
-      // Prevent text selection while dragging
-      event?.preventDefault();
-      el.scrollLeft -= dx;
+      if (event.pointerType === "mouse" && event.button !== 0) return;
+
+      dragState.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        scrollLeft: el.scrollLeft,
+        dragging: false,
+      };
+      shouldSuppressClick.current = false;
     },
-    {
-      axis: "x",
-      pointer: { touch: true },
-      filterTaps: true,
-      from: [0, 0],
+    onPointerMoveCapture: (event: PointerEvent<HTMLElement>) => {
+      const el = ref.current;
+      const state = dragState.current;
+      if (!el || !enabled || !state || state.pointerId !== event.pointerId) return;
+
+      const movementX = event.clientX - state.startX;
+      const movementY = event.clientY - state.startY;
+      if (!state.dragging) {
+        if (Math.abs(movementX) <= 3) return;
+        if (event.pointerType !== "mouse" && Math.abs(movementY) > Math.abs(movementX)) {
+          dragState.current = null;
+          if (el.hasPointerCapture(event.pointerId)) {
+            el.releasePointerCapture(event.pointerId);
+          }
+          return;
+        }
+        state.dragging = true;
+        shouldSuppressClick.current = true;
+        el.setPointerCapture(event.pointerId);
+      }
+
+      event.preventDefault();
+      el.scrollLeft = state.scrollLeft - movementX;
     },
-  );
+    onPointerUpCapture: (event: PointerEvent<HTMLElement>) => {
+      const el = ref.current;
+      const state = dragState.current;
+      if (!el || !state || state.pointerId !== event.pointerId) return;
+
+      dragState.current = null;
+      if (el.hasPointerCapture(event.pointerId)) {
+        el.releasePointerCapture(event.pointerId);
+      }
+      if (shouldSuppressClick.current) {
+        window.setTimeout(() => {
+          shouldSuppressClick.current = false;
+        }, 0);
+      }
+    },
+    onPointerCancelCapture: (event: PointerEvent<HTMLElement>) => {
+      const el = ref.current;
+      const state = dragState.current;
+      if (!el || !state || state.pointerId !== event.pointerId) return;
+
+      dragState.current = null;
+      if (el.hasPointerCapture(event.pointerId)) {
+        el.releasePointerCapture(event.pointerId);
+      }
+    },
+    onClickCapture: (event: MouseEvent<HTMLElement>) => {
+      if (!shouldSuppressClick.current) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      shouldSuppressClick.current = false;
+    },
+  });
 }
 
 // ─── Overflow detection ───────────────────────────────────────────────

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -173,7 +173,7 @@ export function Tabs({
         {...bindDrag()}
         className={cn(
           "relative flex min-w-0 shrink items-stretch",
-          isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 touch-pan-y ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
+          isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
           isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
           isOverflowing && "cursor-grab active:cursor-grabbing",
           isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
@@ -226,10 +226,8 @@ export function Tabs({
 // ─── Horizontal drag-to-scroll ────────────────────────────────────────
 
 /**
- * Enables pointer/touch drag to horizontally scroll the tab list.
- * Only active when the list is overflowing. Prevents vertical scroll
- * interference and uses `touch-action: pan-y` so native vertical
- * scrolling is preserved.
+ * Enables mouse drag to horizontally scroll the tab list.
+ * Touch devices keep native horizontal overflow scrolling and inertia.
  */
 function useHorizontalDragScroll(
   ref: React.RefObject<HTMLElement | null>,
@@ -238,7 +236,6 @@ function useHorizontalDragScroll(
   const dragState = useRef<{
     pointerId: number;
     startX: number;
-    startY: number;
     scrollLeft: number;
     dragging: boolean;
   } | null>(null);
@@ -248,12 +245,11 @@ function useHorizontalDragScroll(
     onPointerDownCapture: (event: PointerEvent<HTMLElement>) => {
       const el = ref.current;
       if (!el || !enabled) return;
-      if (event.pointerType === "mouse" && event.button !== 0) return;
+      if (event.pointerType !== "mouse" || event.button !== 0) return;
 
       dragState.current = {
         pointerId: event.pointerId,
         startX: event.clientX,
-        startY: event.clientY,
         scrollLeft: el.scrollLeft,
         dragging: false,
       };
@@ -265,16 +261,8 @@ function useHorizontalDragScroll(
       if (!el || !enabled || !state || state.pointerId !== event.pointerId) return;
 
       const movementX = event.clientX - state.startX;
-      const movementY = event.clientY - state.startY;
       if (!state.dragging) {
         if (Math.abs(movementX) <= 3) return;
-        if (event.pointerType !== "mouse" && Math.abs(movementY) > Math.abs(movementX)) {
-          dragState.current = null;
-          if (el.hasPointerCapture(event.pointerId)) {
-            el.releasePointerCapture(event.pointerId);
-          }
-          return;
-        }
         state.dragging = true;
         shouldSuppressClick.current = true;
         el.setPointerCapture(event.pointerId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       '@shikijs/themes':
         specifier: ^4.0.0
         version: 4.0.0
-      '@use-gesture/react':
-        specifier: ^10.3.1
-        version: 10.3.1(react@19.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2599,14 +2596,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
-  '@use-gesture/core@10.3.1':
-    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
-
-  '@use-gesture/react@10.3.1':
-    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
-    peerDependencies:
-      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -8355,13 +8344,6 @@ snapshots:
     optional: true
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@use-gesture/core@10.3.1': {}
-
-  '@use-gesture/react@10.3.1(react@19.2.0)':
-    dependencies:
-      '@use-gesture/core': 10.3.1
-      react: 19.2.0
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:


### PR DESCRIPTION
## Summary
- Replace the overflowing segmented Tabs drag handler with pointer-threshold logic that preserves normal tab clicks.
- Add grab/grabbing cursors when segmented tabs overflow.
- Remove the now-unused `@use-gesture/react` dependency from `@cloudflare/kumo`.

## Testing
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: interaction timing needs human verification in browser
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: verified drag-to-scroll and tab click interactions locally during implementation
- [x] Additional testing not necessary because: lint and typecheck cover the code change and browser interaction was manually verified