### PR TITLE
fix(docs): prevent stray <p> elements around inline <code> in MDX

### DIFF
--- a/.changeset/docs-fix-inline-code-paragraph-break.md
+++ b/.changeset/docs-fix-inline-code-paragraph-break.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Fix stray `<p>` elements rendering around inline `<code>` in MDX docs (notably on the Select page's Grouped Options section). Replace inline `<code class="...">` tags with markdown backticks so Prettier line-wrapping no longer breaks the surrounding paragraph.

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -41,7 +41,7 @@ import {
 
 ### Barrel
 
-  <CodeBlock code={`import { Combobox } from "@cloudflare/kumo";`} lang="tsx" />
+<CodeBlock code={`import { Combobox } from "@cloudflare/kumo";`} lang="tsx" />
 
 ### Granular
 
@@ -140,7 +140,12 @@ export default function Example() {
 
 ### Custom Trigger
 
-<p>Use <code>Combobox.Trigger</code> with a <code>render</code> prop to replace the default input-like trigger with your own element. Pair with <code>Combobox.Value</code> to display the selected value. Useful for account switchers, sidebar navigation, or anywhere the default chrome doesn't fit.</p>
+<p>
+  Use <code>Combobox.Trigger</code> with a <code>render</code> prop to replace
+  the default input-like trigger with your own element. Pair with
+  <code>Combobox.Value</code> to display the selected value. Useful for account
+  switchers, sidebar navigation, or anywhere the default chrome doesn't fit.
+</p>
 <ComponentExample demo="ComboboxCustomTriggerDemo">
   <ComboboxCustomTriggerDemo client:load />
 </ComponentExample>
@@ -211,12 +216,12 @@ export default function Example() {
 
 ## Customizing Dropdown Height
 
-  <p>
-    By default, <code class="text-surface">Combobox.Content</code> has a max height of <code class="text-surface">24rem</code> (384px) or the available viewport space, whichever is smaller. The dropdown scrolls automatically when content exceeds this height.
-  </p>
-  <p>
-    To customize the max height, pass a className to <code class="text-surface">Combobox.Content</code>:
-  </p>
+<p>
+  By default, `Combobox.Content` has a max height of `24rem` (384px) or the
+  available viewport space, whichever is smaller. The dropdown scrolls
+  automatically when content exceeds this height.
+</p>
+<p>To customize the max height, pass a className to `Combobox.Content`:</p>
 
 ```tsx
 // Shorter dropdown (200px)

--- a/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/date-picker.mdx
@@ -56,11 +56,9 @@ import {
 
 ## Usage
 
-  <p>
-    DatePicker supports three selection modes: `single`,
-    `multiple`, and
-    `range`.
-  </p>
+<p>
+  DatePicker supports three selection modes: `single`, `multiple`, and `range`.
+</p>
 
 ```tsx
 import { useState } from "react";
@@ -155,9 +153,7 @@ export default function Example() {
 
 ## Full Popover Example
 
-  <p>
-    Here's a complete example showing how to compose DatePicker with Popover:
-  </p>
+<p>Here's a complete example showing how to compose DatePicker with Popover:</p>
 
 ```tsx
 import { useState } from "react";
@@ -194,24 +190,41 @@ export function DatePickerDropdown() {
 
 ## API Reference
 
-  <p>
-    DatePicker forwards all props to <a href="https://daypicker.dev/api/interfaces/PropsBase" target="_blank" rel="noopener noreferrer">react-day-picker</a>. 
-    Key props include:
-  </p>
-  <ul class="mt-4 list-disc list-inside space-y-2">
-    <li>`mode` — <code class="text-xs">"single" | "multiple" | "range"</code> — Selection mode (required)</li>
-    <li>`selected` — Currently selected date(s)</li>
-    <li>`onChange` — Callback when selection changes</li>
-    <li>`numberOfMonths` — Number of months to display</li>
-    <li>`disabled` — Dates that cannot be selected</li>
-    <li>`min` / `max` — Min/max selection constraints</li>
-    <li>`footer` — Content rendered below the calendar</li>
-    <li>`locale` — date-fns locale for internationalization</li>
-    <li>`className` — Additional CSS classes</li>
-  </ul>
-  <p class="mt-4 text-kumo-subtle text-sm">
-    See the <a href="https://daypicker.dev/docs" target="_blank" rel="noopener noreferrer">react-day-picker documentation</a> for the full API.
-  </p>
+<p>
+  DatePicker forwards all props to
+  <a
+    href="https://daypicker.dev/api/interfaces/PropsBase"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    react-day-picker
+  </a>
+  . Key props include:
+</p>
+<ul class="mt-4 list-disc list-inside space-y-2">
+  <li>
+    `mode` — `"single" | "multiple" | "range"` — Selection mode (required)
+  </li>
+  <li>`selected` — Currently selected date(s)</li>
+  <li>`onChange` — Callback when selection changes</li>
+  <li>`numberOfMonths` — Number of months to display</li>
+  <li>`disabled` — Dates that cannot be selected</li>
+  <li>`min` / `max` — Min/max selection constraints</li>
+  <li>`footer` — Content rendered below the calendar</li>
+  <li>`locale` — date-fns locale for internationalization</li>
+  <li>`className` — Additional CSS classes</li>
+</ul>
+<p class="mt-4 text-kumo-subtle text-sm">
+  See the
+  <a
+    href="https://daypicker.dev/docs"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    react-day-picker documentation
+  </a>
+  for the full API.
+</p>
 
 ### Differences from react-day-picker
 

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -36,7 +36,7 @@ import {
 
 ### Barrel
 
-  <CodeBlock code={`import { Dialog } from "@cloudflare/kumo";`} lang="tsx" />
+<CodeBlock code={`import { Dialog } from "@cloudflare/kumo";`} lang="tsx" />
 
 ### Granular
 
@@ -85,10 +85,10 @@ export default function Example() {
 
 ## Dialog vs Alert Dialog
 
-  <p>
-    The Dialog component supports two ARIA roles to properly convey semantic
-    meaning to assistive technologies:
-  </p>
+<p>
+  The Dialog component supports two ARIA roles to properly convey semantic
+  meaning to assistive technologies:
+</p>
 
   <div class="overflow-hidden rounded-lg border border-kumo-hairline">
     <table class="w-full text-sm">
@@ -142,10 +142,7 @@ export default function Example() {
   dialog with `role="alertdialog"` instead of `role="dialog"`.
 </p>
 <div class="mb-4 rounded-lg border border-kumo-info/30 bg-kumo-info/10 p-4 text-sm text-kumo-info">
-  <p class="font-medium mb-2 text-sm">
-    When to use{" "}
-    <code class="bg-kumo-info/20 px-1 rounded">role="alertdialog"</code>:
-  </p>
+  <p class="font-medium mb-2 text-sm">When to use `role="alertdialog"`:</p>
   <ul class="list-disc list-inside space-y-1 ml-2 mb-0">
     <li>Destructive actions (delete, discard, remove)</li>
     <li>Confirmation flows requiring explicit user acknowledgment</li>

--- a/packages/kumo-docs-astro/src/pages/components/popover.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/popover.mdx
@@ -116,14 +116,10 @@ export default function Example() {
         <tr>
           <td class="px-4 py-3 font-medium">ARIA Role</td>
           <td class="px-4 py-3">
-            <code class="rounded bg-kumo-elevated px-1.5 py-0.5 font-mono text-xs">
-              role="tooltip"
-            </code>
+            `role="tooltip"`
           </td>
           <td class="px-4 py-3">
-            <code class="rounded bg-kumo-elevated px-1.5 py-0.5 font-mono text-xs">
-              aria-haspopup
-            </code>
+            `aria-haspopup`
           </td>
         </tr>
         <tr>

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -90,10 +90,9 @@ export default function Example() {
 ### Basic
 
 <p>
-  A select with a visible label. When you provide the{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code> prop,
-  the select automatically renders inside a Field wrapper with the label
-  displayed above it.
+  A select with a visible label. When you provide the `label` prop, the select
+  automatically renders inside a Field wrapper with the label displayed above
+  it.
 </p>
 
   <ComponentExample demo="SelectBasicDemo">
@@ -107,10 +106,7 @@ export default function Example() {
 
 ### Sizes
 
-<p>
-  Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">size</code>{" "}
-  prop to match Input sizing (xs, sm, base, lg).
-</p>
+<p>Use the `size` prop to match Input sizing (xs, sm, base, lg).</p>
 
   <ComponentExample demo="SelectSizesDemo">
     <SelectSizesDemo client:load />
@@ -156,10 +152,8 @@ export default function Example() {
 ### With Error
 
 <p>
-  Pass the{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">error</code> prop to
-  display a validation error. When an error is present, it replaces the
-  description in the UI.
+  Pass the `error` prop to display a validation error. When an error is present,
+  it replaces the description in the UI.
 </p>
 
   <ComponentExample demo="SelectWithErrorDemo">
@@ -174,15 +168,9 @@ export default function Example() {
 ### Placeholder
 
 <p>
-  Use the{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code>{" "}
-  prop to show text when no value is selected. When using{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
-  to customize the display of selected values, the placeholder is shown instead
-  of calling{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
-  when the value is{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">null</code>.
+  Use the `placeholder` prop to show text when no value is selected. When using
+  `renderValue` to customize the display of selected values, the placeholder is
+  shown instead of calling `renderValue` when the value is `null`.
 </p>
 
 ```tsx
@@ -205,8 +193,8 @@ export default function Example() {
 ### Label with Tooltip
 
 <p>
-  Add a tooltip icon next to the label for additional context using{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
+  Add a tooltip icon next to the label for additional context using
+  `labelTooltip`.
 </p>
 
   <ComponentExample demo="SelectWithTooltipDemo">
@@ -221,11 +209,9 @@ export default function Example() {
 ### Custom Rendering
 
 <p>
-  Use{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
-  to customize how the selected value appears in the trigger button. This is
-  useful when working with complex object data structures instead of simple
-  string values.
+  Use `renderValue` to customize how the selected value appears in the trigger
+  button. This is useful when working with complex object data structures
+  instead of simple string values.
 </p>
 
 <ComponentExample demo="SelectCustomRenderingDemo">
@@ -233,21 +219,15 @@ export default function Example() {
 </ComponentExample>
 
 <p>
-  The{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
-  function is only called when a value is selected. Use{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code>{" "}
-  to define what to show when no value is selected.
+  The `renderValue` function is only called when a value is selected. Use
+  `placeholder` to define what to show when no value is selected.
 </p>
 
 <p>
   Select compares value with items to find which one is selected. For object
   items, it will compare if the object is the same reference not by value by
-  default. If you want to compare object items by value, you can use{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
-    isItemEqualToValue
-  </code>{" "}
-  prop.
+  default. If you want to compare object items by value, you can use
+  `isItemEqualToValue` prop.
 </p>
 
 ```tsx
@@ -282,8 +262,7 @@ export default function Example() {
 
 <p>
   A select component with loading state. The loading state is passed to the
-  component via the{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">loading</code> prop.
+  component via the `loading` prop.
 </p>
 
   <ComponentExample demo="SelectLoadingDemo">
@@ -303,13 +282,9 @@ export default function Example() {
 ### Multiple Selection
 
 <p>
-  Enable multiple selection with the{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">multiple</code>{" "}
-  prop. The value becomes an array of selected items. Use{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code>{" "}
-  for the empty state and{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>{" "}
-  to customize how selections are displayed.
+  Enable multiple selection with the `multiple` prop. The value becomes an array
+  of selected items. Use `placeholder` for the empty state and `renderValue` to
+  customize how selections are displayed.
 </p>
 
 ```tsx
@@ -348,9 +323,8 @@ export default function Example() {
 ### Disabled Options
 
 <p>
-  Options can be disabled with the{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code>{" "}
-  prop. Disabled options are greyed out and cannot be selected.
+  Options can be disabled with the `disabled` prop. Disabled options are greyed
+  out and cannot be selected.
 </p>
 
   <ComponentExample demo="SelectDisabledOptionsDemo">
@@ -365,9 +339,7 @@ export default function Example() {
 ### Disabled Items (via items prop)
 
 <p>
-  The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code>{" "}
-  object-map prop accepts descriptor objects with{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code>{" "}
+  The `items` object-map prop accepts descriptor objects with `disabled`
   alongside plain string values.
 </p>
 
@@ -383,16 +355,8 @@ export default function Example() {
 ### Grouped Options
 
 <p>
-  Use{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>,{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
-    Select.GroupLabel
-  </code>
-  , and{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
-    Select.Separator
-  </code>{" "}
-  to organize options under labeled headers with visual dividers.
+  Use `Select.Group`, `Select.GroupLabel`, and `Select.Separator` to organize
+  options under labeled headers with visual dividers.
 </p>
 
   <ComponentExample demo="SelectGroupedDemo">
@@ -449,24 +413,18 @@ export default function Example() {
 ### Select.Group
 
 <p>
-  Groups related options together with an accessible{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>.
-  Use with{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
-    Select.GroupLabel
-  </code>{" "}
-  to provide a visible heading.
+  Groups related options together with an accessible `role="group"`. Use with
+  `Select.GroupLabel` to provide a visible heading.
 </p>
 
 ### Select.GroupLabel
 
 <p>
-  A visible heading for a{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>.
-  Automatically associated with its parent group for accessibility.
+  A visible heading for a `Select.Group`. Automatically associated with its
+  parent group for accessibility.
 </p>
 
 ### Select.Separator
 
-  <p>A visual divider line between option groups. Renders with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="separator"</code>.</p>
+  <p>A visual divider line between option groups. Renders with `role="separator"`.</p>
 </ComponentSection>


### PR DESCRIPTION
## What

Inline `<code class="...">` elements in MDX files (notably `select.mdx`) were rendering with stray `<p>` siblings breaking the surrounding paragraph. On the Select page this was most visible in the **Grouped Options** section, where `Select.GroupLabel` and `Select.Separator` appeared on their own lines instead of inline.

## Why

Prettier wraps long single-line `<code class="rounded bg-kumo-control px-1 py-0.5 text-sm">…</code>` tags across multiple lines once the indentation pushes them past the 80-char print width. Multi-line JSX inside an MDX paragraph is treated by remark as block-level content and terminates the surrounding `<p>`, emitting stray `<p>` wrappers around each `<code>`.

## How

Replaced inline `<code class="...">…</code>` usages with markdown backticks. `kumo-prose` already styles bare `<code>` elements, so the explicit classNames were redundant. Backticks are parsed as inline markdown content and never break the surrounding paragraph regardless of line length.

## Verification

Built the docs and grepped the emitted HTML — `0` occurrences of `</code><p>` or `<code><p>` across all 67 generated pages. The previously-broken Grouped Options paragraph now renders as a single `<p>` containing three inline `<code>` elements.

```bash
pnpm --filter @cloudflare/kumo-docs-astro build
grep -rE '</code><p>|<code[^>]*><p>' packages/kumo-docs-astro/dist/  # → 0 matches
```

## Files changed

| File | Replacements |
|------|--------------|
| `select.mdx` | 26 |
| `popover.mdx` | 2 |
| `combobox.mdx` | 3 |
| `dialog.mdx` | 1 |
| `date-picker.mdx` | 1 |

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: docs-only MDX content edits with no logic changes
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: 
- [x] Additional testing not necessary because: change is verified by `grep` on the built HTML; docs site has no test coverage for MDX rendering
