### PR TITLE
Add red border in error state to Combobox, Select, Autocomplete, and SensitiveInput

### DIFF
--- a/.changeset/red-borders-fix.md
+++ b/.changeset/red-borders-fix.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix error state red border on Combobox, Select, Autocomplete, and SensitiveInput to match Input behavior

--- a/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
@@ -79,18 +79,34 @@ export function SelectWithoutLabelDemo() {
   );
 }
 
-/** Select with label, description, and error handling. */
-export function SelectWithFieldDemo() {
+/** Select with label and description text. */
+export function SelectWithDescriptionDemo() {
   const [value, setValue] = useState<string | null>(null);
 
   return (
     <Select
       label="Issue Type"
       description="Choose the category that best describes your issue"
-      error={!value ? "Please select an issue type" : undefined}
       className="w-[280px]"
       value={value}
       onValueChange={(v) => setValue(v as string | null)}
+      items={{
+        bug: "Bug",
+        documentation: "Documentation",
+        feature: "Feature",
+      }}
+    />
+  );
+}
+
+/** Select with label and validation error. */
+export function SelectWithErrorDemo() {
+  return (
+    <Select
+      label="Issue Type"
+      error="Please select an issue type"
+      className="w-[280px]"
+      value={null}
       items={{
         bug: "Bug",
         documentation: "Documentation",

--- a/packages/kumo-docs-astro/src/components/demos/SelectStressTestDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SelectStressTestDemo.tsx
@@ -345,7 +345,10 @@ export function SelectGroupedOptionsDemo() {
 // ============================================================================
 
 /**
- * Tests: Field integration with error and description.
+ * Tests: Field integration with error and description together.
+ * The Field component treats description and error as mutually exclusive —
+ * when an error is present, it replaces the description in the UI.
+ * This stress test verifies that toggling between the two states works correctly.
  */
 export function SelectFieldIntegrationDemo() {
   const [value, setValue] = useState<string | null>(null);

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -14,7 +14,8 @@ import {
   SelectBasicDemo,
   SelectSizesDemo,
   SelectWithoutLabelDemo,
-  SelectWithFieldDemo,
+  SelectWithDescriptionDemo,
+  SelectWithErrorDemo,
   SelectPlaceholderDemo,
   SelectWithTooltipDemo,
   SelectCustomRenderingDemo,
@@ -45,7 +46,7 @@ import {
 
 ### Barrel
 
-  <CodeBlock code={`import { Select } from "@cloudflare/kumo";`} lang="tsx" />
+<CodeBlock code={`import { Select } from "@cloudflare/kumo";`} lang="tsx" />
 
 ### Granular
 
@@ -106,10 +107,10 @@ export default function Example() {
 
 ### Sizes
 
-  <p>
-    Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">size</code> prop
-    to match Input sizing (xs, sm, base, lg).
-  </p>
+<p>
+  Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">size</code>{" "}
+  prop to match Input sizing (xs, sm, base, lg).
+</p>
 
   <ComponentExample demo="SelectSizesDemo">
     <SelectSizesDemo client:load />
@@ -122,28 +123,47 @@ export default function Example() {
 
 ### Without Visible Label
 
-  <p>
-    When a visible label isn't needed (e.g., in compact UIs or when context is clear),
-    use `aria-label` for accessibility.
-  </p>
+<p>
+  When a visible label isn't needed (e.g., in compact UIs or when context is
+  clear), use `aria-label` for accessibility.
+</p>
 
   <ComponentExample demo="SelectWithoutLabelDemo">
     <SelectWithoutLabelDemo client:load />
   </ComponentExample>
 </ComponentSection>
 
-{/* With Description and Error */}
+{/* With Description */}
 
 <ComponentSection>
 
-### With Description and Error
+### With Description
 
-  <p>
-    Select integrates with the Field wrapper to show description text and validation errors.
-  </p>
+<p>
+  Select integrates with the Field wrapper to show description text below the
+  input.
+</p>
 
-  <ComponentExample demo="SelectWithFieldDemo">
-    <SelectWithFieldDemo client:load />
+  <ComponentExample demo="SelectWithDescriptionDemo">
+    <SelectWithDescriptionDemo client:load />
+  </ComponentExample>
+</ComponentSection>
+
+{/* With Error */}
+
+<ComponentSection>
+
+### With Error
+
+<p>
+  Pass the{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">error</code> prop to
+  display a validation error. When an error is present, it replaces the
+  description in the UI.
+</p>
+
+  <ComponentExample demo="SelectWithErrorDemo">
+    <SelectWithErrorDemo client:load />
   </ComponentExample>
 </ComponentSection>
 
@@ -153,12 +173,17 @@ export default function Example() {
 
 ### Placeholder
 
-  <p>
-    Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> prop
-    to show text when no value is selected. When using <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to
-    customize the display of selected values, the placeholder is shown instead of
-    calling <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> when the value is <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">null</code>.
-  </p>
+<p>
+  Use the{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code>{" "}
+  prop to show text when no value is selected. When using{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
+  to customize the display of selected values, the placeholder is shown instead
+  of calling{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
+  when the value is{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">null</code>.
+</p>
 
 ```tsx
 <Select
@@ -179,10 +204,10 @@ export default function Example() {
 
 ### Label with Tooltip
 
-  <p>
-    Add a tooltip icon next to the label for additional context using <code
-      class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
-  </p>
+<p>
+  Add a tooltip icon next to the label for additional context using{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
+</p>
 
   <ComponentExample demo="SelectWithTooltipDemo">
     <SelectWithTooltipDemo client:load />
@@ -195,11 +220,13 @@ export default function Example() {
 
 ### Custom Rendering
 
-  <p>
-    Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to customize how the selected value
-    appears in the trigger button. This is useful when working with complex object
-    data structures instead of simple string values.
-  </p>
+<p>
+  Use{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
+  to customize how the selected value appears in the trigger button. This is
+  useful when working with complex object data structures instead of simple
+  string values.
+</p>
 
 <ComponentExample demo="SelectCustomRenderingDemo">
   <SelectCustomRenderingDemo client:load />
@@ -253,11 +280,11 @@ export default function Example() {
 
 ### Loading
 
-  <p>
-    A select component with loading state. The loading state is passed to
-    the component via the <code
-      class="rounded bg-kumo-control px-1 py-0.5 text-sm">loading</code> prop.
-  </p>
+<p>
+  A select component with loading state. The loading state is passed to the
+  component via the{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">loading</code> prop.
+</p>
 
   <ComponentExample demo="SelectLoadingDemo">
     <div class="flex flex-col gap-4">
@@ -275,11 +302,15 @@ export default function Example() {
 
 ### Multiple Selection
 
-  <p>
-    Enable multiple selection with the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">multiple</code> prop.
-    The value becomes an array of selected items. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> for the empty state
-    and <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to customize how selections are displayed.
-  </p>
+<p>
+  Enable multiple selection with the{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">multiple</code>{" "}
+  prop. The value becomes an array of selected items. Use{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code>{" "}
+  for the empty state and{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
+  to customize how selections are displayed.
+</p>
 
 ```tsx
 <Select
@@ -316,10 +347,11 @@ export default function Example() {
 
 ### Disabled Options
 
-  <p>
-    Options can be disabled with the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> prop.
-    Disabled options are greyed out and cannot be selected.
-  </p>
+<p>
+  Options can be disabled with the{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code>{" "}
+  prop. Disabled options are greyed out and cannot be selected.
+</p>
 
   <ComponentExample demo="SelectDisabledOptionsDemo">
     <SelectDisabledOptionsDemo client:load />
@@ -332,11 +364,12 @@ export default function Example() {
 
 ### Disabled Items (via items prop)
 
-  <p>
-    The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code> object-map prop
-    accepts descriptor objects with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> alongside
-    plain string values.
-  </p>
+<p>
+  The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code>{" "}
+  object-map prop accepts descriptor objects with{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code>{" "}
+  alongside plain string values.
+</p>
 
   <ComponentExample demo="SelectDisabledItemsDemo">
     <SelectDisabledItemsDemo client:load />
@@ -349,12 +382,18 @@ export default function Example() {
 
 ### Grouped Options
 
-  <p>
-    Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>,{" "}
-    <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.GroupLabel</code>, and{" "}
-    <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Separator</code> to
-    organize options under labeled headers with visual dividers.
-  </p>
+<p>
+  Use{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>,{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
+    Select.GroupLabel
+  </code>
+  , and{" "}
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
+    Select.Separator
+  </code>{" "}
+  to organize options under labeled headers with visual dividers.
+</p>
 
   <ComponentExample demo="SelectGroupedDemo">
     <SelectGroupedDemo client:load />
@@ -367,10 +406,10 @@ export default function Example() {
 
 ### Groups with Disabled Options
 
-  <p>
-    Combine groups, separators, and disabled options with info tooltips to
-    clearly separate available and unavailable choices.
-  </p>
+<p>
+  Combine groups, separators, and disabled options with info tooltips to clearly
+  separate available and unavailable choices.
+</p>
 
   <ComponentExample demo="SelectGroupedWithDisabledDemo">
     <SelectGroupedWithDisabledDemo client:load />
@@ -383,10 +422,10 @@ export default function Example() {
 
 ### Long List (Scrolling Test)
 
-  <p>
-    A select component with many options to test popup scrolling behavior.
-    The popup should scroll smoothly without bounce/overscroll issues.
-  </p>
+<p>
+  A select component with many options to test popup scrolling behavior. The
+  popup should scroll smoothly without bounce/overscroll issues.
+</p>
 
   <ComponentExample demo="SelectLongListDemo">
     <SelectLongListDemo client:load />
@@ -401,7 +440,7 @@ export default function Example() {
 
 ### Select
 
-  <PropsTable component="Select" />
+<PropsTable component="Select" />
 
 ### Select.Option
 

--- a/packages/kumo/src/components/autocomplete/autocomplete.test.tsx
+++ b/packages/kumo/src/components/autocomplete/autocomplete.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Autocomplete,
+  KUMO_AUTOCOMPLETE_VARIANTS,
+  KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS,
+} from "./autocomplete";
+
+const countries = ["Argentina", "Brazil", "Canada"];
+
+/** Helper that renders a minimal Autocomplete. */
+function renderAutocomplete(
+  props: Partial<React.ComponentProps<typeof Autocomplete>> = {},
+) {
+  return render(
+    <Autocomplete items={countries} {...props}>
+      <Autocomplete.InputGroup placeholder="Search countries…" />
+      <Autocomplete.Content>
+        <Autocomplete.List>
+          {(item: string) => (
+            <Autocomplete.Item key={item} value={item}>
+              {item}
+            </Autocomplete.Item>
+          )}
+        </Autocomplete.List>
+      </Autocomplete.Content>
+    </Autocomplete>,
+  );
+}
+
+describe("Autocomplete", () => {
+  // Rendering
+
+  it("renders without crashing", () => {
+    renderAutocomplete();
+    expect(screen.getByRole("combobox")).toBeTruthy();
+  });
+
+  it("renders input with placeholder text", () => {
+    renderAutocomplete();
+    expect(screen.getByPlaceholderText("Search countries…")).toBeTruthy();
+  });
+
+  // Variants export
+
+  it("exports KUMO_AUTOCOMPLETE_VARIANTS with size axis", () => {
+    expect(KUMO_AUTOCOMPLETE_VARIANTS.size.xs).toBeDefined();
+    expect(KUMO_AUTOCOMPLETE_VARIANTS.size.sm).toBeDefined();
+    expect(KUMO_AUTOCOMPLETE_VARIANTS.size.base).toBeDefined();
+    expect(KUMO_AUTOCOMPLETE_VARIANTS.size.lg).toBeDefined();
+  });
+
+  it("exports KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS with correct defaults", () => {
+    expect(KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS.size).toBe("base");
+  });
+
+  // displayName
+
+  it("sets displayName on sub-components", () => {
+    expect(Autocomplete.displayName).toBe("Autocomplete.Root");
+    expect(Autocomplete.InputGroup.displayName).toBe("Autocomplete.InputGroup");
+    expect(Autocomplete.Content.displayName).toBe("Autocomplete.Content");
+    expect(Autocomplete.Item.displayName).toBe("Autocomplete.Item");
+    expect(Autocomplete.GroupLabel.displayName).toBe("Autocomplete.GroupLabel");
+    expect(Autocomplete.Group.displayName).toBe("Autocomplete.Group");
+    expect(Autocomplete.Separator.displayName).toBe("Autocomplete.Separator");
+  });
+
+  // Field wrapper integration
+
+  describe("label and Field wrapper", () => {
+    it("renders with Field wrapper when label is provided", () => {
+      renderAutocomplete({ label: "Country" });
+      expect(screen.getByText("Country")).toBeTruthy();
+    });
+
+    it("renders description text when description prop is set", () => {
+      renderAutocomplete({
+        label: "Country",
+        description: "Select your country of residence",
+      });
+      expect(screen.getByText("Select your country of residence")).toBeTruthy();
+    });
+  });
+
+  // Error states
+
+  describe("error styling", () => {
+    it("applies error border to InputGroup when error prop is truthy", () => {
+      renderAutocomplete({ error: "Country is required" });
+
+      const input = screen.getByRole("combobox");
+      expect(input.className).toContain("ring-kumo-danger");
+    });
+
+    it("renders error message string with label", () => {
+      renderAutocomplete({
+        label: "Country",
+        error: "Please select a country",
+      });
+      expect(screen.getByText("Please select a country")).toBeTruthy();
+    });
+
+    it("renders error object with label", () => {
+      renderAutocomplete({
+        label: "Country",
+        error: { message: "Country is required", match: true },
+      });
+      expect(screen.getByText("Country is required")).toBeTruthy();
+    });
+  });
+
+  // Input structure
+
+  describe("input", () => {
+    it("has aria-haspopup listbox on the combobox input", () => {
+      renderAutocomplete();
+
+      const input = screen.getByRole("combobox");
+      expect(input.getAttribute("aria-haspopup")).toBe("listbox");
+    });
+
+    it("has aria-autocomplete list attribute", () => {
+      renderAutocomplete();
+
+      const input = screen.getByRole("combobox");
+      expect(input.getAttribute("aria-autocomplete")).toBe("list");
+    });
+  });
+});

--- a/packages/kumo/src/components/autocomplete/autocomplete.tsx
+++ b/packages/kumo/src/components/autocomplete/autocomplete.tsx
@@ -1,10 +1,14 @@
 import { Autocomplete as AutocompleteBase } from "@base-ui/react/autocomplete";
 import { CheckIcon } from "@phosphor-icons/react";
-import { type ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import { inputVariants, KUMO_INPUT_VARIANTS } from "../input/input";
 import { cn } from "../../utils/cn";
 import { resolveVariant } from "../../utils/resolve-variant";
 import { Field, type FieldErrorMatch } from "../field/field";
+
+const AutocompleteContext = createContext<{ hasError: boolean }>({
+  hasError: false,
+});
 
 /** Autocomplete variant definitions. */
 export const KUMO_AUTOCOMPLETE_VARIANTS = {
@@ -33,7 +37,13 @@ export interface KumoAutocompleteVariantsProps {
 export function autocompleteVariants({
   size = KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS.size,
 }: KumoAutocompleteVariantsProps = {}) {
-  return cn(resolveVariant(KUMO_INPUT_VARIANTS.size, size, KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS.size).classes);
+  return cn(
+    resolveVariant(
+      KUMO_INPUT_VARIANTS.size,
+      size,
+      KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS.size,
+    ).classes,
+  );
 }
 
 /**
@@ -106,7 +116,9 @@ function Root<ItemValue>({
     items?: readonly ItemValue[];
   };
   const control = (
-    <AutocompleteBase.Root {...rootProps}>{children}</AutocompleteBase.Root>
+    <AutocompleteContext value={{ hasError: Boolean(error) }}>
+      <AutocompleteBase.Root {...rootProps}>{children}</AutocompleteBase.Root>
+    </AutocompleteContext>
   );
 
   if (label) {
@@ -141,10 +153,15 @@ function InputGroup({
   size?: KumoAutocompleteSize;
   placeholder?: string;
 }) {
+  const { hasError } = useContext(AutocompleteContext);
   return (
     <AutocompleteBase.Input
       className={cn(
-        inputVariants({ size, focusIndicator: true }),
+        inputVariants({
+          size,
+          variant: hasError ? "error" : "default",
+          focusIndicator: true,
+        }),
         "w-full",
         className,
       )}

--- a/packages/kumo/src/components/combobox/combobox.test.tsx
+++ b/packages/kumo/src/components/combobox/combobox.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Combobox,
+  KUMO_COMBOBOX_VARIANTS,
+  KUMO_COMBOBOX_DEFAULT_VARIANTS,
+} from "./combobox";
+
+const fruits = ["Apple", "Banana", "Cherry"];
+
+/** Helper that renders a minimal Combobox with TriggerInput. */
+function renderComboboxWithInput(
+  props: Partial<React.ComponentProps<typeof Combobox>> = {},
+) {
+  return render(
+    <Combobox items={fruits} {...props}>
+      <Combobox.TriggerInput placeholder="Pick a fruit…" />
+      <Combobox.Content>
+        <Combobox.List>
+          {(item: string) => (
+            <Combobox.Item key={item} value={item}>
+              {item}
+            </Combobox.Item>
+          )}
+        </Combobox.List>
+      </Combobox.Content>
+    </Combobox>,
+  );
+}
+
+describe("Combobox", () => {
+  // Rendering
+
+  it("renders without crashing", () => {
+    renderComboboxWithInput();
+    expect(screen.getByRole("combobox")).toBeTruthy();
+  });
+
+  it("renders a combobox input with placeholder text", () => {
+    renderComboboxWithInput();
+    expect(screen.getByPlaceholderText("Pick a fruit…")).toBeTruthy();
+  });
+
+  // Variants export
+
+  it("exports KUMO_COMBOBOX_VARIANTS with size and inputSide axes", () => {
+    expect(KUMO_COMBOBOX_VARIANTS.size.xs).toBeDefined();
+    expect(KUMO_COMBOBOX_VARIANTS.size.base).toBeDefined();
+    expect(KUMO_COMBOBOX_VARIANTS.inputSide.right).toBeDefined();
+    expect(KUMO_COMBOBOX_VARIANTS.inputSide.top).toBeDefined();
+  });
+
+  it("exports KUMO_COMBOBOX_DEFAULT_VARIANTS with correct defaults", () => {
+    expect(KUMO_COMBOBOX_DEFAULT_VARIANTS.size).toBe("base");
+    expect(KUMO_COMBOBOX_DEFAULT_VARIANTS.inputSide).toBe("right");
+  });
+
+  // displayName
+
+  it("sets displayName on sub-components", () => {
+    expect(Combobox.displayName).toBe("Combobox.Root");
+    expect(Combobox.Content.displayName).toBe("Combobox.Content");
+    expect(Combobox.TriggerInput.displayName).toBe("Combobox.TriggerInput");
+    expect(Combobox.TriggerValue.displayName).toBe("Combobox.TriggerValue");
+    expect(Combobox.Item.displayName).toBe("Combobox.Item");
+    expect(Combobox.Chip.displayName).toBe("Combobox.Chip");
+  });
+
+  // Field wrapper integration
+
+  describe("label and Field wrapper", () => {
+    it("renders with Field wrapper when label is provided", () => {
+      renderComboboxWithInput({ label: "Fruit" });
+      expect(screen.getByText("Fruit")).toBeTruthy();
+    });
+
+    it("renders description text when description prop is set", () => {
+      renderComboboxWithInput({
+        label: "Fruit",
+        description: "Choose your favorite fruit",
+      });
+      expect(screen.getByText("Choose your favorite fruit")).toBeTruthy();
+    });
+  });
+
+  // Error states
+
+  describe("error styling", () => {
+    it("applies error border to TriggerInput when error prop is truthy", () => {
+      renderComboboxWithInput({ error: "Selection required" });
+
+      const input = screen.getByRole("combobox");
+      expect(input.className).toContain("ring-kumo-danger");
+    });
+
+    it("applies error border to TriggerValue when error prop is truthy", () => {
+      render(
+        <Combobox
+          items={fruits}
+          error="Selection required"
+          defaultValue="Apple"
+        >
+          <Combobox.TriggerValue placeholder="Select a fruit" />
+          <Combobox.Content>
+            <Combobox.List>
+              {(item: string) => (
+                <Combobox.Item key={item} value={item}>
+                  {item}
+                </Combobox.Item>
+              )}
+            </Combobox.List>
+          </Combobox.Content>
+        </Combobox>,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(trigger.className).toContain("ring-kumo-danger");
+    });
+
+    it("renders error message string with label", () => {
+      renderComboboxWithInput({
+        label: "Fruit",
+        error: "Please select a fruit",
+      });
+      expect(screen.getByText("Please select a fruit")).toBeTruthy();
+    });
+
+    it("renders error object with label", () => {
+      renderComboboxWithInput({
+        label: "Fruit",
+        error: { message: "Fruit is required", match: true },
+      });
+      expect(screen.getByText("Fruit is required")).toBeTruthy();
+    });
+  });
+
+  // Trigger structure
+
+  describe("trigger", () => {
+    it("has aria-haspopup listbox on the combobox input", () => {
+      renderComboboxWithInput();
+
+      const input = screen.getByRole("combobox");
+      expect(input.getAttribute("aria-haspopup")).toBe("listbox");
+    });
+
+    it("renders a show-options trigger button for TriggerInput", () => {
+      renderComboboxWithInput();
+
+      const trigger = screen.getByRole("button", { name: "Show options" });
+      expect(trigger).toBeTruthy();
+    });
+  });
+});

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -40,8 +40,11 @@ export const KUMO_COMBOBOX_DEFAULT_VARIANTS = {
   inputSide: "right",
 } as const;
 
-// Context to pass size down to sub-components
-const ComboboxSizeContext = createContext<KumoInputSize>("base");
+// Context to pass size and error state down to sub-components
+const ComboboxContext = createContext<{
+  size: KumoInputSize;
+  hasError: boolean;
+}>({ size: "base", hasError: false });
 
 // Derived types from KUMO_COMBOBOX_VARIANTS
 export type KumoComboboxSize = keyof typeof KUMO_COMBOBOX_VARIANTS.size;
@@ -70,7 +73,13 @@ export interface KumoComboboxVariantsProps {
 export function comboboxVariants({
   inputSide = KUMO_COMBOBOX_DEFAULT_VARIANTS.inputSide,
 }: KumoComboboxVariantsProps = {}) {
-  return cn(resolveVariant(KUMO_COMBOBOX_VARIANTS.inputSide, inputSide, KUMO_COMBOBOX_DEFAULT_VARIANTS.inputSide).classes);
+  return cn(
+    resolveVariant(
+      KUMO_COMBOBOX_VARIANTS.inputSide,
+      inputSide,
+      KUMO_COMBOBOX_DEFAULT_VARIANTS.inputSide,
+    ).classes,
+  );
 }
 
 // Legacy type alias for backwards compatibility
@@ -158,9 +167,9 @@ function Root<Value, Multiple extends boolean | undefined = false>({
   size?: KumoComboboxSize;
 }) {
   const comboboxControl = (
-    <ComboboxSizeContext.Provider value={size}>
+    <ComboboxContext value={{ size, hasError: Boolean(error) }}>
       <ComboboxBase.Root {...props}>{children}</ComboboxBase.Root>
-    </ComboboxSizeContext.Provider>
+    </ComboboxContext>
   );
 
   // Render with Field wrapper if label, description, or error are provided
@@ -252,13 +261,13 @@ function TriggerValue({
   className,
   ...props
 }: ComboboxBase.Value.Props & { className?: string }) {
-  const size = useContext(ComboboxSizeContext);
+  const { size, hasError } = useContext(ComboboxContext);
   const iconStyles = triggerValueIconStyles[size];
 
   return (
     <ComboboxBase.Trigger
       className={cn(
-        inputVariants({ size }),
+        inputVariants({ size, variant: hasError ? "error" : "default" }),
         "relative flex items-center",
         "data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed",
         "data-[placeholder]:text-kumo-placeholder",
@@ -324,7 +333,7 @@ function TriggerInput({
    */
   showOptionsLabel?: string;
 }) {
-  const size = useContext(ComboboxSizeContext);
+  const { size, hasError } = useContext(ComboboxContext);
   const iconStyles = triggerInputIconStyles[size];
 
   return (
@@ -338,7 +347,7 @@ function TriggerInput({
       <ComboboxBase.Input
         {...props}
         className={cn(
-          inputVariants({ size }),
+          inputVariants({ size, variant: hasError ? "error" : "default" }),
           "w-full",
           iconStyles.padding,
           "disabled:cursor-not-allowed",
@@ -515,14 +524,14 @@ function TriggerMultipleWithInput<ValueType>({
   /** Optional controlled value for rendering chips (use when pre-selecting values) */
   value?: ValueType[];
 }) {
-  const size = useContext(ComboboxSizeContext);
+  const { size, hasError } = useContext(ComboboxContext);
   // Determine which value to use for rendering chips
   const chipsToRender = controlledValue;
 
   return (
     <ComboboxBase.Chips
       className={cn(
-        inputVariants({ size }),
+        inputVariants({ size, variant: hasError ? "error" : "default" }),
         "flex flex-col",
         "gap-1 py-1 px-1.5",
         sizeToMinHeight[size],

--- a/packages/kumo/src/components/select/select.test.tsx
+++ b/packages/kumo/src/components/select/select.test.tsx
@@ -520,6 +520,19 @@ describe("Select", () => {
     });
   });
 
+  describe("error styling", () => {
+    it("applies error border when error prop is truthy", () => {
+      render(
+        <Select aria-label="Pick one" error="Please select a value">
+          <Select.Option value="a">Option A</Select.Option>
+        </Select>,
+      );
+
+      const trigger = screen.getByRole("combobox");
+      expect(trigger.className).toContain("ring-kumo-danger");
+    });
+  });
+
   describe("popup structure", () => {
     it("opens a listbox popup from the trigger", async () => {
       render(

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -446,6 +446,8 @@ export function Select<T, Multiple extends boolean | undefined = false>({
         className={cn(
           selectVariants({ size }),
           props.disabled && "cursor-not-allowed opacity-50",
+          error &&
+            "!ring-kumo-danger focus:ring-kumo-danger/50 focus:ring-[1.5px]",
           className,
         )}
         aria-label={triggerAriaLabel}

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.test.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";
+import { render } from "@testing-library/react";
 import { SensitiveInput } from "./sensitive-input";
 
 describe("SensitiveInput", () => {
@@ -34,5 +35,14 @@ describe("SensitiveInput", () => {
       className: "custom-class",
     };
     expect(() => createElement(SensitiveInput, props)).not.toThrow();
+  });
+
+  it("applies error border when error prop is truthy", () => {
+    const { container } = render(
+      <SensitiveInput aria-label="API Key" error="Invalid key" />,
+    );
+    // Error styling (ring-kumo-danger) is on the container div wrapping the password input
+    const inputEl = container.querySelector("input");
+    expect(inputEl?.parentElement?.className).toContain("ring-kumo-danger");
   });
 });

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -94,7 +94,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
       onValueChange,
       onCopy,
       size = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.size,
-      variant = KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS.variant,
+      variant: variantProp,
       disabled = false,
       readOnly = false,
       id,
@@ -109,6 +109,18 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
     },
     ref,
   ) => {
+    // Deprecation warning for variant="error"
+    if (process.env.NODE_ENV !== "production" && variantProp === "error") {
+      console.warn(
+        '[Kumo SensitiveInput]: variant="error" is deprecated. ' +
+          "Error styling is now automatically applied when the `error` prop is truthy. " +
+          "Simply remove the variant prop and pass an error message instead.",
+      );
+    }
+
+    // Auto-apply error styling when error prop is truthy
+    // Explicit variant prop takes precedence for backwards compatibility
+    const variant = variantProp ?? (error ? "error" : "default");
     // For aria-label, only use string labels (ReactNode labels can't be used for aria-label)
     const ariaLabelFallback =
       typeof label === "string" ? label : "Sensitive value";


### PR DESCRIPTION
The `error` prop on Combobox, Select, Autocomplete, and SensitiveInput would show the error message text but not turn the border red, unlike Input which correctly applies `ring-kumo-danger`. This fixes all four components to match Input's behavior.

### What changed

- **SensitiveInput** — Auto-applies `variant: "error"` when `error` prop is truthy, matching Input's existing pattern
- **Combobox** — Renamed `ComboboxSizeContext` → `ComboboxContext` to carry `{ size, hasError }`, propagated to `TriggerValue`, `TriggerInput`, and `TriggerMultipleWithInput`
- **Select** — Added conditional `!ring-kumo-danger` error classes to the trigger element
- **Autocomplete** — Created `AutocompleteContext` to propagate `hasError` from Root to `InputGroup`

### Tests

Added unit tests for all four components verifying `ring-kumo-danger` is applied on error. Also added baseline test coverage for Combobox and Autocomplete (rendering, variants, displayName, field wrapper, error states, aria attributes).

### Screenshots
| Before | After |
|--------|--------|
|<img width="1781" height="1195" alt="Screenshot 2026-05-21 at 16 19 47" src="https://github.com/user-attachments/assets/5316ea4f-69c8-4732-a464-ccd05a2adcc8" />|<img width="1781" height="1195" alt="Screenshot 2026-05-21 at 16 18 40" src="https://github.com/user-attachments/assets/bdbba073-22f2-475d-a98c-b999a7e40def" />|
|<img width="1781" height="1195" alt="Screenshot 2026-05-21 at 16 20 10" src="https://github.com/user-attachments/assets/2bf0cb7c-cfb9-46be-be7f-721a3de2ccfb" />|<img width="1781" height="1195" alt="Screenshot 2026-05-21 at 16 18 49" src="https://github.com/user-attachments/assets/0085d5ff-fdeb-4c20-b418-e87086f7de61" />|
|<img width="1781" height="1195" alt="Screenshot 2026-05-21 at 16 20 19" src="https://github.com/user-attachments/assets/21921192-da7f-47c8-947f-e7934f38c3f2" />|<img width="1781" height="1195" alt="Screenshot 2026-05-21 at 16 19 02" src="https://github.com/user-attachments/assets/d8893654-d500-4d84-af01-4bb7cd45edf3" />|

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: visual styling fix requires human review
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because: