### PR TITLE
Fix border token docs

### DIFF
--- a/packages/kumo-docs-astro/src/pages/colors.mdx
+++ b/packages/kumo-docs-astro/src/pages/colors.mdx
@@ -5,7 +5,6 @@ description: "Kumo uses semantic color tokens that automatically adapt to light 
 ---
 
 import { TailwindColorTokens } from "~/components/demos/ColorsDemo";
-import { Badge } from "@cloudflare/kumo";
 
 ## Usage
 
@@ -323,17 +322,12 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span className="inline-flex items-center gap-2">
-            <code>kumo-hairline</code>
-            <Badge variant="info">New</Badge>
-          </span>
-        </td>
-        <td>A border/ring color to distinguish between flat surfaces where no shadow is present (i.e. <code>LayerCard</code>).</td>
+        <td><code>kumo-hairline</code></td>
+        <td>A border/ring color to distinguish between flat surfaces where no shadow is present.</td>
       </tr>
       <tr>
-        <td><code>kumo-hairline</code></td>
-        <td>A thicker border/ring color that defines the edge of an elevated surface alongside a shadow.</td>
+        <td><code>kumo-line</code></td>
+        <td>A stronger border/ring color that defines the edge of an elevated surface alongside a shadow.</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Updates the Colors docs border/ring token table to remove a stale `New` badge and correct the duplicated `kumo-hairline` row to `kumo-line`.

## Before

![Before screenshot showing duplicate kumo-hairline content](https://raw.githubusercontent.com/geoquant/kumo/geoquant/pr-assets-color-docs-border-fix/.github/pr-assets/color-docs-border-fix-before.png)

## Changes

- Removes the stale `New` badge from `kumo-hairline`.
- Changes the duplicated elevated-surface row from `kumo-hairline` to `kumo-line`.
- Updates the wording from “thicker” to “stronger” because the token controls color, not border width.
- No changeset is required because this is a docs-only change outside the published `packages/kumo` library source.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: docs-only copy fix
- Tests
- [ ] Tests included/updated
- [x] Automated tests not possible - manual testing has been completed as follows: verified the local MDX diff
- [ ] Additional testing not necessary because: <your reason here>
