### PR TITLE
fix(tabs): improve scroll fades and active tab visibility

### DIFF
--- a/.changeset/small-tabs-scroll.md
+++ b/.changeset/small-tabs-scroll.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix segmented Tabs scroll fades for tiny horizontal overflows and keep the selected tab visible when tab lists scroll.

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -101,6 +101,42 @@ export function TabsManyDemo() {
   );
 }
 
+export function TabsTinyOverflowDemo() {
+  const [width, setWidth] = useState(596);
+
+  return (
+    <div className="w-full space-y-4">
+      <label className="flex max-w-md flex-col gap-2 text-sm text-kumo-subtle">
+        Container width: {width}px
+        <input
+          type="range"
+          min="520"
+          max="720"
+          value={width}
+          onChange={(event) => setWidth(Number(event.currentTarget.value))}
+        />
+      </label>
+      <div className="w-full overflow-hidden">
+        <div style={{ width }} className="max-w-full">
+          <Tabs
+            tabs={[
+              { value: "overview", label: "Overview" },
+              { value: "metrics", label: "Metrics" },
+              { value: "deployments", label: "Deployments" },
+              { value: "previews", label: "Previews" },
+              { value: "bindings", label: "Bindings" },
+              { value: "observability", label: "Observability" },
+              { value: "domains", label: "Domains" },
+              { value: "settings", label: "Settings" },
+            ]}
+            selectedValue="overview"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function TabsSmDemo() {
   return (
     <div className="flex flex-col gap-6">

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -15,6 +15,7 @@ import {
   TabsSmDemo,
   TabsControlledDemo,
   TabsManyDemo,
+  TabsTinyOverflowDemo,
 } from "~/components/demos/TabsDemo";
 
 {/* Hero Demo */}
@@ -116,6 +117,16 @@ export default function Example() {
 <p>Tabs automatically scroll horizontally when there are many items.</p>
 <ComponentExample demo="TabsManyDemo">
   <TabsManyDemo client:visible />
+</ComponentExample>
+
+### Tiny Overflow
+
+<p>
+  When tabs overflow by only a few pixels, the edge fade still reflects the
+  actual hidden content on each side.
+</p>
+<ComponentExample demo="TabsTinyOverflowDemo">
+  <TabsTinyOverflowDemo client:visible />
 </ComponentExample>
 
 </ComponentSection>

--- a/packages/kumo/src/components/tabs/tabs.test.tsx
+++ b/packages/kumo/src/components/tabs/tabs.test.tsx
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { Tabs } from "./tabs";
+
+const tabs = [
+  { value: "overview", label: "Overview" },
+  { value: "metrics", label: "Metrics" },
+  { value: "settings", label: "Settings" },
+];
+
+let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+let OriginalResizeObserver: typeof ResizeObserver;
+let originalGetAnimationsDescriptor: PropertyDescriptor | undefined;
+
+function setHorizontalScrollMetrics(
+  el: HTMLElement,
+  {
+    clientWidth,
+    scrollLeft = 0,
+    scrollWidth,
+  }: { clientWidth: number; scrollLeft?: number; scrollWidth: number },
+) {
+  Object.defineProperties(el, {
+    clientWidth: { configurable: true, value: clientWidth },
+    scrollWidth: { configurable: true, value: scrollWidth },
+  });
+  el.scrollLeft = scrollLeft;
+}
+
+async function renderTabs(ui: ReactElement) {
+  const result = render(ui);
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return result;
+}
+
+function triggerResize() {
+  act(() => {
+    for (const callback of resizeObserverCallbacks) {
+      callback([], {} as ResizeObserver);
+    }
+  });
+}
+
+function setElementOffsetMetrics(
+  el: HTMLElement,
+  { offsetLeft, offsetWidth }: { offsetLeft: number; offsetWidth: number },
+) {
+  Object.defineProperties(el, {
+    offsetLeft: { configurable: true, value: offsetLeft },
+    offsetWidth: { configurable: true, value: offsetWidth },
+  });
+}
+
+function mockElementScrollTo(el: HTMLElement) {
+  const scrollToMock = vi.fn();
+  Object.defineProperty(el, "scrollTo", {
+    configurable: true,
+    value: scrollToMock,
+  });
+  return scrollToMock;
+}
+
+describe("Tabs", () => {
+  beforeEach(() => {
+    OriginalResizeObserver = globalThis.ResizeObserver;
+    originalGetAnimationsDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "getAnimations",
+    );
+    Object.defineProperty(HTMLElement.prototype, "getAnimations", {
+      configurable: true,
+      value: vi.fn(() => []),
+    });
+    resizeObserverCallbacks = [];
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallbacks.push(callback);
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = OriginalResizeObserver;
+    if (originalGetAnimationsDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "getAnimations",
+        originalGetAnimationsDescriptor,
+      );
+    } else {
+      delete (HTMLElement.prototype as { getAnimations?: unknown }).getAnimations;
+    }
+    resizeObserverCallbacks = [];
+    vi.restoreAllMocks();
+  });
+
+  it("renders segmented tabs as a Base UI ScrollArea viewport with the fade hook", async () => {
+    await renderTabs(<Tabs tabs={tabs} />);
+    const list = screen.getByRole("tablist");
+
+    expect(list.getAttribute("data-kumo-scroll-fade")).toBe("");
+    expect(list.className).toContain("base-ui-disable-scrollbar");
+    expect(list.className).toContain("overflow-y-hidden!");
+  });
+
+  it("keeps underline tabs out of a ScrollArea viewport so focus rings are not clipped", async () => {
+    await renderTabs(<Tabs tabs={tabs} variant="underline" />);
+    const list = screen.getByRole("tablist");
+
+    expect(list.hasAttribute("data-kumo-scroll-fade")).toBe(false);
+    expect(list.className).not.toContain("base-ui-disable-scrollbar");
+    expect(list.className).toContain("border-b");
+  });
+
+  it("does not autoscroll underline tabs", async () => {
+    await renderTabs(<Tabs tabs={tabs} variant="underline" value="settings" />);
+    const list = screen.getByRole("tablist");
+    const scrollToMock = mockElementScrollTo(list);
+
+    setHorizontalScrollMetrics(list, { clientWidth: 200, scrollWidth: 500 });
+    triggerResize();
+
+    expect(scrollToMock).not.toHaveBeenCalled();
+  });
+
+  it("does not autoscroll when segmented tabs do not overflow", async () => {
+    await renderTabs(<Tabs tabs={tabs} value="settings" />);
+    const list = screen.getByRole("tablist");
+    const scrollToMock = mockElementScrollTo(list);
+
+    setHorizontalScrollMetrics(list, { clientWidth: 300, scrollWidth: 300 });
+    triggerResize();
+
+    expect(scrollToMock).not.toHaveBeenCalled();
+  });
+
+  it("positions the selected segmented tab after overflow is measured", async () => {
+    await renderTabs(<Tabs tabs={tabs} value="settings" />);
+    const list = screen.getByRole("tablist");
+    const selectedTab = screen.getByRole("tab", { selected: true });
+    const scrollToMock = mockElementScrollTo(list);
+
+    setHorizontalScrollMetrics(list, { clientWidth: 200, scrollWidth: 500 });
+    setElementOffsetMetrics(selectedTab, { offsetLeft: 260, offsetWidth: 80 });
+    triggerResize();
+
+    await waitFor(() => {
+      expect(scrollToMock).toHaveBeenCalledWith({ left: 188, behavior: "auto" });
+    });
+  });
+
+  it("smoothly scrolls when the controlled selected segmented tab changes", async () => {
+    const { rerender } = await renderTabs(<Tabs tabs={tabs} value="metrics" />);
+    const list = screen.getByRole("tablist");
+    const scrollToMock = mockElementScrollTo(list);
+    const settingsTab = screen.getByRole("tab", { name: "Settings" });
+    setElementOffsetMetrics(screen.getByRole("tab", { selected: true }), {
+      offsetLeft: 60,
+      offsetWidth: 80,
+    });
+
+    setHorizontalScrollMetrics(list, { clientWidth: 200, scrollWidth: 500 });
+    triggerResize();
+    scrollToMock.mockClear();
+
+    setElementOffsetMetrics(settingsTab, {
+      offsetLeft: 260,
+      offsetWidth: 80,
+    });
+    await act(async () => {
+      rerender(<Tabs tabs={tabs} value="settings" />);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(scrollToMock).toHaveBeenCalledWith({ left: 188, behavior: "smooth" });
+    });
+  });
+
+  it("only scrolls the tablist horizontally when positioning the active tab", async () => {
+    const windowScrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    await renderTabs(<Tabs tabs={tabs} value="settings" />);
+    const list = screen.getByRole("tablist");
+    const selectedTab = screen.getByRole("tab", { selected: true });
+    const scrollToMock = mockElementScrollTo(list);
+
+    setHorizontalScrollMetrics(list, { clientWidth: 200, scrollWidth: 500 });
+    setElementOffsetMetrics(selectedTab, { offsetLeft: 260, offsetWidth: 80 });
+    triggerResize();
+
+    await waitFor(() => {
+      expect(scrollToMock).toHaveBeenCalledWith({ left: 188, behavior: "auto" });
+    });
+    expect(windowScrollTo).not.toHaveBeenCalled();
+  });
+
+  it("uses scroll padding on the tab list so native scrolling keeps tabs out of fade zones", async () => {
+    await renderTabs(<Tabs tabs={tabs} />);
+    const list = screen.getByRole("tablist");
+
+    expect(list.className).toContain(
+      "[scroll-padding-inline:var(--scroll-fade-width,3rem)]",
+    );
+  });
+});

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useRef, useState, type MouseEvent, type PointerEvent, type ReactNode } from "react";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+import { ScrollArea as ScrollAreaBase } from "@base-ui/react/scroll-area";
 import type { TabsTab } from "@base-ui/react/tabs";
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cn } from "../../utils/cn";
@@ -108,6 +117,70 @@ export type TabsProps = KumoTabsVariantsProps & {
   indicatorClassName?: string;
 };
 
+const SCROLL_EDGE_THRESHOLD_PX = 1;
+
+function toPixels(value: string, element: HTMLElement) {
+  const trimmedValue = value.trim();
+  const numericValue = Number.parseFloat(trimmedValue);
+
+  if (!Number.isFinite(numericValue)) return 48;
+  if (trimmedValue.endsWith("rem")) {
+    return (
+      numericValue *
+      Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
+    );
+  }
+  if (trimmedValue.endsWith("em")) {
+    return numericValue * Number.parseFloat(getComputedStyle(element).fontSize);
+  }
+
+  return numericValue;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function scrollActiveTabIntoView(
+  list: HTMLElement | null,
+  behavior: ScrollBehavior = "auto",
+) {
+  const activeTab = list?.querySelector<HTMLElement>(
+    '[role="tab"][aria-selected="true"]',
+  );
+
+  if (!list || !activeTab) return false;
+
+  const maxScrollLeft = list.scrollWidth - list.clientWidth;
+  if (maxScrollLeft <= SCROLL_EDGE_THRESHOLD_PX) return false;
+
+  const fadeWidth = toPixels(
+    getComputedStyle(list).getPropertyValue("--scroll-fade-width") || "3rem",
+    list,
+  );
+  const canScrollLeft = list.scrollLeft > SCROLL_EDGE_THRESHOLD_PX;
+  const canScrollRight = list.scrollLeft < maxScrollLeft - SCROLL_EDGE_THRESHOLD_PX;
+  const visibleLeft = list.scrollLeft + (canScrollLeft ? fadeWidth : 0);
+  const visibleRight =
+    list.scrollLeft + list.clientWidth - (canScrollRight ? fadeWidth : 0);
+  const activeLeft = activeTab.offsetLeft;
+  const activeRight = activeLeft + activeTab.offsetWidth;
+
+  if (activeLeft < visibleLeft) {
+    list.scrollTo({
+      left: clamp(activeLeft - fadeWidth, 0, maxScrollLeft),
+      behavior,
+    });
+  } else if (activeRight > visibleRight) {
+    list.scrollTo({
+      left: clamp(activeRight - list.clientWidth + fadeWidth, 0, maxScrollLeft),
+      behavior,
+    });
+  }
+
+  return true;
+}
+
 /**
  * Tab navigation component with segmented or underline style.
  * Built on Base UI Tabs with animated active indicator.
@@ -142,6 +215,12 @@ export function Tabs({
 
   const fallbackValue = items[0]?.value;
   const isControlled = value !== undefined;
+  const [uncontrolledValueForScroll, setUncontrolledValueForScroll] = useState(
+    selectedValue ?? fallbackValue,
+  );
+  const selectedValueForScroll = isControlled
+    ? value
+    : uncontrolledValueForScroll;
   const rootProps = {
     value: isControlled ? value : undefined,
     defaultValue: isControlled ? undefined : (selectedValue ?? fallbackValue),
@@ -150,8 +229,52 @@ export function Tabs({
   const isSegmented = variant === "segmented";
   const isUnderline = variant === "underline";
   const isSm = size === "sm";
-  const { ref: listRef, isOverflowing } = useOverflowDetect(isSegmented);
-  const bindDrag = useHorizontalDragScroll(listRef, isOverflowing);
+  const listRef = useRef<HTMLDivElement>(null);
+  useActiveTabScroll(listRef, selectedValueForScroll, isSegmented);
+  const bindDrag = useHorizontalDragScroll(listRef);
+
+  const tabsListContent = (
+    <>
+      {items.map((tab) => (
+        <TabsPrimitive.Tab
+          key={tab.value}
+          data-kumo-component="Tabs"
+          data-kumo-part="tab"
+          value={tab.value}
+          render={tab.render}
+          className={cn(
+            "relative z-2 flex items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand cursor-pointer group-data-[has-overflow-x]/tabs-list:cursor-grab group-data-[has-overflow-x]/tabs-list:active:cursor-grabbing",
+            isSm ? "text-xs" : "text-base",
+            isSegmented &&
+              "my-0.5 rounded-md text-kumo-subtle hover:text-kumo-default aria-selected:text-kumo-default focus-visible:ring-inset",
+            isSegmented && (isSm ? "px-2" : "px-2.5"),
+            isUnderline &&
+              "text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default aria-selected:hover:bg-kumo-tint aria-selected:font-medium aria-selected:text-kumo-default",
+            isUnderline && (isSm ? "px-1.5 py-2.5" : "px-2 py-3"),
+            tab.className,
+          )}
+        >
+          {tab.label}
+        </TabsPrimitive.Tab>
+      ))}
+      <TabsPrimitive.Indicator
+        render={(props) => (
+          <div
+            {...props}
+            className={cn(
+              "absolute z-1 left-0",
+              "w-(--active-tab-width) translate-x-(--active-tab-left) transition-all duration-200",
+              "data-[rendered=false]:scale-90 data-[rendered=false]:opacity-0",
+              isSegmented &&
+                cn("top-(--active-tab-top) h-(--active-tab-height) bg-kumo-base shadow-sm ring ring-kumo-line", isSm ? "rounded" : "rounded-md"),
+              isUnderline && "bottom-0 h-0.5 bg-kumo-brand",
+              indicatorClassName,
+            )}
+          />
+        )}
+      />
+    </>
+  );
 
   return (
     <TabsPrimitive.Root
@@ -159,6 +282,9 @@ export function Tabs({
       className={cn("relative isolate min-w-0 font-medium", className)}
       onValueChange={(nextValue) => {
         const stringValue = String(nextValue);
+        if (!isControlled) {
+          setUncontrolledValueForScroll(stringValue);
+        }
         onValueChange?.(stringValue);
       }}
     >
@@ -166,63 +292,81 @@ export function Tabs({
       {isSegmented && (
         <div className={cn("absolute inset-x-0 top-1/2 z-0 -translate-y-1/2 rounded-lg bg-kumo-recessed", isSm ? "h-6.5" : "h-9")} />
       )}
-      <TabsPrimitive.List
-        ref={listRef}
-        activateOnFocus={activateOnFocus}
-        data-overflowing={isOverflowing ? "" : undefined}
-        {...bindDrag()}
-        className={cn(
-          "relative flex min-w-0 shrink items-stretch",
-          isSegmented && "kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]",
-          isSegmented && (isSm ? "h-6.5 rounded-md" : "h-9"),
-          isOverflowing && "cursor-grab active:cursor-grabbing",
-          isUnderline && "gap-4 border-b border-kumo-hairline pb-2",
-          isUnderline && (isSm ? "h-6.5" : "h-7.5"),
-          listClassName,
-        )}
-      >
-        {items.map((tab) => (
-          <TabsPrimitive.Tab
-            key={tab.value}
-            data-kumo-component="Tabs"
-            data-kumo-part="tab"
-            value={tab.value}
-            render={tab.render}
+      {isSegmented ? (
+        <ScrollAreaBase.Root className="min-w-0 shrink" overflowEdgeThreshold={1}>
+          <TabsPrimitive.List
+            ref={listRef}
+            render={<ScrollAreaBase.Viewport />}
+            activateOnFocus={activateOnFocus}
+            data-kumo-scroll-fade=""
+            {...bindDrag()}
             className={cn(
-              "relative z-2 flex items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand",
-              isOverflowing ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
-              isSm ? "text-xs" : "text-base",
-              isSegmented &&
-                "my-0.5 rounded-md text-kumo-subtle hover:text-kumo-default aria-selected:text-kumo-default focus-visible:ring-inset",
-              isSegmented && (isSm ? "px-2" : "px-2.5"),
-              isUnderline &&
-                "text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default aria-selected:hover:bg-kumo-tint aria-selected:font-medium aria-selected:text-kumo-default",
-              isUnderline && (isSm ? "px-1.5 py-2.5" : "px-2 py-3"),
-              tab.className,
+              "relative flex min-w-0 shrink items-stretch group/tabs-list",
+              "kumo-tabs-list overflow-x-auto! overflow-y-hidden! rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem] [scroll-padding-inline:var(--scroll-fade-width,3rem)] data-[has-overflow-x]:cursor-grab data-[has-overflow-x]:active:cursor-grabbing",
+              isSm ? "h-6.5 rounded-md" : "h-9",
+              listClassName,
             )}
           >
-            {tab.label}
-          </TabsPrimitive.Tab>
-        ))}
-        <TabsPrimitive.Indicator
-          render={(props) => (
-            <div
-              {...props}
-              className={cn(
-                "absolute z-1 left-0",
-                "w-(--active-tab-width) translate-x-(--active-tab-left) transition-all duration-200",
-                "data-[rendered=false]:scale-90 data-[rendered=false]:opacity-0",
-                isSegmented &&
-                  cn("top-(--active-tab-top) h-(--active-tab-height) bg-kumo-base shadow-sm ring ring-kumo-line", isSm ? "rounded" : "rounded-md"),
-                isUnderline && "bottom-0 h-0.5 bg-kumo-brand",
-                indicatorClassName,
-              )}
-            />
+            {tabsListContent}
+          </TabsPrimitive.List>
+          <ScrollAreaBase.Scrollbar
+            orientation="horizontal"
+            keepMounted
+            className="pointer-events-none h-0 overflow-hidden opacity-0"
+          >
+            <ScrollAreaBase.Thumb />
+          </ScrollAreaBase.Scrollbar>
+        </ScrollAreaBase.Root>
+      ) : (
+        <TabsPrimitive.List
+          ref={listRef}
+          activateOnFocus={activateOnFocus}
+          className={cn(
+            "relative flex min-w-0 shrink items-stretch group/tabs-list",
+            "gap-4 border-b border-kumo-hairline pb-2",
+            isSm ? "h-6.5" : "h-7.5",
+            listClassName,
           )}
-        />
-      </TabsPrimitive.List>
+        >
+          {tabsListContent}
+        </TabsPrimitive.List>
+      )}
     </TabsPrimitive.Root>
   );
+}
+
+function useActiveTabScroll(
+  listRef: RefObject<HTMLElement | null>,
+  selectedValue: string | undefined,
+  enabled: boolean,
+) {
+  const hasPositionedInitialTab = useRef(false);
+
+  const positionActiveTab = (behavior: ScrollBehavior) => {
+    const didPosition = scrollActiveTabIntoView(listRef.current, behavior);
+    if (didPosition) {
+      hasPositionedInitialTab.current = true;
+    }
+  };
+
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    positionActiveTab(hasPositionedInitialTab.current ? "smooth" : "auto");
+  }, [enabled, selectedValue]);
+
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    const list = listRef.current;
+    if (!list || typeof ResizeObserver === "undefined") return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      positionActiveTab("auto");
+    });
+
+    resizeObserver.observe(list);
+
+    return () => resizeObserver.disconnect();
+  }, [enabled]);
 }
 
 // ─── Horizontal drag-to-scroll ────────────────────────────────────────
@@ -233,7 +377,6 @@ export function Tabs({
  */
 function useHorizontalDragScroll(
   ref: React.RefObject<HTMLElement | null>,
-  enabled: boolean,
 ) {
   const dragState = useRef<{
     pointerId: number;
@@ -246,7 +389,7 @@ function useHorizontalDragScroll(
   return () => ({
     onPointerDownCapture: (event: PointerEvent<HTMLElement>) => {
       const el = ref.current;
-      if (!el || !enabled) return;
+      if (!el || !el.hasAttribute("data-has-overflow-x")) return;
       if (event.pointerType !== "mouse" || event.button !== 0) return;
 
       dragState.current = {
@@ -260,7 +403,7 @@ function useHorizontalDragScroll(
     onPointerMoveCapture: (event: PointerEvent<HTMLElement>) => {
       const el = ref.current;
       const state = dragState.current;
-      if (!el || !enabled || !state || state.pointerId !== event.pointerId) return;
+      if (!el || !state || state.pointerId !== event.pointerId) return;
 
       const movementX = event.clientX - state.startX;
       if (!state.dragging) {
@@ -307,32 +450,4 @@ function useHorizontalDragScroll(
       shouldSuppressClick.current = false;
     },
   });
-}
-
-// ─── Overflow detection ───────────────────────────────────────────────
-
-/**
- * Detects whether the element's content overflows horizontally.
- * Returns a ref to attach and a boolean for conditional rendering.
- * The `data-overflowing` attribute drives the scroll-fade CSS.
- */
-function useOverflowDetect(enabled: boolean) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-
-  useEffect(() => {
-    if (!enabled) return;
-    const el = ref.current;
-    if (!el) return;
-
-    const check = () => setIsOverflowing(el.scrollWidth > el.clientWidth);
-
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    check();
-
-    return () => ro.disconnect();
-  }, [enabled]);
-
-  return { ref, isOverflowing };
 }

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -214,51 +214,27 @@
   }
 }
 
-/* Scroll-fade: gradient masks that appear on the edges of a horizontally
-   scrollable container based on scroll position. Uses scroll-driven
-   animations (Chrome 115+, Edge 115+). Degrades gracefully to no fade.
-   Activated by the `data-overflowing` attribute (set via JS ResizeObserver). */
-@keyframes scroll-fade-x-left {
-  to {
-    mask-size:
-      var(--scroll-fade-width, 3rem) 100%,
-      100% 100%,
-      var(--scroll-fade-width, 3rem) 100%;
-  }
-}
-
-@keyframes scroll-fade-x-right {
-  to {
-    mask-size:
-      var(--scroll-fade-width, 3rem) 100%,
-      100% 100%,
-      0 100%;
-  }
-}
-
-[data-overflowing] {
-  @supports (animation-timeline: scroll()) {
-    mask-image:
-      linear-gradient(to right, white, transparent),
-      linear-gradient(white, white),
-      linear-gradient(to right, transparent, white);
-    mask-size:
-      0 100%,
-      100% 100%,
-      var(--scroll-fade-width, 3rem) 100%;
-    mask-repeat: no-repeat;
-    mask-composite: exclude;
-    mask-position: left, center, right;
-
-    animation-name: scroll-fade-x-left, scroll-fade-x-right;
-    animation-timing-function: linear, linear;
-    animation-timeline: scroll(self x);
-    animation-range:
-      0 var(--scroll-fade-range, 3rem),
-      calc(100% - var(--scroll-fade-range, 3rem)) 100%;
-    animation-fill-mode: both;
-    animation-composition: replace;
-  }
+/* Scroll-fade: gradient masks driven by Base UI ScrollArea overflow distance
+   variables. This avoids scroll-timeline edge cases when overflow is only a
+   few px because the fade width is clamped to actual hidden content. */
+[data-kumo-scroll-fade] {
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black min(
+      var(--scroll-fade-width, 3rem),
+      var(--scroll-area-overflow-x-start, 0px)
+    ),
+    black calc(
+      100% -
+        min(
+          var(--scroll-fade-width, 3rem),
+          var(--scroll-area-overflow-x-end, 0px)
+        )
+    ),
+    transparent 100%
+  );
+  mask-repeat: no-repeat;
 }
 
 /* Tab list scroll behavior. Scrollbar is only hidden when scroll-driven
@@ -268,7 +244,7 @@
   overscroll-behavior-x: contain;
 }
 
-@supports (animation-timeline: scroll()) {
+@supports (mask-image: linear-gradient(white, transparent)) {
   .kumo-tabs-list {
     scrollbar-width: none;
     -ms-overflow-style: none;


### PR DESCRIPTION
## Summary

Fixes segmented `Tabs` scroll fades when the tab list only overflows by a few pixels, and keeps the selected tab visible when the tab list scrolls horizontally.

## Why

The previous scroll fade used CSS scroll-driven animations:

```css
animation-range:
  0 var(--scroll-fade-range, 3rem),
  calc(100% - var(--scroll-fade-range, 3rem)) 100%;
```

That works when the scroll range is larger than the default fade range (`3rem`). It breaks when tabs barely overflow, for example a `10px` scroll range with a `48px` fade range. In that case the left and right animation ranges overlap, so Chrome can compute a left fade even at `scrollLeft === 0`.

## What changed

- Segmented tabs now render `Tabs.List` as a Base UI `ScrollArea.Viewport`.
- The fade mask uses Base UI ScrollArea overflow distance variables:
  - `--scroll-area-overflow-x-start`
  - `--scroll-area-overflow-x-end`
- Fade width is clamped to the actual hidden content on each side, so tiny overflows render correctly.
- Selected tabs are scrolled into view when selected, with `scroll-padding-inline` matching the fade width so native scrolling keeps tabs out of the gradient zone.
- Underline tabs stay on the plain `Tabs.List` path to avoid clipping focus rings in a scroll viewport.
- Added a docs “Tiny Overflow” example to make this edge case easy to verify manually.
- Added focused unit coverage for the new segmented scroll/fade integration and selected-tab visibility behavior.

## Testing

- `pnpm --filter @cloudflare/kumo exec vitest run src/components/tabs/tabs.test.tsx`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint` (passes with existing unrelated warnings)
- Built `@cloudflare/kumo` locally and manually verified in docs:
  - tiny-overflow segmented tabs render the correct edge fade
  - active segmented tab scrolls into view
  - underline tabs no longer clip focus rings
  - segmented tab list does not vertically scroll

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual scroll/fade behavior depends on browser layout and manual verification
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [ ] Additional testing not necessary because: <your reason here>
