### PR TITLE
Top-align checkbox and radio indicators with multi-line labels

### DIFF
--- a/.changeset/top-align-checkbox-radio-indicators.md
+++ b/.changeset/top-align-checkbox-radio-indicators.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fixed vertical alignment of checkbox and radio indicators with multi-line labels.
+
+When label text wrapped to multiple lines, the indicators were vertically centered against the entire text block. They now align to the top, sitting next to the first line of text.

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -261,7 +261,8 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
         disabled={disabled}
         onCheckedChange={onCheckedChange}
         className={cn(
-          "relative flex h-4 w-4 items-center justify-center rounded-sm border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
+          "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
+          label && "mt-0.5",
           variant === "error" ? "ring-kumo-danger" : "ring-kumo-hairline",
           !disabled &&
             "hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand",
@@ -298,7 +299,7 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       <FieldBase.Root className="inline-flex">
         <FieldBase.Label
           className={cn(
-            "!m-0 !min-h-0 !text-base inline-flex items-center gap-2",
+            "!m-0 !min-h-0 !text-base inline-flex items-start gap-2",
             controlFirst ? "flex-row" : "flex-row-reverse justify-end",
             disabled ? "cursor-not-allowed" : "cursor-pointer",
           )}
@@ -340,7 +341,7 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
     return (
       <label
         className={cn(
-          "m-0 relative inline-flex items-center gap-2",
+          "m-0 relative inline-flex items-start gap-2",
           // Control first (default): checkbox before label
           // Label first: label before checkbox using flex-row-reverse
           !controlFirst && "flex-row-reverse justify-end",
@@ -357,7 +358,7 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
           disabled={disabled}
           onCheckedChange={onCheckedChange}
           className={cn(
-            "peer relative flex h-4 w-4 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2",
+            "peer relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2",
             variant === "error" ? "ring-kumo-danger" : "ring-kumo-hairline",
             !disabled &&
               "group-hover:ring-kumo-hairline hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand",

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -319,7 +319,7 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
     return (
       <label
         className={cn(
-          "m-0 group relative inline-flex items-center gap-2",
+          "m-0 group relative inline-flex items-start gap-2",
           // "start" (default): radio before label
           // "end": label before radio using flex-row-reverse
           effectiveControlPosition === "end" && "flex-row-reverse justify-end",
@@ -332,7 +332,7 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
           value={value}
           disabled={disabled}
           className={cn(
-            "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
+            "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
             variant === "error" ? "ring-kumo-danger" : "ring-kumo-line",
             !disabled &&
               variant !== "error" &&


### PR DESCRIPTION
When a checkbox or radio label wraps to multiple lines in a narrow container, the indicator was vertically centered against the entire text block instead of sitting next to the first line.

Fix applied to three places in `checkbox.tsx` and one in `radio.tsx`:
- `items-center` → `items-start` on the label flex container
- `mt-0.5` on the indicator for optical alignment with the first line's cap height
- `shrink-0` on the checkbox indicator to prevent it from compressing

| Before | After |
|--------|--------|
|<img width="650" height="80" alt="Screenshot 2026-05-26 at 16 06 32" src="https://github.com/user-attachments/assets/ec43f242-d717-494d-a22a-b7448d5c9855" />|<img width="1393" height="1161" alt="Screenshot 2026-05-26 at 15 50 34" src="https://github.com/user-attachments/assets/a2af517b-fcbd-4d3d-9195-e36d81e32b30" />|
||<img width="1393" height="1161" alt="Screenshot 2026-05-26 at 15 50 42" src="https://github.com/user-attachments/assets/afebec24-fda4-41cf-b915-a4255ee3f4a9" />|

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual alignment fix, no logic changes
- Tests
- [x] Additional testing not necessary because: pure CSS class change, no behaviour affected