### PR TITLE
fix(sidebar): smooth collapse transitions, mobile rewrite, and new props

### DIFF
--- a/.changeset/every-meals-switch.md
+++ b/.changeset/every-meals-switch.md
@@ -1,0 +1,28 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Sidebar: mobile rewrite, smooth collapse transitions, and new props
+
+**New features:**
+
+- `mobileBreakpoint` prop on Provider — configurable viewport width for mobile detection
+- `contentClassName` prop on Sidebar root — pass-through class for the inner content container
+- Controlled mobile state — `open` prop now controls the mobile sidebar too, not just desktop
+
+**Fixes:**
+
+- Replaced Base UI Dialog mobile sidebar with a plain `<aside>` + backdrop for simpler, more predictable transitions
+- Collapsible sections now animate closed smoothly when the sidebar collapses instead of snapping shut
+- Removed `hidden` class from `Sidebar.MenuSub` so sub-menus participate in collapse animations
+- Removed `inertValue` React-version helper — `SidebarSlidingView` now sets `inert` imperatively for React 18 compatibility
+- Removed `inert` and `data-open` attributes from `SidebarCollapsibleContent`
+
+**Styling:**
+
+- `bg-kumo-tint` → `bg-(--sidebar-active-bg)` CSS variable for active/hover/focus backgrounds
+- Icon opacity `0.5` → `0.4`; chevron gains hover opacity transition
+- Header gains `shrink-0` and animated padding on collapse
+- Content scroll area gains animated `gap` transition and `tabIndex={-1}` on viewport
+- Sliding views container gains `max-w-(--sidebar-width)` to prevent overflow
+- Mobile sidebar uses `--sidebar-animation-duration` CSS variable for slide transition

--- a/.changeset/every-meals-switch.md
+++ b/.changeset/every-meals-switch.md
@@ -12,11 +12,11 @@ Sidebar: mobile rewrite, smooth collapse transitions, and new props
 
 **Fixes:**
 
-- Replaced Base UI Dialog mobile sidebar with a plain `<aside>` + backdrop for simpler, more predictable transitions
+- Replaced Base UI Dialog mobile sidebar with a plain `<nav>` + backdrop for simpler, more predictable transitions
 - Collapsible sections now animate closed smoothly when the sidebar collapses instead of snapping shut
 - Removed `hidden` class from `Sidebar.MenuSub` so sub-menus participate in collapse animations
 - Removed `inertValue` React-version helper — `SidebarSlidingView` now sets `inert` imperatively for React 18 compatibility
-- Removed `inert` and `data-open` attributes from `SidebarCollapsibleContent`
+- Restored `inert` on closed `SidebarCollapsibleContent` while removing its `data-open` attribute
 
 **Styling:**
 

