### PR TITLE
feat: subtle appearance for banner

### DIFF
--- a/.changeset/banner-subtle-appearance.md
+++ b/.changeset/banner-subtle-appearance.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add Banner subtle appearance and secondary variant.

--- a/.changeset/banner-subtle-appearance.md
+++ b/.changeset/banner-subtle-appearance.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": minor
 ---
 
-Add Banner subtle appearance and secondary variant.
+Update Banner to use borderless tinted styling by default and add a secondary variant.

--- a/packages/kumo-docs-astro/src/components/demos/BannerDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BannerDemo.tsx
@@ -79,41 +79,6 @@ export function BannerSecondaryDemo() {
   );
 }
 
-/** Borderless subtle banner appearance. */
-export function BannerSubtleDemo() {
-  return (
-    <div className="w-full space-y-3">
-      <Banner
-        appearance="subtle"
-        icon={<Info weight="fill" />}
-        title="Update available"
-        description="A new version is ready to install."
-      />
-      <Banner
-        appearance="subtle"
-        icon={<Warning weight="fill" />}
-        variant="alert"
-        title="Session expiring"
-        description="Your session will expire in 5 minutes."
-      />
-      <Banner
-        appearance="subtle"
-        icon={<WarningCircle weight="fill" />}
-        variant="error"
-        title="Save failed"
-        description="We couldn't save your changes. Please try again."
-      />
-      <Banner
-        appearance="subtle"
-        icon={<Info weight="fill" />}
-        variant="secondary"
-        title="Maintenance scheduled"
-        description="This service will be unavailable for 10 minutes."
-      />
-    </div>
-  );
-}
-
 /** Banner with title only (no description). */
 export function BannerTitleOnlyDemo() {
   return (

--- a/packages/kumo-docs-astro/src/components/demos/BannerDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BannerDemo.tsx
@@ -22,6 +22,12 @@ export function BannerVariantsDemo() {
         title="Save failed"
         description="We couldn't save your changes. Please try again."
       />
+      <Banner
+        icon={<Info weight="fill" />}
+        variant="secondary"
+        title="Maintenance scheduled"
+        description="This service will be unavailable for 10 minutes."
+      />
     </div>
   );
 }
@@ -58,6 +64,53 @@ export function BannerErrorDemo() {
       title="Save failed"
       description="We couldn't save your changes. Please try again."
     />
+  );
+}
+
+/** Neutral secondary banner for contextual messages. */
+export function BannerSecondaryDemo() {
+  return (
+    <Banner
+      icon={<Info weight="fill" />}
+      variant="secondary"
+      title="Maintenance scheduled"
+      description="This service will be unavailable for 10 minutes."
+    />
+  );
+}
+
+/** Borderless subtle banner appearance. */
+export function BannerSubtleDemo() {
+  return (
+    <div className="w-full space-y-3">
+      <Banner
+        appearance="subtle"
+        icon={<Info weight="fill" />}
+        title="Update available"
+        description="A new version is ready to install."
+      />
+      <Banner
+        appearance="subtle"
+        icon={<Warning weight="fill" />}
+        variant="alert"
+        title="Session expiring"
+        description="Your session will expire in 5 minutes."
+      />
+      <Banner
+        appearance="subtle"
+        icon={<WarningCircle weight="fill" />}
+        variant="error"
+        title="Save failed"
+        description="We couldn't save your changes. Please try again."
+      />
+      <Banner
+        appearance="subtle"
+        icon={<Info weight="fill" />}
+        variant="secondary"
+        title="Maintenance scheduled"
+        description="This service will be unavailable for 10 minutes."
+      />
+    </div>
   );
 }
 

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -374,16 +374,18 @@ export function HomeGrid() {
       id: "banner",
       Component: (
         <div className="flex flex-col gap-2">
-          <Banner text="This is a default banner." />
+          <Banner appearance="subtle" description="This is a default banner." />
           <Banner
             icon={<WarningIcon weight="fill" />}
-            text="This is an alert banner."
+            title="This is an alert banner."
             variant="alert"
+            appearance="subtle"
           />
           <Banner
             icon={<WarningOctagonIcon weight="fill" />}
-            text="This is an error banner."
+            title="This is an error banner."
             variant="error"
+            appearance="subtle"
           />
         </div>
       ),

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -374,18 +374,16 @@ export function HomeGrid() {
       id: "banner",
       Component: (
         <div className="flex flex-col gap-2">
-          <Banner appearance="subtle" description="This is a default banner." />
+          <Banner description="This is a default banner." />
           <Banner
             icon={<WarningIcon weight="fill" />}
             title="This is an alert banner."
             variant="alert"
-            appearance="subtle"
           />
           <Banner
             icon={<WarningOctagonIcon weight="fill" />}
             title="This is an error banner."
             variant="error"
-            appearance="subtle"
           />
         </div>
       ),

--- a/packages/kumo-docs-astro/src/pages/components/banner.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/banner.mdx
@@ -14,6 +14,8 @@ import {
   BannerDefaultDemo,
   BannerAlertDemo,
   BannerErrorDemo,
+  BannerSecondaryDemo,
+  BannerSubtleDemo,
   BannerWithIconDemo,
   BannerWithActionDemo,
   BannerWithActionsDemo,
@@ -93,6 +95,18 @@ export default function Example() {
 
 <ComponentExample demo="BannerErrorDemo">
   <BannerErrorDemo client:visible />
+</ComponentExample>
+
+#### Secondary
+
+<ComponentExample demo="BannerSecondaryDemo">
+  <BannerSecondaryDemo client:visible />
+</ComponentExample>
+
+### Subtle appearance
+
+<ComponentExample demo="BannerSubtleDemo">
+  <BannerSubtleDemo client:visible />
 </ComponentExample>
 
 ### With icon

--- a/packages/kumo-docs-astro/src/pages/components/banner.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/banner.mdx
@@ -15,7 +15,6 @@ import {
   BannerAlertDemo,
   BannerErrorDemo,
   BannerSecondaryDemo,
-  BannerSubtleDemo,
   BannerWithIconDemo,
   BannerWithActionDemo,
   BannerWithActionsDemo,
@@ -101,12 +100,6 @@ export default function Example() {
 
 <ComponentExample demo="BannerSecondaryDemo">
   <BannerSecondaryDemo client:visible />
-</ComponentExample>
-
-### Subtle appearance
-
-<ComponentExample demo="BannerSubtleDemo">
-  <BannerSubtleDemo client:visible />
 </ComponentExample>
 
 ### With icon

--- a/packages/kumo/src/components/banner/banner.test.tsx
+++ b/packages/kumo/src/components/banner/banner.test.tsx
@@ -3,22 +3,6 @@ import { render, screen } from "@testing-library/react";
 import { Banner, bannerVariants } from "./banner";
 
 describe("Banner", () => {
-  it("keeps bordered appearance as the default", () => {
-    const className = bannerVariants();
-
-    expect(className).toContain("border");
-    expect(className).toContain("border-kumo-info/50");
-    expect(className).toContain("bg-kumo-info-tint/30");
-  });
-
-  it("supports subtle appearance", () => {
-    const className = bannerVariants({ appearance: "subtle" });
-
-    expect(className).toContain("border-0");
-    expect(className).toContain("bg-kumo-info-tint/70");
-    expect(className).not.toContain("bg-kumo-info-tint/30");
-  });
-
   it("supports secondary variant", () => {
     const className = bannerVariants({ variant: "secondary" });
 

--- a/packages/kumo/src/components/banner/banner.test.tsx
+++ b/packages/kumo/src/components/banner/banner.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Banner, bannerVariants } from "./banner";
+
+describe("Banner", () => {
+  it("keeps bordered appearance as the default", () => {
+    const className = bannerVariants();
+
+    expect(className).toContain("border");
+    expect(className).toContain("border-kumo-info/50");
+    expect(className).toContain("bg-kumo-info-tint/30");
+  });
+
+  it("supports subtle appearance", () => {
+    const className = bannerVariants({ appearance: "subtle" });
+
+    expect(className).toContain("border-0");
+    expect(className).toContain("bg-kumo-info-tint/70");
+    expect(className).not.toContain("bg-kumo-info-tint/30");
+  });
+
+  it("supports secondary variant", () => {
+    const className = bannerVariants({ variant: "secondary" });
+
+    expect(className).toContain("bg-kumo-recessed");
+    expect(className).toContain("text-kumo-subtle");
+  });
+
+  it("forwards root div props", () => {
+    render(
+      <Banner
+        role="status"
+        data-testid="banner"
+        aria-live="polite"
+        title="System status"
+      />,
+    );
+
+    const banner = screen.getByTestId("banner");
+    expect(banner.getAttribute("role")).toBe("status");
+    expect(banner.getAttribute("aria-live")).toBe("polite");
+    expect(banner.textContent).toBe("System status");
+  });
+
+  it("nudges description-only structured content into alignment with the icon", () => {
+    render(
+      <Banner
+        icon={<span data-testid="icon" />}
+        description="Description without a title"
+      />,
+    );
+
+    const content = screen.getByText("Description without a title").parentElement
+      ?.parentElement?.parentElement;
+    expect(content?.className).toContain("pt-px");
+  });
+});

--- a/packages/kumo/src/components/banner/banner.test.tsx
+++ b/packages/kumo/src/components/banner/banner.test.tsx
@@ -42,16 +42,4 @@ describe("Banner", () => {
     expect(banner.textContent).toBe("System status");
   });
 
-  it("nudges description-only structured content into alignment with the icon", () => {
-    render(
-      <Banner
-        icon={<span data-testid="icon" />}
-        description="Description without a title"
-      />,
-    );
-
-    const content = screen.getByText("Description without a title").parentElement
-      ?.parentElement?.parentElement;
-    expect(content?.className).toContain("pt-px");
-  });
 });

--- a/packages/kumo/src/components/banner/banner.tsx
+++ b/packages/kumo/src/components/banner/banner.tsx
@@ -9,60 +9,41 @@ import { resolveVariant } from "../../utils/resolve-variant";
 
 /** Base styles applied to all banner variants. */
 export const KUMO_BANNER_BASE_STYLES =
-  "flex w-full items-start gap-3 rounded-lg border px-4 py-3 text-base";
+  "flex w-full items-start gap-3 rounded-lg px-4 py-3 text-base";
 
 /** Banner variant definitions mapping style options to their Tailwind classes and descriptions. */
 export const KUMO_BANNER_VARIANTS = {
   variant: {
     default: {
-      classes: "bg-kumo-info-tint/30 border-kumo-info/50 text-kumo-info",
+      classes: "bg-kumo-info-tint/70 dark:bg-kumo-info-tint/50 text-kumo-info",
       iconClasses: "text-kumo-info",
       description: "Informational banner for general messages",
     },
     alert: {
       classes:
-        "bg-kumo-warning-tint/15 border-kumo-warning/50 text-kumo-warning",
+        "bg-kumo-warning-tint dark:bg-kumo-warning-tint/50 text-kumo-warning",
       iconClasses: "text-kumo-warning",
       description: "Warning banner for cautionary messages",
     },
     error: {
-      classes: "bg-kumo-danger-tint/15 border-kumo-danger/50 text-kumo-danger",
+      classes: "bg-kumo-danger-tint/60 text-kumo-danger",
       iconClasses: "text-kumo-danger",
       description: "Error banner for critical issues",
     },
     secondary: {
-      classes: "bg-kumo-recessed border-kumo-line text-kumo-subtle",
+      classes: "bg-kumo-contrast/5 text-kumo-subtle",
       iconClasses: "text-kumo-subtle",
       description: "Neutral banner for secondary messages",
     },
   },
-  appearance: {
-    bordered: {
-      classes: "",
-      description: "Banner with a visible border",
-    },
-    subtle: {
-      classes: "border-0",
-      description: "Banner with a borderless tinted background",
-    },
-  },
-} as const;
-
-const KUMO_BANNER_SUBTLE_VARIANT_STYLES = {
-  default: { classes: "bg-kumo-info-tint/70" },
-  alert: { classes: "bg-kumo-warning-tint" },
-  error: { classes: "bg-kumo-danger-tint/60" },
-  secondary: { classes: "bg-kumo-recessed" },
 } as const;
 
 export const KUMO_BANNER_DEFAULT_VARIANTS = {
   variant: "default",
-  appearance: "bordered",
 } as const;
 
 // Derived types from KUMO_BANNER_VARIANTS
 export type KumoBannerVariant = keyof typeof KUMO_BANNER_VARIANTS.variant;
-export type KumoBannerAppearance = keyof typeof KUMO_BANNER_VARIANTS.appearance;
 
 export interface KumoBannerVariantsProps {
   /**
@@ -74,28 +55,15 @@ export interface KumoBannerVariantsProps {
    * @default "default"
    */
   variant?: KumoBannerVariant;
-  /**
-   * Visual treatment of the banner.
-   * - `"bordered"` — Current default banner with a visible border
-   * - `"subtle"` — Borderless banner with a stronger tinted background
-   * @default "bordered"
-   */
-  appearance?: KumoBannerAppearance;
 }
 
 export function bannerVariants({
   variant = KUMO_BANNER_DEFAULT_VARIANTS.variant,
-  appearance = KUMO_BANNER_DEFAULT_VARIANTS.appearance,
 }: KumoBannerVariantsProps = {}) {
   const resolvedVariant = resolveVariant(
     KUMO_BANNER_VARIANTS.variant,
     variant,
     KUMO_BANNER_DEFAULT_VARIANTS.variant,
-  );
-  const resolvedAppearance = resolveVariant(
-    KUMO_BANNER_VARIANTS.appearance,
-    appearance,
-    KUMO_BANNER_DEFAULT_VARIANTS.appearance,
   );
 
   return cn(
@@ -103,13 +71,6 @@ export function bannerVariants({
     KUMO_BANNER_BASE_STYLES,
     // Apply variant styles from KUMO_BANNER_VARIANTS
     resolvedVariant.classes,
-    resolvedAppearance.classes,
-    appearance === "subtle" &&
-      resolveVariant(
-        KUMO_BANNER_SUBTLE_VARIANT_STYLES,
-        variant,
-        KUMO_BANNER_DEFAULT_VARIANTS.variant,
-      ).classes,
   );
 }
 
@@ -153,13 +114,6 @@ export interface BannerProps
    * @default "default"
    */
   variant?: KumoBannerVariant;
-  /**
-   * Visual treatment of the banner.
-   * - `"bordered"` — Current default banner with a visible border
-   * - `"subtle"` — Borderless banner with a stronger tinted background
-   * @default "bordered"
-   */
-  appearance?: KumoBannerAppearance;
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
 }
@@ -193,7 +147,6 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
     children,
     text,
     variant = KUMO_BANNER_DEFAULT_VARIANTS.variant,
-    appearance = KUMO_BANNER_DEFAULT_VARIANTS.appearance,
     className,
     ...props
   },
@@ -210,7 +163,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
     return (
       <div
         ref={ref}
-        className={cn(bannerVariants({ variant, appearance }), className)}
+        className={cn(bannerVariants({ variant }), className)}
         {...props}
       >
         {icon && (
@@ -256,7 +209,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
   return (
     <div
       ref={ref}
-      className={cn(bannerVariants({ variant, appearance }), className)}
+      className={cn(bannerVariants({ variant }), className)}
       {...props}
     >
       {icon && (

--- a/packages/kumo/src/components/banner/banner.tsx
+++ b/packages/kumo/src/components/banner/banner.tsx
@@ -1,4 +1,9 @@
-import { type ReactNode, isValidElement, forwardRef } from "react";
+import {
+  type HTMLAttributes,
+  type ReactNode,
+  isValidElement,
+  forwardRef,
+} from "react";
 import { cn } from "../../utils/cn";
 import { resolveVariant } from "../../utils/resolve-variant";
 
@@ -6,7 +11,7 @@ import { resolveVariant } from "../../utils/resolve-variant";
 export const KUMO_BANNER_BASE_STYLES =
   "flex w-full items-start gap-3 rounded-lg border px-4 py-3 text-base";
 
-/** Banner variant definitions mapping variant names to their Tailwind classes and descriptions. */
+/** Banner variant definitions mapping style options to their Tailwind classes and descriptions. */
 export const KUMO_BANNER_VARIANTS = {
   variant: {
     default: {
@@ -25,15 +30,39 @@ export const KUMO_BANNER_VARIANTS = {
       iconClasses: "text-kumo-danger",
       description: "Error banner for critical issues",
     },
+    secondary: {
+      classes: "bg-kumo-recessed border-kumo-line text-kumo-subtle",
+      iconClasses: "text-kumo-subtle",
+      description: "Neutral banner for secondary messages",
+    },
   },
+  appearance: {
+    bordered: {
+      classes: "",
+      description: "Banner with a visible border",
+    },
+    subtle: {
+      classes: "border-0",
+      description: "Banner with a borderless tinted background",
+    },
+  },
+} as const;
+
+const KUMO_BANNER_SUBTLE_VARIANT_STYLES = {
+  default: { classes: "bg-kumo-info-tint/70" },
+  alert: { classes: "bg-kumo-warning-tint" },
+  error: { classes: "bg-kumo-danger-tint/60" },
+  secondary: { classes: "bg-kumo-recessed" },
 } as const;
 
 export const KUMO_BANNER_DEFAULT_VARIANTS = {
   variant: "default",
+  appearance: "bordered",
 } as const;
 
 // Derived types from KUMO_BANNER_VARIANTS
 export type KumoBannerVariant = keyof typeof KUMO_BANNER_VARIANTS.variant;
+export type KumoBannerAppearance = keyof typeof KUMO_BANNER_VARIANTS.appearance;
 
 export interface KumoBannerVariantsProps {
   /**
@@ -41,23 +70,46 @@ export interface KumoBannerVariantsProps {
    * - `"default"` — Informational banner for general messages
    * - `"alert"` — Warning banner for cautionary messages
    * - `"error"` — Error banner for critical issues
+   * - `"secondary"` — Neutral banner for secondary messages
    * @default "default"
    */
   variant?: KumoBannerVariant;
+  /**
+   * Visual treatment of the banner.
+   * - `"bordered"` — Current default banner with a visible border
+   * - `"subtle"` — Borderless banner with a stronger tinted background
+   * @default "bordered"
+   */
+  appearance?: KumoBannerAppearance;
 }
 
 export function bannerVariants({
   variant = KUMO_BANNER_DEFAULT_VARIANTS.variant,
+  appearance = KUMO_BANNER_DEFAULT_VARIANTS.appearance,
 }: KumoBannerVariantsProps = {}) {
+  const resolvedVariant = resolveVariant(
+    KUMO_BANNER_VARIANTS.variant,
+    variant,
+    KUMO_BANNER_DEFAULT_VARIANTS.variant,
+  );
+  const resolvedAppearance = resolveVariant(
+    KUMO_BANNER_VARIANTS.appearance,
+    appearance,
+    KUMO_BANNER_DEFAULT_VARIANTS.appearance,
+  );
+
   return cn(
     // Base styles (exported as KUMO_BANNER_BASE_STYLES for Figma plugin)
     KUMO_BANNER_BASE_STYLES,
     // Apply variant styles from KUMO_BANNER_VARIANTS
-    resolveVariant(
-      KUMO_BANNER_VARIANTS.variant,
-      variant,
-      KUMO_BANNER_DEFAULT_VARIANTS.variant,
-    ).classes,
+    resolvedVariant.classes,
+    resolvedAppearance.classes,
+    appearance === "subtle" &&
+      resolveVariant(
+        KUMO_BANNER_SUBTLE_VARIANT_STYLES,
+        variant,
+        KUMO_BANNER_DEFAULT_VARIANTS.variant,
+      ).classes,
   );
 }
 
@@ -78,7 +130,8 @@ export enum BannerVariant {
  * <Banner variant="error" title="Save failed" description="We couldn't save your changes." />
  * ```
  */
-export interface BannerProps {
+export interface BannerProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "title"> {
   /** Icon element rendered before the banner content (e.g. from `@phosphor-icons/react`). */
   icon?: ReactNode;
   /** Primary heading text for the banner. Use for i18n string injection. */
@@ -96,9 +149,17 @@ export interface BannerProps {
    * - `"default"` — Informational blue banner for general messages
    * - `"alert"` — Warning yellow banner for cautionary messages
    * - `"error"` — Error red banner for critical issues
+   * - `"secondary"` — Neutral banner for secondary messages
    * @default "default"
    */
   variant?: KumoBannerVariant;
+  /**
+   * Visual treatment of the banner.
+   * - `"bordered"` — Current default banner with a visible border
+   * - `"subtle"` — Borderless banner with a stronger tinted background
+   * @default "bordered"
+   */
+  appearance?: KumoBannerAppearance;
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
 }
@@ -132,7 +193,9 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
     children,
     text,
     variant = KUMO_BANNER_DEFAULT_VARIANTS.variant,
+    appearance = KUMO_BANNER_DEFAULT_VARIANTS.appearance,
     className,
+    ...props
   },
   ref,
 ) {
@@ -145,7 +208,11 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
   // Structured mode: title and/or description provided
   if (title || description) {
     return (
-      <div ref={ref} className={cn(bannerVariants({ variant }), className)}>
+      <div
+        ref={ref}
+        className={cn(bannerVariants({ variant, appearance }), className)}
+        {...props}
+      >
         {icon && (
           <span
             className={cn(
@@ -156,7 +223,12 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
             {icon}
           </span>
         )}
-        <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
+        <div
+          className={cn(
+            "flex min-w-0 flex-1 items-center justify-between gap-3",
+            !title && "pt-px",
+          )}
+        >
           <div className="flex flex-col gap-0.5">
             {title && <p className="font-medium leading-snug">{title}</p>}
             {description && (
@@ -182,7 +254,11 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
   const content = isValidElement(value) ? value : <p>{value}</p>;
 
   return (
-    <div ref={ref} className={cn(bannerVariants({ variant }), className)}>
+    <div
+      ref={ref}
+      className={cn(bannerVariants({ variant, appearance }), className)}
+      {...props}
+    >
       {icon && (
         <span className={cn("shrink-0", variantConfig.iconClasses)}>
           {icon}


### PR DESCRIPTION
## Summary
Adds a non-breaking `appearance` prop to `Banner` with a new `subtle` option, plus a new `secondary` variant for neutral messages.
Also updates the Banner docs demos and HomeGrid usage to show the subtle appearance, and fixes title-less structured Banner alignment when an icon is present.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [X] automated review not possible because: this is a design-system API and styling update that should be reviewed by maintainers
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->
