### PR TITLE
Expose useFilter from Combobox and Autocomplete

### DIFF
--- a/.changeset/expose-usefilter-hook.md
+++ b/.changeset/expose-usefilter-hook.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Re-export `useFilter` from `Combobox` and `Autocomplete` namespaces. Use it to write custom `filter` props that preserve Base UI's default case- and accent-insensitive matching via `Intl.Collator`.

--- a/packages/kumo-docs-astro/src/components/demos/AutocompleteDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/AutocompleteDemo.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Autocomplete } from "@cloudflare/kumo";
 import { languages, type Language } from "./data/languages";
 
@@ -125,15 +125,18 @@ export function AutocompleteDemo() {
 export function AutocompleteWithFieldDemo() {
   const { contains } = Autocomplete.useFilter();
 
+  const filter = useCallback(
+    (item: Language, query: string) => contains(item.label, query),
+    [contains],
+  );
+
   return (
     <div className="w-80">
       <Autocomplete
         items={languages}
         label="Language"
         description="Start typing to filter languages"
-        filter={(item: Language, query: string) =>
-          contains(item.label, query)
-        }
+        filter={filter}
       >
         <Autocomplete.InputGroup placeholder="Search a language…" />
         <Autocomplete.Content>
@@ -154,15 +157,18 @@ export function AutocompleteWithFieldDemo() {
 export function AutocompleteErrorDemo() {
   const { contains } = Autocomplete.useFilter();
 
+  const filter = useCallback(
+    (item: Country, query: string) => contains(item.label, query),
+    [contains],
+  );
+
   return (
     <div className="w-80">
       <Autocomplete
         items={countries}
         label="Country"
         error={{ message: "Please enter a valid country", match: true }}
-        filter={(item: Country, query: string) =>
-          contains(item.label, query)
-        }
+        filter={filter}
       >
         <Autocomplete.InputGroup placeholder="Search countries…" />
         <Autocomplete.Content>

--- a/packages/kumo-docs-astro/src/components/demos/AutocompleteDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/AutocompleteDemo.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Autocomplete } from "@cloudflare/kumo";
+import { languages, type Language } from "./data/languages";
 
 const fruits = [
   "Apple",
@@ -122,22 +123,24 @@ export function AutocompleteDemo() {
 
 /** Autocomplete with label, description, and Field wrapper. */
 export function AutocompleteWithFieldDemo() {
+  const { contains } = Autocomplete.useFilter();
+
   return (
     <div className="w-80">
       <Autocomplete
-        items={countries}
-        label="Country"
-        description="Start typing to filter countries"
-        filter={(item: Country, query: string) =>
-          item.label.toLowerCase().includes(query.toLowerCase())
+        items={languages}
+        label="Language"
+        description="Start typing to filter languages"
+        filter={(item: Language, query: string) =>
+          contains(item.label, query)
         }
       >
-        <Autocomplete.InputGroup placeholder="Search countries…" />
+        <Autocomplete.InputGroup placeholder="Search a language…" />
         <Autocomplete.Content>
           <Autocomplete.List>
-            {(item: Country) => (
-              <Autocomplete.Item key={item.code} value={item}>
-                {item.label}
+            {(item: Language) => (
+              <Autocomplete.Item key={item.value} value={item}>
+                {item.emoji} {item.label}
               </Autocomplete.Item>
             )}
           </Autocomplete.List>
@@ -149,6 +152,8 @@ export function AutocompleteWithFieldDemo() {
 
 /** Autocomplete with error state via the Field wrapper. */
 export function AutocompleteErrorDemo() {
+  const { contains } = Autocomplete.useFilter();
+
   return (
     <div className="w-80">
       <Autocomplete
@@ -156,7 +161,7 @@ export function AutocompleteErrorDemo() {
         label="Country"
         error={{ message: "Please enter a valid country", match: true }}
         filter={(item: Country, query: string) =>
-          item.label.toLowerCase().includes(query.toLowerCase())
+          contains(item.label, query)
         }
       >
         <Autocomplete.InputGroup placeholder="Search countries…" />

--- a/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ComboboxDemo.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { CaretUpDownIcon } from "@phosphor-icons/react";
 import { Combobox, Text, Button } from "@cloudflare/kumo";
+import { languages, type Language } from "./data/languages";
 
 // Basic fruits list for simple demos (expanded to test scrolling)
 const fruits = [
@@ -41,46 +42,6 @@ const fruits = [
   "Strawberry",
   "Tangerine",
   "Watermelon",
-];
-
-// Languages with emoji for searchable inside popup demo
-type Language = {
-  value: string;
-  label: string;
-  emoji: string;
-};
-
-const languages: Language[] = [
-  { value: "en", label: "English", emoji: "🇬🇧" },
-  { value: "fr", label: "French", emoji: "🇫🇷" },
-  { value: "de", label: "German", emoji: "🇩🇪" },
-  { value: "es", label: "Spanish", emoji: "🇪🇸" },
-  { value: "it", label: "Italian", emoji: "🇮🇹" },
-  { value: "pt", label: "Portuguese", emoji: "🇵🇹" },
-  { value: "nl", label: "Dutch", emoji: "🇳🇱" },
-  { value: "pl", label: "Polish", emoji: "🇵🇱" },
-  { value: "ru", label: "Russian", emoji: "🇷🇺" },
-  { value: "ja", label: "Japanese", emoji: "🇯🇵" },
-  { value: "zh", label: "Chinese", emoji: "🇨🇳" },
-  { value: "ko", label: "Korean", emoji: "🇰🇷" },
-  { value: "ar", label: "Arabic", emoji: "🇸🇦" },
-  { value: "hi", label: "Hindi", emoji: "🇮🇳" },
-  { value: "tr", label: "Turkish", emoji: "🇹🇷" },
-  { value: "vi", label: "Vietnamese", emoji: "🇻🇳" },
-  { value: "th", label: "Thai", emoji: "🇹🇭" },
-  { value: "sv", label: "Swedish", emoji: "🇸🇪" },
-  { value: "no", label: "Norwegian", emoji: "🇳🇴" },
-  { value: "da", label: "Danish", emoji: "🇩🇰" },
-  { value: "fi", label: "Finnish", emoji: "🇫🇮" },
-  { value: "el", label: "Greek", emoji: "🇬🇷" },
-  { value: "cs", label: "Czech", emoji: "🇨🇿" },
-  { value: "ro", label: "Romanian", emoji: "🇷🇴" },
-  { value: "hu", label: "Hungarian", emoji: "🇭🇺" },
-  { value: "uk", label: "Ukrainian", emoji: "🇺🇦" },
-  { value: "id", label: "Indonesian", emoji: "🇮🇩" },
-  { value: "ms", label: "Malay", emoji: "🇲🇾" },
-  { value: "he", label: "Hebrew", emoji: "🇮🇱" },
-  { value: "fa", label: "Persian", emoji: "🇮🇷" },
 ];
 
 // Server locations for grouped demo

--- a/packages/kumo-docs-astro/src/components/demos/data/languages.ts
+++ b/packages/kumo-docs-astro/src/components/demos/data/languages.ts
@@ -1,0 +1,20 @@
+export type Language = {
+  value: string;
+  label: string;
+  emoji: string;
+};
+
+export const languages: Language[] = [
+  { value: "en", label: "English", emoji: "🇬🇧" },
+  { value: "de", label: "Deutsch", emoji: "🇩🇪" },
+  { value: "es", label: "Español", emoji: "🇪🇸" },
+  { value: "fr", label: "Français", emoji: "🇫🇷" },
+  { value: "it", label: "Italiano", emoji: "🇮🇹" },
+  { value: "pt-BR", label: "Português (Brasil)", emoji: "🇧🇷" },
+  { value: "pt-PT", label: "Português (Portugal)", emoji: "🇵🇹" },
+  { value: "tr", label: "Türkçe", emoji: "🇹🇷" },
+  { value: "ja", label: "日本語", emoji: "🇯🇵" },
+  { value: "ko", label: "한국어", emoji: "🇰🇷" },
+  { value: "zh-Hans", label: "简体中文", emoji: "🇨🇳" },
+  { value: "zh-Hant", label: "繁體中文", emoji: "🇹🇼" },
+];

--- a/packages/kumo-docs-astro/src/components/demos/data/languages.ts
+++ b/packages/kumo-docs-astro/src/components/demos/data/languages.ts
@@ -6,13 +6,17 @@ export type Language = {
 
 export const languages: Language[] = [
   { value: "en", label: "English", emoji: "🇬🇧" },
+  { value: "cs", label: "Čeština", emoji: "🇨🇿" },
   { value: "de", label: "Deutsch", emoji: "🇩🇪" },
   { value: "es", label: "Español", emoji: "🇪🇸" },
   { value: "fr", label: "Français", emoji: "🇫🇷" },
   { value: "it", label: "Italiano", emoji: "🇮🇹" },
   { value: "pt-BR", label: "Português (Brasil)", emoji: "🇧🇷" },
   { value: "pt-PT", label: "Português (Portugal)", emoji: "🇵🇹" },
+  { value: "sv", label: "Svenska", emoji: "🇸🇪" },
+  { value: "vi", label: "Tiếng Việt", emoji: "🇻🇳" },
   { value: "tr", label: "Türkçe", emoji: "🇹🇷" },
+  { value: "ru", label: "Русский", emoji: "🇷🇺" },
   { value: "ja", label: "日本語", emoji: "🇯🇵" },
   { value: "ko", label: "한국어", emoji: "🇰🇷" },
   { value: "zh-Hans", label: "简体中文", emoji: "🇨🇳" },

--- a/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
@@ -152,11 +152,14 @@ import {
 ```tsx
 function LanguagePicker() {
   const { contains } = Autocomplete.useFilter();
+
+  const filter = useCallback(
+    (item: Language, query: string) => contains(item.label, query),
+    [contains],
+  );
+
   return (
-    <Autocomplete
-      items={languages}
-      filter={(item, query) => contains(item.label, query)}
-    >
+    <Autocomplete items={languages} filter={filter}>
       {/* ... */}
     </Autocomplete>
   );

--- a/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
@@ -132,14 +132,14 @@ import {
 </ComponentExample>
 </ComponentSection>
 
-{/* Custom Filtering */}
+{/* Filtering */}
 
 <ComponentSection>
 
-## Custom Filtering
+## Filtering
 
 <p>
-  Filtering is **case- and accent-insensitive by default**, powered by
+  Filtering is case- and accent-insensitive by default, powered by
   `Intl.Collator` under the hood. For most cases you don't need a custom
   `filter` at all — Base UI handles string items automatically.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
@@ -140,21 +140,21 @@ import {
 
 <p>
   Filtering is case- and accent-insensitive by default, powered by
-  `Intl.Collator` under the hood. For most cases you don't need a custom
-  `filter` at all — Base UI handles string items automatically.
+  `Intl.Collator` under the hood. For string items, no custom `filter` is
+  needed.
 </p>
 <p>
-  When you need to filter on a property of object items, use
+  When filtering on a property of object items, use
   `Autocomplete.useFilter()` to preserve the built-in accent-insensitive
   matching:
 </p>
 
 ```tsx
-function CountryPicker() {
+function LanguagePicker() {
   const { contains } = Autocomplete.useFilter();
   return (
     <Autocomplete
-      items={countries}
+      items={languages}
       filter={(item, query) => contains(item.label, query)}
     >
       {/* ... */}

--- a/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
@@ -139,23 +139,36 @@ import {
 ## Custom Filtering
 
 <p>
-  By default, Base UI filters items using a built-in string match. Pass a custom
-  `filter` function for advanced logic such as fuzzy matching or object
-  properties.
+  Filtering is **case- and accent-insensitive by default**, powered by
+  `Intl.Collator` under the hood. For most cases you don't need a custom
+  `filter` at all — Base UI handles string items automatically.
+</p>
+<p>
+  When you need to filter on a property of object items, use
+  `Autocomplete.useFilter()` to preserve the built-in accent-insensitive
+  matching:
 </p>
 
 ```tsx
-// Filter on a property of object items
-<Autocomplete
-  items={countries}
-  filter={(item, query) =>
-    item.label.toLowerCase().includes(query.toLowerCase())
-  }
->
-  ...
-</Autocomplete>
+function CountryPicker() {
+  const { contains } = Autocomplete.useFilter();
+  return (
+    <Autocomplete
+      items={countries}
+      filter={(item, query) => contains(item.label, query)}
+    >
+      {/* ... */}
+    </Autocomplete>
+  );
+}
+```
 
-// Disable filtering entirely (e.g. async search)
+<p>
+  To disable filtering entirely (e.g. when results come from a server), pass
+  `filter={null}`:
+</p>
+
+```tsx
 <Autocomplete items={results} filter={null}>
   ...
 </Autocomplete>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -214,6 +214,41 @@ export default function Example() {
 
 <ComponentSection>
 
+## Filtering
+
+<p>
+  Filtering is **case- and accent-insensitive by default**, powered by
+  `Intl.Collator` under the hood. For string items, no custom `filter` is
+  needed.
+</p>
+<p>
+  When filtering on a property of object items, use `Combobox.useFilter()` to
+  preserve the built-in accent-insensitive matching:
+</p>
+
+```tsx
+function LanguagePicker() {
+  const { contains } = Combobox.useFilter();
+  return (
+    <Combobox
+      items={languages}
+      filter={(item, query) => contains(item.label, query)}
+    >
+      {/* ... */}
+    </Combobox>
+  );
+}
+```
+
+<p>
+  To disable filtering entirely (e.g. when results come from a server), pass
+  `filter={null}`.
+</p>
+
+</ComponentSection>
+
+<ComponentSection>
+
 ## Customizing Dropdown Height
 
 <p>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -217,7 +217,7 @@ export default function Example() {
 ## Filtering
 
 <p>
-  Filtering is **case- and accent-insensitive by default**, powered by
+  Filtering is case- and accent-insensitive by default, powered by
   `Intl.Collator` under the hood. For string items, no custom `filter` is
   needed.
 </p>

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -242,8 +242,14 @@ function LanguagePicker() {
 
 <p>
   To disable filtering entirely (e.g. when results come from a server), pass
-  `filter={null}`.
+  `filter={null}`:
 </p>
+
+```tsx
+<Combobox items={results} filter={null}>
+  ...
+</Combobox>
+```
 
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -229,11 +229,14 @@ export default function Example() {
 ```tsx
 function LanguagePicker() {
   const { contains } = Combobox.useFilter();
+
+  const filter = useCallback(
+    (item: Language, query: string) => contains(item.label, query),
+    [contains],
+  );
+
   return (
-    <Combobox
-      items={languages}
-      filter={(item, query) => contains(item.label, query)}
-    >
+    <Combobox items={languages} filter={filter}>
       {/* ... */}
     </Combobox>
   );

--- a/packages/kumo/src/components/autocomplete/autocomplete.tsx
+++ b/packages/kumo/src/components/autocomplete/autocomplete.tsx
@@ -319,4 +319,7 @@ export const Autocomplete = Object.assign(Root, {
   // Pass-through Base UI sub-components
   Empty: AutocompleteBase.Empty,
   Collection: AutocompleteBase.Collection,
+
+  // Filtering
+  useFilter: AutocompleteBase.useFilter,
 });

--- a/packages/kumo/src/components/autocomplete/index.ts
+++ b/packages/kumo/src/components/autocomplete/index.ts
@@ -6,3 +6,5 @@ export {
   KUMO_AUTOCOMPLETE_VARIANTS,
   KUMO_AUTOCOMPLETE_DEFAULT_VARIANTS,
 } from "./autocomplete";
+
+export type { AutocompleteFilter } from "@base-ui/react/autocomplete";

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -630,4 +630,7 @@ export const Combobox = Object.assign(Root, {
   Trigger: ComboboxBase.Trigger,
   Value: ComboboxBase.Value,
   Icon: ComboboxBase.Icon,
+
+  // Filtering
+  useFilter: ComboboxBase.useFilter,
 });

--- a/packages/kumo/src/components/combobox/index.ts
+++ b/packages/kumo/src/components/combobox/index.ts
@@ -3,3 +3,5 @@ export {
   type ComboboxProps,
   type ComboboxInputSide,
 } from "./combobox";
+
+export type { ComboboxFilter } from "@base-ui/react/combobox";


### PR DESCRIPTION
Re-export Base UI's `useFilter` from Kumo's `Combobox` and `Autocomplete` namespaces.

Base UI defaults to case- and accent-insensitive filtering via `Intl.Collator`, but consumers writing a custom `filter` often silently override it with naive `.toLowerCase().includes()`. Typing "portugues" then fails to find "Português", and "cote" fails to find "Côte d'Ivoire". Two of our own demos shipped this anti-pattern.

- Re-export `useFilter` and `Filter` types from `Combobox` and `Autocomplete`
- Fix the two broken Autocomplete demos to use `useFilter().contains`
- Switch combobox demos to a shared 12-item native-name `languages` list so accent-insensitivity is demonstrable
- Document the default + override pattern in `combobox.mdx` and `autocomplete.mdx`

After the change, the recommended pattern is:
```tsx
function LanguagePicker() {
  const { contains } = Autocomplete.useFilter();
  return (
    <Autocomplete
      items={languages}
      filter={(item, query) => contains(item.label, query)}
    >
      {/* ... */}
    </Autocomplete>
  );
}
```

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: mostly demo data, docs, and a single re-export
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [x] Additional testing not necessary because: re-exports an already-tested Base UI hook