### PR TITLE
ci: bump lil bonk to Kimi K2.6

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -48,7 +48,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5"
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: kumo
           mentions: "/bonk"
           opencode_version: "1.15.11"


### PR DESCRIPTION
Updates the lil Bonk workflow model from Kimi K2.5 to Kimi K2.6.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this updates the bonk workflow itself
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: verified workflow diff locally
- [x] Additional testing not necessary because: workflow-only model version bump