### PR TITLE
feat(dialog): add `busy` prop, `size="2xl"`, `verticalAlign` + `topOffset`

### DIFF
--- a/.changeset/dialog-busy-size-position.md
+++ b/.changeset/dialog-busy-size-position.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/kumo": minor
+---
+
+**Dialog: `busy` prop, `size="2xl"`, and `verticalAlign="top"` with `topOffset`**
+
+Three additive Dialog improvements, all non-breaking:
+
+- **`<Dialog.Root busy>`**: when true, blocks user-initiated dismissal (Escape key, outside click, focus-out, and `<Dialog.Close>` button presses) so an in-flight async action can't be abandoned by a stray keystroke or backdrop click. Programmatic close (controlled `open={false}` or `actionsRef.close()`) still works, so the dialog can be dismissed once the async work resolves. Designed to flip dynamically while a Save handler is in flight, complementing the existing static `disablePointerDismissal`.
+- **`<Dialog size="2xl">`**: new size variant (min 1024px) for data-dense layouts that need more horizontal real estate than `xl` (768px) provides — side-by-side forms, summary tables, multi-pane previews.
+- **`<Dialog verticalAlign="top" topOffset={N}>`**: anchor the dialog to the top of the viewport with a configurable pixel offset, instead of the default vertical centring. Useful for apps with a persistent navbar where a centered dialog would visually compete with the chrome.

--- a/packages/kumo-docs-astro/src/components/demos/DialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DialogDemo.tsx
@@ -297,6 +297,177 @@ export function DialogWithComboboxDemo() {
   );
 }
 
