### PR TITLE
Bump Base UI to 1.5.0

### DIFF
--- a/.changeset/base-ui-1-5-0.md
+++ b/.changeset/base-ui-1-5-0.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update Base UI to 1.5.0.

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -462,7 +462,7 @@
     }
   },
   "dependencies": {
-    "@base-ui/react": "^1.4.0",
+    "@base-ui/react": "^1.5.0",
     "@shikijs/langs": "^4.0.0",
     "@shikijs/themes": "^4.0.0",
     "clsx": "^2.1.1",

--- a/packages/kumo/scripts/generate-primitives.ts
+++ b/packages/kumo/scripts/generate-primitives.ts
@@ -45,7 +45,12 @@ function main() {
 
   // Extract and sort component subpaths alphabetically
   const subpaths = Object.keys(exports)
-    .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+    .filter(
+      (key) =>
+        key.startsWith("./") &&
+        !key.startsWith("./internals/") &&
+        !EXCLUDED_EXPORTS.has(key),
+    )
     .sort();
 
   // Ensure directory exists

--- a/packages/kumo/src/components/dialog/dialog.tsx
+++ b/packages/kumo/src/components/dialog/dialog.tsx
@@ -254,8 +254,11 @@ function DialogContent({
 // ============================================================================
 
 type BaseDialogRootProps = ComponentPropsWithoutRef<typeof DialogBase.Root>;
+type BaseAlertDialogRootProps = ComponentPropsWithoutRef<
+  typeof AlertDialogBase.Root
+>;
 
-export type DialogRootProps = BaseDialogRootProps & {
+type StandardDialogRootProps = BaseDialogRootProps & {
   /**
    * The ARIA role for the dialog.
    * - `"dialog"` — Standard dialog for general-purpose modals. Dismissible via outside click by default.
@@ -268,19 +271,35 @@ export type DialogRootProps = BaseDialogRootProps & {
    *
    * @default "dialog"
    */
-  role?: KumoDialogRole;
+  role?: "dialog";
 };
 
-function DialogRoot({
-  children,
-  role = KUMO_DIALOG_DEFAULT_VARIANTS.role,
-  ...props
-}: DialogRootProps) {
-  const BaseRoot =
-    role === "alertdialog" ? AlertDialogBase.Root : DialogBase.Root;
+type AlertDialogRootProps = BaseAlertDialogRootProps & {
+  role: "alertdialog";
+};
+
+export type DialogRootProps = StandardDialogRootProps | AlertDialogRootProps;
+
+function DialogRoot(props: DialogRootProps) {
+  if (props.role === "alertdialog") {
+    const { children, role, ...rootProps } = props;
+
+    return (
+      <DialogRoleContext.Provider value={role}>
+        <AlertDialogBase.Root {...rootProps}>{children}</AlertDialogBase.Root>
+      </DialogRoleContext.Provider>
+    );
+  }
+
+  const {
+    children,
+    role = KUMO_DIALOG_DEFAULT_VARIANTS.role,
+    ...rootProps
+  } = props;
+
   return (
     <DialogRoleContext.Provider value={role}>
-      <BaseRoot {...props}>{children}</BaseRoot>
+      <DialogBase.Root {...rootProps}>{children}</DialogBase.Root>
     </DialogRoleContext.Provider>
   );
 }
@@ -294,14 +313,26 @@ DialogRoot.displayName = "Dialog.Root";
 type BaseDialogTriggerProps = ComponentPropsWithoutRef<
   typeof DialogBase.Trigger
 >;
+type BaseAlertDialogTriggerProps = ComponentPropsWithoutRef<
+  typeof AlertDialogBase.Trigger
+>;
 
-export type DialogTriggerProps = BaseDialogTriggerProps;
+export type DialogTriggerProps =
+  | BaseDialogTriggerProps
+  | BaseAlertDialogTriggerProps;
 
 function DialogTrigger({ children, ...props }: DialogTriggerProps) {
   const role = useDialogRole();
-  const BaseTrigger =
-    role === "alertdialog" ? AlertDialogBase.Trigger : DialogBase.Trigger;
-  return <BaseTrigger {...props}>{children}</BaseTrigger>;
+
+  if (role === "alertdialog") {
+    return (
+      <AlertDialogBase.Trigger {...(props as BaseAlertDialogTriggerProps)}>
+        {children}
+      </AlertDialogBase.Trigger>
+    );
+  }
+
+  return <DialogBase.Trigger {...props}>{children}</DialogBase.Trigger>;
 }
 
 DialogTrigger.displayName = "Dialog.Trigger";

--- a/packages/kumo/tests/imports/primitives.test.ts
+++ b/packages/kumo/tests/imports/primitives.test.ts
@@ -41,6 +41,14 @@ const EXCLUDED_EXPORTS = new Set([
   "./use-render",
 ]);
 
+function isIncludedBaseUiExport(key: string) {
+  return (
+    key.startsWith("./") &&
+    !key.startsWith("./internals/") &&
+    !EXCLUDED_EXPORTS.has(key)
+  );
+}
+
 describe("Primitives Export", () => {
   describe("Package.json configuration", () => {
     it("should have primitives export in package.json", () => {
@@ -78,7 +86,7 @@ describe("Primitives Export", () => {
         readFileSync(baseUiPackagePath, "utf-8"),
       );
       const baseUiExports = Object.keys(baseUiPackage.exports || {})
-        .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+        .filter(isIncludedBaseUiExport)
         .map((key) => key.replace("./", ""));
 
       // Import kumo primitives
@@ -120,7 +128,7 @@ describe("Primitives Export", () => {
         readFileSync(baseUiPackagePath, "utf-8"),
       );
       const baseUiExports = Object.keys(baseUiPackage.exports || {})
-        .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+        .filter(isIncludedBaseUiExport)
         .map((key) => key.replace("./", ""));
 
       const primitivesSource = readFileSync(primitivesSourcePath, "utf-8");
@@ -206,7 +214,7 @@ describe("Primitives Export", () => {
         readFileSync(baseUiPackagePath, "utf-8"),
       );
       const baseUiExports = Object.keys(baseUiPackage.exports || {})
-        .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+        .filter(isIncludedBaseUiExport)
         .map((key) => key.replace("./", ""));
 
       const missingFiles: string[] = [];
@@ -236,7 +244,7 @@ describe("Primitives Export", () => {
         readFileSync(baseUiPackagePath, "utf-8"),
       );
       const baseUiExports = Object.keys(baseUiPackage.exports || {})
-        .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+        .filter(isIncludedBaseUiExport)
         .map((key) => key.replace("./", ""));
 
       const missingExports: string[] = [];
@@ -263,7 +271,7 @@ describe("Primitives Export", () => {
         readFileSync(baseUiPackagePath, "utf-8"),
       );
       const baseUiExports = Object.keys(baseUiPackage.exports || {})
-        .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+        .filter(isIncludedBaseUiExport)
         .map((key) => key.replace("./", ""));
 
       const invalidExports: string[] = [];
@@ -319,7 +327,7 @@ describe("Primitives Export", () => {
         readFileSync(baseUiPackagePath, "utf-8"),
       );
       const baseUiExports = Object.keys(baseUiPackage.exports || {})
-        .filter((key) => key.startsWith("./") && !EXCLUDED_EXPORTS.has(key))
+        .filter(isIncludedBaseUiExport)
         .map((key) => key.replace("./", ""));
 
       const invalidFiles: string[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/kumo:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.4.0
-        version: 1.4.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^1.5.0
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -602,8 +602,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.4.0':
-    resolution: {integrity: sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -612,11 +612,15 @@ packages:
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
     peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
       '@types/react':
         optional: true
+      date-fns:
+        optional: true
 
-  '@base-ui/utils@0.2.7':
-    resolution: {integrity: sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==}
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -6707,21 +6711,21 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.7(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@date-fns/tz': 1.4.1
+      '@base-ui/utils': 0.2.9(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@floating-ui/utils': 0.2.11
-      date-fns: 4.1.0
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
     optionalDependencies:
+      '@date-fns/tz': 1.4.1
       '@types/react': 19.2.4
+      date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.7(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@base-ui/utils@0.2.9(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11


### PR DESCRIPTION
## Summary
- bump @base-ui/react to 1.5.0
- keep Dialog and AlertDialog handle types separated for Base UI 1.5
- exclude Base UI internals from primitive generation

## Testing
- pnpm --filter @cloudflare/kumo codegen:primitives
- pnpm --filter @cloudflare/kumo typecheck
- pnpm --filter @cloudflare/kumo lint (passes with existing warnings)

## Note
- pnpm minimumReleaseAge is 4320 minutes, so normal installs will accept this version after Fri May 22 09:22:48 EDT.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: draft PR created for dependency update before reviewer assignment
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [x] Additional testing not necessary because: dependency compatibility was verified with primitive codegen, typecheck, and lint