### PR TITLE
fix: constrain Tooltip popup width to available viewport space

### DIFF
--- a/.changeset/tooltip-overflow-constraint.md
+++ b/.changeset/tooltip-overflow-constraint.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Tooltip popup overflowing viewport when content is wider than available space. The popup now constrains its width to `var(--available-width)`, a CSS variable provided by Base UI's Positioner that reflects the space between the trigger and the viewport edge.

--- a/packages/kumo-docs-astro/src/components/demos/TooltipDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TooltipDemo.tsx
@@ -1,5 +1,5 @@
-import { Tooltip, TooltipProvider, Button } from "@cloudflare/kumo";
-import { Info, PlusIcon, TranslateIcon } from "@phosphor-icons/react";
+import { Tooltip, TooltipProvider, Button } from '@cloudflare/kumo';
+import { Info, PlusIcon, TranslateIcon } from '@phosphor-icons/react';
 
 export function TooltipHeroDemo() {
   return (
@@ -71,6 +71,43 @@ export function TooltipCustomTriggerDemo() {
  * Control the delay before opening and closing the tooltip.
  * `delay` controls open delay (default: 600ms), `closeDelay` controls close delay (default: 0ms).
  */
+/**
+ * Demonstrates that long tooltip content respects available viewport space.
+ * Tooltips near the edge of the viewport constrain their width to
+ * `--available-width` so they don't overflow.
+ */
+export function TooltipOverflowDemo() {
+  const longContent =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.';
+  return (
+    <TooltipProvider>
+      <div className="flex w-full justify-between">
+        <Tooltip
+          content={longContent}
+          side="bottom"
+          render={<Button variant="secondary" />}
+        >
+          Near left edge
+        </Tooltip>
+        <Tooltip
+          content={longContent}
+          side="bottom"
+          render={<Button variant="secondary" />}
+        >
+          Centered
+        </Tooltip>
+        <Tooltip
+          content={longContent}
+          side="bottom"
+          render={<Button variant="secondary" />}
+        >
+          Near right edge
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  );
+}
+
 export function TooltipDelayDemo() {
   return (
     <TooltipProvider>

--- a/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tooltip.mdx
@@ -14,6 +14,7 @@ import {
   TooltipBasicDemo,
   TooltipMultipleDemo,
   TooltipDelayDemo,
+  TooltipOverflowDemo,
 } from "~/components/demos/TooltipDemo";
 
 {/* Hero Demo */}
@@ -82,6 +83,17 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
 
 <ComponentExample demo="TooltipMultipleDemo">
   <TooltipMultipleDemo client:load />
+</ComponentExample>
+
+### Long Content / Overflow
+
+<p>
+  Tooltips with long content automatically constrain their width to the available
+  viewport space using `--available-width` from Base UI's Positioner. Hover over
+  the edge buttons to see the tooltip wrap instead of overflowing the viewport.
+</p>
+<ComponentExample demo="TooltipOverflowDemo">
+  <TooltipOverflowDemo client:load />
 </ComponentExample>
 
 ### Delay Control

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -183,7 +183,7 @@ export function Tooltip({
         {asChild ? undefined : (children as ReactNode)}
       </TooltipBase.Trigger>
       <TooltipBase.Portal container={container}>
-        <TooltipBase.Positioner align={align} side={side} sideOffset={10}>
+        <TooltipBase.Positioner align={align} side={side} sideOffset={10} className="max-w-[var(--available-width)]">
           <TooltipBase.Popup
             className={cn(
               "flex origin-[var(--transform-origin)] flex-col rounded-md bg-kumo-base px-2.5 py-1.5 text-sm text-kumo-default",


### PR DESCRIPTION
## Problem

Kumo's `Tooltip` popup has no `max-width` constraint. When tooltip content is long (e.g. multi-sentence descriptions), the popup grows unbounded and overflows past the viewport edge.

## Fix

Adds `max-w-[var(--available-width)]` to the Tooltip popup. `--available-width` is a CSS variable that Base UI's `Positioner` already sets on the positioner element — it represents the available space between the trigger and the viewport edge. Since CSS custom properties inherit, the Popup (a child of the Positioner) can use it directly.

This means:
- Tooltips near the center of the page remain unconstrained (available width is large)
- Tooltips near viewport edges automatically wrap to fit
- No hardcoded magic number — the constraint is dynamic and responsive

Applied to both the `Tooltip` component and the `tooltipVariants()` utility function.

## Demo

Added a "Long Content / Overflow" example to the Astro docs (`/components/tooltip`) with three triggers spread across the full width, each with long lorem ipsum content. Hovering the edge triggers shows the tooltip wrapping instead of overflowing.

## Checklist

- [x] automated review not possible because: single CSS class addition, no logic changes
- [x] Additional testing not necessary because: visual behavior only — added a demo to the Astro docs for manual verification