### PR TITLE
Expose optionUpdateBehavior prop on TimeseriesChart

### DIFF
--- a/.changeset/expose-optionUpdateBehavior-timeserieschart.md
+++ b/.changeset/expose-optionUpdateBehavior-timeserieschart.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Expose `optionUpdateBehavior` prop on `TimeseriesChart` to control how ECharts applies option updates

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -1,6 +1,6 @@
 import type * as echarts from "echarts/core";
 import type { LineSeriesOption, BarSeriesOption } from "echarts/charts";
-import type { EChartsOption, SeriesOption } from "echarts";
+import type { EChartsOption, SeriesOption, SetOptionOpts } from "echarts";
 import { useEffect, useMemo, useRef } from "react";
 import { Chart, ChartEvents, KumoChartOption } from "./EChart";
 
@@ -87,6 +87,11 @@ export interface TimeseriesChartProps {
    * @see https://echarts.apache.org/handbook/en/best-practices/aria/
    */
   ariaDescription?: string;
+  /**
+   * Additional options passed as the second argument to `chart.setOption()`.
+   * Defaults to `{ notMerge: false, lazyUpdate: true }`.
+   */
+  optionUpdateBehavior?: SetOptionOpts;
 }
 
 /**
@@ -138,6 +143,7 @@ export function TimeseriesChart({
   gradient,
   loading,
   ariaDescription,
+  optionUpdateBehavior,
 }: TimeseriesChartProps) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   const incompleteBefore = incomplete?.before;
@@ -392,6 +398,7 @@ export function TimeseriesChart({
           height={height}
           isDarkMode={isDarkMode}
           onEvents={events}
+          optionUpdateBehavior={optionUpdateBehavior}
         />
       )}
     </div>


### PR DESCRIPTION
This PR exposes the `optionUpdateBehavior` prop on `TimeseriesChart`, allowing consumers to control how ECharts applies option updates (e.g., `notMerge`, `lazyUpdate`, `replaceMerge`). The prop was already available on the low-level `Chart` component; this change simply passes it through from the higher-level `TimeseriesChart`.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: trivial prop pass-through
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [x] Additional testing not necessary because: trivial prop pass-through from Chart component