### PR TITLE
fix: normalize language aliases in ShikiProvider and highlight hook

### DIFF
--- a/.changeset/fix-language-aliases.md
+++ b/.changeset/fix-language-aliases.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix language alias normalization in ShikiProvider
+
+- Add `normalizeLanguage()` function that maps common language aliases (js, ts, sh, yml, py, md, gql) to their canonical SupportedLanguage names
+- Normalize language aliases in `ShikiProvider` when preloading grammars, so passing `['js', 'ts']` works the same as `['javascript', 'typescript']`
+- Normalize language aliases in `highlight()` hook at runtime, so code fences using `js` or `ts` highlight correctly without warnings
+- Export `normalizeLanguage` from `@cloudflare/kumo/code` for consumers who need to normalize aliases themselves
+- Intentionally omit `mdx` alias since MDX has a distinct grammar that would lose JSX highlighting if mapped to `markdown`

--- a/packages/kumo/src/code/index.ts
+++ b/packages/kumo/src/code/index.ts
@@ -26,11 +26,11 @@
  */
 
 // Components
-export { ShikiProvider } from "./provider";
-export { CodeHighlighted } from "./code-highlighted";
+export { ShikiProvider, normalizeLanguage } from './provider';
+export { CodeHighlighted } from './code-highlighted';
 
 // Hook
-export { useShikiHighlighter } from "./use-shiki-highlighter";
+export { useShikiHighlighter } from './use-shiki-highlighter';
 
 // Types
 export type {
@@ -38,5 +38,5 @@ export type {
   CodeHighlightedProps,
   UseShikiHighlighterResult,
   ShikiEngine,
-  BundledLanguage,
-} from "./types";
+  BundledLanguage
+} from './types';

--- a/packages/kumo/src/code/index.ts
+++ b/packages/kumo/src/code/index.ts
@@ -32,6 +32,9 @@ export { CodeHighlighted } from "./code-highlighted";
 // Hook
 export { useShikiHighlighter } from "./use-shiki-highlighter";
 
+// Constants
+export { LANGUAGE_ALIASES } from "./types";
+
 // Types
 export type {
   ShikiProviderProps,
@@ -39,4 +42,6 @@ export type {
   UseShikiHighlighterResult,
   ShikiEngine,
   BundledLanguage,
+  LanguageAlias,
+  LanguageInput,
 } from "./types";

--- a/packages/kumo/src/code/index.ts
+++ b/packages/kumo/src/code/index.ts
@@ -26,11 +26,11 @@
  */
 
 // Components
-export { ShikiProvider, normalizeLanguage } from './provider';
-export { CodeHighlighted } from './code-highlighted';
+export { ShikiProvider, normalizeLanguage } from "./provider";
+export { CodeHighlighted } from "./code-highlighted";
 
 // Hook
-export { useShikiHighlighter } from './use-shiki-highlighter';
+export { useShikiHighlighter } from "./use-shiki-highlighter";
 
 // Types
 export type {
@@ -38,5 +38,5 @@ export type {
   CodeHighlightedProps,
   UseShikiHighlighterResult,
   ShikiEngine,
-  BundledLanguage
-} from './types';
+  BundledLanguage,
+} from "./types";

--- a/packages/kumo/src/code/provider.test.ts
+++ b/packages/kumo/src/code/provider.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLanguage } from "./provider";
+
+describe("normalizeLanguage", () => {
+  it("returns canonical names unchanged", () => {
+    expect(normalizeLanguage("javascript")).toBe("javascript");
+    expect(normalizeLanguage("typescript")).toBe("typescript");
+    expect(normalizeLanguage("bash")).toBe("bash");
+    expect(normalizeLanguage("markdown")).toBe("markdown");
+    expect(normalizeLanguage("yaml")).toBe("yaml");
+    expect(normalizeLanguage("python")).toBe("python");
+    expect(normalizeLanguage("graphql")).toBe("graphql");
+    expect(normalizeLanguage("sql")).toBe("sql");
+    expect(normalizeLanguage("json")).toBe("json");
+    expect(normalizeLanguage("html")).toBe("html");
+    expect(normalizeLanguage("css")).toBe("css");
+    expect(normalizeLanguage("jsx")).toBe("jsx");
+    expect(normalizeLanguage("tsx")).toBe("tsx");
+    expect(normalizeLanguage("jsonc")).toBe("jsonc");
+    expect(normalizeLanguage("shell")).toBe("shell");
+    expect(normalizeLanguage("diff")).toBe("diff");
+    expect(normalizeLanguage("hcl")).toBe("hcl");
+    expect(normalizeLanguage("toml")).toBe("toml");
+  });
+
+  it("normalizes common aliases to canonical names", () => {
+    // JavaScript variants
+    expect(normalizeLanguage("js")).toBe("javascript");
+    expect(normalizeLanguage("cjs")).toBe("javascript");
+    expect(normalizeLanguage("mjs")).toBe("javascript");
+
+    // TypeScript variants
+    expect(normalizeLanguage("ts")).toBe("typescript");
+    expect(normalizeLanguage("cts")).toBe("typescript");
+    expect(normalizeLanguage("mts")).toBe("typescript");
+
+    // Shell variants
+    expect(normalizeLanguage("sh")).toBe("bash");
+    expect(normalizeLanguage("zsh")).toBe("bash");
+
+    // Other aliases
+    expect(normalizeLanguage("yml")).toBe("yaml");
+    expect(normalizeLanguage("py")).toBe("python");
+    expect(normalizeLanguage("md")).toBe("markdown");
+    expect(normalizeLanguage("gql")).toBe("graphql");
+  });
+
+  it("returns null for unsupported or unknown languages", () => {
+    expect(normalizeLanguage("rust")).toBeNull();
+    expect(normalizeLanguage("go")).toBeNull();
+    expect(normalizeLanguage("java")).toBeNull();
+    expect(normalizeLanguage("cpp")).toBeNull();
+    expect(normalizeLanguage("")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(normalizeLanguage("")).toBeNull();
+  });
+});

--- a/packages/kumo/src/code/provider.test.tsx
+++ b/packages/kumo/src/code/provider.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { createHighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 import { ShikiProvider } from "./provider";
+import { useShikiHighlighter } from "./use-shiki-highlighter";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -228,5 +229,30 @@ describe("ShikiProvider", () => {
     });
 
     expect(createOnigurumaEngine).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes normalized languages in context so hook alias resolution works end-to-end", async () => {
+    // This is the integration test for the bug where the context stores raw
+    // aliases (e.g., ["js", "ts"]) but the hook normalizes to canonical names
+    // (e.g., "javascript") and checks languages.includes("javascript") → false.
+
+    function HighlightConsumer() {
+      const { highlight, isReady } = useShikiHighlighter();
+      if (!isReady) return <div data-testid="status">loading</div>;
+      const result = highlight("const x = 1;", "js");
+      return (
+        <div data-testid="status">{result === null ? "failed" : "ok"}</div>
+      );
+    }
+
+    render(
+      <ShikiProvider engine="javascript" languages={["js", "ts"]}>
+        <HighlightConsumer />
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("ok");
+    });
   });
 });

