### PR TITLE
fix(radio): add shrink-0 to prevent oval distortion with long labels

### DIFF
--- a/.changeset/radio-shrink-fix.md
+++ b/.changeset/radio-shrink-fix.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(radio): prevent radio button distortion with long labels by adding `shrink-0` to the default appearance radio indicator

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -332,7 +332,7 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
           value={value}
           disabled={disabled}
           className={cn(
-            "relative flex h-4 w-4 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
+            "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
             variant === "error" ? "ring-kumo-danger" : "ring-kumo-line",
             !disabled &&
               variant !== "error" &&


### PR DESCRIPTION
## Summary

- Adds missing `shrink-0` to the default appearance radio indicator, preventing the radio button from being squished into an oval when paired with long labels
- The card appearance already had `shrink-0`; this brings the default path in line

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: trivial one-class CSS fix
- Tests
- [x] Additional testing not necessary because: single Tailwind utility addition with no behavioral change