--- a/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
@@ -386,7 +386,96 @@ export function SidebarPeekingDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// 6. Sliding Views — animated horizontal transitions between surfaces
+// 6. Auto Scroll — keep long collapsible content in view
+// ---------------------------------------------------------------------------
+
+/** Long sidebar where opening a lower collapsible scrolls its revealed content into view. */
+export function SidebarAutoScrollDemo() {
+  return (
+    <div className="relative h-[420px] w-full overflow-hidden rounded-lg border border-kumo-line bg-kumo-base">
+      <Sidebar.Provider contained defaultOpen className="min-h-0! h-full">
+        <Sidebar>
+          <Sidebar.Header>
+            <BrandLogo />
+          </Sidebar.Header>
+          <Sidebar.Content>
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuButton icon={HouseIcon} active>
+                  Home
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={ChartBarIcon}>
+                  Analytics
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={GlobeIcon}>
+                  Domains
+                </Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Platform</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuButton icon={DatabaseIcon}>
+                  Storage
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={ShieldCheckIcon}>
+                  Security
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={LockIcon}>
+                  Zero Trust
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={GearIcon}>
+                  Settings
+                </Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Build</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuItem>
+                  <Sidebar.Collapsible autoScrollOnOpen>
+                    <Sidebar.CollapsibleTrigger
+                      render={
+                        <Sidebar.MenuButton icon={CodeIcon}>
+                          Workers
+                          <Sidebar.MenuChevron />
+                        </Sidebar.MenuButton>
+                      }
+                    />
+                    <Sidebar.CollapsibleContent>
+                      <Sidebar.MenuSub>
+                        <Sidebar.MenuSubButton>Overview</Sidebar.MenuSubButton>
+                        <Sidebar.MenuSubButton>Deployments</Sidebar.MenuSubButton>
+                        <Sidebar.MenuSubButton>Observability</Sidebar.MenuSubButton>
+                        <Sidebar.MenuSubButton>Settings</Sidebar.MenuSubButton>
+                      </Sidebar.MenuSub>
+                    </Sidebar.CollapsibleContent>
+                  </Sidebar.Collapsible>
+                </Sidebar.MenuItem>
+                <Sidebar.MenuButton icon={CubeIcon}>
+                  Containers
+                  <Sidebar.MenuBadge>Beta</Sidebar.MenuBadge>
+                </Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+          </Sidebar.Content>
+          <Sidebar.Footer>
+            <Sidebar.Trigger />
+          </Sidebar.Footer>
+        </Sidebar>
+        <DemoMain>
+          <p>Open Workers near the bottom of the list</p>
+        </DemoMain>
+      </Sidebar.Provider>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Sliding Views — animated horizontal transitions between surfaces
 // ---------------------------------------------------------------------------
 
 /** Sidebar with animated sliding views between Account and Zone navigation. */
@@ -477,7 +566,7 @@ export function SidebarSlidingViewsDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// 7. Full — kitchen sink showcasing every subcomponent
+// 8. Full — kitchen sink showcasing every subcomponent
 // ---------------------------------------------------------------------------
 
 /** Kitchen sink sidebar showcasing every subcomponent: header with account switcher, groups with labels, collapsible sections with nested expandable, badges, sliding views via Domains, and a footer trigger. */
@@ -644,7 +733,7 @@ export function SidebarFullDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// 8. Mobile — modal sidebar sheet with focus trap and Escape to close
+// 9. Mobile — navigation drawer with Escape to close
 // ---------------------------------------------------------------------------
 
 function MobileToggleButton() {

--- a/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
@@ -67,7 +67,7 @@ function AccountSwitcher() {
         render={
           <button
             type="button"
-            className="cursor-pointer flex w-full min-w-0 items-center gap-2 rounded-lg px-3 group-data-[state=collapsed]/sidebar:px-1.5 py-2 text-left text-sm font-medium text-kumo-default hover:bg-kumo-tint focus-visible:ring-1 focus-visible:ring-kumo-line outline-none transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)"
+            className="cursor-pointer flex w-full min-w-0 items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium text-kumo-default hover:bg-kumo-tint focus-visible:ring-1 focus-visible:ring-kumo-line outline-none transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)"
           >
             <active.icon
               className="size-4 shrink-0 text-kumo-brand"
@@ -502,7 +502,7 @@ export function SidebarFullDemo() {
                     <Sidebar.MenuButton
                       icon={MagnifyingGlassIcon}
                       tooltip="Search"
-                      className="ring ring-kumo-line group-data-[state=collapsed]/sidebar:ring-transparent"
+                      className="ring ring-kumo-line group-data-[state=collapsed]/sidebar:ring-transparent mb-3 group-data-[state=collapsed]/sidebar:mb-0 transition-[margin] duration-(--sidebar-animation-duration)"
                     >
                       Quick search&hellip;
                     </Sidebar.MenuButton>
@@ -640,5 +640,75 @@ export function SidebarFullDemo() {
         <DemoMain />
       </Sidebar.Provider>
     </DemoContainer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Mobile — modal sidebar sheet with focus trap and Escape to close
+// ---------------------------------------------------------------------------
+
+function MobileToggleButton() {
+  const { toggleSidebar, openMobile } = useSidebar();
+  return (
+    <button
+      type="button"
+      onClick={toggleSidebar}
+      className="cursor-pointer rounded-lg border border-kumo-line bg-kumo-base px-3 py-1.5 text-base text-kumo-default transition-colors hover:bg-kumo-tint"
+    >
+      {openMobile ? "Close sidebar" : "Open sidebar"}
+    </button>
+  );
+}
+
+/** Mobile sidebar demo. Uses a high `mobileBreakpoint` to force mobile mode at any viewport width. */
+export function SidebarMobileDemo() {
+  return (
+    <div className="relative h-[540px] w-full overflow-hidden rounded-lg border border-kumo-line bg-kumo-base">
+      <Sidebar.Provider contained mobileBreakpoint={9999} className="h-full">
+        <Sidebar>
+          <Sidebar.Header>
+            <BrandLogo />
+          </Sidebar.Header>
+          <Sidebar.Content>
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuButton icon={HouseIcon} active>
+                  Home
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={ChartBarIcon}>
+                  Analytics
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={GlobeIcon}>
+                  Domains
+                </Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Build</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuButton icon={CodeIcon}>
+                  Compute
+                </Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={DatabaseIcon}>
+                  Storage
+                </Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+          </Sidebar.Content>
+          <Sidebar.Footer>
+            <Sidebar.Trigger />
+          </Sidebar.Footer>
+        </Sidebar>
+        <DemoMain>
+          <MobileToggleButton />
+          <p>Click the button to open the mobile sidebar</p>
+          <p className="text-sm text-kumo-subtle">
+            Press Escape or click the backdrop to close
+          </p>
+        </DemoMain>
+      </Sidebar.Provider>
+    </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -13,6 +13,7 @@ import {
   SidebarRightDemo,
   SidebarPeekingDemo,
   SidebarSlidingViewsDemo,
+  SidebarMobileDemo,
 } from "../../components/demos/SidebarDemo";
 ---
 
@@ -276,6 +277,22 @@ const { state, isPeeking } = useSidebar();
   </Sidebar.Footer>
 </Sidebar>`}>
           <SidebarFullDemo client:load />
+        </ComponentExample>
+      </div>
+
+      <div>
+        <Heading level={3}>Mobile</Heading>
+        <p>
+          On narrow viewports the sidebar renders as a modal sheet. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">mobileBreakpoint</code> to control the threshold.
+          The sheet includes <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">inert</code>, <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">aria-hidden</code>, focus management, and Escape-to-close.
+          This demo forces mobile mode via a high breakpoint.
+        </p>
+        <ComponentExample code={`<Sidebar.Provider mobileBreakpoint={9999}>
+  <Sidebar>
+    <Sidebar.Content>...</Sidebar.Content>
+  </Sidebar>
+</Sidebar.Provider>`}>
+          <SidebarMobileDemo client:load />
         </ComponentExample>
       </div>
 

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -12,6 +12,7 @@ import {
   SidebarResizableDemo,
   SidebarRightDemo,
   SidebarPeekingDemo,
+  SidebarAutoScrollDemo,
   SidebarSlidingViewsDemo,
   SidebarMobileDemo,
 } from "../../components/demos/SidebarDemo";
@@ -208,6 +209,28 @@ const { toggleSidebar } = useSidebar();`}>
 const { state, isPeeking } = useSidebar();
 // state: "expanded" | "collapsed" | "peeking"`}>
           <SidebarPeekingDemo client:load />
+        </ComponentExample>
+      </div>
+
+      <div>
+        <Heading level={3}>Auto Scroll</Heading>
+        <p>
+          Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">autoScrollOnOpen</code> on long collapsible sections to keep newly revealed content in view.
+          This is useful when a group near the bottom of a scrollable sidebar expands below the visible area.
+        </p>
+        <ComponentExample code={`<Sidebar.Collapsible autoScrollOnOpen>
+  <Sidebar.CollapsibleTrigger
+    render={
+      <Sidebar.MenuButton icon={CodeIcon}>
+        Workers <Sidebar.MenuChevron />
+      </Sidebar.MenuButton>
+    }
+  />
+  <Sidebar.CollapsibleContent>
+    <Sidebar.MenuSub>...</Sidebar.MenuSub>
+  </Sidebar.CollapsibleContent>
+</Sidebar.Collapsible>`}>
+          <SidebarAutoScrollDemo client:load />
         </ComponentExample>
       </div>
 

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -283,8 +283,8 @@ const { state, isPeeking } = useSidebar();
       <div>
         <Heading level={3}>Mobile</Heading>
         <p>
-          On narrow viewports the sidebar renders as a modal sheet. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">mobileBreakpoint</code> to control the threshold.
-          The sheet includes <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">inert</code>, <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">aria-hidden</code>, focus management, and Escape-to-close.
+          On narrow viewports the sidebar renders as a navigation drawer. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">mobileBreakpoint</code> to control the threshold.
+          The drawer uses <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">inert</code> and <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">aria-hidden</code> while closed, moves focus in on open, and supports Escape-to-close.
           This demo forces mobile mode via a high breakpoint.
         </p>
         <ComponentExample code={`<Sidebar.Provider mobileBreakpoint={9999}>
@@ -306,7 +306,7 @@ const { state, isPeeking } = useSidebar();
       <div>
         <h3 class="mb-3 text-lg font-semibold font-mono">Sidebar</h3>
         <p>
-          The main sidebar container. Renders as <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;aside&gt;</code> on desktop, Dialog sheet on mobile.
+          The main sidebar container. Renders as <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;aside&gt;</code> on desktop and a navigation drawer on mobile.
         </p>
         <PropsTable component="Sidebar" />
       </div>

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -3,7 +3,7 @@ if (!HTMLElement.prototype.getAnimations) {
   HTMLElement.prototype.getAnimations = () => [];
 }
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
@@ -66,12 +66,11 @@ function StateReader() {
   );
 }
 
-// Stub matchMedia for useIsMobile — always return desktop
-beforeEach(() => {
+function setMobileMatchMedia(matches: boolean) {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({
-      matches: false,
+      matches,
       media: query,
       onchange: null,
       addListener: vi.fn(),
@@ -81,6 +80,11 @@ beforeEach(() => {
       dispatchEvent: vi.fn(),
     })),
   });
+}
+
+// Stub matchMedia for useIsMobile — default to desktop
+beforeEach(() => {
+  setMobileMatchMedia(false);
 });
 
 // ============================================================================
@@ -551,5 +555,105 @@ describe("Sidebar contained mode", () => {
     );
     const wrapper = document.querySelector("[data-sidebar-wrapper]")!;
     expect(wrapper.className).toContain("min-h-svh");
+  });
+});
+
+// ============================================================================
+// Mobile behavior
+// ============================================================================
+
+describe("Sidebar mobile behavior", () => {
+  function MobileToggle() {
+    const { toggleSidebar } = useSidebar();
+    return (
+      <button type="button" onClick={toggleSidebar} data-testid="mobile-toggle">
+        Open sidebar
+      </button>
+    );
+  }
+
+  function MobileTest() {
+    return (
+      <SidebarProvider mobileBreakpoint={9999}>
+        <MobileToggle />
+        <Sidebar>
+          <SidebarContent>
+            <SidebarMenu>
+              <SidebarMenuButton>Home</SidebarMenuButton>
+            </SidebarMenu>
+          </SidebarContent>
+        </Sidebar>
+        <button type="button" data-testid="after-sidebar">
+          After sidebar
+        </button>
+      </SidebarProvider>
+    );
+  }
+
+  it("should render closed mobile navigation as inert and aria-hidden", () => {
+    setMobileMatchMedia(true);
+    render(<MobileTest />);
+
+    const nav = document.querySelector("nav[data-sidebar='sidebar']")!;
+    expect(nav.getAttribute("aria-hidden")).toBe("true");
+    expect(nav.hasAttribute("inert")).toBe(true);
+  });
+
+  it("should open mobile navigation and move focus to the first item", async () => {
+    setMobileMatchMedia(true);
+    const user = userEvent.setup();
+    render(<MobileTest />);
+
+    const nav = document.querySelector("nav[data-sidebar='sidebar']")!;
+    await user.click(screen.getByTestId("mobile-toggle"));
+
+    await waitFor(() => expect(nav.getAttribute("aria-hidden")).toBe("false"));
+    expect(nav.hasAttribute("inert")).toBe(false);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Home" }),
+      ),
+    );
+  });
+
+  it("should close on Escape and return focus to the opener", async () => {
+    setMobileMatchMedia(true);
+    const user = userEvent.setup();
+    render(<MobileTest />);
+
+    const toggle = screen.getByTestId("mobile-toggle");
+    const nav = document.querySelector("nav[data-sidebar='sidebar']")!;
+    await user.click(toggle);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Home" }),
+      ),
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(nav.getAttribute("aria-hidden")).toBe("true"));
+    await waitFor(() => expect(document.activeElement).toBe(toggle));
+  });
+
+  it("should close on focus leave without stealing focus back", async () => {
+    setMobileMatchMedia(true);
+    const user = userEvent.setup();
+    render(<MobileTest />);
+
+    const nav = document.querySelector("nav[data-sidebar='sidebar']")!;
+    const afterSidebar = screen.getByTestId("after-sidebar");
+    await user.click(screen.getByTestId("mobile-toggle"));
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Home" }),
+      ),
+    );
+
+    afterSidebar.focus();
+    fireEvent.focusOut(nav, { relatedTarget: afterSidebar });
+
+    await waitFor(() => expect(nav.getAttribute("aria-hidden")).toBe("true"));
+    expect(document.activeElement).toBe(afterSidebar);
   });
 });

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -340,8 +340,14 @@ describe("Sidebar.Collapsible", () => {
   it("should scroll opened content into view when enabled", () => {
     vi.useFakeTimers();
     const scrollIntoView = vi.fn();
-    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
-    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollIntoView",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
 
     try {
       render(<CollapsibleTest autoScrollOnOpen />);
@@ -356,7 +362,15 @@ describe("Sidebar.Collapsible", () => {
         behavior: "smooth",
       });
     } finally {
-      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      if (originalScrollIntoViewDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollIntoView",
+          originalScrollIntoViewDescriptor,
+        );
+      } else {
+        delete HTMLElement.prototype.scrollIntoView;
+      }
       vi.useRealTimers();
     }
   });

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -3,7 +3,7 @@ if (!HTMLElement.prototype.getAnimations) {
   HTMLElement.prototype.getAnimations = () => [];
 }
 
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
@@ -255,13 +255,22 @@ describe("Sidebar toggle", () => {
 // ============================================================================
 
 describe("Sidebar.Collapsible", () => {
-  function CollapsibleTest({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  function CollapsibleTest({
+    defaultOpen = false,
+    autoScrollOnOpen = false,
+  }: {
+    defaultOpen?: boolean;
+    autoScrollOnOpen?: boolean;
+  }) {
     return (
       <TestSidebar defaultOpen>
         <SidebarContent>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarCollapsible defaultOpen={defaultOpen}>
+              <SidebarCollapsible
+                defaultOpen={defaultOpen}
+                autoScrollOnOpen={autoScrollOnOpen}
+              >
                 <SidebarCollapsibleTrigger
                   render={
                     <SidebarMenuButton>
@@ -326,6 +335,30 @@ describe("Sidebar.Collapsible", () => {
     const content = screen.getByTestId("collapsible-content");
     expect(content.hasAttribute("inert")).toBe(true);
     expect(content.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("should scroll opened content into view when enabled", () => {
+    vi.useFakeTimers();
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    try {
+      render(<CollapsibleTest autoScrollOnOpen />);
+
+      fireEvent.click(screen.getByText("Compute").closest("button")!);
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -317,10 +317,11 @@ describe("Sidebar.Collapsible", () => {
     expect(content.getAttribute("role")).toBe("region");
   });
 
-  it("should set inert on closed content", () => {
+  it("should not set inert on closed content (uses aria-hidden + grid-rows instead)", () => {
     render(<CollapsibleTest />);
     const content = screen.getByTestId("collapsible-content");
-    expect(content.hasAttribute("inert")).toBe(true);
+    expect(content.hasAttribute("inert")).toBe(false);
+    expect(content.getAttribute("aria-hidden")).toBe("true");
   });
 });
 
@@ -421,13 +422,17 @@ describe("Sidebar.SlidingViews", () => {
 
   it("should show the active view", () => {
     render(<SlidingTest activeKey="a" />);
-    const viewA = screen.getByTestId("view-a").closest("[data-sidebar='sliding-view']")!;
+    const viewA = screen
+      .getByTestId("view-a")
+      .closest("[data-sidebar='sliding-view']")!;
     expect(viewA.getAttribute("aria-hidden")).toBe("false");
   });
 
   it("should hide inactive views with aria-hidden and inert", () => {
     render(<SlidingTest activeKey="a" />);
-    const viewB = screen.getByTestId("view-b").closest("[data-sidebar='sliding-view']")!;
+    const viewB = screen
+      .getByTestId("view-b")
+      .closest("[data-sidebar='sliding-view']")!;
     expect(viewB.getAttribute("aria-hidden")).toBe("true");
     expect(viewB.hasAttribute("inert")).toBe(true);
   });
@@ -437,8 +442,12 @@ describe("Sidebar.SlidingViews", () => {
 
     rerender(<SlidingTest activeKey="b" />);
 
-    const viewA = screen.getByTestId("view-a").closest("[data-sidebar='sliding-view']")!;
-    const viewB = screen.getByTestId("view-b").closest("[data-sidebar='sliding-view']")!;
+    const viewA = screen
+      .getByTestId("view-a")
+      .closest("[data-sidebar='sliding-view']")!;
+    const viewB = screen
+      .getByTestId("view-b")
+      .closest("[data-sidebar='sliding-view']")!;
     expect(viewA.getAttribute("aria-hidden")).toBe("true");
     expect(viewB.getAttribute("aria-hidden")).toBe("false");
   });
@@ -451,7 +460,13 @@ describe("Sidebar.SlidingViews", () => {
 describe("Sidebar.ResizeHandle", () => {
   it("should have correct ARIA attributes", () => {
     render(
-      <TestSidebar defaultOpen resizable defaultWidth={240} minWidth={180} maxWidth={400}>
+      <TestSidebar
+        defaultOpen
+        resizable
+        defaultWidth={240}
+        minWidth={180}
+        maxWidth={400}
+      >
         <Sidebar.ResizeHandle data-testid="handle" />
       </TestSidebar>,
     );

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -317,10 +317,10 @@ describe("Sidebar.Collapsible", () => {
     expect(content.getAttribute("role")).toBe("region");
   });
 
-  it("should not set inert on closed content (uses aria-hidden + grid-rows instead)", () => {
+  it("should set inert on closed content", () => {
     render(<CollapsibleTest />);
     const content = screen.getByTestId("collapsible-content");
-    expect(content.hasAttribute("inert")).toBe(false);
+    expect(content.hasAttribute("inert")).toBe(true);
     expect(content.getAttribute("aria-hidden")).toBe("true");
   });
 });

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -12,7 +12,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Dialog as DialogBase } from "@base-ui/react/dialog";
 import { ScrollArea as ScrollAreaBase } from "@base-ui/react/scroll-area";
 
 import { CaretRightIcon } from "@phosphor-icons/react";
@@ -100,16 +99,16 @@ const MOBILE_BREAKPOINT = 768;
 // Mobile detection hook
 // ============================================================================
 
-function useIsMobile() {
+function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
     const onChange = () => setIsMobile(mql.matches);
     mql.addEventListener("change", onChange);
     setIsMobile(mql.matches);
     return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [breakpoint]);
 
   return isMobile;
 }
@@ -147,17 +146,6 @@ export interface SidebarContextValue {
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
-
-const reactMajorVersion = parseInt(React.version, 10);
-
-function inertValue(value: boolean): boolean | undefined {
-  if (reactMajorVersion >= 19) {
-    return value;
-  }
-
-  // React <19 does not emit unknown boolean attributes like `inert={true}`.
-  return (value ? "true" : undefined) as boolean | undefined;
-}
 
 /**
  * Hook to access sidebar state and actions from any descendant component.
@@ -220,6 +208,12 @@ export interface SidebarProviderProps {
    * @default 250
    */
   animationDuration?: number;
+  /**
+   * Viewport width (in px) below which the sidebar renders as a mobile dialog
+   * sheet instead of the desktop aside rail.
+   * @default 768
+   */
+  mobileBreakpoint?: number;
   /** Content — typically `<Sidebar>` + main content. */
   children: ReactNode;
   /** Additional CSS classes for the wrapper div. */
@@ -259,15 +253,32 @@ function SidebarProvider({
   contained = false,
   peekable = false,
   animationDuration = SIDEBAR_ANIMATION_DURATION_MS,
+  mobileBreakpoint,
   children,
   className,
   style,
 }: SidebarProviderProps) {
-  const isMobile = useIsMobile();
-  const [openMobile, setOpenMobile] = useState(false);
+  const isMobile = useIsMobile(mobileBreakpoint);
+  const [_openMobile, _setOpenMobile] = useState(false);
   const [width, setWidthState] = useState(defaultWidth);
   const [isResizing, setIsResizing] = useState(false);
   const [isPeeking, setIsPeeking] = useState(false);
+
+  // When controlled (`openProp` provided), use it directly for mobile too.
+  // When uncontrolled, use internal `_openMobile` state.
+  const openMobile =
+    isMobile && openProp !== undefined ? openProp : _openMobile;
+
+  const setOpenMobile = useCallback(
+    (next: boolean) => {
+      _setOpenMobile(next);
+      // In controlled mode on mobile, notify the consumer
+      if (isMobile && openProp !== undefined) {
+        setOpenProp?.(next);
+      }
+    },
+    [isMobile, openProp, setOpenProp],
+  );
 
   const setWidth = useCallback(
     (newWidth: number) => {
@@ -291,12 +302,12 @@ function SidebarProvider({
 
   const toggleSidebar = useCallback(() => {
     if (isMobile) {
-      setOpenMobile((prev) => !prev);
+      setOpenMobile(!openMobile);
     } else {
       setIsPeeking(false);
       setOpen((prev: boolean) => !prev);
     }
-  }, [isMobile, setOpen]);
+  }, [isMobile, openMobile, setOpenMobile, setOpen]);
 
   const startPeek = useCallback(() => {
     if (peekable && !open && !isMobile) {
@@ -318,12 +329,34 @@ function SidebarProvider({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- all values are
   // either stable (props, setters) or derived from state that triggers re-render
-  const contextValue = useMemo<SidebarContextValue>(() => ({
-    state, open, setOpen, openMobile, setOpenMobile, isMobile,
-    toggleSidebar, variant, side, collapsible, width, resizable,
-    minWidth, maxWidth, isResizing, setIsResizing, setWidth,
-    isPeeking, peekable, startPeek, stopPeek, contained, animationDuration,
-  }), [state, open, openMobile, isMobile, width, isResizing, isPeeking]);
+  const contextValue = useMemo<SidebarContextValue>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      openMobile,
+      setOpenMobile,
+      isMobile,
+      toggleSidebar,
+      variant,
+      side,
+      collapsible,
+      width,
+      resizable,
+      minWidth,
+      maxWidth,
+      isResizing,
+      setIsResizing,
+      setWidth,
+      isPeeking,
+      peekable,
+      startPeek,
+      stopPeek,
+      contained,
+      animationDuration,
+    }),
+    [state, open, openMobile, isMobile, width, isResizing, isPeeking],
+  );
 
   return (
     <SidebarContext.Provider value={contextValue}>
@@ -337,13 +370,12 @@ function SidebarProvider({
             "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
             "--sidebar-animation-duration": `${animationDuration}ms`,
             "--sidebar-easing": SIDEBAR_EASING,
-            "--sidebar-bg": "var(--color-kumo-base)",
             ...style,
           } as CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper isolate flex w-full",
-          !contained && "min-h-svh",
+          "group/sidebar-wrapper relative isolate flex w-full [--sidebar-bg:var(--color-kumo-base)] [--sidebar-active-bg:var(--color-kumo-tint)]",
+          !contained && !isMobile && "min-h-svh",
           "has-data-[variant=inset]:bg-kumo-recessed",
           isResizing && "select-none",
           className,
@@ -364,6 +396,8 @@ SidebarProvider.displayName = "Sidebar.Provider";
 export interface SidebarRootProps extends ComponentPropsWithoutRef<"aside"> {
   /** Additional CSS classes for the sidebar element. */
   className?: string;
+  /** Additional CSS classes for the inner content container. */
+  contentClassName?: string;
   /** Sidebar content — Header, Content, Footer, etc. */
   children: ReactNode;
 }
@@ -384,7 +418,7 @@ export interface SidebarRootProps extends ComponentPropsWithoutRef<"aside"> {
  * ```
  */
 const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ className, contentClassName, children, ...props }, ref) => {
     const {
       state,
       open,
@@ -435,45 +469,47 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
 
     if (isMobile) {
       return (
-        <DialogBase.Root open={openMobile} onOpenChange={setOpenMobile}>
-          <DialogBase.Portal>
-            <DialogBase.Backdrop data-sidebar-backdrop="" className="fixed inset-0 bg-black/50 transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-            <DialogBase.Popup
-              data-sidebar-popup=""
-              className={cn(
-                "fixed inset-y-0 flex w-[--sidebar-width] flex-col bg-kumo-base p-0",
-                "duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
-                side === "left" &&
-                  "left-0 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full",
-                side === "right" &&
-                  "right-0 data-[ending-style]:translate-x-full data-[starting-style]:translate-x-full",
-              )}
-              style={
-                {
-                  "--sidebar-width": SIDEBAR_WIDTH,
-                  transitionProperty: "transform, opacity",
-                  transitionTimingFunction:
-                    "var(--default-transition-timing-function)",
-                } as CSSProperties
-              }
-            >
-              <div
-                data-state="expanded"
-                data-side={side}
-                data-variant={variant}
-                data-collapsible={collapsible}
-                data-sidebar="sidebar"
-                data-mobile="true"
-                className={cn(
-                  "group/sidebar flex h-full w-full flex-col bg-kumo-base text-kumo-default",
-                  className,
-                )}
-              >
-                {children}
-              </div>
-            </DialogBase.Popup>
-          </DialogBase.Portal>
-        </DialogBase.Root>
+        <>
+          {/* Backdrop — click to close */}
+          <div
+            data-sidebar-backdrop=""
+            className={cn(
+              "fixed inset-0 z-40 bg-kumo-recessed",
+              "transition-opacity duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
+              "motion-reduce:transition-none",
+              openMobile ? "opacity-80" : "opacity-0 pointer-events-none",
+            )}
+            onClick={() => setOpenMobile(false)}
+            aria-hidden="true"
+          />
+
+          {/* Sidebar — same structure as desktop, slides via transform */}
+          <aside
+            ref={ref}
+            data-state={openMobile ? "expanded" : "collapsed"}
+            data-side={side}
+            data-variant={variant}
+            data-collapsible={collapsible}
+            data-sidebar="sidebar"
+            data-mobile="true"
+            className={cn(
+              "group/sidebar fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden",
+              "border-r border-kumo-line bg-(--sidebar-bg) text-kumo-default",
+              "transition-transform duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
+              "motion-reduce:transition-none",
+              side === "left" && "left-0",
+              side === "right" && "right-0",
+              side === "left" &&
+                (openMobile ? "translate-x-0" : "-translate-x-full"),
+              side === "right" &&
+                (openMobile ? "translate-x-0" : "translate-x-full"),
+              className,
+            )}
+            {...props}
+          >
+            {children}
+          </aside>
+        </>
       );
     }
 
@@ -537,12 +573,14 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             const footerChildren = childArray.filter(
               (child) =>
                 React.isValidElement(child) &&
-                (child.type as { displayName?: string })?.displayName === "Sidebar.Footer",
+                (child.type as { displayName?: string })?.displayName ===
+                  "Sidebar.Footer",
             );
             const nonFooterChildren = childArray.filter(
               (child) =>
                 !React.isValidElement(child) ||
-                (child.type as { displayName?: string })?.displayName !== "Sidebar.Footer",
+                (child.type as { displayName?: string })?.displayName !==
+                  "Sidebar.Footer",
             );
 
             return (
@@ -557,13 +595,15 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
                   "transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
                   "motion-reduce:transition-none",
                   isResizing && "transition-none!",
-                  !open && cn(
-                    contained ? "absolute" : "fixed",
-                    "inset-y-0 z-40",
-                    side === "left" && "left-0",
-                    side === "right" && "right-0",
-                  ),
+                  !open &&
+                    cn(
+                      contained ? "absolute" : "fixed",
+                      "inset-y-0 z-40",
+                      side === "left" && "left-0",
+                      side === "right" && "right-0",
+                    ),
                   open && "relative",
+                  contentClassName,
                 )}
               >
                 {/* Peek zone — header + content (not footer) */}
@@ -614,7 +654,9 @@ const SidebarHeader = forwardRef<
     ref={ref}
     data-sidebar="header"
     className={cn(
-      "flex h-[58px] items-center gap-1 border-b border-kumo-line px-3.5",
+      "flex h-[58px] shrink-0 items-center gap-1 border-b border-kumo-line",
+      "px-2 group-not-data-[state=collapsed]/sidebar:px-3.5",
+      "transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
       "overflow-hidden",
       className,
     )}
@@ -649,15 +691,16 @@ const SidebarContent = forwardRef<
     {...props}
   >
     <ScrollAreaBase.Viewport
+      tabIndex={-1}
       className={cn(
-        "h-full px-[11px] py-[13px] group-not-data-[state=collapsed]/sidebar:px-3.5",
+        "h-full px-[11px] py-3 group-not-data-[state=collapsed]/sidebar:px-3.5",
         "transition-[padding] duration-(--sidebar-animation-duration)",
         "group-data-[state=collapsed]/sidebar:overflow-x-hidden!",
         // Scroll fade via CSS mask driven by Base UI overflow CSS variables
         "[mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]",
       )}
     >
-      <ScrollAreaBase.Content className="flex min-w-0 flex-col gap-2 group-data-[state=collapsed]/sidebar:min-w-0!">
+      <ScrollAreaBase.Content className="flex min-w-0 flex-col gap-3 group-data-[state=collapsed]/sidebar:gap-0 group-data-[state=collapsed]/sidebar:min-w-0! transition-[gap] duration-(--sidebar-animation-duration)">
         {children}
       </ScrollAreaBase.Content>
     </ScrollAreaBase.Viewport>
@@ -669,9 +712,7 @@ const SidebarContent = forwardRef<
         "data-[scrolling]:opacity-100 data-[hovering]:opacity-100",
       )}
     >
-      <ScrollAreaBase.Thumb
-        className="flex-1 rounded-full bg-kumo-line"
-      />
+      <ScrollAreaBase.Thumb className="flex-1 rounded-full bg-kumo-line" />
     </ScrollAreaBase.Scrollbar>
   </ScrollAreaBase.Root>
 ));
@@ -734,18 +775,19 @@ SidebarFooter.displayName = "Sidebar.Footer";
  * </Sidebar.Group>
  * ```
  */
-const SidebarGroup = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(
-  ({ className, children, ...props }, ref) => (
-    <div
-      ref={ref}
-      data-sidebar="group"
-      className={cn("flex min-w-0 flex-col gap-y-px", className)}
-      {...props}
-    >
-      {children}
-    </div>
-  ),
-);
+const SidebarGroup = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, children, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="group"
+    className={cn("flex min-w-0 flex-col gap-y-px", className)}
+    {...props}
+  >
+    {children}
+  </div>
+));
 
 SidebarGroup.displayName = "Sidebar.Group";
 
@@ -774,6 +816,8 @@ const SidebarGroupLabel = forwardRef<
       // Grid-rows for smooth collapse animation
       "grid overflow-hidden",
       "transition-[grid-template-rows,margin,border-color] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
+      // Mobile: no collapse animation — sidebar is always expanded
+      "group-data-[mobile=true]/sidebar:transition-none",
       // Collapsed: spacer with divider line between icon groups
       "grid-rows-[0fr] my-3 border-b border-kumo-line",
       // First group: no spacer or divider needed
@@ -885,7 +929,10 @@ const SidebarMenuItem = forwardRef<
     <li
       ref={ref}
       data-sidebar="menu-item"
-      className={cn("relative group-data-[state=collapsed]/sidebar:overflow-hidden", className)}
+      className={cn(
+        "relative group-data-[state=collapsed]/sidebar:overflow-hidden",
+        className,
+      )}
       {...props}
     >
       {children}
@@ -901,10 +948,11 @@ SidebarMenuItem.displayName = "Sidebar.MenuItem";
 
 export type SidebarMenuButtonSize = "base" | "sm";
 
-export interface SidebarMenuButtonProps extends Omit<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  "className" | "children"
-> {
+export interface SidebarMenuButtonProps
+  extends Omit<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    "className" | "children"
+  > {
   icon?: React.ComponentType<{ className?: string }> | React.ReactNode;
   active?: boolean;
   /**
@@ -970,7 +1018,10 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
       const Comp = IconProp as React.ComponentType<{ className?: string }>;
       return (
         <Comp
-          className={cn("shrink-0 opacity-50", size === "base" ? "size-4" : "size-3.5")}
+          className={cn(
+            "shrink-0 opacity-40",
+            size === "base" ? "size-4" : "size-3.5",
+          )}
         />
       );
     })();
@@ -1002,14 +1053,14 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
       size === "base" && "min-h-8.5 px-3 py-0 text-sm font-medium",
       size === "sm" && "min-h-7 px-2 py-0 text-sm",
       "text-kumo-default",
-      "transition-[color,background-color,box-shadow,outline] duration-(--sidebar-animation-duration)",
-      !active && "hover:bg-kumo-tint",
+      "transition-[color,box-shadow,outline] duration-(--sidebar-animation-duration)",
+      !active && "hover:bg-(--sidebar-active-bg)",
       // Active state
-      active && "bg-kumo-tint",
+      active && "bg-(--sidebar-active-bg)",
       // When a child sub-button is active, don't show active styling on the parent trigger
-      "has-[[data-active]]:bg-transparent has-[[data-active]]:hover:bg-kumo-tint",
+      "has-[[data-active]]:bg-transparent has-[[data-active]]:hover:bg-(--sidebar-active-bg)",
       // Focus
-      "focus:outline-none focus-visible:text-kumo-strong focus-visible:bg-kumo-tint",
+      "focus:outline-none focus-visible:text-kumo-strong focus-visible:bg-(--sidebar-active-bg)",
       className,
     );
 
@@ -1071,7 +1122,10 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
     // Auto-wrap in <li> when not already inside a MenuItem
     if (!isInsideMenuItem) {
       return (
-        <li data-sidebar="menu-item" className="relative group-data-[state=collapsed]/sidebar:overflow-hidden">
+        <li
+          data-sidebar="menu-item"
+          className="relative group-data-[state=collapsed]/sidebar:overflow-hidden"
+        >
           {button}
         </li>
       );
@@ -1146,8 +1200,6 @@ const SidebarMenuSub = forwardRef<
     data-sidebar="menu-sub"
     className={cn(
       "relative m-0 flex min-w-0 list-none flex-col gap-y-px p-0 pl-7 pr-0 overflow-hidden",
-      // Hidden when collapsed
-      "group-data-[state=collapsed]/sidebar:hidden",
       className,
     )}
     {...props}
@@ -1191,7 +1243,8 @@ SidebarMenuSubItem.displayName = "Sidebar.MenuSubItem";
 // Sidebar MenuSubButton
 // ============================================================================
 
-export interface SidebarMenuSubButtonProps extends ComponentPropsWithoutRef<"button"> {
+export interface SidebarMenuSubButtonProps
+  extends ComponentPropsWithoutRef<"button"> {
   /** Marks this sub-item as currently active/selected. @default false */
   active?: boolean;
   /** Navigation URL. When set, renders as a link via LinkProvider. */
@@ -1220,12 +1273,12 @@ const SidebarMenuSubButton = forwardRef<
   const isInsideMenuSubItem = useContext(MenuSubItemContext);
 
   const buttonClasses = cn(
-    "relative flex w-full min-w-0 items-center gap-2 rounded-lg min-h-8.5 px-3 py-0 text-sm font-medium outline-none cursor-pointer",
+    "group/menu-button relative flex w-full min-w-0 items-center gap-2 rounded-lg min-h-8.5 px-3 py-0 text-sm font-medium outline-none cursor-pointer",
     "before:absolute before:inset-x-0 before:-inset-y-px",
-    "text-kumo-default transition-colors duration-150",
-    !active && "hover:bg-kumo-tint",
-    active && "bg-kumo-tint",
-    "focus:outline-none focus-visible:text-kumo-strong focus-visible:bg-kumo-tint",
+    "text-kumo-default transition-[color] duration-150",
+    !active && "hover:bg-(--sidebar-active-bg)",
+    active && "bg-(--sidebar-active-bg)",
+    "focus:outline-none focus-visible:text-kumo-strong focus-visible:bg-(--sidebar-active-bg)",
     className,
   );
 
@@ -1300,10 +1353,7 @@ const SidebarSeparator = forwardRef<
   <div
     ref={ref}
     data-sidebar="separator"
-    className={cn(
-      "my-3 px-2",
-      className,
-    )}
+    className={cn("my-3 px-2", className)}
     {...props}
   >
     <div className="border-b border-kumo-line" />
@@ -1379,8 +1429,8 @@ const SidebarTrigger = forwardRef<
       aria-expanded={open}
       aria-label={open ? "Collapse sidebar" : "Expand sidebar"}
       className={cn(
-        "flex size-8.5 justify-center items-center rounded-lg cursor-pointer",
-        "text-kumo-subtle hover:text-kumo-default hover:bg-kumo-tint",
+        "flex shrink-0 size-8.5 justify-center items-center rounded-lg cursor-pointer",
+        "text-kumo-subtle hover:text-kumo-default hover:bg-(--sidebar-active-bg)",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand",
         className,
       )}
@@ -1453,8 +1503,17 @@ const SidebarResizeHandle = forwardRef<
   HTMLButtonElement,
   ComponentPropsWithoutRef<"button">
 >(({ className, ...props }, ref) => {
-  const { side, resizable, setIsResizing, setWidth, setOpen, open, minWidth, width: currentWidth, maxWidth } =
-    useSidebar();
+  const {
+    side,
+    resizable,
+    setIsResizing,
+    setWidth,
+    setOpen,
+    open,
+    minWidth,
+    width: currentWidth,
+    maxWidth,
+  } = useSidebar();
   const startX = useRef(0);
   const startWidth = useRef(0);
   const wasCollapsed = useRef(false);
@@ -1591,7 +1650,8 @@ const SidebarCollapseContext = createContext<SidebarCollapseContextValue>({
   toggle: () => {},
 });
 
-export interface SidebarCollapsibleProps extends ComponentPropsWithoutRef<"div"> {
+export interface SidebarCollapsibleProps
+  extends ComponentPropsWithoutRef<"div"> {
   /** Initial open state (uncontrolled). @default false */
   defaultOpen?: boolean;
   /** Controlled open state. */
@@ -1623,7 +1683,17 @@ export interface SidebarCollapsibleProps extends ComponentPropsWithoutRef<"div">
  * ```
  */
 const SidebarCollapsible = forwardRef<HTMLDivElement, SidebarCollapsibleProps>(
-  ({ defaultOpen = false, open: openProp, onOpenChange, className, children, ...props }, ref) => {
+  (
+    {
+      defaultOpen = false,
+      open: openProp,
+      onOpenChange,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
     const [internalOpen, setInternalOpen] = useState(defaultOpen);
     const isOpen = openProp ?? internalOpen;
     const contentId = useId();
@@ -1720,7 +1790,9 @@ function SidebarCollapsibleTrigger({ render }: SidebarCollapsibleTriggerProps) {
     "data-open": isOpen || undefined,
     onClick: (e: React.MouseEvent) => {
       // Call any existing onClick on the render element
-      const existingOnClick = (render.props as { onClick?: (e: React.MouseEvent) => void }).onClick;
+      const existingOnClick = (
+        render.props as { onClick?: (e: React.MouseEvent) => void }
+      ).onClick;
       existingOnClick?.(e);
       toggle();
     },
@@ -1739,7 +1811,12 @@ const SidebarCollapsibleContent = forwardRef<
   HTMLDivElement,
   ComponentPropsWithoutRef<"div">
 >(({ className, children, ...props }, ref) => {
-  const { contentId, isOpen } = useContext(SidebarCollapseContext);
+  const { contentId, isOpen: isCollapsibleOpen } = useContext(
+    SidebarCollapseContext,
+  );
+  const { state } = useSidebar();
+
+  const isOpen = isCollapsibleOpen && state !== "collapsed";
 
   return (
     <div
@@ -1747,8 +1824,6 @@ const SidebarCollapsibleContent = forwardRef<
       id={contentId}
       role="region"
       aria-hidden={!isOpen}
-      inert={inertValue(!isOpen)}
-      data-open={isOpen || undefined}
       className={cn(
         "grid",
         "transition-[grid-template-rows] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
@@ -1788,7 +1863,7 @@ function SidebarMenuChevron({ className }: { className?: string }) {
       size={12}
       weight="bold"
       className={cn(
-        "ml-auto shrink-0 text-kumo-subtle transition-transform duration-200",
+        "ml-auto shrink-0 opacity-40 group-hover/menu-button:opacity-100 transition-[transform,rotate,opacity] duration-200",
         isCollapsible && isOpen && "rotate-90",
         // Hidden when sidebar is collapsed
         "group-data-[state=collapsed]/sidebar:hidden",
@@ -1806,7 +1881,8 @@ SidebarMenuChevron.displayName = "Sidebar.MenuChevron";
 
 const SlidingViewActiveContext = createContext<string>("");
 
-export interface SidebarSlidingViewsProps extends ComponentPropsWithoutRef<"div"> {
+export interface SidebarSlidingViewsProps
+  extends ComponentPropsWithoutRef<"div"> {
   /** Key of the currently active view. Must match a child `SlidingView` value. */
   activeKey: string;
   /**
@@ -1836,8 +1912,20 @@ export interface SidebarSlidingViewsProps extends ComponentPropsWithoutRef<"div"
  * </Sidebar.SlidingViews>
  * ```
  */
-const SidebarSlidingViews = forwardRef<HTMLDivElement, SidebarSlidingViewsProps>(
-  ({ activeKey, direction: _direction = "left", className, children, ...props }, ref) => {
+const SidebarSlidingViews = forwardRef<
+  HTMLDivElement,
+  SidebarSlidingViewsProps
+>(
+  (
+    {
+      activeKey,
+      direction: _direction = "left",
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
     const childArray = React.Children.toArray(children);
     const activeIndex = childArray.findIndex(
       (child) =>
@@ -1855,7 +1943,10 @@ const SidebarSlidingViews = forwardRef<HTMLDivElement, SidebarSlidingViewsProps>
         <div
           ref={ref}
           data-sidebar="sliding-views"
-          className={cn("flex flex-1 min-h-0 overflow-hidden", className)}
+          className={cn(
+            "flex flex-1 min-h-0 max-w-(--sidebar-width) overflow-hidden",
+            className,
+          )}
           {...props}
         >
           <div
@@ -1877,7 +1968,8 @@ const SidebarSlidingViews = forwardRef<HTMLDivElement, SidebarSlidingViewsProps>
 
 SidebarSlidingViews.displayName = "Sidebar.SlidingViews";
 
-export interface SidebarSlidingViewProps extends ComponentPropsWithoutRef<"div"> {
+export interface SidebarSlidingViewProps
+  extends ComponentPropsWithoutRef<"div"> {
   /** Unique key matching this view. Must correspond to `activeKey` on `SlidingViews`. */
   value: string;
 }
@@ -1891,13 +1983,40 @@ const SidebarSlidingView = forwardRef<HTMLDivElement, SidebarSlidingViewProps>(
     const activeKey = useContext(SlidingViewActiveContext);
     const isActive = activeKey === value;
 
+    // Imperatively set inert — React 18.2 doesn't reliably forward the inert
+    // attribute to the DOM when set as a JSX prop on initial mount.
+    const inertRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        if (node) {
+          if (!isActive) {
+            node.setAttribute("inert", "");
+          } else {
+            node.removeAttribute("inert");
+          }
+        }
+      },
+      [isActive],
+    );
+
+    // Merge forwarded ref with inert ref
+    const mergedRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        inertRef(node);
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        }
+      },
+      [ref, inertRef],
+    );
+
     return (
       <div
-        ref={ref}
+        ref={mergedRef}
         data-sidebar="sliding-view"
         data-value={value}
         aria-hidden={!isActive}
-        inert={inertValue(!isActive)}
         className={cn(
           "flex w-full shrink-0 flex-col min-h-0",
           !isActive && "pointer-events-none",

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -403,7 +403,7 @@ export interface SidebarRootProps extends ComponentPropsWithoutRef<"aside"> {
 }
 
 /**
- * Main sidebar container. Renders as `<aside>` on desktop, Dialog sheet on mobile.
+ * Main sidebar container. Renders as `<aside>` on desktop, modal sidebar sheet on mobile.
  * Must be used inside `Sidebar.Provider`.
  *
  * @example
@@ -467,6 +467,64 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       );
     }
 
+    // Imperatively set inert on the mobile sidebar — React 18 doesn't
+    // reliably forward the inert attribute as a JSX prop on initial mount.
+    const mobileAsideRef = useCallback(
+      (node: HTMLElement | null) => {
+        if (node) {
+          if (!openMobile) {
+            node.setAttribute("inert", "");
+          } else {
+            node.removeAttribute("inert");
+          }
+        }
+      },
+      [openMobile],
+    );
+
+    // Merge forwarded ref with inert ref for the mobile aside
+    const mergedMobileRef = useCallback(
+      (node: HTMLElement | null) => {
+        mobileAsideRef(node);
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLElement | null>).current = node;
+        }
+      },
+      [ref, mobileAsideRef],
+    );
+
+    // Escape key closes the mobile sidebar
+    useEffect(() => {
+      if (!isMobile || !openMobile) return;
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          setOpenMobile(false);
+        }
+      };
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [isMobile, openMobile, setOpenMobile]);
+
+    // When the mobile sidebar opens, move focus into it;
+    // when it closes, return focus to the element that opened it.
+    const triggerRef = useRef<Element | null>(null);
+    const mobileNodeRef = useRef<HTMLElement | null>(null);
+    useEffect(() => {
+      if (!isMobile) return;
+      if (openMobile) {
+        triggerRef.current = document.activeElement;
+        // Wait a frame so the aside is no longer inert before focusing
+        requestAnimationFrame(() => {
+          mobileNodeRef.current?.focus();
+        });
+      } else if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+        triggerRef.current = null;
+      }
+    }, [isMobile, openMobile]);
+
     if (isMobile) {
       return (
         <>
@@ -483,9 +541,16 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             aria-hidden="true"
           />
 
-          {/* Sidebar — same structure as desktop, slides via transform */}
+          {/* Mobile sidebar — modal sheet with focus management */}
           <aside
-            ref={ref}
+            ref={(node) => {
+              mergedMobileRef(node);
+              mobileNodeRef.current = node;
+            }}
+            tabIndex={-1}
+            role="dialog"
+            aria-modal={openMobile}
+            aria-hidden={!openMobile}
             data-state={openMobile ? "expanded" : "collapsed"}
             data-side={side}
             data-variant={variant}
@@ -963,6 +1028,8 @@ export interface SidebarMenuButtonProps
    */
   size?: SidebarMenuButtonSize;
   href?: string;
+  /** Link target — only meaningful when `href` is provided. */
+  target?: React.HTMLAttributeAnchorTarget;
   tooltip?: string;
   className?: string;
   children?: ReactNode;
@@ -1001,6 +1068,7 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
       active = false,
       size = "base",
       href,
+      target,
       tooltip,
       children,
       ...props
@@ -1073,6 +1141,7 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
           className={cn(buttonClasses, "no-underline!")}
           href={href}
           to={href}
+          target={target}
           data-active={active || undefined}
           data-sidebar="menu-button"
           data-kumo-component="Sidebar"

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1743,6 +1743,7 @@ interface SidebarCollapseContextValue {
   contentId: string;
   isOpen: boolean;
   isCollapsible: boolean;
+  autoScrollOnOpen: boolean;
   toggle: () => void;
 }
 
@@ -1750,6 +1751,7 @@ const SidebarCollapseContext = createContext<SidebarCollapseContextValue>({
   contentId: "",
   isOpen: true,
   isCollapsible: false,
+  autoScrollOnOpen: false,
   toggle: () => {},
 });
 
@@ -1761,6 +1763,8 @@ export interface SidebarCollapsibleProps
   open?: boolean;
   /** Callback when open state changes. */
   onOpenChange?: (open: boolean) => void;
+  /** Scroll the expanded content into view after opening. @default false */
+  autoScrollOnOpen?: boolean;
 }
 
 /**
@@ -1791,6 +1795,7 @@ const SidebarCollapsible = forwardRef<HTMLDivElement, SidebarCollapsibleProps>(
       defaultOpen = false,
       open: openProp,
       onOpenChange,
+      autoScrollOnOpen = false,
       className,
       children,
       ...props
@@ -1811,8 +1816,14 @@ const SidebarCollapsible = forwardRef<HTMLDivElement, SidebarCollapsibleProps>(
     }, [isOpen, onOpenChange]);
 
     const contextValue = useMemo<SidebarCollapseContextValue>(
-      () => ({ contentId, isOpen, isCollapsible: true, toggle }),
-      [contentId, isOpen, toggle],
+      () => ({
+        contentId,
+        isOpen,
+        isCollapsible: true,
+        autoScrollOnOpen,
+        toggle,
+      }),
+      [contentId, isOpen, autoScrollOnOpen, toggle],
     );
 
     const handleFocusIn = useCallback(
@@ -1917,9 +1928,27 @@ const SidebarCollapsibleContent = forwardRef<
   const { contentId, isOpen: isCollapsibleOpen } = useContext(
     SidebarCollapseContext,
   );
-  const { state } = useSidebar();
+  const { state, animationDuration } = useSidebar();
+  const { autoScrollOnOpen } = useContext(SidebarCollapseContext);
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
   const isOpen = isCollapsibleOpen && state !== "collapsed";
+
+  useEffect(() => {
+    if (!isOpen || !autoScrollOnOpen) return;
+
+    const timeout = window.setTimeout(() => {
+      const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
+      contentRef.current?.scrollIntoView({
+        block: "nearest",
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+      });
+    }, animationDuration);
+
+    return () => window.clearTimeout(timeout);
+  }, [isOpen, autoScrollOnOpen, animationDuration]);
 
   // Imperatively set inert — React 18 doesn't reliably forward
   // the inert attribute as a JSX prop on initial mount.
@@ -1938,6 +1967,7 @@ const SidebarCollapsibleContent = forwardRef<
 
   const mergedRef = useCallback(
     (node: HTMLDivElement | null) => {
+      contentRef.current = node;
       inertRef(node);
       if (typeof ref === "function") {
         ref(node);

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -100,7 +100,10 @@ const MOBILE_BREAKPOINT = 768;
 // ============================================================================
 
 function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches;
+  });
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
@@ -437,35 +440,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       contained,
     } = useSidebar();
 
-    if (collapsible === "none") {
-      return (
-        <aside
-          ref={ref}
-          data-state="expanded"
-          data-side={side}
-          data-variant={variant}
-          data-sidebar="sidebar"
-          style={{
-            width: "var(--sidebar-width)",
-            minWidth: "var(--sidebar-width)",
-            maxWidth: "var(--sidebar-width)",
-          }}
-          className={cn(
-            "relative flex h-full shrink-0 grow-0 flex-col overflow-hidden bg-(--sidebar-bg) text-kumo-default",
-            variant === "sidebar" &&
-              (side === "left"
-                ? "border-r border-kumo-line"
-                : "border-l border-kumo-line"),
-            variant === "floating" &&
-              "m-2 rounded-lg border border-kumo-line shadow-lg",
-            className,
-          )}
-          {...props}
-        >
-          {children}
-        </aside>
-      );
-    }
+    // --- Mobile a11y hooks (must be before early returns) ---
 
     // Imperatively set inert on the mobile sidebar — React 18 doesn't
     // reliably forward the inert attribute as a JSX prop on initial mount.
@@ -525,6 +500,36 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       }
     }, [isMobile, openMobile]);
 
+    if (collapsible === "none") {
+      return (
+        <aside
+          ref={ref}
+          data-state="expanded"
+          data-side={side}
+          data-variant={variant}
+          data-sidebar="sidebar"
+          style={{
+            width: "var(--sidebar-width)",
+            minWidth: "var(--sidebar-width)",
+            maxWidth: "var(--sidebar-width)",
+          }}
+          className={cn(
+            "relative flex h-full shrink-0 grow-0 flex-col overflow-hidden bg-(--sidebar-bg) text-kumo-default",
+            variant === "sidebar" &&
+              (side === "left"
+                ? "border-r border-kumo-line"
+                : "border-l border-kumo-line"),
+            variant === "floating" &&
+              "m-2 rounded-lg border border-kumo-line shadow-lg",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </aside>
+      );
+    }
+
     if (isMobile) {
       return (
         <>
@@ -532,7 +537,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
           <div
             data-sidebar-backdrop=""
             className={cn(
-              "fixed inset-0 z-40 bg-kumo-recessed",
+              contained ? "absolute inset-0 z-40 bg-kumo-recessed" : "fixed inset-0 z-40 bg-kumo-recessed",
               "transition-opacity duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
               "motion-reduce:transition-none",
               openMobile ? "opacity-80" : "opacity-0 pointer-events-none",
@@ -558,7 +563,9 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             data-sidebar="sidebar"
             data-mobile="true"
             className={cn(
-              "group/sidebar fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden",
+              contained
+                ? "group/sidebar absolute inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden"
+                : "group/sidebar fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden",
               "border-r border-kumo-line bg-(--sidebar-bg) text-kumo-default",
               "transition-transform duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
               "motion-reduce:transition-none",
@@ -720,9 +727,7 @@ const SidebarHeader = forwardRef<
     data-sidebar="header"
     className={cn(
       "flex h-[58px] shrink-0 items-center gap-1 border-b border-kumo-line",
-      "px-2 group-not-data-[state=collapsed]/sidebar:px-3.5",
-      "transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
-      "overflow-hidden",
+      "px-3 overflow-hidden",
       className,
     )}
     {...props}
@@ -765,7 +770,7 @@ const SidebarContent = forwardRef<
         "[mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]",
       )}
     >
-      <ScrollAreaBase.Content className="flex min-w-0 flex-col gap-3 group-data-[state=collapsed]/sidebar:gap-0 group-data-[state=collapsed]/sidebar:min-w-0! transition-[gap] duration-(--sidebar-animation-duration)">
+      <ScrollAreaBase.Content className="flex min-w-0 flex-col group-data-[state=collapsed]/sidebar:min-w-0!">
         {children}
       </ScrollAreaBase.Content>
     </ScrollAreaBase.Viewport>
@@ -889,6 +894,8 @@ const SidebarGroupLabel = forwardRef<
       "[[data-sidebar=group]:first-child_&]:my-0 [[data-sidebar=group]:first-child_&]:border-transparent",
       // Expanded: reveal the label text
       "group-not-data-[state=collapsed]/sidebar:grid-rows-[1fr] group-not-data-[state=collapsed]/sidebar:my-0 group-not-data-[state=collapsed]/sidebar:border-transparent",
+      // Mobile: always show labels (sidebar content is always expanded on mobile)
+      "group-data-[mobile=true]/sidebar:grid-rows-[1fr] group-data-[mobile=true]/sidebar:my-0 group-data-[mobile=true]/sidebar:border-transparent",
       className,
     )}
     {...props}
@@ -896,7 +903,7 @@ const SidebarGroupLabel = forwardRef<
     <div className="min-h-0">
       <div
         className={cn(
-          "truncate px-3 mt-4 mb-2 text-sm font-medium text-kumo-subtle",
+          "truncate px-3 mt-6 mb-2 text-sm font-medium text-kumo-subtle",
           // First group: less top margin
           "[[data-sidebar=group]:first-child_&]:mt-2",
         )}

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -470,22 +470,34 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       [ref, mobileAsideRef],
     );
 
-    // Escape key closes the mobile sidebar
+    // Refs for mobile focus management (declared before effects that use them)
+    const triggerRef = useRef<Element | null>(null);
+    const mobileNodeRef = useRef<HTMLElement | null>(null);
+
+    // Escape key and focus-leave close the mobile sidebar
     useEffect(() => {
       if (!isMobile || !openMobile) return;
+      const node = mobileNodeRef.current;
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
           setOpenMobile(false);
         }
       };
+      const handleFocusOut = (e: FocusEvent) => {
+        if (node && !node.contains(e.relatedTarget as Node)) {
+          setOpenMobile(false);
+        }
+      };
       document.addEventListener("keydown", handleKeyDown);
-      return () => document.removeEventListener("keydown", handleKeyDown);
+      node?.addEventListener("focusout", handleFocusOut);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+        node?.removeEventListener("focusout", handleFocusOut);
+      };
     }, [isMobile, openMobile, setOpenMobile]);
 
     // When the mobile sidebar opens, move focus into it;
     // when it closes, return focus to the element that opened it.
-    const triggerRef = useRef<Element | null>(null);
-    const mobileNodeRef = useRef<HTMLElement | null>(null);
     useEffect(() => {
       if (!isMobile) return;
       if (openMobile) {
@@ -499,6 +511,15 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
         triggerRef.current = null;
       }
     }, [isMobile, openMobile]);
+
+    const handlePeekBlur = useCallback(
+      (e: React.FocusEvent<HTMLDivElement>) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          stopPeek();
+        }
+      },
+      [stopPeek],
+    );
 
     if (collapsible === "none") {
       return (
@@ -546,15 +567,14 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             aria-hidden="true"
           />
 
-          {/* Mobile sidebar — modal sheet with focus management */}
-          <aside
+          {/* Mobile sidebar — navigation landmark with focus management */}
+          <nav
             ref={(node) => {
               mergedMobileRef(node);
               mobileNodeRef.current = node;
             }}
             tabIndex={-1}
-            role="dialog"
-            aria-modal={openMobile}
+            aria-label="Navigation"
             aria-hidden={!openMobile}
             data-state={openMobile ? "expanded" : "collapsed"}
             data-side={side}
@@ -580,7 +600,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             {...props}
           >
             {children}
-          </aside>
+          </nav>
         </>
       );
     }
@@ -588,15 +608,6 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
     // --- Desktop two-layer architecture ---
     // Rail: the <aside> whose width drives layout (stays collapsed during peek).
     // Content container: holds actual sidebar content, can overlay when peeking.
-
-    const handlePeekBlur = useCallback(
-      (e: React.FocusEvent<HTMLDivElement>) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          stopPeek();
-        }
-      },
-      [stopPeek],
-    );
 
     // Rail width: based on open state only (not peeking)
     const collapsedWidth =
@@ -1894,9 +1905,36 @@ const SidebarCollapsibleContent = forwardRef<
 
   const isOpen = isCollapsibleOpen && state !== "collapsed";
 
+  // Imperatively set inert — React 18 doesn't reliably forward
+  // the inert attribute as a JSX prop on initial mount.
+  const inertRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node) {
+        if (!isOpen) {
+          node.setAttribute("inert", "");
+        } else {
+          node.removeAttribute("inert");
+        }
+      }
+    },
+    [isOpen],
+  );
+
+  const mergedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      inertRef(node);
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    },
+    [ref, inertRef],
+  );
+
   return (
     <div
-      ref={ref}
+      ref={mergedRef}
       id={contentId}
       role="region"
       aria-hidden={!isOpen}

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -94,6 +94,8 @@ const SIDEBAR_WIDTH_ICON = "57px";
 const SIDEBAR_EASING = "cubic-bezier(0.77, 0, 0.175, 1)";
 const SIDEBAR_ANIMATION_DURATION_MS = 250;
 const MOBILE_BREAKPOINT = 768;
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 // ============================================================================
 // Mobile detection hook
@@ -473,6 +475,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
     // Refs for mobile focus management (declared before effects that use them)
     const triggerRef = useRef<Element | null>(null);
     const mobileNodeRef = useRef<HTMLElement | null>(null);
+    const shouldRestoreFocusRef = useRef(false);
 
     // Escape key and focus-leave close the mobile sidebar
     useEffect(() => {
@@ -480,11 +483,13 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       const node = mobileNodeRef.current;
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
+          shouldRestoreFocusRef.current = true;
           setOpenMobile(false);
         }
       };
       const handleFocusOut = (e: FocusEvent) => {
         if (node && !node.contains(e.relatedTarget as Node)) {
+          shouldRestoreFocusRef.current = false;
           setOpenMobile(false);
         }
       };
@@ -502,12 +507,20 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
       if (!isMobile) return;
       if (openMobile) {
         triggerRef.current = document.activeElement;
+        shouldRestoreFocusRef.current = false;
         // Wait a frame so the aside is no longer inert before focusing
         requestAnimationFrame(() => {
-          mobileNodeRef.current?.focus();
+          const firstFocusable = mobileNodeRef.current?.querySelector<HTMLElement>(
+            FOCUSABLE_SELECTOR,
+          );
+          (firstFocusable ?? mobileNodeRef.current)?.focus();
         });
-      } else if (triggerRef.current instanceof HTMLElement) {
+      } else if (
+        shouldRestoreFocusRef.current &&
+        triggerRef.current instanceof HTMLElement
+      ) {
         triggerRef.current.focus();
+        shouldRestoreFocusRef.current = false;
         triggerRef.current = null;
       }
     }, [isMobile, openMobile]);
@@ -563,7 +576,10 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
               "motion-reduce:transition-none",
               openMobile ? "opacity-80" : "opacity-0 pointer-events-none",
             )}
-            onClick={() => setOpenMobile(false)}
+            onClick={() => {
+              shouldRestoreFocusRef.current = true;
+              setOpenMobile(false);
+            }}
             aria-hidden="true"
           />
 


### PR DESCRIPTION
## Summary

Incremental improvements to the sidebar component on top of the v2.4.0 modernization.

### New features

- `mobileBreakpoint` prop on Provider — configurable viewport width for mobile detection
- `contentClassName` prop on Sidebar root — pass-through class for the inner content container
- Controlled mobile state — `open` prop now controls the mobile sidebar too, not just desktop

### Fixes

- Replaced Base UI Dialog mobile sidebar with a plain `<aside>` + backdrop for simpler, more predictable transitions
- Collapsible sections now animate closed smoothly when the sidebar collapses instead of snapping shut
- Removed `hidden` class from `Sidebar.MenuSub` so sub-menus participate in collapse animations
- Removed `inertValue` React-version helper — `SidebarSlidingView` now sets `inert` imperatively for React 18 compatibility
- Removed `inert` and `data-open` attributes from `SidebarCollapsibleContent`

### Styling

- `bg-kumo-tint` → `bg-(--sidebar-active-bg)` CSS variable for active/hover/focus backgrounds
- Icon opacity `0.5` → `0.4`; chevron gains hover opacity transition
- Header gains `shrink-0` and animated padding on collapse
- Content scroll area gains animated `gap` transition and `tabIndex={-1}` on viewport
- Sliding views container gains `max-w-(--sidebar-width)` to prevent overflow
- Mobile sidebar uses `--sidebar-animation-duration` CSS variable for slide transition

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: compound component with cross-cutting animation/a11y/layout concerns

- Tests
- [x] Tests included/updated