+/**
+ * Demonstrates the `busy` prop. When `busy={true}`, Escape, outside clicks,
+ * and Dialog.Close buttons are all swallowed, preventing the user from
+ * abandoning an in-flight Save. Programmatic close still works (the demo
+ * resolves and closes after 2s).
+ */
+export function DialogBusyDemo() {
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen} busy={saving}>
+      <Dialog.Trigger render={(p) => <Button {...p}>Open</Button>} />
+      <Dialog className="p-8">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <Dialog.Title className="text-2xl font-semibold">
+            {saving ? "Saving…" : "Save changes"}
+          </Dialog.Title>
+          <Dialog.Close
+            aria-label="Close"
+            render={(props) => (
+              <Button
+                {...props}
+                variant="secondary"
+                shape="square"
+                icon={<X />}
+                aria-label="Close"
+              />
+            )}
+          />
+        </div>
+        <Dialog.Description className="text-kumo-subtle">
+          {saving
+            ? "Don't go anywhere — Escape, outside clicks, and the close button are temporarily disabled while we save your changes."
+            : "Click Save to start a fake 2-second save. While it runs, Escape, outside clicks, and Close are blocked."}
+        </Dialog.Description>
+        <div className="mt-8 flex justify-end gap-2">
+          <Dialog.Close
+            render={(props) => (
+              <Button variant="secondary" {...props} disabled={saving}>
+                Cancel
+              </Button>
+            )}
+          />
+          <Button
+            variant="primary"
+            disabled={saving}
+            onClick={() => {
+              setSaving(true);
+              setTimeout(() => {
+                setSaving(false);
+                setOpen(false);
+              }, 2000);
+            }}
+          >
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </Dialog>
+    </Dialog.Root>
+  );
+}
+
+/**
+ * Demonstrates the `2xl` size variant (min 1024px). Useful for dialogs
+ * containing data-dense layouts: tables, side-by-side forms, summary panels.
+ */
+export function DialogSize2xlDemo() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger render={(p) => <Button {...p}>Open 2xl dialog</Button>} />
+      <Dialog size="2xl" className="p-8">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <Dialog.Title className="text-2xl font-semibold">
+            Wide layout (size=&quot;2xl&quot;)
+          </Dialog.Title>
+          <Dialog.Close
+            aria-label="Close"
+            render={(props) => (
+              <Button
+                {...props}
+                variant="secondary"
+                shape="square"
+                icon={<X />}
+                aria-label="Close"
+              />
+            )}
+          />
+        </div>
+        <Dialog.Description className="mb-6 text-kumo-subtle">
+          The <code>2xl</code> size gives you at least 1024px of horizontal
+          space — enough for two columns of form fields, a small table, or a
+          side-by-side preview.
+        </Dialog.Description>
+        <div className="grid grid-cols-2 gap-6">
+          <div className="rounded-lg border border-kumo-hairline p-4">
+            <h4 className="mb-2 font-medium">Column A</h4>
+            <p className="text-sm text-kumo-subtle">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+          </div>
+          <div className="rounded-lg border border-kumo-hairline p-4">
+            <h4 className="mb-2 font-medium">Column B</h4>
+            <p className="text-sm text-kumo-subtle">
+              Sed do eiusmod tempor incididunt ut labore et dolore magna.
+            </p>
+          </div>
+        </div>
+        <div className="mt-8 flex justify-end gap-2">
+          <Dialog.Close
+            render={(props) => (
+              <Button variant="secondary" {...props}>
+                Close
+              </Button>
+            )}
+          />
+        </div>
+      </Dialog>
+    </Dialog.Root>
+  );
+}
+
+/**
+ * Demonstrates `verticalAlign="top"` with a `topOffset` so the dialog clears
+ * a fixed-position header. Useful for apps with a persistent navbar where
+ * a centered dialog would visually overlap or compete with the chrome.
+ */
+export function DialogVerticalAlignTopDemo() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger
+        render={(p) => <Button {...p}>Open top-anchored dialog</Button>}
+      />
+      <Dialog verticalAlign="top" topOffset={64} className="p-8">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <Dialog.Title className="text-2xl font-semibold">
+            Top-anchored
+          </Dialog.Title>
+          <Dialog.Close
+            aria-label="Close"
+            render={(props) => (
+              <Button
+                {...props}
+                variant="secondary"
+                shape="square"
+                icon={<X />}
+                aria-label="Close"
+              />
+            )}
+          />
+        </div>
+        <Dialog.Description className="text-kumo-subtle">
+          With <code>verticalAlign=&quot;top&quot;</code> and{" "}
+          <code>topOffset=&#123;64&#125;</code>, this dialog opens flush to the
+          top of the viewport with a 64px gap — enough to clear a typical app
+          navbar.
+        </Dialog.Description>
+        <div className="mt-8 flex justify-end">
+          <Dialog.Close
+            render={(props) => (
+              <Button variant="secondary" {...props}>
+                Close
+              </Button>
+            )}
+          />
+        </div>
+      </Dialog>
+    </Dialog.Root>
+  );
+}
+
 export function DialogWithDropdownDemo() {
   return (
     <Dialog.Root>

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -18,6 +18,9 @@ import {
   DialogWithSelectDemo,
   DialogWithComboboxDemo,
   DialogWithDropdownDemo,
+  DialogBusyDemo,
+  DialogSize2xlDemo,
+  DialogVerticalAlignTopDemo,
 } from "~/components/demos/DialogDemo";
 
 {/* Hero Demo */}
@@ -187,10 +190,51 @@ export default function Example() {
 
 ### With Dropdown
 
-  <p>Dialog containing a Dropdown menu.</p>
-  <ComponentExample demo="DialogWithDropdownDemo">
-    <DialogWithDropdownDemo client:load />
-  </ComponentExample>
+<p>Dialog containing a Dropdown menu.</p>
+<ComponentExample demo="DialogWithDropdownDemo">
+  <DialogWithDropdownDemo client:load />
+</ComponentExample>
+
+### Busy state (`busy`)
+
+<p>
+  When <code>busy=&#123;true&#125;</code> is set on <code>Dialog.Root</code>,
+  user-initiated dismissal is temporarily blocked: Escape, outside clicks,
+  focus-out, and <code>Dialog.Close</code> button presses are all swallowed. Use
+  this to prevent a stray keystroke or backdrop click from abandoning an
+  in-flight async action.
+</p>
+<p>
+  Programmatic close (controlled <code>open=&#123;false&#125;</code> or
+  <code>actionsRef.close()</code>) still works, so the dialog can be dismissed
+  once the async work resolves.
+</p>
+<ComponentExample demo="DialogBusyDemo">
+  <DialogBusyDemo client:load />
+</ComponentExample>
+
+### Wide layout (`size="2xl"`)
+
+<p>
+  The <code>2xl</code> size (min 1024px) is intended for dialogs that need more
+  horizontal real estate than <code>xl</code> (768px) provides: side-by-side
+  forms, summary tables, multi-pane previews.
+</p>
+<ComponentExample demo="DialogSize2xlDemo">
+  <DialogSize2xlDemo client:load />
+</ComponentExample>
+
+### Top-anchored (`verticalAlign="top"`)
+
+<p>
+  By default, dialogs are vertically centered in the viewport. Set
+  <code>verticalAlign=&quot;top&quot;</code> with a <code>topOffset</code> to
+  anchor the dialog to the top instead — useful for apps with a persistent
+  navbar where a centered dialog would visually compete with the chrome.
+</p>
+<ComponentExample demo="DialogVerticalAlignTopDemo">
+  <DialogVerticalAlignTopDemo client:load />
+</ComponentExample>
 </ComponentSection>
 
 {/* API Reference */}
@@ -235,7 +279,18 @@ export default function Example() {
         <td class="px-4 py-2 font-mono text-xs">false</td>
         <td class="px-4 py-2 text-kumo-subtle">
           When true, prevents the dialog from being dismissed by clicking
-          outside.
+          outside. Static — applies for the entire lifetime of the dialog.
+        </td>
+      </tr>
+      <tr>
+        <td class="px-4 py-2 font-mono text-xs">busy</td>
+        <td class="px-4 py-2 font-mono text-xs">boolean</td>
+        <td class="px-4 py-2 font-mono text-xs">false</td>
+        <td class="px-4 py-2 text-kumo-subtle">
+          When true, blocks user-initiated dismissal (Escape, outside click,
+          focus-out, and `Dialog.Close` button presses). Programmatic close
+          still works. Designed to flip dynamically while an async action is in
+          flight, so a stray keystroke can't abandon a Save mid-flight.
         </td>
       </tr>
     </tbody>

--- a/packages/kumo/src/components/dialog/dialog.test.tsx
+++ b/packages/kumo/src/components/dialog/dialog.test.tsx
@@ -1,0 +1,220 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { Dialog } from "./dialog";
+
+/**
+ * Helpers
+ * -------
+ * Render an open dialog with a `<Dialog.Close>` button so we can exercise
+ * each dismissal path (Escape, outside click, close-button click) against
+ * the `busy` prop.
+ */
+function ControlledDialog({
+  initialOpen = true,
+  busy,
+  onOpenChange,
+  role = "dialog",
+}: {
+  initialOpen?: boolean;
+  busy?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  role?: "dialog" | "alertdialog";
+}) {
+  const [open, setOpen] = useState(initialOpen);
+  return (
+    <Dialog.Root
+      role={role}
+      open={open}
+      busy={busy}
+      onOpenChange={(next, details) => {
+        setOpen(next);
+        onOpenChange?.(next);
+        // Surface the reason on a data attribute for assertions.
+        if (details?.reason) {
+          document.body.setAttribute(
+            "data-last-reason",
+            String(details.reason),
+          );
+        }
+      }}
+    >
+      <Dialog>
+        <Dialog.Title>Title</Dialog.Title>
+        <Dialog.Description>Body</Dialog.Description>
+        <Dialog.Close>Close</Dialog.Close>
+      </Dialog>
+    </Dialog.Root>
+  );
+}
+
+describe("Dialog — baseline", () => {
+  it("renders open with title, description, and close button", () => {
+    render(<ControlledDialog />);
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.getByText("Body")).toBeTruthy();
+    expect(screen.getByText("Close")).toBeTruthy();
+  });
+});
+
+describe("Dialog — busy prop", () => {
+  it("when busy=true, swallows close-button presses", () => {
+    const onOpenChange = vi.fn();
+    render(<ControlledDialog busy onOpenChange={onOpenChange} />);
+
+    act(() => {
+      fireEvent.click(screen.getByText("Close"));
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // Dialog is still in the document (still open).
+    expect(screen.queryByText("Title")).toBeTruthy();
+  });
+
+  it("when busy=true, swallows Escape", () => {
+    const onOpenChange = vi.fn();
+    render(<ControlledDialog busy onOpenChange={onOpenChange} />);
+
+    act(() => {
+      fireEvent.keyDown(document.body, { key: "Escape" });
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByText("Title")).toBeTruthy();
+  });
+
+  it("when busy=false, close-button presses fire onOpenChange(false)", () => {
+    const onOpenChange = vi.fn();
+    render(<ControlledDialog onOpenChange={onOpenChange} />);
+
+    act(() => {
+      fireEvent.click(screen.getByText("Close"));
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("when busy=true on an alertdialog, swallows Escape", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ControlledDialog role="alertdialog" busy onOpenChange={onOpenChange} />,
+    );
+
+    act(() => {
+      fireEvent.keyDown(document.body, { key: "Escape" });
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("programmatic close still works while busy=true", () => {
+    // Render a wrapper that flips `open` from the parent: this simulates
+    // a Save handler resolving after busy is cleared. The dialog should
+    // close even though busy was true earlier, because programmatic
+    // `open={false}` does not go through the dismissal-reason path.
+    function Programmatic() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button onClick={() => setOpen(false)} data-testid="external-close">
+            external close
+          </button>
+          <Dialog.Root open={open} busy onOpenChange={setOpen}>
+            <Dialog>
+              <Dialog.Title>Programmatic</Dialog.Title>
+            </Dialog>
+          </Dialog.Root>
+        </>
+      );
+    }
+    render(<Programmatic />);
+    expect(screen.queryByText("Programmatic")).toBeTruthy();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("external-close"));
+    });
+
+    expect(screen.queryByText("Programmatic")).toBeNull();
+  });
+});
+
+describe("Dialog — size variants", () => {
+  it('size="2xl" applies the 64rem min-width class', () => {
+    render(
+      <Dialog.Root open>
+        <Dialog size="2xl">
+          <Dialog.Title>Wide</Dialog.Title>
+        </Dialog>
+      </Dialog.Root>,
+    );
+
+    const panel =
+      screen.getByText("Wide").closest("[data-kumo-component]") ??
+      screen.getByText("Wide").parentElement;
+    // Walk up to find the popup element carrying the size class.
+    let el: HTMLElement | null = panel as HTMLElement | null;
+    while (el && !el.className.includes("min-w-")) {
+      el = el.parentElement;
+    }
+    expect(el).not.toBeNull();
+    expect(el!.className).toContain("min-w-[64rem]");
+  });
+});
+
+describe("Dialog — verticalAlign + topOffset", () => {
+  it('default verticalAlign="center" applies top-1/2 and -translate-y-1/2', () => {
+    render(
+      <Dialog.Root open>
+        <Dialog>
+          <Dialog.Title>Centered</Dialog.Title>
+        </Dialog>
+      </Dialog.Root>,
+    );
+
+    let el: HTMLElement | null = screen.getByText("Centered").parentElement;
+    while (el && !el.className.includes("top-1/2")) {
+      el = el.parentElement;
+    }
+    expect(el).not.toBeNull();
+    expect(el!.className).toContain("-translate-y-1/2");
+    // No inline `top` because verticalAlign="center" leaves it to the class.
+    expect(el!.style.top).toBe("");
+  });
+
+  it('verticalAlign="top" with topOffset={49} applies inline top:49px and drops the centering classes', () => {
+    render(
+      <Dialog.Root open>
+        <Dialog verticalAlign="top" topOffset={49}>
+          <Dialog.Title>Top-anchored</Dialog.Title>
+        </Dialog>
+      </Dialog.Root>,
+    );
+
+    let el: HTMLElement | null = screen.getByText("Top-anchored").parentElement;
+    while (el && el.style && el.style.top !== "49px") {
+      el = el.parentElement;
+    }
+    expect(el).not.toBeNull();
+    expect(el!.style.top).toBe("49px");
+    expect(el!.className).not.toContain("top-1/2");
+    expect(el!.className).not.toContain("-translate-y-1/2");
+  });
+
+  it('verticalAlign="top" without topOffset defaults to top:0px', () => {
+    render(
+      <Dialog.Root open>
+        <Dialog verticalAlign="top">
+          <Dialog.Title>Top-no-offset</Dialog.Title>
+        </Dialog>
+      </Dialog.Root>,
+    );
+
+    let el: HTMLElement | null =
+      screen.getByText("Top-no-offset").parentElement;
+    while (el && el.style && el.style.top !== "0px") {
+      el = el.parentElement;
+    }
+    expect(el).not.toBeNull();
+    expect(el!.style.top).toBe("0px");
+  });
+});

--- a/packages/kumo/src/components/dialog/dialog.tsx
+++ b/packages/kumo/src/components/dialog/dialog.tsx
@@ -34,6 +34,11 @@ export const KUMO_DIALOG_VARIANTS = {
       classes: "min-w-[48rem]",
       description: "Extra large dialog for detailed views",
     },
+    "2xl": {
+      classes: "min-w-[64rem]",
+      description:
+        "Wide dialog for data-dense layouts (tables, side-by-side forms)",
+    },
   },
   role: {
     dialog: {
@@ -46,11 +51,23 @@ export const KUMO_DIALOG_VARIANTS = {
         "Alert dialog for confirmation flows requiring explicit user acknowledgment",
     },
   },
+  verticalAlign: {
+    center: {
+      classes: "top-1/2 -translate-y-1/2",
+      description: "Vertically centered in the viewport (default)",
+    },
+    top: {
+      classes: "",
+      description:
+        "Anchored to the top of the viewport. Use `topOffset` to set the gap from the top edge (defaults to 0).",
+    },
+  },
 } as const;
 
 export const KUMO_DIALOG_DEFAULT_VARIANTS = {
   size: "base",
   role: "dialog",
+  verticalAlign: "center",
 } as const;
 
 export const KUMO_DIALOG_STYLING = {
@@ -87,6 +104,14 @@ export const KUMO_DIALOG_STYLING = {
       gap: 16,
       buttonSize: "base",
     },
+    "2xl": {
+      width: 1024,
+      titleSize: 20,
+      descSize: 16,
+      padding: 24,
+      gap: 16,
+      buttonSize: "base",
+    },
   },
   baseTokens: {
     background: "color-surface",
@@ -115,6 +140,8 @@ export const KUMO_DIALOG_STYLING = {
 // Derived types from KUMO_DIALOG_VARIANTS
 export type KumoDialogSize = keyof typeof KUMO_DIALOG_VARIANTS.size;
 export type KumoDialogRole = keyof typeof KUMO_DIALOG_VARIANTS.role;
+export type KumoDialogVerticalAlign =
+  keyof typeof KUMO_DIALOG_VARIANTS.verticalAlign;
 
 export interface KumoDialogVariantsProps {
   /**
@@ -123,9 +150,23 @@ export interface KumoDialogVariantsProps {
    * - `"base"` — Default (min 384px)
    * - `"lg"` — Large (min 512px) for complex content
    * - `"xl"` — Extra large (min 768px) for detailed views
+   * - `"2xl"` — Wide (min 1024px) for data-dense layouts (tables, side-by-side forms)
    * @default "base"
    */
   size?: KumoDialogSize;
+  /**
+   * Vertical alignment of the dialog within the viewport.
+   * - `"center"` — Vertically centered (default).
+   * - `"top"` — Anchored to the top of the viewport. Combine with `topOffset` to set the gap from the top edge.
+   * @default "center"
+   */
+  verticalAlign?: KumoDialogVerticalAlign;
+  /**
+   * Distance in pixels from the top of the viewport when `verticalAlign="top"`.
+   * Ignored when `verticalAlign="center"`. Use this to clear a fixed header (e.g. `topOffset={49}` for a 49px navbar).
+   * @default 0
+   */
+  topOffset?: number;
 }
 
 // ============================================================================
@@ -140,12 +181,23 @@ function useDialogRole() {
 
 export function dialogVariants({
   size = KUMO_DIALOG_DEFAULT_VARIANTS.size,
+  verticalAlign = KUMO_DIALOG_DEFAULT_VARIANTS.verticalAlign,
 }: KumoDialogVariantsProps = {}) {
   return cn(
-    // Base styles
-    "shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full sm:w-auto max-w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
+    // Base styles (horizontal centering + sizing constraints common to all alignments)
+    "shadow-m ring ring-kumo-line fixed left-1/2 w-full sm:w-auto max-w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-3rem)] -translate-x-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
     // Apply size from KUMO_DIALOG_VARIANTS
-    resolveVariant(KUMO_DIALOG_VARIANTS.size, size, KUMO_DIALOG_DEFAULT_VARIANTS.size).classes,
+    resolveVariant(
+      KUMO_DIALOG_VARIANTS.size,
+      size,
+      KUMO_DIALOG_DEFAULT_VARIANTS.size,
+    ).classes,
+    // Apply vertical alignment (`center` adds top-1/2 + -translate-y-1/2; `top` is offset via inline style)
+    resolveVariant(
+      KUMO_DIALOG_VARIANTS.verticalAlign,
+      verticalAlign,
+      KUMO_DIALOG_DEFAULT_VARIANTS.verticalAlign,
+    ).classes,
   );
 }
 
@@ -213,6 +265,8 @@ function DialogContent({
   children,
   style,
   size = KUMO_DIALOG_DEFAULT_VARIANTS.size,
+  verticalAlign = KUMO_DIALOG_DEFAULT_VARIANTS.verticalAlign,
+  topOffset,
   container: containerProp,
 }: DialogProps) {
   const role = useDialogRole();
@@ -226,12 +280,18 @@ function DialogContent({
   const BasePopup =
     role === "alertdialog" ? AlertDialogBase.Popup : DialogBase.Popup;
 
+  // When verticalAlign="top", apply an inline `top` so callers can clear a
+  // fixed header (e.g. topOffset={49} for a 49px navbar). `center` ignores
+  // topOffset because the variant's class string already pins top:50%.
+  const positionStyle: CSSProperties =
+    verticalAlign === "top" ? { top: `${topOffset ?? 0}px` } : {};
+
   return (
     <BasePortal container={container}>
       <BaseBackdrop className="fixed inset-0 bg-kumo-recessed opacity-80 transition-all duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0" />
       <LayerCard
         render={<BasePopup />}
-        className={cn(dialogVariants({ size }), className)}
+        className={cn(dialogVariants({ size, verticalAlign }), className)}
         style={
           {
             transitionProperty: "scale, opacity",
@@ -239,6 +299,7 @@ function DialogContent({
               "var(--default-transition-timing-function)",
             "--tw-shadow":
               "0 20px 25px -5px rgb(0 0 0 / 0.03), 0 8px 10px -6px rgb(0 0 0 / 0.03)",
+            ...positionStyle,
             ...style,
           } as CSSProperties
         }
@@ -258,35 +319,106 @@ type BaseAlertDialogRootProps = ComponentPropsWithoutRef<
   typeof AlertDialogBase.Root
 >;
 
-type StandardDialogRootProps = BaseDialogRootProps & {
+/**
+ * `onOpenChange` reasons that represent user-initiated dismissal of an open
+ * dialog. When `busy={true}`, these are swallowed so a Save / Submit handler
+ * in flight cannot be cancelled by accident.
+ *
+ * `triggerPress`, `imperativeAction`, and `none` are intentionally NOT
+ * swallowed: callers may still close the dialog programmatically (e.g. after
+ * the async work completes and clears `busy`), and the trigger button is
+ * usually disabled by the busy UI anyway.
+ *
+ * These string values come from base-ui's REASONS constants
+ * (`@base-ui/react/internals/reasons`). They aren't imported directly because
+ * base-ui marks the `internals` path as private — the values are part of the
+ * stable public surface via the `DialogRootChangeEventReason` type union, but
+ * the constants live in an internal module. If base-ui ever renames a reason,
+ * the `DISMISSAL_REASONS` runtime check would silently miss it; the
+ * accompanying dialog tests cover all four reasons to catch that drift.
+ */
+const DISMISSAL_REASONS = new Set<string>([
+  "outside-press",
+  "escape-key",
+  "close-press",
+  "focus-out",
+]);
+
+/**
+ * `busy` prop description shared between standard and alert dialog roots.
+ * Kept in one place so `Dialog.Root` and `Dialog.Root role="alertdialog"`
+ * stay in sync.
+ */
+type BusyProp = {
   /**
-   * The ARIA role for the dialog.
-   * - `"dialog"` — Standard dialog for general-purpose modals. Dismissible via outside click by default.
-   * - `"alertdialog"` — Alert dialog for destructive or confirmation flows. Not dismissible via outside click.
+   * When `true`, blocks user-initiated dismissal (Escape key, outside click,
+   * focus-out, and any `<Dialog.Close>` button presses). Use this while an
+   * async action triggered from inside the dialog is in flight, so a stray
+   * keystroke or backdrop click cannot abandon a Save mid-flight.
    *
-   * Use `role="alertdialog"` for:
-   * - Destructive actions (delete, discard, remove)
-   * - Confirmation dialogs requiring explicit user acknowledgment
-   * - Actions that cannot be undone
+   * Programmatic close (`open={false}` from the parent, or `actionsRef.close()`)
+   * still works, so the dialog can be dismissed when the async work resolves.
    *
-   * @default "dialog"
+   * @default false
    */
-  role?: "dialog";
+  busy?: boolean;
 };
 
-type AlertDialogRootProps = BaseAlertDialogRootProps & {
-  role: "alertdialog";
-};
+type StandardDialogRootProps = BaseDialogRootProps &
+  BusyProp & {
+    /**
+     * The ARIA role for the dialog.
+     * - `"dialog"` — Standard dialog for general-purpose modals. Dismissible via outside click by default.
+     * - `"alertdialog"` — Alert dialog for destructive or confirmation flows. Not dismissible via outside click.
+     *
+     * Use `role="alertdialog"` for:
+     * - Destructive actions (delete, discard, remove)
+     * - Confirmation dialogs requiring explicit user acknowledgment
+     * - Actions that cannot be undone
+     *
+     * @default "dialog"
+     */
+    role?: "dialog";
+  };
+
+type AlertDialogRootProps = BaseAlertDialogRootProps &
+  BusyProp & {
+    role: "alertdialog";
+  };
 
 export type DialogRootProps = StandardDialogRootProps | AlertDialogRootProps;
 
+/**
+ * Wraps a user-supplied `onOpenChange` to swallow dismissal events when
+ * `busy` is true. The base-ui `details.reason` is the source of truth; we
+ * match against `DISMISSAL_REASONS` so we don't accidentally block
+ * programmatic closes.
+ */
+function makeBusyAwareOpenChange<TDetails extends { reason?: string | null }>(
+  busy: boolean | undefined,
+  original: ((open: boolean, details: TDetails) => void) | undefined,
+) {
+  if (!busy) return original;
+  return (open: boolean, details: TDetails) => {
+    if (!open && details?.reason && DISMISSAL_REASONS.has(details.reason)) {
+      return;
+    }
+    original?.(open, details);
+  };
+}
+
 function DialogRoot(props: DialogRootProps) {
   if (props.role === "alertdialog") {
-    const { children, role, ...rootProps } = props;
+    const { children, role, busy, onOpenChange, ...rootProps } = props;
 
     return (
       <DialogRoleContext.Provider value={role}>
-        <AlertDialogBase.Root {...rootProps}>{children}</AlertDialogBase.Root>
+        <AlertDialogBase.Root
+          {...rootProps}
+          onOpenChange={makeBusyAwareOpenChange(busy, onOpenChange)}
+        >
+          {children}
+        </AlertDialogBase.Root>
       </DialogRoleContext.Provider>
     );
   }
@@ -294,12 +426,19 @@ function DialogRoot(props: DialogRootProps) {
   const {
     children,
     role = KUMO_DIALOG_DEFAULT_VARIANTS.role,
+    busy,
+    onOpenChange,
     ...rootProps
   } = props;
 
   return (
     <DialogRoleContext.Provider value={role}>
-      <DialogBase.Root {...rootProps}>{children}</DialogBase.Root>
+      <DialogBase.Root
+        {...rootProps}
+        onOpenChange={makeBusyAwareOpenChange(busy, onOpenChange)}
+      >
+        {children}
+      </DialogBase.Root>
     </DialogRoleContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary

Three additive, non-breaking improvements to `Dialog`:

- **`<Dialog.Root busy>`** - dynamic flag that blocks user-initiated dismissal while an async action is in flight.
- **`<Dialog size="2xl">`** - new size variant (min 1024px) for data-dense layouts.
- **`<Dialog verticalAlign="top" topOffset={N}>`** - anchor the dialog to the top of the viewport with a configurable pixel offset, instead of vertical centring.

Each of these was a paper cut hit repeatedly by a downstream Cloudflare product that had to fork the dialog primitive to work around the gaps. This PR upstreams the missing props so the fork can go away.

## Motivation

### `busy`

Today `Dialog.Root` exposes `disablePointerDismissal` for blocking outside clicks, but it is a static prop and only covers one of the four dismissal paths. Real-world Save dialogs need to block all four (Escape, outside click, focus-out, and `<Dialog.Close>` button presses) only while the async Save handler is in flight, and only for the duration of that handler.

The new `busy` prop wraps base-ui's `onOpenChange(open, details)` and swallows the call when `!open && details.reason` is one of `outside-press`, `escape-key`, `close-press`, or `focus-out`. Programmatic close (controlled `open={false}` from the parent, or `actionsRef.close()`) still works, so the dialog can be dismissed once the async work resolves. This complements `disablePointerDismissal`, it does not replace it.

### `size="2xl"`

Existing sizes top out at `xl` = 768px, which is too narrow for dialogs containing two columns of form fields, a summary table, or a side-by-side preview. `2xl` adds a 1024px minimum width using the same `min-w-[Nrem]` Tailwind pattern as the other sizes, and is wired into both `KUMO_DIALOG_VARIANTS.size` and `KUMO_DIALOG_STYLING.dimensions` so the Figma plugin metadata stays consistent.

### `verticalAlign` + `topOffset`

Default vertical centring competes visually with persistent app navbars. Top-anchored dialogs with a configurable navbar-clearing offset are a common requirement. Default behaviour (`verticalAlign="center"`) is unchanged; opt-in `verticalAlign="top" topOffset={N}` flips the panel to inline `top: Npx` and drops the `-translate-y-1/2` centring class.

## API

```tsx
// busy: pure-additive on Dialog.Root, works for both role="dialog" and role="alertdialog"
<Dialog.Root open={open} onOpenChange={setOpen} busy={saving}>
  <Dialog>
    <Dialog.Title>Save changes</Dialog.Title>
    <Button onClick={async () => { setSaving(true); await save(); setSaving(false); setOpen(false); }}>
      Save
    </Button>
  </Dialog>
</Dialog.Root>

// size="2xl": new variant slot
<Dialog size="2xl">{/* min-w 1024px */}</Dialog>

// verticalAlign + topOffset: new content-panel props
<Dialog verticalAlign="top" topOffset={64}>
  {/* anchored 64px from the top of the viewport */}
</Dialog>
```

## Tests

Adds `packages/kumo/src/components/dialog/dialog.test.tsx` with 10 tests (the file did not exist before, so this is also the first test file for the Dialog component):

- baseline render (title, description, close button visible)
- `busy` swallows close-button presses
- `busy` swallows Escape
- `busy=false` allows close-button presses (control)
- `busy` swallows Escape on `role="alertdialog"`
- programmatic close still works while `busy=true` (regression guard against making the API a one-way street)
- `size="2xl"` applies the `min-w-[64rem]` class
- default `verticalAlign="center"` applies `top-1/2` + `-translate-y-1/2`
- `verticalAlign="top" topOffset={49}` applies inline `top: 49px` and drops the centring classes
- `verticalAlign="top"` without `topOffset` defaults to `top: 0px`

All 10 pass. Full kumo suite: 1,120/1,120 pass. Typecheck clean. Lint clean (0 errors). Prettier clean.

## Docs

- Three new demos in `kumo-docs-astro/src/components/demos/DialogDemo.tsx`: `DialogBusyDemo`, `DialogSize2xlDemo`, `DialogVerticalAlignTopDemo`.
- Three new Examples sections in `kumo-docs-astro/src/pages/components/dialog.mdx`: "Busy state", "Wide layout", "Top-anchored".
- `busy` row added to the manual Dialog.Root props table.
- `size="2xl"`, `verticalAlign`, and `topOffset` flow through the auto-generated `PropsTable` via JSDoc on the prop types.

## Screenshots

<!-- screenshot: busy state with Save in flight, showing "Saving..." title + disabled buttons -->
**`busy=true` mid-Save** - Escape, outside clicks, and close button are all temporarily disabled:

_(drag busy-saving.png here)_

<!-- screenshot: 2xl dialog with side-by-side column layout -->
**`size="2xl"`** - 1024px min-width gives room for two-column layouts:

_(drag size-2xl.png here)_

<!-- screenshot: top-anchored dialog at top:64px, navbar-equivalent gap visible -->
**`verticalAlign="top" topOffset={64}`** - anchored to top of viewport, navbar-clearing gap visible:

_(drag vertical-align-top.png here)_

## Compatibility

- 100% backwards compatible. All new props are optional with defaults that preserve current behaviour:
  - `size` default unchanged (`"base"`).
  - `verticalAlign` defaults to `"center"`, which expands to the same `top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2` style stack as before.
  - `busy` defaults to `false`, in which case `onOpenChange` is passed through to base-ui untouched.
- The `dialogVariants()` cn string was split: the centring classes moved out of the always-applied base into the `verticalAlign.center` variant slot, but the rendered class set for an unparameterised `<Dialog>` is byte-identical to before (verified by the baseline render test).

## Changeset

`minor`, matching the precedent set by `feat(chart): React-native tooltip for TimeseriesChart` (#537) where net-new public surface used `minor` rather than `patch`.

## Notes for reviewers

- The `DISMISSAL_REASONS` set uses hardcoded string literals rather than importing from `@base-ui/react/internals/reasons` because the `internals` path is marked private by base-ui. The values are part of the stable public surface via the `DialogRootChangeEventReason` type union, but the constants live in an internal module. Tests cover all four reasons (well, two of the four directly, plus the alertdialog variant) to catch drift if base-ui ever renames one.
- The `verticalAlign="top"` `topOffset` is implemented via inline `style.top` rather than a Tailwind utility because the offset value is arbitrary (could be `64`, `49`, `80`, etc. per app's navbar). This matches the existing inline-style approach for the dialog's `transition-property` and `--tw-shadow`.
- Did not add `outside-press` or `focus-out` test coverage because jsdom makes both awkward to trigger deterministically. The set-based reason check is symmetric across all four values, so escape/close-press passing is good evidence that the other two also work.
