### PR TITLE
fix: narrow React compatibility test scope

### DIFF
--- a/.changeset/smart-walls-peel.md
+++ b/.changeset/smart-walls-peel.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Restore React 18-compatible Sidebar inert attribute handling while keeping the full React compatibility CI suite.

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -148,6 +148,17 @@ export interface SidebarContextValue {
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 
+const reactMajorVersion = parseInt(React.version, 10);
+
+function inertValue(value: boolean): boolean | undefined {
+  if (reactMajorVersion >= 19) {
+    return value;
+  }
+
+  // React <19 does not emit unknown boolean attributes like `inert={true}`.
+  return (value ? "true" : undefined) as boolean | undefined;
+}
+
 /**
  * Hook to access sidebar state and actions from any descendant component.
  *
@@ -1736,7 +1747,7 @@ const SidebarCollapsibleContent = forwardRef<
       id={contentId}
       role="region"
       aria-hidden={!isOpen}
-      inert={!isOpen ? ("true" as unknown as boolean) : undefined}
+      inert={inertValue(!isOpen)}
       data-open={isOpen || undefined}
       className={cn(
         "grid",
@@ -1886,7 +1897,7 @@ const SidebarSlidingView = forwardRef<HTMLDivElement, SidebarSlidingViewProps>(
         data-sidebar="sliding-view"
         data-value={value}
         aria-hidden={!isActive}
-        inert={!isActive ? ("true" as unknown as boolean) : undefined}
+        inert={inertValue(!isActive)}
         className={cn(
           "flex w-full shrink-0 flex-col min-h-0",
           !isActive && "pointer-events-none",


### PR DESCRIPTION
## Summary

- Keep the full React 18/19 compatibility matrix running Kumo typecheck and the full unit suite.
- Replace the inline Sidebar `inert` cast with a small Base UI-style `inertValue()` helper.
- Preserve React 19 boolean `inert` behavior while emitting the attribute correctly under React 18.

## Testing

```bash
pnpm --filter @cloudflare/kumo typecheck
pnpm --filter @cloudflare/kumo test -- src/components/sidebar/sidebar.test.tsx src/react-compat.test.tsx
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pullrequest.yml'); puts 'valid yaml'"
```

Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: follow-up CI/runtime compatibility correction

Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: n/a