### PR TITLE
Fix Select placeholder not showing when renderValue is provided and value is empty

### DIFF
--- a/.changeset/fix-select-render-value-placeholder.md
+++ b/.changeset/fix-select-render-value-placeholder.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix `Select` placeholder not showing when `renderValue` is provided and the value is empty, or when `renderValue` returns `null`/`undefined`.

--- a/.changeset/fix-select-render-value-placeholder.md
+++ b/.changeset/fix-select-render-value-placeholder.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Fix `Select` placeholder not showing when `renderValue` is provided and the value is empty, or when `renderValue` returns `null`/`undefined`.
+Fix `Select` placeholder not showing when `renderValue` is provided and the value is empty.

--- a/packages/kumo/src/components/select/select.test.tsx
+++ b/packages/kumo/src/components/select/select.test.tsx
@@ -592,4 +592,112 @@ describe("Select", () => {
       expect(listbox.className).toContain("overscroll-none");
     });
   });
+
+  describe("renderValue with placeholder", () => {
+    it("shows placeholder when value is empty string", () => {
+      render(
+        <Select
+          aria-label="Pick one"
+          placeholder="Choose..."
+          value=""
+          renderValue={(v) => `Selected: ${v}`}
+          items={[
+            { value: "a", label: "Option A" },
+            { value: "b", label: "Option B" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Choose...")).toBeTruthy();
+      expect(screen.queryByText("Selected:")).toBeNull();
+    });
+
+    it("shows placeholder when value is null", () => {
+      render(
+        <Select
+          aria-label="Pick one"
+          placeholder="Choose..."
+          value={null}
+          renderValue={(v) => `Selected: ${v}`}
+          items={[
+            { value: "a", label: "Option A" },
+            { value: "b", label: "Option B" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Choose...")).toBeTruthy();
+    });
+
+    it("shows placeholder when value is undefined", () => {
+      render(
+        <Select
+          aria-label="Pick one"
+          placeholder="Choose..."
+          value={undefined}
+          renderValue={(v) => `Selected: ${v}`}
+          items={[
+            { value: "a", label: "Option A" },
+            { value: "b", label: "Option B" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Choose...")).toBeTruthy();
+    });
+
+    it("falls back to placeholder when renderValue returns undefined", () => {
+      render(
+        <Select
+          aria-label="Pick one"
+          placeholder="Choose..."
+          value="a"
+          renderValue={() => undefined}
+          items={[
+            { value: "a", label: "Option A" },
+            { value: "b", label: "Option B" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Choose...")).toBeTruthy();
+    });
+
+    it("renders the ReactNode returned by renderValue", () => {
+      render(
+        <Select
+          aria-label="Pick one"
+          placeholder="Choose..."
+          value="a"
+          renderValue={(v) => `Selected: ${v}`}
+          items={[
+            { value: "a", label: "Option A" },
+            { value: "b", label: "Option B" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Selected: a")).toBeTruthy();
+      expect(screen.queryByText("Choose...")).toBeNull();
+    });
+
+    it("renders nothing without crashing when value is empty string and no placeholder", () => {
+      const { container } = render(
+        <Select
+          aria-label="Pick one"
+          value=""
+          renderValue={(v) => `Selected: ${v}`}
+          items={[
+            { value: "a", label: "Option A" },
+            { value: "b", label: "Option B" },
+          ]}
+        />,
+      );
+
+      const trigger = container.querySelector('[role="combobox"]');
+      expect(trigger).toBeTruthy();
+      // Should not render the renderValue output for empty string
+      expect(screen.queryByText("Selected:")).toBeNull();
+    });
+  });
 });

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -404,19 +404,23 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   // - When value is non-null, call user's renderValue
   const valueChildrenFn = renderValue
     ? (value: unknown) => {
-        // Treat null, undefined, and empty string as "no selection"
+        const placeholderNode =
+          placeholder != null ? (
+            <span className="text-kumo-placeholder">{placeholder}</span>
+          ) : null;
+
         if (value == null || value === "") {
-          if (placeholder == null) return null;
-          return <span className="text-kumo-placeholder">{placeholder}</span>;
+          return placeholderNode;
         }
+
         // Cast through `any` as a deliberate type boundary: Base UI passes `unknown`,
-        // but our renderValue expects the generic T (or T[] for multiple).
-        // If renderValue returns nullish, fall back to placeholder.
+        // but our renderValue expects the generic T (or T[] for multiple)
         const rendered = renderValue(value as any);
+
         if (rendered == null) {
-          if (placeholder == null) return null;
-          return <span className="text-kumo-placeholder">{placeholder}</span>;
+          return placeholderNode;
         }
+
         return rendered;
       }
     : undefined;

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -404,16 +404,20 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   // - When value is non-null, call user's renderValue
   const valueChildrenFn = renderValue
     ? (value: unknown) => {
-        if (value == null) {
-          // If no placeholder provided, return null to show nothing (same as no renderValue)
-          if (placeholder == null) {
-            return null;
-          }
+        // Treat null, undefined, and empty string as "no selection"
+        if (value == null || value === "") {
+          if (placeholder == null) return null;
           return <span className="text-kumo-placeholder">{placeholder}</span>;
         }
         // Cast through `any` as a deliberate type boundary: Base UI passes `unknown`,
-        // but our renderValue expects the generic T (or T[] for multiple)
-        return renderValue(value as any);
+        // but our renderValue expects the generic T (or T[] for multiple).
+        // If renderValue returns nullish, fall back to placeholder.
+        const rendered = renderValue(value as any);
+        if (rendered == null) {
+          if (placeholder == null) return null;
+          return <span className="text-kumo-placeholder">{placeholder}</span>;
+        }
+        return rendered;
       }
     : undefined;
 


### PR DESCRIPTION
When using Select with renderValue and a form library like Formik, the placeholder never appeared if the value was "", the trigger just went blank. Same thing if `renderValue` couldn't find a label for the given value and returned `undefined`.

The root cause is in valueChildrenFn: it only checked for `null`/`undefined` as "nothing selected," but "" slipped through. And if `renderValue` came back empty, there was no fallback.

The fix:
- Treat "" the same as `null`/`undefined` and show the placeholder
- If `renderValue` returns nothing, fall back to the placeholder instead of going blank


**Before**: placeholder goes blank
**After**: shows "Pick a fruit" in placeholder styling

```tsx
<Select
  value={formik.values.fruit}    // ""
  renderValue={(v) => labels[v]} // "apple" → "Apple"
  placeholder="Pick a fruit"
/>
```

| Before | After |
|--------|--------|
|<img width="245" height="175" alt="Screenshot 2026-05-26 at 17 54 00" src="https://github.com/user-attachments/assets/064a9fb1-d21f-42d7-be76-b806fd846d2c" />|<img width="245" height="175" alt="Screenshot 2026-05-26 at 17 53 29" src="https://github.com/user-attachments/assets/9f618d01-6035-4812-ac3f-42fb49d883e8" />|

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: straightforward guard clause fix with full test coverage
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [ ] Additional testing not necessary because: <your reason here>