### PR TITLE
feat(sankey): Add inline label layout and fix auto-assigned node colo…

### DIFF
--- a/.changeset/six-bags-train.md
+++ b/.changeset/six-bags-train.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+"@cloudflare/kumo": patch
+---
+
+Add inline label layout and fix auto-assigned node colors in tooltips

--- a/packages/kumo-docs-astro/src/components/demos/Chart/SankeyChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/SankeyChartDemo.tsx
@@ -473,3 +473,39 @@ export function SankeyChartDrillDownDemo() {
     </div>
   );
 }
+
+/** Demo showing inline label layout for small nodes */
+export function SankeyChartInlineLabelDemo() {
+  const isDarkMode = useIsDarkMode();
+
+  // Data with many small nodes where stacked labels would overlap
+  const nodes = [
+    { name: "Workloads", value: 109870 },
+    { name: "Users", value: 45 },
+    { name: "API Management", value: 42 },
+    { name: "Device Enrollment", value: 38 },
+    { name: "Service Token", value: 109870 },
+    { name: "Self-hosted", value: 109826 },
+    { name: "Tunnels", value: 87 },
+    { name: "Mesh", value: 87 },
+  ];
+
+  const links = [
+    { source: 0, target: 4, value: 80000 },
+    { source: 0, target: 5, value: 29870 },
+    { source: 1, target: 5, value: 45 },
+    { source: 2, target: 6, value: 42 },
+    { source: 3, target: 7, value: 38 },
+  ];
+
+  return (
+    <SankeyChart
+      echarts={echarts}
+      nodes={nodes}
+      links={links}
+      height={300}
+      nodeLabelLayout="inline"
+      isDarkMode={isDarkMode}
+    />
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/charts/sankey.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/sankey.astro
@@ -13,6 +13,7 @@ import {
   SankeyChartRichTooltipDemo,
   SankeyChartInteractiveDemo,
   SankeyChartDrillDownDemo,
+  SankeyChartInlineLabelDemo,
 } from "~/components/demos/Chart/SankeyChartDemo";
 ---
 
@@ -180,6 +181,22 @@ const handleNodeClick = (node: { name: string }) => {
   onNodeClick={handleNodeClick}
 />`}>
           <SankeyChartDrillDownDemo client:load />
+        </ComponentExample>
+      </div>
+
+      <div>
+        <Heading level={3}>Inline Label Layout</Heading>
+        <p class="mb-4 text-kumo-subtle">
+          Use <code class="text-kumo-default">nodeLabelLayout="inline"</code> to display node values and names on a single line. This prevents label overlap on small nodes where the default stacked layout would cause text to collide.
+        </p>
+        <ComponentExample code={`<SankeyChart
+  echarts={echarts}
+  nodes={nodes}
+  links={links}
+  height={300}
+  nodeLabelLayout="inline"
+/>`}>
+          <SankeyChartInlineLabelDemo client:visible />
         </ComponentExample>
       </div>
     </div>

--- a/packages/kumo/src/components/chart/SankeyChart.test.tsx
+++ b/packages/kumo/src/components/chart/SankeyChart.test.tsx
@@ -674,4 +674,142 @@ describe("security utilities", () => {
       expect(result).not.toContain("javascript:");
     });
   });
+
+  describe("nodeLabelLayout", () => {
+    it("uses stacked layout by default (value above name)", () => {
+      const mockChart = createMockChart();
+      const mockEcharts = createMockEcharts(mockChart);
+
+      render(
+        <SankeyChart
+          echarts={mockEcharts as any}
+          nodes={[{ name: "Node A", value: 100 }]}
+          links={[]}
+        />,
+      );
+
+      const options = mockChart.setOption.mock.calls[0][0];
+      const formatter = options.series[0].label.formatter;
+
+      const result = formatter({ name: "Node A" });
+      // Stacked layout: value\nname (newline between)
+      expect(result).toContain("\n");
+      expect(result).toMatch(/\{value\|.*\}\n\{name\|.*\}/);
+    });
+
+    it("uses inline layout when nodeLabelLayout is 'inline'", () => {
+      const mockChart = createMockChart();
+      const mockEcharts = createMockEcharts(mockChart);
+
+      render(
+        <SankeyChart
+          echarts={mockEcharts as any}
+          nodes={[{ name: "Node A", value: 100 }]}
+          links={[]}
+          nodeLabelLayout="inline"
+        />,
+      );
+
+      const options = mockChart.setOption.mock.calls[0][0];
+      const formatter = options.series[0].label.formatter;
+
+      const result = formatter({ name: "Node A" });
+      // Inline layout: name value (space between, no newline)
+      expect(result).not.toContain("\n");
+      expect(result).toMatch(/\{name\|.*\} \{value\|.*\}/);
+    });
+
+    it("sets lineHeight for stacked layout", () => {
+      const mockChart = createMockChart();
+      const mockEcharts = createMockEcharts(mockChart);
+
+      render(
+        <SankeyChart
+          echarts={mockEcharts as any}
+          nodes={[{ name: "Node A", value: 100 }]}
+          links={[]}
+          nodeLabelLayout="stacked"
+        />,
+      );
+
+      const options = mockChart.setOption.mock.calls[0][0];
+      expect(options.series[0].label.rich.value.lineHeight).toBe(16);
+    });
+
+    it("does not set lineHeight for inline layout", () => {
+      const mockChart = createMockChart();
+      const mockEcharts = createMockEcharts(mockChart);
+
+      render(
+        <SankeyChart
+          echarts={mockEcharts as any}
+          nodes={[{ name: "Node A", value: 100 }]}
+          links={[]}
+          nodeLabelLayout="inline"
+        />,
+      );
+
+      const options = mockChart.setOption.mock.calls[0][0];
+      expect(options.series[0].label.rich.value.lineHeight).toBeUndefined();
+    });
+  });
+
+  describe("auto-assigned node colors", () => {
+    it("uses auto-assigned colors in link tooltips when nodes have no explicit color", () => {
+      const mockChart = createMockChart();
+      const mockEcharts = createMockEcharts(mockChart);
+
+      render(
+        <SankeyChart
+          echarts={mockEcharts as any}
+          nodes={[
+            { name: "Source" }, // No explicit color
+            { name: "Target" }, // No explicit color
+          ]}
+          links={[{ source: 0, target: 1, value: 50 }]}
+        />,
+      );
+
+      const options = mockChart.setOption.mock.calls[0][0];
+      const formatter = options.tooltip.formatter;
+
+      // Simulate link tooltip
+      const result = formatter({
+        dataType: "edge",
+        data: { source: "Source", target: "Target", value: 50 },
+      });
+
+      // Should NOT contain the fallback gray color #666
+      // Should contain auto-assigned categorical colors
+      expect(result).not.toContain("#666");
+    });
+
+    it("assigns consistent colors to nodes without explicit colors", () => {
+      const mockChart = createMockChart();
+      const mockEcharts = createMockEcharts(mockChart);
+
+      render(
+        <SankeyChart
+          echarts={mockEcharts as any}
+          nodes={[
+            { name: "Node A" }, // No color - gets categorical(0)
+            { name: "Node B" }, // No color - gets categorical(1)
+            { name: "Node C", color: "#custom" }, // Explicit color
+          ]}
+          links={[]}
+        />,
+      );
+
+      const options = mockChart.setOption.mock.calls[0][0];
+      const nodeData = options.series[0].data;
+
+      // First two nodes should have auto-assigned colors (not undefined)
+      expect(nodeData[0].itemStyle.color).toBeDefined();
+      expect(nodeData[1].itemStyle.color).toBeDefined();
+      // Third node should have explicit color
+      expect(nodeData[2].itemStyle.color).toBe("#custom");
+      // Auto-assigned colors should be different
+      expect(nodeData[0].itemStyle.color).not.toBe(nodeData[1].itemStyle.color);
+    });
+  });
 });

--- a/packages/kumo/src/components/chart/SankeyChart.tsx
+++ b/packages/kumo/src/components/chart/SankeyChart.tsx
@@ -69,6 +69,11 @@ export interface SankeyChartProps {
   height?: number;
   /** Show node values above labels (default: true if any node has a value) */
   showNodeValues?: boolean;
+  /** Layout for node labels when showNodeValues is true.
+   * - 'stacked': value on top, name below (default)
+   * - 'inline': "value name" on a single line (better for small nodes)
+   */
+  nodeLabelLayout?: "stacked" | "inline";
   /** Format function for node values (default: toLocaleString) */
   formatValue?: (value: number) => string;
   /** Custom tooltip formatter. Return HTML string or empty string to hide tooltip. */
@@ -169,6 +174,7 @@ export function SankeyChart({
   nodePadding = 10,
   showTooltip: enableTooltip = true,
   showNodeValues,
+  nodeLabelLayout = "stacked",
   formatValue = defaultFormatValue,
   tooltipFormatter,
   defaultNodeColor,
@@ -183,20 +189,29 @@ export function SankeyChart({
 }: SankeyChartProps) {
   const hasNodeValues = nodes.some((n) => n.value !== undefined);
   const shouldShowValues = showNodeValues ?? hasNodeValues;
+  const isInlineLayout = nodeLabelLayout === "inline";
   const options = useMemo<EChartsOption>(() => {
     const labelColor = ChartPalette.text("primary", isDarkMode);
     const secondaryColor = ChartPalette.text("secondary", isDarkMode);
-    // Build a map of node name to original node data for tooltip access
-    const nodeDataMap = new Map(nodes.map((n) => [n.name, n]));
+
+    // Compute colors for each node (explicit color > default > categorical)
+    const nodeColors = nodes.map(
+      (node, index) =>
+        node.color ??
+        defaultNodeColor ??
+        ChartPalette.categorical(index, isDarkMode),
+    );
+
+    // Build a map of node name to original node data + computed color for tooltip access
+    const nodeDataMap = new Map(
+      nodes.map((n, i) => [n.name, { ...n, computedColor: nodeColors[i] }]),
+    );
 
     const echartsNodes = nodes.map((node, index) => ({
       name: node.name,
       value: node.value,
       itemStyle: {
-        color:
-          node.color ??
-          defaultNodeColor ??
-          ChartPalette.categorical(index, isDarkMode),
+        color: nodeColors[index],
       },
     }));
 
@@ -222,7 +237,7 @@ export function SankeyChart({
               if (params.dataType === "node" && params.name) {
                 const nodeData = nodeDataMap.get(params.name);
                 const color = sanitizeColor(
-                  nodeData?.color ?? params.color ?? "#666",
+                  nodeData?.computedColor ?? params.color ?? "#666",
                 );
 
                 // Use custom formatter if provided
@@ -259,8 +274,12 @@ export function SankeyChart({
                 // Get colors for source and target nodes
                 const sourceNode = nodeDataMap.get(source ?? "");
                 const targetNode = nodeDataMap.get(target ?? "");
-                const sourceColor = sanitizeColor(sourceNode?.color ?? "#666");
-                const targetColor = sanitizeColor(targetNode?.color ?? "#666");
+                const sourceColor = sanitizeColor(
+                  sourceNode?.computedColor ?? "#666",
+                );
+                const targetColor = sanitizeColor(
+                  targetNode?.computedColor ?? "#666",
+                );
 
                 // Default link tooltip with colored dots
                 const safeSource = escapeHtml(source ?? "");
@@ -307,7 +326,13 @@ export function SankeyChart({
                   const nodeData = nodeDataMap.get(name);
                   const safeName = escapeRichText(name);
                   if (nodeData?.value !== undefined) {
-                    return `{value|${escapeRichText(formatValue(nodeData.value))}}\n{name|${safeName}}`;
+                    const formattedValue = escapeRichText(
+                      formatValue(nodeData.value),
+                    );
+                    // Inline: "name value" on single line; Stacked: value above name
+                    return isInlineLayout
+                      ? `{name|${safeName}} {value|${formattedValue}}`
+                      : `{value|${formattedValue}}\n{name|${safeName}}`;
                   }
                   return safeName;
                 }
@@ -317,7 +342,7 @@ export function SankeyChart({
                   value: {
                     fontSize: 11,
                     color: labelColor,
-                    lineHeight: 16,
+                    lineHeight: isInlineLayout ? undefined : 16,
                   },
                   name: {
                     fontSize: 12,
@@ -343,6 +368,7 @@ export function SankeyChart({
     linkColor,
     linkOpacity,
     shouldShowValues,
+    isInlineLayout,
     formatValue,
     tooltipFormatter,
   ]);


### PR DESCRIPTION
#### Changes

**1. New `nodeLabelLayout` prop**
- Added `nodeLabelLayout` prop with two options:
  - `"stacked"` (default): Value on top, name below (two lines)
  - `"inline"`: "Name Value" on a single line
- Inline layout prevents label overlap on small nodes where stacked labels would collide

**2. Bug fix: Auto-assigned node colors now appear in tooltips**
- Previously, when nodes didn't have explicit `color` properties, the auto-assigned colors from [ChartPalette.categorical()](cci:1://file:///Users/brendandavies/Code/github/cloudflare/kumo/packages/kumo/src/components/chart/Color.ts:121:2-136:3) were not reflected in link tooltips (fell back to gray `#666`)
- Now computes `nodeColors` array upfront and stores `computedColor` in the node data map
- Both node and link tooltips now correctly display auto-assigned colors

#### Files Changed
| File | Changes |
|------|---------|
| [packages/kumo/src/components/chart/SankeyChart.tsx](cci:7://file:///Users/brendandavies/Code/github/cloudflare/kumo/packages/kumo/src/components/chart/SankeyChart.tsx:0:0-0:0) | Added `nodeLabelLayout` prop, fixed color computation |
| [packages/kumo-docs-astro/src/components/demos/Chart/SankeyChartDemo.tsx](cci:7://file:///Users/brendandavies/Code/github/cloudflare/kumo/packages/kumo-docs-astro/src/components/demos/Chart/SankeyChartDemo.tsx:0:0-0:0) | Added [SankeyChartInlineLabelDemo](cci:1://file:///Users/brendandavies/Code/github/cloudflare/kumo/packages/kumo-docs-astro/src/components/demos/Chart/SankeyChartDemo.tsx:476:0-510:1) |
| [packages/kumo-docs-astro/src/pages/charts/sankey.astro](cci:7://file:///Users/brendandavies/Code/github/cloudflare/kumo/packages/kumo-docs-astro/src/pages/charts/sankey.astro:0:0-0:0) | Added "Inline Label Layout" documentation section |

#### Usage

```tsx
<SankeyChart
  echarts={echarts}
  nodes={nodes}
  links={links}
  height={300}
  nodeLabelLayout="inline"  // Single line: "Workloads 109,870"
/>
```

<img width="789" height="360" alt="image" src="https://github.com/user-attachments/assets/4d2d3256-2242-4002-a37b-b6fb01e587bd" />


<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
