### PR TITLE
fix: mark echarts peerDependency as optional so it isn't installed everytime

### DIFF
--- a/.changeset/vast-feet-allow.md
+++ b/.changeset/vast-feet-allow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Mark echarts peer dependency as optional so it isn't installed everytime

--- a/.changeset/vast-feet-allow.md
+++ b/.changeset/vast-feet-allow.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Mark echarts peer dependency as optional so it isn't installed everytime
+echarts is now an optional peer dependency. If you don't use Chart components (Chart, TimeseriesChart, SankeyChart), it will no longer be installed automatically. If you do use them, run npm install echarts (as documented).

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -459,6 +459,9 @@
   "peerDependenciesMeta": {
     "zod": {
       "optional": true
+    },
+    "echarts": {
+      "optional": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
Marks echarts as an optional peer dependency so it isn't installed everytime.

I saw that echarts was being installed that took about 66MB (61MB echarts + 5MB zrender - a dependency of echarts) on my disk when i installed it in a project. Since our docs say that we need to explicitly install it, wouldn't it be better to mark it as optional as well?

Let me know what you think about this, maybe not making it optional breaks kumo somewhere?

Doc: https://kumo-ui.com/charts/

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: cannot run bonk myself <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: just marks dependency as optional for users

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
