### PR TITLE
feat(badge): added dot style variant

### DIFF
--- a/.changeset/badge-dot-updates.md
+++ b/.changeset/badge-dot-updates.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/kumo": patch
+"@cloudflare/kumo": minor
 "@cloudflare/kumo-docs-astro": patch
 ---
 

--- a/.changeset/badge-dot-updates.md
+++ b/.changeset/badge-dot-updates.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Added `Badge` dot styling as a new variant for indicators that need a subtle visual cue.
+Updated badge docs and demo examples to reflect the new badge variant and dot-style behavior.

--- a/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
@@ -37,3 +37,13 @@ export function BadgeInSentenceDemo() {
     </p>
   );
 }
+
+export function BadgeDotDemo() {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge variant="success" style="dot">Healthy</Badge>
+      <Badge variant="warning" style="dot">Warning</Badge>
+      <Badge variant="error" style="dot">Error</Badge>
+    </div>
+  );
+}

--- a/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
@@ -44,6 +44,7 @@ export function BadgeDotDemo() {
       <Badge variant="success" style="dot">Healthy</Badge>
       <Badge variant="warning" style="dot">Warning</Badge>
       <Badge variant="error" style="dot">Error</Badge>
+      <Badge variant="neutral" style="dot">Neutral</Badge>
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
@@ -41,10 +41,10 @@ export function BadgeInSentenceDemo() {
 export function BadgeDotDemo() {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <Badge variant="success" style="dot">Healthy</Badge>
-      <Badge variant="warning" style="dot">Warning</Badge>
-      <Badge variant="error" style="dot">Error</Badge>
-      <Badge variant="neutral" style="dot">Neutral</Badge>
+      <Badge variant="success" appearance="dot">Healthy</Badge>
+      <Badge variant="warning" appearance="dot">Warning</Badge>
+      <Badge variant="error" appearance="dot">Error</Badge>
+      <Badge variant="neutral" appearance="dot">Neutral</Badge>
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/badge.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/badge.mdx
@@ -61,6 +61,8 @@ Other color variants for specific products/use cases where the semantic badges a
 
 ### Dot badges
 
+Use `appearance="dot"` for a subtle status indicator with a colored dot. Supported with `success`, `warning`, `error`, and `neutral` variants.
+
 <ComponentExample demo="BadgeDotDemo">
   <BadgeDotDemo client:visible />
 </ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/components/badge.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/badge.mdx
@@ -11,6 +11,7 @@ import {
   BadgeSemanticVariantsDemo,
   BadgeColorVariantsDemo,
   BadgeInSentenceDemo,
+  BadgeDotDemo,
 } from "~/components/demos/BadgeDemo";
 
 
@@ -50,12 +51,18 @@ export default function Example() {
   <BadgeSemanticVariantsDemo client:visible />
 </ComponentExample>
 
-### Other variants
+### Other color variants
 
-Other variants for specific products/use cases where the semantic badges aren't enough to convey intended meaning or status.
+Other color variants for specific products/use cases where the semantic badges aren't enough to convey intended meaning or status.
 
 <ComponentExample demo="BadgeColorVariantsDemo">
   <BadgeColorVariantsDemo client:visible />
+</ComponentExample>
+
+### Dot badges
+
+<ComponentExample demo="BadgeDotDemo">
+  <BadgeDotDemo client:visible />
 </ComponentExample>
 
 ### In a sentence

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -508,8 +508,8 @@ export const THEME_CONFIG: ThemeConfig = {
       description: "Green badge background",
       theme: {
         kumo: {
-          light: "var(--color-emerald-700, oklch(50.8% 0.118 165.612))",
-          dark: "var(--color-emerald-700, oklch(50.8% 0.118 165.612))",
+          light: "var(--color-emerald-500, oklch(69.6% 0.17 162.48))",
+          dark: "var(--color-emerald-400, oklch(76.5% 0.177 163.223))",
         },
       },
     },
@@ -554,7 +554,7 @@ export const THEME_CONFIG: ThemeConfig = {
       description: "Neutral badge background",
       theme: {
         kumo: {
-          light: "var(--color-neutral-600, oklch(43.9% 0 0))",
+          light: "var(--color-neutral-500, oklch(55.6% 0 0))",
           dark: "var(--color-neutral-600, oklch(43.9% 0 0))",
         },
       },

--- a/packages/kumo/src/components/badge/badge.test.tsx
+++ b/packages/kumo/src/components/badge/badge.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  Badge,
+  badgeVariants,
+  KUMO_BADGE_VARIANTS,
+} from "./badge";
+
+describe("Badge", () => {
+  it("renders children as text content", () => {
+    render(<Badge>Active</Badge>);
+    expect(screen.getByText("Active")).toBeTruthy();
+  });
+
+  it("renders as a <span> element", () => {
+    render(<Badge>Status</Badge>);
+    const el = screen.getByText("Status");
+    expect(el.tagName).toBe("SPAN");
+  });
+
+  it("merges custom className", () => {
+    render(<Badge className="my-custom">Tag</Badge>);
+    const el = screen.getByText("Tag");
+    expect(el.className).toContain("my-custom");
+  });
+
+  describe("filled appearance (default)", () => {
+    it("applies variant classes for filled badges", () => {
+      render(<Badge variant="error">Error</Badge>);
+      const el = screen.getByText("Error");
+      expect(el.className).toContain("bg-kumo-danger-tint/60");
+    });
+
+    it("does not render a dot indicator", () => {
+      render(<Badge variant="success">OK</Badge>);
+      const el = screen.getByText("OK");
+      expect(el.querySelector("[aria-hidden]")).toBeNull();
+    });
+  });
+
+  describe("dot appearance", () => {
+    it("renders a dot indicator for supported variants", () => {
+      render(
+        <Badge variant="success" appearance="dot">
+          Healthy
+        </Badge>,
+      );
+      const badge = screen.getByText("Healthy").closest("span")!;
+      const dot = badge.querySelector("[aria-hidden='true']");
+      expect(dot).toBeTruthy();
+      expect(dot!.className).toContain("bg-kumo-badge-green");
+    });
+
+    it("applies dot appearance classes instead of variant classes", () => {
+      render(
+        <Badge variant="error" appearance="dot">
+          Down
+        </Badge>,
+      );
+      const badge = screen.getByText("Down").closest("span")!;
+      // Dot appearance overrides variant bg/text
+      expect(badge.className).toContain("bg-transparent");
+      expect(badge.className).toContain("text-kumo-default");
+      // Should NOT contain the filled error classes
+      expect(badge.className).not.toContain("bg-kumo-danger-tint/60");
+    });
+
+    it("renders correct dot color per variant", () => {
+      const cases = [
+        { variant: "success" as const, expected: "bg-kumo-badge-green" },
+        { variant: "warning" as const, expected: "bg-kumo-badge-orange" },
+        { variant: "error" as const, expected: "bg-kumo-badge-red" },
+        { variant: "neutral" as const, expected: "bg-kumo-badge-neutral" },
+      ];
+
+      for (const { variant, expected } of cases) {
+        const { unmount } = render(
+          <Badge variant={variant} appearance="dot">
+            {variant}
+          </Badge>,
+        );
+        const badge = screen.getByText(variant).closest("span")!;
+        const dot = badge.querySelector("[aria-hidden='true']");
+        expect(dot, `dot should exist for variant="${variant}"`).toBeTruthy();
+        expect(
+          dot!.className,
+          `dot class for variant="${variant}"`,
+        ).toContain(expected);
+        unmount();
+      }
+    });
+
+    it("does not render a dot for unsupported variants", () => {
+      // Suppress the expected dev warning from resolveVariant
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      render(
+        <Badge variant="primary" appearance="dot">
+          No dot
+        </Badge>,
+      );
+      const badge = screen.getByText("No dot").closest("span")!;
+      const dot = badge.querySelector("[aria-hidden='true']");
+      expect(dot).toBeNull();
+
+      warn.mockRestore();
+    });
+
+    it("dot element is aria-hidden", () => {
+      render(
+        <Badge variant="error" appearance="dot">
+          Err
+        </Badge>,
+      );
+      const badge = screen.getByText("Err").closest("span")!;
+      const dot = badge.querySelector("[aria-hidden='true']");
+      expect(dot).toBeTruthy();
+      expect(dot!.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+});
+
+describe("badgeVariants", () => {
+  it("returns base styles with no arguments", () => {
+    const result = badgeVariants();
+    expect(result).toContain("inline-flex");
+    expect(result).toContain("rounded-full");
+  });
+
+  it("includes variant classes for filled appearance", () => {
+    const result = badgeVariants({ variant: "success" });
+    expect(result).toContain("bg-kumo-success-tint/70");
+  });
+
+  it("omits variant classes for dot appearance", () => {
+    const result = badgeVariants({ variant: "success", appearance: "dot" });
+    expect(result).not.toContain("bg-kumo-success-tint/70");
+    expect(result).toContain("bg-transparent");
+  });
+
+  it("survives invalid variant without throwing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const BOGUS = "nope" as any;
+
+    expect(() => badgeVariants({ variant: BOGUS })).not.toThrow();
+    expect(typeof badgeVariants({ variant: BOGUS })).toBe("string");
+
+    expect(() =>
+      badgeVariants({ variant: BOGUS, appearance: BOGUS }),
+    ).not.toThrow();
+    expect(typeof badgeVariants({ appearance: BOGUS })).toBe("string");
+
+    warn.mockRestore();
+  });
+
+  it("returns default classes for invalid variant", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(badgeVariants({ variant: "nope" as any })).toBe(badgeVariants());
+    warn.mockRestore();
+  });
+});
+
+describe("KUMO_BADGE_VARIANTS", () => {
+  it("has variant, appearance, and dotColor dimensions", () => {
+    expect(KUMO_BADGE_VARIANTS.variant).toBeDefined();
+    expect(KUMO_BADGE_VARIANTS.appearance).toBeDefined();
+    expect(KUMO_BADGE_VARIANTS.dotColor).toBeDefined();
+  });
+
+  it("every variant entry has classes and description", () => {
+    for (const [dim, entries] of Object.entries(KUMO_BADGE_VARIANTS)) {
+      for (const [key, entry] of Object.entries(
+        entries as Record<string, { classes: string; description: string }>,
+      )) {
+        expect(entry.classes, `${dim}.${key}.classes`).toBeDefined();
+        expect(
+          typeof entry.description,
+          `${dim}.${key}.description`,
+        ).toBe("string");
+      }
+    }
+  });
+});

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -90,7 +90,7 @@ export const KUMO_BADGE_VARIANTS = {
     },
     dot: {
       classes:
-        "gap-1.5 bg-transparent text-kumo-default ring ring-kumo-line",
+        "gap-1.5 bg-transparent text-kumo-default ring ring-kumo-hairline",
       description: "Outlined badge with a colored circle dot indicating status",
     },
   },
@@ -111,9 +111,10 @@ export const KUMO_BADGE_DEFAULT_VARIANTS = {
  */
 const KUMO_BADGE_DOT_COLORS = {
   none: { classes: "" },
-  success: { classes: "bg-kumo-success" },
-  warning: { classes: "bg-kumo-warning" },
+  success: { classes: "bg-kumo-badge-green" },
+  warning: { classes: "bg-kumo-badge-orange" },
   error: { classes: "bg-kumo-badge-red" },
+  neutral: { classes: "bg-kumo-badge-neutral" },
 } as const;
 
 // Derived types from KUMO_BADGE_VARIANTS

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -83,7 +83,7 @@ export const KUMO_BADGE_VARIANTS = {
       description: "Blue badge",
     },
   },
-  style: {
+  appearance: {
     filled: {
       classes: "",
       description: "Filled badge with background color (default)",
@@ -94,59 +94,67 @@ export const KUMO_BADGE_VARIANTS = {
       description: "Outlined badge with a colored circle dot indicating status",
     },
   },
+  dotColor: {
+    none: {
+      classes: "",
+      description: "No dot indicator (used when appearance is not dot, or variant has no dot color)",
+    },
+    success: {
+      classes: "bg-kumo-badge-green",
+      description: "Green dot for success status",
+    },
+    warning: {
+      classes: "bg-kumo-badge-orange",
+      description: "Orange dot for warning status",
+    },
+    error: {
+      classes: "bg-kumo-badge-red",
+      description: "Red dot for error status",
+    },
+    neutral: {
+      classes: "bg-kumo-badge-neutral",
+      description: "Neutral dot for informational status",
+    },
+  },
 } as const;
 
 export const KUMO_BADGE_DEFAULT_VARIANTS = {
   variant: "primary",
-  style: "filled",
-} as const;
-
-/**
- * Dot color classes for the `style="dot"` variant, keyed by the subset of
- * `variant` values that support the dot style. Shaped like KUMO_BADGE_VARIANTS
- * entries so it can be accessed via `resolveVariant` for crash-safe lookups.
- *
- * The `"none"` fallback is used when `style="dot"` is paired with a variant
- * that doesn't have a dot color — it renders no dot rather than crashing.
- */
-const KUMO_BADGE_DOT_COLORS = {
-  none: { classes: "" },
-  success: { classes: "bg-kumo-badge-green" },
-  warning: { classes: "bg-kumo-badge-orange" },
-  error: { classes: "bg-kumo-badge-red" },
-  neutral: { classes: "bg-kumo-badge-neutral" },
+  appearance: "filled",
+  dotColor: "none",
 } as const;
 
 // Derived types from KUMO_BADGE_VARIANTS
 export type KumoBadgeVariant = keyof typeof KUMO_BADGE_VARIANTS.variant;
-export type KumoBadgeStyle = keyof typeof KUMO_BADGE_VARIANTS.style;
+export type KumoBadgeAppearance = keyof typeof KUMO_BADGE_VARIANTS.appearance;
+export type KumoBadgeDotColor = keyof typeof KUMO_BADGE_VARIANTS.dotColor;
 
 export interface KumoBadgeVariantsProps {
   variant?: KumoBadgeVariant;
-  style?: KumoBadgeStyle;
+  appearance?: KumoBadgeAppearance;
 }
 
 export function badgeVariants({
   variant = KUMO_BADGE_DEFAULT_VARIANTS.variant,
-  style = KUMO_BADGE_DEFAULT_VARIANTS.style,
+  appearance = KUMO_BADGE_DEFAULT_VARIANTS.appearance,
 }: KumoBadgeVariantsProps = {}) {
   const variantClasses = resolveVariant(
     KUMO_BADGE_VARIANTS.variant,
     variant,
     KUMO_BADGE_DEFAULT_VARIANTS.variant,
   ).classes;
-  const styleClasses = resolveVariant(
-    KUMO_BADGE_VARIANTS.style,
-    style,
-    KUMO_BADGE_DEFAULT_VARIANTS.style,
+  const appearanceClasses = resolveVariant(
+    KUMO_BADGE_VARIANTS.appearance,
+    appearance,
+    KUMO_BADGE_DEFAULT_VARIANTS.appearance,
   ).classes;
   return cn(
     // Base styles (exported as KUMO_BADGE_BASE_STYLES for Figma plugin)
     KUMO_BADGE_BASE_STYLES,
-    // The dot style overrides background/text colors from the variant,
+    // The dot appearance overrides background/text colors from the variant,
     // so only apply variant classes when we're not in dot mode.
-    style === "dot" ? "" : variantClasses,
-    styleClasses,
+    appearance === "dot" ? "" : variantClasses,
+    appearanceClasses,
   );
 }
 
@@ -161,7 +169,7 @@ export type BadgeVariant = KumoBadgeVariant;
  * <Badge variant="green">Active</Badge>
  * <Badge variant="red">Error</Badge>
  * <Badge variant="neutral">Inactive</Badge>
- * <Badge variant="success" style="dot">Healthy</Badge>
+ * <Badge variant="success" appearance="dot">Healthy</Badge>
  * ```
  */
 export interface BadgeProps {
@@ -185,14 +193,14 @@ export interface BadgeProps {
    */
   variant?: KumoBadgeVariant;
   /**
-   * Visual style of the badge.
+   * Visual appearance of the badge.
    * - `"filled"` — Filled background using the variant color (default)
    * - `"dot"` — Outlined badge with a colored circle dot. Only `success`,
-   *   `warning`, and `error` variants are supported; in these cases the ring
-   *   also tints to match. Other variants render the badge without a dot.
+   *   `warning`, `error`, and `neutral` variants show a dot; other variants
+   *   render the badge without a dot.
    * @default "filled"
    */
-  style?: KumoBadgeStyle;
+  appearance?: KumoBadgeAppearance;
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
   /** Content rendered inside the badge. */
@@ -205,24 +213,28 @@ export interface BadgeProps {
  * @example
  * ```tsx
  * <Badge variant="green">Active</Badge>
- * <Badge variant="success" style="dot">Healthy</Badge>
+ * <Badge variant="success" appearance="dot">Healthy</Badge>
  * ```
  */
 export function Badge({
   variant = KUMO_BADGE_DEFAULT_VARIANTS.variant,
-  style = KUMO_BADGE_DEFAULT_VARIANTS.style,
+  appearance = KUMO_BADGE_DEFAULT_VARIANTS.appearance,
   className,
   children,
 }: BadgeProps) {
-  // Crash-safe dot-color lookup. Same pattern as variant/style resolution above:
-  // unknown variants fall back to "none" (no dot) instead of throwing.
+  // Crash-safe dot-color lookup via resolveVariant — unknown variants fall
+  // back to "none" (no dot) instead of throwing.
   const dotColor =
-    style === "dot"
-      ? resolveVariant(KUMO_BADGE_DOT_COLORS, variant, "none").classes
+    appearance === "dot"
+      ? resolveVariant(
+          KUMO_BADGE_VARIANTS.dotColor,
+          variant,
+          KUMO_BADGE_DEFAULT_VARIANTS.dotColor,
+        ).classes
       : "";
 
   return (
-    <span className={cn(badgeVariants({ variant, style }), className)}>
+    <span className={cn(badgeVariants({ variant, appearance }), className)}>
       {dotColor ? (
         <span
           aria-hidden="true"

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -91,8 +91,7 @@ export const KUMO_BADGE_VARIANTS = {
     dot: {
       classes:
         "gap-1.5 bg-transparent text-kumo-default ring ring-kumo-line",
-      description:
-        "Outlined badge with a colored circle dot and ring color indicating status",
+      description: "Outlined badge with a colored circle dot indicating status",
     },
   },
 } as const;
@@ -103,17 +102,19 @@ export const KUMO_BADGE_DEFAULT_VARIANTS = {
 } as const;
 
 /**
- * Dot color classes for the `style="dot"` variant.
- * Keyed by the subset of `variant` values that support the dot style.
+ * Dot color classes for the `style="dot"` variant, keyed by the subset of
+ * `variant` values that support the dot style. Shaped like KUMO_BADGE_VARIANTS
+ * entries so it can be accessed via `resolveVariant` for crash-safe lookups.
+ *
+ * The `"none"` fallback is used when `style="dot"` is paired with a variant
+ * that doesn't have a dot color — it renders no dot rather than crashing.
  */
 const KUMO_BADGE_DOT_COLORS = {
-  success: "bg-kumo-success",
-  warning: "bg-kumo-warning",
-  error: "bg-kumo-badge-red",
+  none: { classes: "" },
+  success: { classes: "bg-kumo-success" },
+  warning: { classes: "bg-kumo-warning" },
+  error: { classes: "bg-kumo-badge-red" },
 } as const;
-
-/** Variants that support the `style="dot"` treatment. */
-export type KumoBadgeDotVariant = keyof typeof KUMO_BADGE_DOT_COLORS;
 
 // Derived types from KUMO_BADGE_VARIANTS
 export type KumoBadgeVariant = keyof typeof KUMO_BADGE_VARIANTS.variant;
@@ -212,18 +213,19 @@ export function Badge({
   className,
   children,
 }: BadgeProps) {
-  const isDotVariant = style === "dot" && variant in KUMO_BADGE_DOT_COLORS;
-
-  const dotColor = isDotVariant
-    ? KUMO_BADGE_DOT_COLORS[variant as KumoBadgeDotVariant]
-    : undefined;
+  // Crash-safe dot-color lookup. Same pattern as variant/style resolution above:
+  // unknown variants fall back to "none" (no dot) instead of throwing.
+  const dotColor =
+    style === "dot"
+      ? resolveVariant(KUMO_BADGE_DOT_COLORS, variant, "none").classes
+      : "";
 
   return (
     <span className={cn(badgeVariants({ variant, style }), className)}>
       {dotColor ? (
         <span
           aria-hidden="true"
-          className={cn("size-1.75 rounded-full", dotColor)}
+          className={cn("size-1.75 rounded-full shrink-0", dotColor)}
         />
       ) : null}
       {children}

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -83,27 +83,68 @@ export const KUMO_BADGE_VARIANTS = {
       description: "Blue badge",
     },
   },
+  style: {
+    filled: {
+      classes: "",
+      description: "Filled badge with background color (default)",
+    },
+    dot: {
+      classes:
+        "gap-1.5 bg-transparent text-kumo-default ring ring-kumo-line",
+      description:
+        "Outlined badge with a colored circle dot and ring color indicating status",
+    },
+  },
 } as const;
 
 export const KUMO_BADGE_DEFAULT_VARIANTS = {
   variant: "primary",
+  style: "filled",
 } as const;
+
+/**
+ * Dot color classes for the `style="dot"` variant.
+ * Keyed by the subset of `variant` values that support the dot style.
+ */
+const KUMO_BADGE_DOT_COLORS = {
+  success: "bg-kumo-success",
+  warning: "bg-kumo-warning",
+  error: "bg-kumo-badge-red",
+} as const;
+
+/** Variants that support the `style="dot"` treatment. */
+export type KumoBadgeDotVariant = keyof typeof KUMO_BADGE_DOT_COLORS;
 
 // Derived types from KUMO_BADGE_VARIANTS
 export type KumoBadgeVariant = keyof typeof KUMO_BADGE_VARIANTS.variant;
+export type KumoBadgeStyle = keyof typeof KUMO_BADGE_VARIANTS.style;
 
 export interface KumoBadgeVariantsProps {
   variant?: KumoBadgeVariant;
+  style?: KumoBadgeStyle;
 }
 
 export function badgeVariants({
   variant = KUMO_BADGE_DEFAULT_VARIANTS.variant,
+  style = KUMO_BADGE_DEFAULT_VARIANTS.style,
 }: KumoBadgeVariantsProps = {}) {
+  const variantClasses = resolveVariant(
+    KUMO_BADGE_VARIANTS.variant,
+    variant,
+    KUMO_BADGE_DEFAULT_VARIANTS.variant,
+  ).classes;
+  const styleClasses = resolveVariant(
+    KUMO_BADGE_VARIANTS.style,
+    style,
+    KUMO_BADGE_DEFAULT_VARIANTS.style,
+  ).classes;
   return cn(
     // Base styles (exported as KUMO_BADGE_BASE_STYLES for Figma plugin)
     KUMO_BADGE_BASE_STYLES,
-    // Apply variant styles from KUMO_BADGE_VARIANTS (fallback to primary if variant not found)
-    resolveVariant(KUMO_BADGE_VARIANTS.variant, variant, KUMO_BADGE_DEFAULT_VARIANTS.variant).classes,
+    // The dot style overrides background/text colors from the variant,
+    // so only apply variant classes when we're not in dot mode.
+    style === "dot" ? "" : variantClasses,
+    styleClasses,
   );
 }
 
@@ -118,6 +159,7 @@ export type BadgeVariant = KumoBadgeVariant;
  * <Badge variant="green">Active</Badge>
  * <Badge variant="red">Error</Badge>
  * <Badge variant="neutral">Inactive</Badge>
+ * <Badge variant="success" style="dot">Healthy</Badge>
  * ```
  */
 export interface BadgeProps {
@@ -137,9 +179,18 @@ export interface BadgeProps {
    * - `"inverted"`
    * - `"outline"` — Bordered badge with transparent background
    * - `"beta"` — Dashed-border badge for beta/experimental features
-   * @default "secondary"
+   * @default "primary"
    */
   variant?: KumoBadgeVariant;
+  /**
+   * Visual style of the badge.
+   * - `"filled"` — Filled background using the variant color (default)
+   * - `"dot"` — Outlined badge with a colored circle dot. Only `success`,
+   *   `warning`, and `error` variants are supported; in these cases the ring
+   *   also tints to match. Other variants render the badge without a dot.
+   * @default "filled"
+   */
+  style?: KumoBadgeStyle;
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
   /** Content rendered inside the badge. */
@@ -152,15 +203,29 @@ export interface BadgeProps {
  * @example
  * ```tsx
  * <Badge variant="green">Active</Badge>
+ * <Badge variant="success" style="dot">Healthy</Badge>
  * ```
  */
 export function Badge({
   variant = KUMO_BADGE_DEFAULT_VARIANTS.variant,
+  style = KUMO_BADGE_DEFAULT_VARIANTS.style,
   className,
   children,
 }: BadgeProps) {
+  const isDotVariant = style === "dot" && variant in KUMO_BADGE_DOT_COLORS;
+
+  const dotColor = isDotVariant
+    ? KUMO_BADGE_DOT_COLORS[variant as KumoBadgeDotVariant]
+    : undefined;
+
   return (
-    <span className={cn(badgeVariants({ variant }), className)}>
+    <span className={cn(badgeVariants({ variant, style }), className)}>
+      {dotColor ? (
+        <span
+          aria-hidden="true"
+          className={cn("size-1.75 rounded-full", dotColor)}
+        />
+      ) : null}
       {children}
     </span>
   );

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -252,8 +252,8 @@
   );
 
   --color-kumo-badge-green: light-dark(
-    var(--color-emerald-700, oklch(50.8% 0.118 165.612)),
-    var(--color-emerald-700, oklch(50.8% 0.118 165.612))
+    var(--color-emerald-500, oklch(69.6% 0.17 162.48)),
+    var(--color-emerald-400, oklch(76.5% 0.177 163.223))
   );
 
   --color-kumo-badge-teal: light-dark(
@@ -272,7 +272,7 @@
   );
 
   --color-kumo-badge-neutral: light-dark(
-    var(--color-neutral-600, oklch(43.9% 0 0)),
+    var(--color-neutral-500, oklch(55.6% 0 0)),
     var(--color-neutral-600, oklch(43.9% 0 0))
   );
 
@@ -345,11 +345,11 @@
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-orange-subtle: var(--color-orange-100, oklch(95.4% 0.038 75.164));
     --color-kumo-badge-purple: var(--color-purple-600, oklch(60% 0.118 184.704));
-    --color-kumo-badge-green: var(--color-emerald-700, oklch(50.8% 0.118 165.612));
+    --color-kumo-badge-green: var(--color-emerald-500, oklch(69.6% 0.17 162.48));
     --color-kumo-badge-teal: var(--color-teal-650, oklch(54.9% 0.096 184.565));
     --color-kumo-badge-teal-subtle: var(--color-teal-100, oklch(95.3% 0.051 180.801));
     --color-kumo-badge-blue: var(--color-blue-600, oklch(54.6% 0.245 262.881));
-    --color-kumo-badge-neutral: var(--color-neutral-600, oklch(43.9% 0 0));
+    --color-kumo-badge-neutral: var(--color-neutral-500, oklch(55.6% 0 0));
     --color-kumo-badge-inverted: var(--color-neutral-950, oklch(14.5% 0 0));
   }
   
@@ -402,7 +402,7 @@
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-orange-subtle: var(--color-orange-900, oklch(40.8% 0.123 38.172));
     --color-kumo-badge-purple: var(--color-purple-700, oklch(50.8% 0.118 165.612));
-    --color-kumo-badge-green: var(--color-emerald-700, oklch(50.8% 0.118 165.612));
+    --color-kumo-badge-green: var(--color-emerald-400, oklch(76.5% 0.177 163.223));
     --color-kumo-badge-teal: var(--color-teal-700, oklch(51.1% 0.096 186.391));
     --color-kumo-badge-teal-subtle: var(--color-teal-900, oklch(38.6% 0.063 188.416));
     --color-kumo-badge-blue: var(--color-blue-700, oklch(48.8% 0.243 264.376));

--- a/packages/kumo/src/utils/variant-safety.test.ts
+++ b/packages/kumo/src/utils/variant-safety.test.ts
@@ -153,8 +153,11 @@ describe("variant functions survive invalid variant values", () => {
   });
 
   it("badgeVariants", () => {
-    expect(() => badgeVariants({ variant: BOGUS })).not.toThrow();
+    expect(() =>
+      badgeVariants({ variant: BOGUS, appearance: BOGUS }),
+    ).not.toThrow();
     expect(typeof badgeVariants({ variant: BOGUS })).toBe("string");
+    expect(typeof badgeVariants({ appearance: BOGUS })).toBe("string");
   });
 
   it("codeVariants", () => {


### PR DESCRIPTION
Added dot style variant for `Badges` that need a subtle visual cue (i.e. on `Tables`)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: visual updates, no access to bonk
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: ran `pnpm lint`, `pnpm typecheck` and visual changes
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
