### PR TITLE
feat(input): add password manager ignore prop

### DIFF
--- a/.changeset/input-password-manager-ignore.md
+++ b/.changeset/input-password-manager-ignore.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `passwordManagerIgnore` to Input for suppressing password manager overlays on non-credential fields.

--- a/packages/kumo-docs-astro/src/components/demos/InputDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/InputDemo.tsx
@@ -86,6 +86,25 @@ export function InputErrorWithoutLabelDemo() {
   );
 }
 
+/** Side-by-side comparison: Keeper shows its icon on the default input but not the ignored one. */
+export function InputPasswordManagerIgnoreDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Input
+        label="API Key (default)"
+        type="password"
+        placeholder="sk_live_..."
+      />
+      <Input
+        label="API Key (passwordManagerIgnore)"
+        type="password"
+        placeholder="sk_live_..."
+        passwordManagerIgnore
+      />
+    </div>
+  );
+}
+
 export function InputTypesDemo() {
   return (
     <div className="flex flex-col gap-4">

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -19,6 +19,7 @@ import {
   InputDisabledDemo,
   InputBareDemo,
   InputErrorWithoutLabelDemo,
+  InputPasswordManagerIgnoreDemo,
   InputTypesDemo,
   InputOptionalFieldDemo,
   InputLabelTooltipDemo,
@@ -224,14 +225,9 @@ export default function Example() {
   Set `passwordManagerIgnore` on non-credential inputs that password managers
   might incorrectly classify as login fields.
 </p>
-
-```tsx
-import { Input } from "@cloudflare/kumo";
-
-export default function Example() {
-  return <Input label="Search users" passwordManagerIgnore />;
-}
-```
+<ComponentExample demo="InputPasswordManagerIgnoreDemo">
+  <InputPasswordManagerIgnoreDemo client:visible />
+</ComponentExample>
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -43,7 +43,7 @@ import {
 
 ### Barrel
 
-  <CodeBlock code={`import { Input } from "@cloudflare/kumo";`} lang="tsx" />
+<CodeBlock code={`import { Input } from "@cloudflare/kumo";`} lang="tsx" />
 
 ### Granular
 
@@ -61,9 +61,10 @@ import {
 
 ### With Built-in Field (Recommended)
 
-  <p>
-    Use the `label` prop to enable the built-in Field wrapper with label, description, and error support.
-  </p>
+<p>
+  Use the `label` prop to enable the built-in Field wrapper with label,
+  description, and error support.
+</p>
 
 ```tsx
 import { Input } from "@cloudflare/kumo";
@@ -209,12 +210,29 @@ export default function Example() {
 
 ### Input Types
 
-  <p>
-    Supports all HTML input types: `text`, `email`, `password`, `number`, `tel`, `url`, etc.
-  </p>
-  <ComponentExample demo="InputTypesDemo">
-    <InputTypesDemo client:visible />
-  </ComponentExample>
+<p>
+  Supports all HTML input types: `text`, `email`, `password`, `number`, `tel`,
+  `url`, etc.
+</p>
+<ComponentExample demo="InputTypesDemo">
+  <InputTypesDemo client:visible />
+</ComponentExample>
+
+### Password Manager Overlays
+
+<p>
+  Set `passwordManagerIgnore` on non-credential inputs that password managers
+  might incorrectly classify as login fields.
+</p>
+
+```tsx
+import { Input } from "@cloudflare/kumo";
+
+export default function Example() {
+  return <Input label="Search users" passwordManagerIgnore />;
+}
+```
+
 </ComponentSection>
 
 {/* API Reference */}
@@ -223,10 +241,8 @@ export default function Example() {
 
 ## API Reference
 
-  <p>
-    Input accepts all standard HTML input attributes plus the following:
-  </p>
-  <PropsTable component="Input" />
+<p>Input accepts all standard HTML input attributes plus the following:</p>
+<PropsTable component="Input" />
 
 ### Validation Error Types
 
@@ -311,5 +327,6 @@ export default function Example() {
         attributes for screen reader announcement.
       </p>
     </div>
+
   </div>
 </ComponentSection>

--- a/packages/kumo/src/components/input/input.test.tsx
+++ b/packages/kumo/src/components/input/input.test.tsx
@@ -52,7 +52,6 @@ describe("Input", () => {
     expect(input.getAttribute("data-1p-ignore")).toBe("true");
     expect(input.getAttribute("data-bwignore")).toBe("true");
     expect(input.getAttribute("data-form-type")).toBe("other");
-    expect(input.getAttribute("data-keeper-lock")).toBe("true");
     expect(input.getAttribute("data-lpignore")).toBe("true");
   });
 

--- a/packages/kumo/src/components/input/input.test.tsx
+++ b/packages/kumo/src/components/input/input.test.tsx
@@ -45,6 +45,17 @@ describe("Input", () => {
     expect(input).toHaveProperty("disabled", true);
   });
 
+  it("applies password manager ignore hints when requested", () => {
+    render(<Input aria-label="Test" passwordManagerIgnore />);
+    const input = screen.getByRole("textbox");
+    expect(input.className).toContain("keeper-ignore");
+    expect(input.getAttribute("data-1p-ignore")).toBe("true");
+    expect(input.getAttribute("data-bwignore")).toBe("true");
+    expect(input.getAttribute("data-form-type")).toBe("other");
+    expect(input.getAttribute("data-keeper-lock")).toBe("true");
+    expect(input.getAttribute("data-lpignore")).toBe("true");
+  });
+
   // Size variants
   it("renders with default size 'base'", () => {
     render(<Input aria-label="Test" />);

--- a/packages/kumo/src/components/input/input.tsx
+++ b/packages/kumo/src/components/input/input.tsx
@@ -192,7 +192,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
             "data-1p-ignore": "true",
             "data-bwignore": "true",
             "data-form-type": "other",
-            "data-keeper-lock": "true",
             "data-lpignore": "true",
           }
         : {})}

--- a/packages/kumo/src/components/input/input.tsx
+++ b/packages/kumo/src/components/input/input.tsx
@@ -111,9 +111,17 @@ export function inputVariants({
     // Disabled state and placeholder styles (using vanilla CSS class for Chrome compatibility)
     "kumo-input-placeholder disabled:text-kumo-disabled",
     // Apply size styles from KUMO_INPUT_VARIANTS
-    resolveVariant(KUMO_INPUT_VARIANTS.size, size, KUMO_INPUT_DEFAULT_VARIANTS.size).classes,
+    resolveVariant(
+      KUMO_INPUT_VARIANTS.size,
+      size,
+      KUMO_INPUT_DEFAULT_VARIANTS.size,
+    ).classes,
     // Apply variant styles from KUMO_INPUT_VARIANTS
-    resolveVariant(KUMO_INPUT_VARIANTS.variant, variant, KUMO_INPUT_DEFAULT_VARIANTS.variant).classes,
+    resolveVariant(
+      KUMO_INPUT_VARIANTS.variant,
+      variant,
+      KUMO_INPUT_DEFAULT_VARIANTS.variant,
+    ).classes,
     // Focus state handling
     parentFocusIndicator &&
       (variant === "error"
@@ -135,6 +143,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     labelTooltip,
     description,
     error,
+    passwordManagerIgnore = false,
     ...inputProps
   } = props;
 
@@ -175,8 +184,18 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       ref={ref}
       className={cn(
         inputVariants({ size, variant, focusIndicator: true }),
+        passwordManagerIgnore && "keeper-ignore",
         className,
       )}
+      {...(passwordManagerIgnore
+        ? {
+            "data-1p-ignore": "true",
+            "data-bwignore": "true",
+            "data-form-type": "other",
+            "data-keeper-lock": "true",
+            "data-lpignore": "true",
+          }
+        : {})}
       {...inputProps}
     />
   );
@@ -243,4 +262,6 @@ export type InputProps = Pick<KumoInputVariantsProps, "size" | "variant"> &
     description?: ReactNode;
     /** Error message or validation error object */
     error?: string | { message: ReactNode; match: FieldErrorMatch };
+    /** Suppress browser extension password manager overlays on non-credential inputs. */
+    passwordManagerIgnore?: boolean;
   };


### PR DESCRIPTION
## Summary
- Add an opt-in `passwordManagerIgnore` prop to `Input` for non-credential fields that password managers misclassify.
- Apply common password manager suppression hints, including Keeper's documented `keeper-ignore` class.
- Document the prop and cover the emitted hints in the Input tests.

## Testing
- `pnpm --filter @cloudflare/kumo exec vitest run --project=unit src/components/input/input.test.tsx`
- `pnpm exec prettier --check packages/kumo/src/components/input/input.tsx packages/kumo/src/components/input/input.test.tsx packages/kumo-docs-astro/src/pages/components/input.mdx .changeset/input-password-manager-ignore.md`

## Local Check Notes
- `pnpm typecheck` is currently blocked in this checkout by Node `22.22.1` vs required `24.12.0`, missing screenshot-worker dependencies, and missing generated registry/schema state.
- `pnpm --filter @cloudflare/kumo typecheck` and `pnpm --filter @cloudflare/kumo lint` are also blocked by missing generated `packages/kumo/ai/component-registry.json` and dependency mismatches in the local checkout.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this PR was opened by an agent before Bonk review
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: 
- [ ] Additional testing not necessary because: 