--- a/packages/kumo/src/code/provider.test.tsx
+++ b/packages/kumo/src/code/provider.test.tsx
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { createHighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+import { ShikiProvider } from "./provider";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("shiki/core", () => ({
+  createHighlighterCore: vi.fn(),
+}));
+
+vi.mock("shiki/engine/javascript", () => ({
+  createJavaScriptRegexEngine: vi.fn().mockReturnValue({ type: "js-engine" }),
+}));
+
+vi.mock("shiki/engine/oniguruma", () => ({
+  createOnigurumaEngine: vi.fn().mockReturnValue({ type: "wasm-engine" }),
+}));
+
+vi.mock("@shikijs/themes/github-light", () => ({
+  default: { name: "github-light" },
+}));
+
+vi.mock("@shikijs/themes/vesper", () => ({
+  default: { name: "vesper" },
+}));
+
+const mockLang = { default: { id: "mock" } };
+
+vi.mock("@shikijs/langs/javascript", () => mockLang);
+vi.mock("@shikijs/langs/typescript", () => mockLang);
+vi.mock("@shikijs/langs/jsx", () => mockLang);
+vi.mock("@shikijs/langs/tsx", () => mockLang);
+vi.mock("@shikijs/langs/json", () => mockLang);
+vi.mock("@shikijs/langs/jsonc", () => mockLang);
+vi.mock("@shikijs/langs/html", () => mockLang);
+vi.mock("@shikijs/langs/css", () => mockLang);
+vi.mock("@shikijs/langs/python", () => mockLang);
+vi.mock("@shikijs/langs/yaml", () => mockLang);
+vi.mock("@shikijs/langs/markdown", () => mockLang);
+vi.mock("@shikijs/langs/graphql", () => mockLang);
+vi.mock("@shikijs/langs/sql", () => mockLang);
+vi.mock("@shikijs/langs/bash", () => mockLang);
+vi.mock("@shikijs/langs/shellscript", () => mockLang);
+vi.mock("@shikijs/langs/diff", () => mockLang);
+vi.mock("@shikijs/langs/hcl", () => mockLang);
+vi.mock("@shikijs/langs/toml", () => mockLang);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ShikiProvider", () => {
+  beforeEach(() => {
+    vi.mocked(createHighlighterCore).mockClear();
+    vi.mocked(createHighlighterCore).mockResolvedValue({
+      codeToHtml: vi.fn(),
+    } as any);
+    vi.mocked(createJavaScriptRegexEngine).mockClear();
+    vi.mocked(createOnigurumaEngine).mockClear();
+  });
+
+  it("initializes with a single language", async () => {
+    render(
+      <ShikiProvider engine="javascript" languages={["javascript"]}>
+        <div data-testid="child">child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    expect(options.langs).toHaveLength(1);
+  });
+
+  it("deduplicates canonical languages", async () => {
+    render(
+      <ShikiProvider
+        engine="javascript"
+        languages={["javascript", "typescript", "javascript", "typescript"]}
+      >
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    expect(options.langs).toHaveLength(2);
+  });
+
+  it("deduplicates aliases that resolve to the same canonical language", async () => {
+    render(
+      <ShikiProvider
+        engine="javascript"
+        languages={["js", "javascript", "cjs", "mjs"]}
+      >
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    // All JS variants should collapse to a single "javascript" grammar
+    expect(options.langs).toHaveLength(1);
+  });
+
+  it("deduplicates mixed aliases and canonical names", async () => {
+    render(
+      <ShikiProvider
+        engine="javascript"
+        languages={["js", "ts", "javascript", "typescript", "sh", "bash"]}
+      >
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    // Should collapse to: javascript, typescript, bash = 3 unique
+    expect(options.langs).toHaveLength(3);
+  });
+
+  it("filters out unknown languages silently", async () => {
+    render(
+      <ShikiProvider
+        engine="javascript"
+        languages={["javascript", "rust", "typescript", "go"]}
+      >
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    // Only javascript and typescript should remain
+    expect(options.langs).toHaveLength(2);
+  });
+
+  it("handles empty languages array gracefully", async () => {
+    render(
+      <ShikiProvider engine="javascript" languages={[]}>
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    expect(options.langs).toHaveLength(0);
+  });
+
+  it("loads all requested unique languages", async () => {
+    render(
+      <ShikiProvider
+        engine="javascript"
+        languages={[
+          "javascript",
+          "typescript",
+          "tsx",
+          "jsx",
+          "json",
+          "html",
+          "css",
+        ]}
+      >
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    const call = vi.mocked(createHighlighterCore).mock.calls[0];
+    const options = call[0] as { langs: unknown[] };
+    expect(options.langs).toHaveLength(7);
+  });
+
+  it("uses javascript engine when engine='javascript'", async () => {
+    render(
+      <ShikiProvider engine="javascript" languages={["javascript"]}>
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createJavaScriptRegexEngine).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses wasm engine when engine='wasm'", async () => {
+    render(
+      <ShikiProvider engine="wasm" languages={["javascript"]}>
+        <div>child</div>
+      </ShikiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createHighlighterCore).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createOnigurumaEngine).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kumo/src/code/provider.tsx
+++ b/packages/kumo/src/code/provider.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import React, { useState, useEffect, useMemo } from "react";
-import { ShikiContext, type ShikiContextValue } from "./context";
-import type { ShikiProviderProps, SupportedLanguage } from "./types";
+import React, { useState, useEffect, useMemo } from 'react';
+import { ShikiContext, type ShikiContextValue } from './context';
+import type { ShikiProviderProps, SupportedLanguage } from './types';
 
 /**
  * Pre-bundled languages - only these languages are included in the Kumo bundle.
@@ -12,25 +12,63 @@ const BUNDLED_LANGS: Record<
   SupportedLanguage,
   () => Promise<{ default: unknown }>
 > = {
-  javascript: () => import("@shikijs/langs/javascript"),
-  typescript: () => import("@shikijs/langs/typescript"),
-  jsx: () => import("@shikijs/langs/jsx"),
-  tsx: () => import("@shikijs/langs/tsx"),
-  json: () => import("@shikijs/langs/json"),
-  jsonc: () => import("@shikijs/langs/jsonc"),
-  html: () => import("@shikijs/langs/html"),
-  css: () => import("@shikijs/langs/css"),
-  python: () => import("@shikijs/langs/python"),
-  yaml: () => import("@shikijs/langs/yaml"),
-  markdown: () => import("@shikijs/langs/markdown"),
-  graphql: () => import("@shikijs/langs/graphql"),
-  sql: () => import("@shikijs/langs/sql"),
-  bash: () => import("@shikijs/langs/bash"),
-  shell: () => import("@shikijs/langs/shellscript"),
-  diff: () => import("@shikijs/langs/diff"),
-  hcl: () => import("@shikijs/langs/hcl"),
-  toml: () => import("@shikijs/langs/toml"),
+  javascript: () => import('@shikijs/langs/javascript'),
+  typescript: () => import('@shikijs/langs/typescript'),
+  jsx: () => import('@shikijs/langs/jsx'),
+  tsx: () => import('@shikijs/langs/tsx'),
+  json: () => import('@shikijs/langs/json'),
+  jsonc: () => import('@shikijs/langs/jsonc'),
+  html: () => import('@shikijs/langs/html'),
+  css: () => import('@shikijs/langs/css'),
+  python: () => import('@shikijs/langs/python'),
+  yaml: () => import('@shikijs/langs/yaml'),
+  markdown: () => import('@shikijs/langs/markdown'),
+  graphql: () => import('@shikijs/langs/graphql'),
+  sql: () => import('@shikijs/langs/sql'),
+  bash: () => import('@shikijs/langs/bash'),
+  shell: () => import('@shikijs/langs/shellscript'),
+  diff: () => import('@shikijs/langs/diff'),
+  hcl: () => import('@shikijs/langs/hcl'),
+  toml: () => import('@shikijs/langs/toml')
 };
+
+/**
+ * Common language aliases mapped to their canonical SupportedLanguage names.
+ *
+ * Markdown code fences often use short aliases (e.g., `js`, `ts`, `sh`) that
+ * Shiki recognizes but don't match the canonical grammar names in BUNDLED_LANGS.
+ * This map ensures aliases resolve to the correct preloaded grammar, avoiding
+ * "language not found" warnings and falling back to plain text.
+ *
+ * Note: Only aliases for languages in BUNDLED_LANGS are included. Languages
+ * like `mdx` are intentionally omitted because they have distinct grammars
+ * (MDX includes JSX syntax) that would lose highlighting if mapped to `markdown`.
+ */
+const LANGUAGE_ALIASES: Record<string, SupportedLanguage> = {
+  js: 'javascript',
+  cjs: 'javascript',
+  mjs: 'javascript',
+  ts: 'typescript',
+  cts: 'typescript',
+  mts: 'typescript',
+  sh: 'bash',
+  zsh: 'bash',
+  yml: 'yaml',
+  py: 'python',
+  md: 'markdown',
+  gql: 'graphql'
+};
+
+/**
+ * Normalize a language identifier to its canonical SupportedLanguage name.
+ * Returns the canonical name if the input is a known alias or already canonical,
+ * otherwise returns null.
+ */
+export function normalizeLanguage(lang: string): SupportedLanguage | null {
+  if (lang in BUNDLED_LANGS) return lang as SupportedLanguage;
+  if (lang in LANGUAGE_ALIASES) return LANGUAGE_ALIASES[lang];
+  return null;
+}
 
 /**
  * Provider component that initializes and manages Shiki highlighting.
@@ -58,24 +96,24 @@ const BUNDLED_LANGS: Record<
  * ```
  */
 const DEFAULT_LABELS = {
-  copy: "Copy",
-  copied: "Copied!",
+  copy: 'Copy',
+  copied: 'Copied!'
 };
 
 export function ShikiProvider({
   engine,
   languages,
   labels,
-  children,
+  children
 }: ShikiProviderProps): React.JSX.Element {
   const [state, setState] = useState<{
-    highlighter: ShikiContextValue["highlighter"];
+    highlighter: ShikiContextValue['highlighter'];
     isLoading: boolean;
     error: Error | null;
   }>({
     highlighter: null,
     isLoading: true,
-    error: null,
+    error: null
   });
 
   useEffect(() => {
@@ -84,45 +122,50 @@ export function ShikiProvider({
     async function initializeShiki() {
       try {
         // Dynamic import of shiki/core — only loads the core, not all languages
-        const { createHighlighterCore } = await import("shiki/core");
+        const { createHighlighterCore } = await import('shiki/core');
 
         // Load the appropriate engine
         const engineInstance =
-          engine === "wasm"
-            ? await import("shiki/engine/oniguruma").then((m) =>
-                m.createOnigurumaEngine(import("shiki/wasm")),
+          engine === 'wasm'
+            ? await import('shiki/engine/oniguruma').then(m =>
+                m.createOnigurumaEngine(import('shiki/wasm'))
               )
-            : await import("shiki/engine/javascript").then((m) =>
-                m.createJavaScriptRegexEngine(),
+            : await import('shiki/engine/javascript').then(m =>
+                m.createJavaScriptRegexEngine()
               );
 
         // Load themes
         const [githubLight, vesper] = await Promise.all([
-          import("@shikijs/themes/github-light"),
-          import("@shikijs/themes/vesper"),
+          import('@shikijs/themes/github-light'),
+          import('@shikijs/themes/vesper')
         ]);
 
-        // Load only the requested languages from our bundled set
-        const validLanguages = languages.filter(
-          (lang): lang is SupportedLanguage => lang in BUNDLED_LANGS,
-        );
+        // Load only the requested languages from our bundled set,
+        // normalizing aliases (e.g., 'js' -> 'javascript') first
+        const validLanguages = [
+          ...new Set(
+            languages
+              .map(lang => normalizeLanguage(lang))
+              .filter((lang): lang is SupportedLanguage => lang !== null)
+          )
+        ];
 
         const langModules = await Promise.all(
-          validLanguages.map((lang) => BUNDLED_LANGS[lang]()),
+          validLanguages.map(lang => BUNDLED_LANGS[lang]())
         );
 
         const highlighter = await createHighlighterCore({
           themes: [githubLight.default, vesper.default],
 
-          langs: langModules.map((m) => m.default) as any,
-          engine: engineInstance,
+          langs: langModules.map(m => m.default) as any,
+          engine: engineInstance
         });
 
         if (!cancelled) {
           setState({
             highlighter,
             isLoading: false,
-            error: null,
+            error: null
           });
         }
       } catch (err) {
@@ -131,7 +174,7 @@ export function ShikiProvider({
             highlighter: null,
             isLoading: false,
             error:
-              err instanceof Error ? err : new Error("Failed to load Shiki"),
+              err instanceof Error ? err : new Error('Failed to load Shiki')
           });
         }
       }
@@ -146,7 +189,7 @@ export function ShikiProvider({
 
   const mergedLabels = useMemo(
     () => ({ ...DEFAULT_LABELS, ...labels }),
-    [labels],
+    [labels]
   );
 
   const contextValue = useMemo<ShikiContextValue>(
@@ -155,9 +198,9 @@ export function ShikiProvider({
       isLoading: state.isLoading,
       error: state.error,
       languages: languages as SupportedLanguage[],
-      labels: mergedLabels,
+      labels: mergedLabels
     }),
-    [state.highlighter, state.isLoading, state.error, languages, mergedLabels],
+    [state.highlighter, state.isLoading, state.error, languages, mergedLabels]
   );
 
   return (
@@ -167,4 +210,4 @@ export function ShikiProvider({
   );
 }
 
-ShikiProvider.displayName = "ShikiProvider";
+ShikiProvider.displayName = 'ShikiProvider';

--- a/packages/kumo/src/code/provider.tsx
+++ b/packages/kumo/src/code/provider.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useMemo } from 'react';
-import { ShikiContext, type ShikiContextValue } from './context';
-import type { ShikiProviderProps, SupportedLanguage } from './types';
+import React, { useState, useEffect, useMemo } from "react";
+import { ShikiContext, type ShikiContextValue } from "./context";
+import type { ShikiProviderProps, SupportedLanguage } from "./types";
 
 /**
  * Pre-bundled languages - only these languages are included in the Kumo bundle.
@@ -12,24 +12,24 @@ const BUNDLED_LANGS: Record<
   SupportedLanguage,
   () => Promise<{ default: unknown }>
 > = {
-  javascript: () => import('@shikijs/langs/javascript'),
-  typescript: () => import('@shikijs/langs/typescript'),
-  jsx: () => import('@shikijs/langs/jsx'),
-  tsx: () => import('@shikijs/langs/tsx'),
-  json: () => import('@shikijs/langs/json'),
-  jsonc: () => import('@shikijs/langs/jsonc'),
-  html: () => import('@shikijs/langs/html'),
-  css: () => import('@shikijs/langs/css'),
-  python: () => import('@shikijs/langs/python'),
-  yaml: () => import('@shikijs/langs/yaml'),
-  markdown: () => import('@shikijs/langs/markdown'),
-  graphql: () => import('@shikijs/langs/graphql'),
-  sql: () => import('@shikijs/langs/sql'),
-  bash: () => import('@shikijs/langs/bash'),
-  shell: () => import('@shikijs/langs/shellscript'),
-  diff: () => import('@shikijs/langs/diff'),
-  hcl: () => import('@shikijs/langs/hcl'),
-  toml: () => import('@shikijs/langs/toml')
+  javascript: () => import("@shikijs/langs/javascript"),
+  typescript: () => import("@shikijs/langs/typescript"),
+  jsx: () => import("@shikijs/langs/jsx"),
+  tsx: () => import("@shikijs/langs/tsx"),
+  json: () => import("@shikijs/langs/json"),
+  jsonc: () => import("@shikijs/langs/jsonc"),
+  html: () => import("@shikijs/langs/html"),
+  css: () => import("@shikijs/langs/css"),
+  python: () => import("@shikijs/langs/python"),
+  yaml: () => import("@shikijs/langs/yaml"),
+  markdown: () => import("@shikijs/langs/markdown"),
+  graphql: () => import("@shikijs/langs/graphql"),
+  sql: () => import("@shikijs/langs/sql"),
+  bash: () => import("@shikijs/langs/bash"),
+  shell: () => import("@shikijs/langs/shellscript"),
+  diff: () => import("@shikijs/langs/diff"),
+  hcl: () => import("@shikijs/langs/hcl"),
+  toml: () => import("@shikijs/langs/toml"),
 };
 
 /**
@@ -45,18 +45,18 @@ const BUNDLED_LANGS: Record<
  * (MDX includes JSX syntax) that would lose highlighting if mapped to `markdown`.
  */
 const LANGUAGE_ALIASES: Record<string, SupportedLanguage> = {
-  js: 'javascript',
-  cjs: 'javascript',
-  mjs: 'javascript',
-  ts: 'typescript',
-  cts: 'typescript',
-  mts: 'typescript',
-  sh: 'bash',
-  zsh: 'bash',
-  yml: 'yaml',
-  py: 'python',
-  md: 'markdown',
-  gql: 'graphql'
+  js: "javascript",
+  cjs: "javascript",
+  mjs: "javascript",
+  ts: "typescript",
+  cts: "typescript",
+  mts: "typescript",
+  sh: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  py: "python",
+  md: "markdown",
+  gql: "graphql",
 };
 
 /**
@@ -96,24 +96,24 @@ export function normalizeLanguage(lang: string): SupportedLanguage | null {
  * ```
  */
 const DEFAULT_LABELS = {
-  copy: 'Copy',
-  copied: 'Copied!'
+  copy: "Copy",
+  copied: "Copied!",
 };
 
 export function ShikiProvider({
   engine,
   languages,
   labels,
-  children
+  children,
 }: ShikiProviderProps): React.JSX.Element {
   const [state, setState] = useState<{
-    highlighter: ShikiContextValue['highlighter'];
+    highlighter: ShikiContextValue["highlighter"];
     isLoading: boolean;
     error: Error | null;
   }>({
     highlighter: null,
     isLoading: true,
-    error: null
+    error: null,
   });
 
   useEffect(() => {
@@ -122,22 +122,22 @@ export function ShikiProvider({
     async function initializeShiki() {
       try {
         // Dynamic import of shiki/core — only loads the core, not all languages
-        const { createHighlighterCore } = await import('shiki/core');
+        const { createHighlighterCore } = await import("shiki/core");
 
         // Load the appropriate engine
         const engineInstance =
-          engine === 'wasm'
-            ? await import('shiki/engine/oniguruma').then(m =>
-                m.createOnigurumaEngine(import('shiki/wasm'))
+          engine === "wasm"
+            ? await import("shiki/engine/oniguruma").then((m) =>
+                m.createOnigurumaEngine(import("shiki/wasm")),
               )
-            : await import('shiki/engine/javascript').then(m =>
-                m.createJavaScriptRegexEngine()
+            : await import("shiki/engine/javascript").then((m) =>
+                m.createJavaScriptRegexEngine(),
               );
 
         // Load themes
         const [githubLight, vesper] = await Promise.all([
-          import('@shikijs/themes/github-light'),
-          import('@shikijs/themes/vesper')
+          import("@shikijs/themes/github-light"),
+          import("@shikijs/themes/vesper"),
         ]);
 
         // Load only the requested languages from our bundled set,
@@ -145,27 +145,27 @@ export function ShikiProvider({
         const validLanguages = [
           ...new Set(
             languages
-              .map(lang => normalizeLanguage(lang))
-              .filter((lang): lang is SupportedLanguage => lang !== null)
-          )
+              .map((lang) => normalizeLanguage(lang))
+              .filter((lang): lang is SupportedLanguage => lang !== null),
+          ),
         ];
 
         const langModules = await Promise.all(
-          validLanguages.map(lang => BUNDLED_LANGS[lang]())
+          validLanguages.map((lang) => BUNDLED_LANGS[lang]()),
         );
 
         const highlighter = await createHighlighterCore({
           themes: [githubLight.default, vesper.default],
 
-          langs: langModules.map(m => m.default) as any,
-          engine: engineInstance
+          langs: langModules.map((m) => m.default) as any,
+          engine: engineInstance,
         });
 
         if (!cancelled) {
           setState({
             highlighter,
             isLoading: false,
-            error: null
+            error: null,
           });
         }
       } catch (err) {
@@ -174,7 +174,7 @@ export function ShikiProvider({
             highlighter: null,
             isLoading: false,
             error:
-              err instanceof Error ? err : new Error('Failed to load Shiki')
+              err instanceof Error ? err : new Error("Failed to load Shiki"),
           });
         }
       }
@@ -189,7 +189,7 @@ export function ShikiProvider({
 
   const mergedLabels = useMemo(
     () => ({ ...DEFAULT_LABELS, ...labels }),
-    [labels]
+    [labels],
   );
 
   const contextValue = useMemo<ShikiContextValue>(
@@ -198,9 +198,9 @@ export function ShikiProvider({
       isLoading: state.isLoading,
       error: state.error,
       languages: languages as SupportedLanguage[],
-      labels: mergedLabels
+      labels: mergedLabels,
     }),
-    [state.highlighter, state.isLoading, state.error, languages, mergedLabels]
+    [state.highlighter, state.isLoading, state.error, languages, mergedLabels],
   );
 
   return (
@@ -210,4 +210,4 @@ export function ShikiProvider({
   );
 }
 
-ShikiProvider.displayName = 'ShikiProvider';
+ShikiProvider.displayName = "ShikiProvider";

--- a/packages/kumo/src/code/provider.tsx
+++ b/packages/kumo/src/code/provider.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState, useEffect, useMemo } from "react";
 import { ShikiContext, type ShikiContextValue } from "./context";
-import type { ShikiProviderProps, SupportedLanguage } from "./types";
+import { LANGUAGE_ALIASES } from "./types";
+import type { ShikiProviderProps, SupportedLanguage, LanguageAlias } from "./types";
 
 /**
  * Pre-bundled languages - only these languages are included in the Kumo bundle.
@@ -33,40 +34,13 @@ const BUNDLED_LANGS: Record<
 };
 
 /**
- * Common language aliases mapped to their canonical SupportedLanguage names.
- *
- * Markdown code fences often use short aliases (e.g., `js`, `ts`, `sh`) that
- * Shiki recognizes but don't match the canonical grammar names in BUNDLED_LANGS.
- * This map ensures aliases resolve to the correct preloaded grammar, avoiding
- * "language not found" warnings and falling back to plain text.
- *
- * Note: Only aliases for languages in BUNDLED_LANGS are included. Languages
- * like `mdx` are intentionally omitted because they have distinct grammars
- * (MDX includes JSX syntax) that would lose highlighting if mapped to `markdown`.
- */
-const LANGUAGE_ALIASES: Record<string, SupportedLanguage> = {
-  js: "javascript",
-  cjs: "javascript",
-  mjs: "javascript",
-  ts: "typescript",
-  cts: "typescript",
-  mts: "typescript",
-  sh: "bash",
-  zsh: "bash",
-  yml: "yaml",
-  py: "python",
-  md: "markdown",
-  gql: "graphql",
-};
-
-/**
  * Normalize a language identifier to its canonical SupportedLanguage name.
  * Returns the canonical name if the input is a known alias or already canonical,
  * otherwise returns null.
  */
 export function normalizeLanguage(lang: string): SupportedLanguage | null {
   if (lang in BUNDLED_LANGS) return lang as SupportedLanguage;
-  if (lang in LANGUAGE_ALIASES) return LANGUAGE_ALIASES[lang];
+  if (lang in LANGUAGE_ALIASES) return LANGUAGE_ALIASES[lang as LanguageAlias];
   return null;
 }
 
@@ -110,10 +84,12 @@ export function ShikiProvider({
     highlighter: ShikiContextValue["highlighter"];
     isLoading: boolean;
     error: Error | null;
+    languages: SupportedLanguage[];
   }>({
     highlighter: null,
     isLoading: true,
     error: null,
+    languages: [],
   });
 
   useEffect(() => {
@@ -166,6 +142,7 @@ export function ShikiProvider({
             highlighter,
             isLoading: false,
             error: null,
+            languages: validLanguages,
           });
         }
       } catch (err) {
@@ -175,6 +152,7 @@ export function ShikiProvider({
             isLoading: false,
             error:
               err instanceof Error ? err : new Error("Failed to load Shiki"),
+            languages: [],
           });
         }
       }
@@ -197,10 +175,10 @@ export function ShikiProvider({
       highlighter: state.highlighter,
       isLoading: state.isLoading,
       error: state.error,
-      languages: languages as SupportedLanguage[],
+      languages: state.languages,
       labels: mergedLabels,
     }),
-    [state.highlighter, state.isLoading, state.error, languages, mergedLabels],
+    [state.highlighter, state.isLoading, state.error, state.languages, mergedLabels],
   );
 
   return (

--- a/packages/kumo/src/code/types.ts
+++ b/packages/kumo/src/code/types.ts
@@ -7,31 +7,31 @@
  * If you need additional languages, use Shiki directly with fine-grained imports.
  */
 export type SupportedLanguage =
-  | "javascript"
-  | "typescript"
-  | "jsx"
-  | "tsx"
-  | "json"
-  | "jsonc"
-  | "html"
-  | "css"
-  | "python"
-  | "yaml"
-  | "markdown"
-  | "graphql"
-  | "sql"
-  | "bash"
-  | "shell"
-  | "diff"
-  | "hcl"
-  | "toml";
+  | 'javascript'
+  | 'typescript'
+  | 'jsx'
+  | 'tsx'
+  | 'json'
+  | 'jsonc'
+  | 'html'
+  | 'css'
+  | 'python'
+  | 'yaml'
+  | 'markdown'
+  | 'graphql'
+  | 'sql'
+  | 'bash'
+  | 'shell'
+  | 'diff'
+  | 'hcl'
+  | 'toml';
 
 /**
  * Shiki engine choice for syntax highlighting.
  * - `"javascript"` — Smaller bundle (~50KB), slightly less accurate
  * - `"wasm"` — Larger bundle (~180KB), VS Code-accurate highlighting
  */
-export type ShikiEngine = "javascript" | "wasm";
+export type ShikiEngine = 'javascript' | 'wasm';
 
 /**
  * Localized labels for the copy button.
@@ -80,8 +80,11 @@ export interface UseShikiHighlighterResult {
    * Highlight code and return HTML string.
    * Returns `null` if highlighter is not ready or highlighting fails.
    * When `null` is returned, render the code as plain text.
+   *
+   * Accepts language aliases (e.g., 'js', 'ts', 'sh') which are automatically
+   * normalized to their canonical SupportedLanguage names.
    */
-  highlight: (code: string, lang: SupportedLanguage) => string | null;
+  highlight: (code: string, lang: string) => string | null;
 
   /** True while Shiki is loading */
   isLoading: boolean;

--- a/packages/kumo/src/code/types.ts
+++ b/packages/kumo/src/code/types.ts
@@ -7,31 +7,31 @@
  * If you need additional languages, use Shiki directly with fine-grained imports.
  */
 export type SupportedLanguage =
-  | 'javascript'
-  | 'typescript'
-  | 'jsx'
-  | 'tsx'
-  | 'json'
-  | 'jsonc'
-  | 'html'
-  | 'css'
-  | 'python'
-  | 'yaml'
-  | 'markdown'
-  | 'graphql'
-  | 'sql'
-  | 'bash'
-  | 'shell'
-  | 'diff'
-  | 'hcl'
-  | 'toml';
+  | "javascript"
+  | "typescript"
+  | "jsx"
+  | "tsx"
+  | "json"
+  | "jsonc"
+  | "html"
+  | "css"
+  | "python"
+  | "yaml"
+  | "markdown"
+  | "graphql"
+  | "sql"
+  | "bash"
+  | "shell"
+  | "diff"
+  | "hcl"
+  | "toml";
 
 /**
  * Shiki engine choice for syntax highlighting.
  * - `"javascript"` — Smaller bundle (~50KB), slightly less accurate
  * - `"wasm"` — Larger bundle (~180KB), VS Code-accurate highlighting
  */
-export type ShikiEngine = 'javascript' | 'wasm';
+export type ShikiEngine = "javascript" | "wasm";
 
 /**
  * Localized labels for the copy button.

--- a/packages/kumo/src/code/types.ts
+++ b/packages/kumo/src/code/types.ts
@@ -27,6 +27,36 @@ export type SupportedLanguage =
   | "toml";
 
 /**
+ * Common language aliases mapped to their canonical SupportedLanguage names.
+ *
+ * Markdown code fences often use short aliases (e.g., `js`, `ts`, `sh`) that
+ * don't match the canonical grammar names but should resolve to them.
+ *
+ * Note: `mdx` is intentionally omitted because it has a distinct grammar
+ * (Markdown + JSX) that would lose JSX highlighting if mapped to `markdown`.
+ */
+export const LANGUAGE_ALIASES = {
+  js: "javascript",
+  cjs: "javascript",
+  mjs: "javascript",
+  ts: "typescript",
+  cts: "typescript",
+  mts: "typescript",
+  sh: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  py: "python",
+  md: "markdown",
+  gql: "graphql",
+} as const satisfies Record<string, SupportedLanguage>;
+
+/** A known alias that maps to a SupportedLanguage. */
+export type LanguageAlias = keyof typeof LANGUAGE_ALIASES;
+
+/** Any language identifier accepted by ShikiProvider and highlight(). */
+export type LanguageInput = SupportedLanguage | LanguageAlias;
+
+/**
  * Shiki engine choice for syntax highlighting.
  * - `"javascript"` — Smaller bundle (~50KB), slightly less accurate
  * - `"wasm"` — Larger bundle (~180KB), VS Code-accurate highlighting
@@ -56,10 +86,10 @@ export interface ShikiProviderProps {
 
   /**
    * Languages to support. Only these languages will be loaded.
-   * Must be from the supported language set.
-   * @example ['tsx', 'typescript', 'bash', 'json']
+   * Accepts canonical names (`'javascript'`) or common aliases (`'js'`).
+   * @example ['tsx', 'ts', 'bash', 'json']
    */
-  languages: SupportedLanguage[];
+  languages: LanguageInput[];
 
   /**
    * Localized labels for UI elements (copy button, etc.).
@@ -84,7 +114,7 @@ export interface UseShikiHighlighterResult {
    * Accepts language aliases (e.g., 'js', 'ts', 'sh') which are automatically
    * normalized to their canonical SupportedLanguage names.
    */
-  highlight: (code: string, lang: string) => string | null;
+  highlight: (code: string, lang: LanguageInput | (string & {})) => string | null;
 
   /** True while Shiki is loading */
   isLoading: boolean;
@@ -108,9 +138,10 @@ export interface CodeHighlightedProps {
 
   /**
    * Language identifier for syntax highlighting.
+   * Accepts canonical names or common aliases (e.g., 'js', 'ts').
    * Must be included in the ShikiProvider's `languages` array.
    */
-  lang: SupportedLanguage;
+  lang: LanguageInput | (string & {});
 
   /** Display line numbers */
   showLineNumbers?: boolean;

--- a/packages/kumo/src/code/use-shiki-highlighter.test.tsx
+++ b/packages/kumo/src/code/use-shiki-highlighter.test.tsx
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { ShikiContext, type ShikiContextValue } from "./context";
+import { useShikiHighlighter } from "./use-shiki-highlighter";
+
+function createMockHighlighter() {
+  return {
+    codeToHtml: vi.fn((code: string) => `<pre>${code}</pre>`),
+  };
+}
+
+function wrapper(contextValue: ShikiContextValue) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <ShikiContext.Provider value={contextValue}>
+        {children}
+      </ShikiContext.Provider>
+    );
+  };
+}
+
+describe("useShikiHighlighter", () => {
+  it("throws when used outside ShikiProvider", () => {
+    expect(() => renderHook(() => useShikiHighlighter())).toThrow(
+      /useShikiHighlighter must be used within a ShikiProvider/,
+    );
+  });
+
+  it("returns null when highlighter is not ready", () => {
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: null,
+        isLoading: true,
+        error: null,
+        languages: ["javascript", "typescript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    expect(result.current.highlight("const x = 1;", "javascript")).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isReady).toBe(false);
+  });
+
+  it("normalizes language aliases before calling codeToHtml", () => {
+    const mockHighlighter = createMockHighlighter();
+
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: mockHighlighter as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript", "typescript", "bash"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    result.current.highlight("const x = 1;", "js");
+    expect(mockHighlighter.codeToHtml).toHaveBeenCalledWith(
+      "const x = 1;",
+      expect.objectContaining({ lang: "javascript" }),
+    );
+
+    result.current.highlight("const x = 1;", "ts");
+    expect(mockHighlighter.codeToHtml).toHaveBeenCalledWith(
+      "const x = 1;",
+      expect.objectContaining({ lang: "typescript" }),
+    );
+
+    result.current.highlight("echo hello", "sh");
+    expect(mockHighlighter.codeToHtml).toHaveBeenCalledWith(
+      "echo hello",
+      expect.objectContaining({ lang: "bash" }),
+    );
+  });
+
+  it("passes canonical language directly to codeToHtml", () => {
+    const mockHighlighter = createMockHighlighter();
+
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: mockHighlighter as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript", "typescript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    result.current.highlight("const x = 1;", "javascript");
+    expect(mockHighlighter.codeToHtml).toHaveBeenCalledWith(
+      "const x = 1;",
+      expect.objectContaining({ lang: "javascript" }),
+    );
+  });
+
+  it("returns null and warns when normalized language is not in languages list", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockHighlighter = createMockHighlighter();
+
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: mockHighlighter as any,
+        isLoading: false,
+        error: null,
+        languages: ["typescript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    // Alias that normalizes to a language NOT in the list
+    const html = result.current.highlight("const x = 1;", "js");
+    expect(html).toBeNull();
+    expect(mockHighlighter.codeToHtml).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Language "js" is not in the ShikiProvider\'s languages list'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns null and warns for unknown languages", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockHighlighter = createMockHighlighter();
+
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: mockHighlighter as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    const html = result.current.highlight("fn main() {}", "rust");
+    expect(html).toBeNull();
+    expect(mockHighlighter.codeToHtml).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Language "rust" is not in the ShikiProvider\'s languages list'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("calls codeToHtml with dual theme config", () => {
+    const mockHighlighter = createMockHighlighter();
+
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: mockHighlighter as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    result.current.highlight("const x = 1;", "javascript");
+    expect(mockHighlighter.codeToHtml).toHaveBeenCalledWith(
+      "const x = 1;",
+      {
+        lang: "javascript",
+        themes: {
+          light: "github-light",
+          dark: "vesper",
+        },
+      },
+    );
+  });
+
+  it("returns null and warns when codeToHtml throws", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockHighlighter = {
+      codeToHtml: vi.fn(() => {
+        throw new Error("highlight error");
+      }),
+    };
+
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: mockHighlighter as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    const html = result.current.highlight("const x = 1;", "javascript");
+    expect(html).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to highlight code with language "javascript"'),
+      expect.any(Error),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("exposes isReady as true when highlighter is loaded", () => {
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: createMockHighlighter() as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript"],
+        labels: { copy: "Copy", copied: "Copied!" },
+      }),
+    });
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("exposes labels from provider", () => {
+    const { result } = renderHook(() => useShikiHighlighter(), {
+      wrapper: wrapper({
+        highlighter: createMockHighlighter() as any,
+        isLoading: false,
+        error: null,
+        languages: ["javascript"],
+        labels: { copy: "Custom Copy", copied: "Custom Copied!" },
+      }),
+    });
+
+    expect(result.current.labels).toEqual({
+      copy: "Custom Copy",
+      copied: "Custom Copied!",
+    });
+  });
+});

--- a/packages/kumo/src/code/use-shiki-highlighter.ts
+++ b/packages/kumo/src/code/use-shiki-highlighter.ts
@@ -1,8 +1,9 @@
-"use client";
+'use client';
 
-import { useContext, useCallback } from "react";
-import { ShikiContext } from "./context";
-import type { UseShikiHighlighterResult, SupportedLanguage } from "./types";
+import { useContext, useCallback } from 'react';
+import { ShikiContext } from './context';
+import { normalizeLanguage } from './provider';
+import type { UseShikiHighlighterResult, SupportedLanguage } from './types';
 
 /**
  * Hook for accessing Shiki highlighting in custom implementations.
@@ -42,25 +43,28 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
 
   if (!context) {
     throw new Error(
-      "useShikiHighlighter must be used within a ShikiProvider. " +
-        "Wrap your app with <ShikiProvider> from '@cloudflare/kumo/code'.",
+      'useShikiHighlighter must be used within a ShikiProvider. ' +
+        "Wrap your app with <ShikiProvider> from '@cloudflare/kumo/code'."
     );
   }
 
   const { highlighter, isLoading, error, languages, labels } = context;
 
   const highlight = useCallback(
-    (code: string, lang: SupportedLanguage): string | null => {
+    (code: string, lang: string): string | null => {
       if (!highlighter) {
         return null;
       }
 
+      // Normalize language aliases (e.g., 'js' -> 'javascript')
+      const normalizedLang = normalizeLanguage(lang);
+
       // Check if the language is supported
-      if (!languages.includes(lang)) {
+      if (!normalizedLang || !languages.includes(normalizedLang)) {
         console.warn(
           `[Kumo CodeHighlighted] Language "${lang}" is not in the ShikiProvider's languages list. ` +
-            `Add it to the languages array: languages={[...existing, '${lang}']}. ` +
-            `Rendering as plain text.`,
+            `Add it to the languages array: languages={[...existing, '${normalizedLang || lang}']}. ` +
+            `Rendering as plain text.`
         );
         return null;
       }
@@ -68,23 +72,23 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
       try {
         // Use dual theme for light/dark mode support with hardcoded themes
         const html = highlighter.codeToHtml(code, {
-          lang,
+          lang: normalizedLang,
           themes: {
-            light: "github-light",
-            dark: "vesper",
-          },
+            light: 'github-light',
+            dark: 'vesper'
+          }
         });
 
         return html;
       } catch (err) {
         console.warn(
           `[Kumo CodeHighlighted] Failed to highlight code with language "${lang}":`,
-          err,
+          err
         );
         return null;
       }
     },
-    [highlighter, languages],
+    [highlighter, languages]
   );
 
   return {
@@ -92,6 +96,6 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
     isLoading,
     isReady: !isLoading && highlighter !== null,
     error,
-    labels,
+    labels
   };
 }

--- a/packages/kumo/src/code/use-shiki-highlighter.ts
+++ b/packages/kumo/src/code/use-shiki-highlighter.ts
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useContext, useCallback } from 'react';
-import { ShikiContext } from './context';
-import { normalizeLanguage } from './provider';
-import type { UseShikiHighlighterResult, SupportedLanguage } from './types';
+import { useContext, useCallback } from "react";
+import { ShikiContext } from "./context";
+import { normalizeLanguage } from "./provider";
+import type { UseShikiHighlighterResult } from "./types";
 
 /**
  * Hook for accessing Shiki highlighting in custom implementations.
@@ -43,8 +43,8 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
 
   if (!context) {
     throw new Error(
-      'useShikiHighlighter must be used within a ShikiProvider. ' +
-        "Wrap your app with <ShikiProvider> from '@cloudflare/kumo/code'."
+      "useShikiHighlighter must be used within a ShikiProvider. " +
+        "Wrap your app with <ShikiProvider> from '@cloudflare/kumo/code'.",
     );
   }
 
@@ -64,7 +64,7 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
         console.warn(
           `[Kumo CodeHighlighted] Language "${lang}" is not in the ShikiProvider's languages list. ` +
             `Add it to the languages array: languages={[...existing, '${normalizedLang || lang}']}. ` +
-            `Rendering as plain text.`
+            `Rendering as plain text.`,
         );
         return null;
       }
@@ -74,21 +74,21 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
         const html = highlighter.codeToHtml(code, {
           lang: normalizedLang,
           themes: {
-            light: 'github-light',
-            dark: 'vesper'
-          }
+            light: "github-light",
+            dark: "vesper",
+          },
         });
 
         return html;
       } catch (err) {
         console.warn(
           `[Kumo CodeHighlighted] Failed to highlight code with language "${lang}":`,
-          err
+          err,
         );
         return null;
       }
     },
-    [highlighter, languages]
+    [highlighter, languages],
   );
 
   return {
@@ -96,6 +96,6 @@ export function useShikiHighlighter(): UseShikiHighlighterResult {
     isLoading,
     isReady: !isLoading && highlighter !== null,
     error,
-    labels
+    labels,
   };
 }


### PR DESCRIPTION
Fixes CFSA-633

## Summary

Fixes language alias resolution so common aliases like `js`, `ts`, `sh`, `yml`, `py`, `md`, `gql` work without warnings in ShikiProvider and the highlight hook.

## Problem

When using `ShikiProvider` with languages like `['js', 'ts']` or when `CodeHighlighted` receives `lang="js"` from markdown code fences, users see warnings:

```
[Kumo CodeHighlighted] Language "js" is not in the ShikiProvider's languages list.
```

This happens because Shiki's grammar names are canonical (e.g., `javascript`, `typescript`) but markdown code fences commonly use short aliases (`js`, `ts`, `sh`, etc.).

## Solution

1. Add `LANGUAGE_ALIASES` map with common aliases → canonical names
2. Add `normalizeLanguage()` function that:
   - Returns canonical name if input is already canonical
   - Returns mapped canonical name if input is a known alias
   - Returns `null` if input is unknown
3. Normalize languages in `ShikiProvider` before preloading grammars
4. Normalize language in `highlight()` hook before checking support
5. Export `normalizeLanguage` for consumers who need it

## Supported Aliases

| Alias | Canonical |
|-------|-----------|
| js, cjs, mjs | javascript |
| ts, cts, mts | typescript |
| sh, zsh | bash |
| yml | yaml |
| py | python |
| md | markdown |
| gql | graphql |

## Intentionally Omitted

- `mdx` → `markdown`: MDX has a distinct grammar (Markdown + JSX) that would lose JSX highlighting if mapped to plain markdown.

## Testing

After this change:
- `<ShikiProvider languages={['js', 'ts']}>` works the same as `languages={['javascript', 'typescript']}`
- `<CodeHighlighted lang="js" >` highlights correctly without warnings
- Unknown languages still fall back gracefully with a warning

## Related

- Stratus workaround MR: https://gitlab.cfdata.org/cloudflare/fe/stratus/-/merge_requests/37900

---

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->
