### PR TITLE
chore(ci): harden GitHub Actions workflows

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
         version: 10.22.0
 
@@ -31,9 +31,11 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      env:
+        FILTER: ${{ inputs.filter }}
       run: |
-        if [ -n "${{ inputs.filter }}" ]; then
-          pnpm install --frozen-lockfile --filter "${{ inputs.filter }}"
+        if [ -n "$FILTER" ]; then
+          pnpm install --frozen-lockfile --filter "$FILTER"
         else
           pnpm install --frozen-lockfile
         fi

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/bonk-check.yml
+++ b/.github/workflows/bonk-check.yml
@@ -25,6 +25,9 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REVIEW_BODY: ${{ github.event.review.body || '' }}
           REVIEW_USER: ${{ github.event.review.user.login || '' }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
 
@@ -36,10 +39,10 @@ jobs:
           }
 
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            SHA="${{ github.event.pull_request.head.sha }}"
+            PR_NUMBER="$PULL_REQUEST_NUMBER"
+            SHA="$PULL_REQUEST_HEAD_SHA"
           else
-            PR_NUMBER="${{ github.event.issue.number }}"
+            PR_NUMBER="$ISSUE_NUMBER"
             SHA=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')
           fi
 
@@ -79,9 +82,12 @@ jobs:
           fi
 
       - name: Summarize result
+        env:
+          FOUND: ${{ steps.check.outputs.found }}
+          BONK_USER: ${{ steps.check.outputs.bonk_user }}
         run: |
-          if [ "${{ steps.check.outputs.found }}" = "true" ]; then
-            echo "✅ /bonk called by ${{ steps.check.outputs.bonk_user }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$FOUND" = "true" ]; then
+            echo "✅ /bonk called by $BONK_USER" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "❌ /bonk has not been called on this PR by a collaborator" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -22,13 +22,12 @@
 name: Preview Deploy (Forks)
 
 on:
+  # zizmor: ignore[dangerous-triggers] Fork previews require a privileged follow-up workflow; this workflow only deploys artifacts and checks out trusted code from main.
   workflow_run:
     workflows: ["Preview"]
     types: [completed]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: preview-deploy-${{ github.event.workflow_run.id }}
@@ -37,6 +36,10 @@ concurrency:
 jobs:
   deploy:
     name: Docs Deploy (Fork)
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     # Only run for:
     # 1. Successful workflow runs
     # 2. Pull request events (not push)
@@ -60,6 +63,7 @@ jobs:
         with:
           sparse-checkout: packages/kumo-docs-astro/wrangler.jsonc
           ref: main
+          persist-credentials: false
 
       - name: Resolve PR metadata
         id: metadata
