### PR TITLE
ci: bump lil bonk opencode

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -51,6 +51,6 @@ jobs:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5"
           agent: kumo
           mentions: "/bonk"
-          opencode_version: "1.4.6"
+          opencode_version: "1.15.11"
           permissions: write
           


### PR DESCRIPTION
Updates the lil Bonk workflow to run opencode 1.15.11 instead of 1.4.6. The Bonk action itself is already pinned to the current upstream main SHA.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this updates the bonk workflow itself
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: verified workflow diff and upstream versions locally
- [x] Additional testing not necessary because: workflow-only version bump