### PR TITLE
Fix Combobox TriggerInput icon span missing flex alignment classes

### DIFF
--- a/.changeset/fix-combobox-icon-flex.md
+++ b/.changeset/fix-combobox-icon-flex.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Add flex items-center to ComboboxBase.Icon in TriggerInput for consistency with TriggerValue and Select
+Add `flex items-center` to `ComboboxBase.Icon` in `TriggerInput` for consistency with `TriggerValue` and `Select`

--- a/.changeset/fix-combobox-icon-flex.md
+++ b/.changeset/fix-combobox-icon-flex.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add flex items-center to ComboboxBase.Icon in TriggerInput for consistency with TriggerValue and Select

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -373,7 +373,7 @@ function TriggerInput({
           iconStyles.caretRight,
         )}
       >
-        <ComboboxBase.Icon>
+        <ComboboxBase.Icon className="flex items-center">
           <CaretDownIcon size={iconStyles.iconSize} className="fill-current" />
         </ComboboxBase.Icon>
       </ComboboxBase.Trigger>


### PR DESCRIPTION
The icon span in Combobox has no `className`, while `TriggerValue` and `Select` both apply `flex items-center` to theirs. Projects using Kumo without Tailwind's Preflight reset see the icon span inflated by line-height (16×24 instead of 16×16), pushing the chevron out of vertical alignment.

| Before | After |
|--------|--------|
|<img width="305" height="75" alt="Screenshot 2026-05-26 at 16 46 51" src="https://github.com/user-attachments/assets/3938ec08-fef4-4305-9dd2-5407d766677f" />|<img width="90" height="60" alt="Screenshot 2026-05-26 at 16 55 35" src="https://github.com/user-attachments/assets/efd2fd4f-223e-428f-9791-9b0944c7a964" />|

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: one-line styling consistency fix
- Tests
  - [x] Additional testing not necessary because: existing combobox tests pass, no behavioral change