@@ -191,6 +195,9 @@ jobs:
     needs: deploy
     if: ${{ needs.deploy.outputs.preview_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 15
     steps:
       # Always check out the VR script from main — never from the fork's SHA.
@@ -202,13 +209,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          persist-credentials: false
           sparse-checkout: |
             ci/visual-regression
             .github/actions/install-dependencies
 
       # Fetch the fork's HEAD so git diff works for changed-file detection.
       - name: Fetch fork HEAD for git diff
-        run: git fetch --depth=1 origin ${{ github.event.workflow_run.head_sha }}
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: git fetch --depth=1 origin "$HEAD_SHA"
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,9 +8,7 @@ on:
       - "opencode/**"
       - "changeset-release/main"
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: preview-${{ github.event.pull_request.number || github.ref }}
@@ -22,6 +20,8 @@ jobs:
     name: Resolve PR
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       pr_number: ${{ steps.find-pr.outputs.pr_number }}
       is_fork: ${{ steps.find-pr.outputs.is_fork }}
@@ -52,12 +52,15 @@ jobs:
     name: Package Preview
     if: ${{ github.repository_owner == 'cloudflare' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -76,12 +79,15 @@ jobs:
   docs-build:
     name: Docs Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -111,6 +117,10 @@ jobs:
   docs-deploy:
     name: Docs Deploy
     needs: [docs-build, resolve-pr]
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     # Run for pull_request (non-fork) OR push events with resolved PR (non-fork)
     if: |
       always() &&
@@ -127,17 +137,22 @@ jobs:
     steps:
       - name: Set PR number
         id: set-pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          RESOLVED_PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "pr_number=$PULL_REQUEST_NUMBER" >> "$GITHUB_OUTPUT"
           else
-            echo "pr_number=${{ needs.resolve-pr.outputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$RESOLVED_PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           sparse-checkout: packages/kumo-docs-astro/wrangler.jsonc
+          persist-credentials: false
 
       - name: Download docs artifact
         uses: actions/download-artifact@v4
@@ -234,6 +249,9 @@ jobs:
     needs: docs-deploy
     if: always() && needs.docs-deploy.result == 'success' && needs.docs-deploy.outputs.preview_url != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 15
     steps:
       # Pin to main so that a PR modifying run-visual-regression.ts cannot
@@ -242,6 +260,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          persist-credentials: false
           sparse-checkout: |
             ci/visual-regression
             .github/actions/install-dependencies
@@ -249,7 +268,9 @@ jobs:
       # Fetch the PR's HEAD so git diff can detect changed files.
       # (HEAD points to main after checkout, so we need the explicit SHA)
       - name: Fetch PR head for git diff
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch --depth=1 origin "$PR_HEAD_SHA"
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/install-dependencies
       - run: pnpm tsx ci/scripts/validate-kumo-changeset.ts
 
@@ -38,6 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: ./.github/actions/install-dependencies
       - run: pnpm --filter @cloudflare/kumo build
       - uses: actions/upload-artifact@v4
@@ -59,6 +61,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: ./.github/actions/install-dependencies
       - uses: actions/download-artifact@v4
         with:
@@ -78,6 +81,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: ./.github/actions/install-dependencies
       - uses: actions/download-artifact@v4
         with:
@@ -97,6 +101,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: ./.github/actions/install-dependencies
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -20,32 +20,41 @@ jobs:
     steps:
       - name: Get PR number
         id: pr-number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Verify PR exists
         id: verify-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} > /dev/null 2>&1; then
+          if gh api "/repos/$REPOSITORY/pulls/$PR_NUMBER" > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "::warning::PR #${{ github.event.pull_request.number }} not found, skipping review"
+            echo "::warning::PR #$PR_NUMBER not found, skipping review"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
         if: steps.verify-pr.outputs.exists == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Get PR details
         if: steps.verify-pr.outputs.exists == 'true'
         id: pr-details
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
         run: |
-          gh api /repos/${{ github.repository }}/pulls/${{ steps.pr-number.outputs.number }} > /tmp/pr_data.json
+          gh api "/repos/$REPOSITORY/pulls/$PR_NUMBER" > /tmp/pr_data.json
           echo "title=$(jq -r .title /tmp/pr_data.json)" >> $GITHUB_OUTPUT
           echo "sha=$(jq -r .head.sha /tmp/pr_data.json)" >> $GITHUB_OUTPUT
           {
@@ -53,8 +62,6 @@ jobs:
             jq -r .body /tmp/pr_data.json
             echo EOF
           } >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Reviewer
         if: steps.verify-pr.outputs.exists == 'true'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - id: cache-semgrep
         uses: actions/cache@v5
         with:

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Align with PR #525: GitHub-maintained first-party actions may remain
+        # tag-pinned; third-party actions must be pinned to immutable SHAs.
+        actions/*: ref-pin
+        "*": hash-pin


### PR DESCRIPTION
## Summary

Hardens GitHub Actions workflows for zizmor by pinning third-party actions, reducing default permissions, disabling checkout credential persistence, and avoiding direct expression interpolation in shell scripts.

[zizmor](https://docs.zizmor.sh/) is a static analysis tool for finding security issues in GitHub Actions workflows.

## Testing

Not run; workflow-only changes.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: workflow security hardening requires human review
- Tests
- [ ] Tests included/updated
- [x] Automated tests not possible - manual testing has been completed as follows: reviewed workflow diffs and permissions
- [ ] Additional testing not necessary because: n/a
