### PR TITLE
Add llms.txt route to Kumo docs

### DIFF
--- a/packages/kumo-docs-astro/src/lib/astro-markdown-pages.test.ts
+++ b/packages/kumo-docs-astro/src/lib/astro-markdown-pages.test.ts
@@ -43,4 +43,16 @@ describe("markdown pages integration", () => {
     expect(content).toContain("1.16.0"); // Recent version
     expect(content).toContain("0.2.0"); // Last/oldest version
   });
+
+  it("generates llms.txt as a curated docs index", () => {
+    const llmsPath = join(distDir, "llms.txt");
+    expect(existsSync(llmsPath)).toBe(true);
+
+    const content = readFileSync(llmsPath, "utf-8");
+    expect(content).toContain("# Kumo");
+    expect(content).toContain("This file is a curated index for LLMs");
+    expect(content).toContain("https://kumo-ui.com/installation.md");
+    expect(content).toContain("https://kumo-ui.com/components/button.md");
+    expect(content).toContain("https://kumo-ui.com/blocks/resource-list.md");
+  });
 });

--- a/packages/kumo-docs-astro/src/pages/llms.txt.ts
+++ b/packages/kumo-docs-astro/src/pages/llms.txt.ts
@@ -1,10 +1,35 @@
 import type { APIRoute } from "astro";
+import componentRegistry from "@cloudflare/kumo/ai/component-registry.json";
 
 const SITE_URL = "https://kumo-ui.com";
+
+const componentDocPages = import.meta.glob("./components/*.{astro,mdx}");
+const blockDocPages = import.meta.glob("./blocks/*.{astro,mdx}");
+
+const registryRouteOverrides: Record<string, string> = {
+  Code: "code-highlighted",
+  DropdownMenu: "dropdown",
+  ResourceListPage: "resource-list",
+  Toasty: "toast",
+};
+
+const titleOverrides: Record<string, string> = {
+  "code-highlighted": "CodeHighlighted",
+  "input-area": "InputArea",
+  "input-group": "InputGroup",
+  "menu-bar": "MenuBar",
+  "resource-list": "Resource List",
+  "table-of-contents": "Table of Contents",
+};
 
 interface LlmLink {
   title: string;
   path: string;
+  description: string;
+}
+
+interface RegistryItem {
+  name: string;
   description: string;
 }
 
@@ -63,57 +88,75 @@ const coreDocs: LlmLink[] = [
   },
 ];
 
-function componentDoc(title: string, path: string): LlmLink {
-  return {
-    title,
-    path,
-    description: `${title} component docs, usage, and examples.`,
-  };
+function slugFromPagePath(pagePath: string) {
+  return pagePath
+    .replace(/^\.\/(components|blocks)\//, "")
+    .replace(/\.(astro|mdx)$/, "");
 }
 
-const components: LlmLink[] = [
-  componentDoc("Autocomplete", "/components/autocomplete.md"),
-  componentDoc("Badge", "/components/badge.md"),
-  componentDoc("Banner", "/components/banner.md"),
-  componentDoc("Breadcrumbs", "/components/breadcrumbs.md"),
-  componentDoc("Button", "/components/button.md"),
-  componentDoc("Checkbox", "/components/checkbox.md"),
-  componentDoc("Clipboard Text", "/components/clipboard-text.md"),
-  componentDoc("Cloudflare Logo", "/components/cloudflare-logo.md"),
-  componentDoc("CodeHighlighted", "/components/code-highlighted.md"),
-  componentDoc("Collapsible", "/components/collapsible.md"),
-  componentDoc("Combobox", "/components/combobox.md"),
-  componentDoc("Command Palette", "/components/command-palette.md"),
-  componentDoc("Date Picker", "/components/date-picker.md"),
-  componentDoc("Dialog", "/components/dialog.md"),
-  componentDoc("Dropdown", "/components/dropdown.md"),
-  componentDoc("Empty", "/components/empty.md"),
-  componentDoc("Flow", "/components/flow.md"),
-  componentDoc("Grid", "/components/grid.md"),
-  componentDoc("Input", "/components/input.md"),
-  componentDoc("InputArea", "/components/input-area.md"),
-  componentDoc("InputGroup", "/components/input-group.md"),
-  componentDoc("Label", "/components/label.md"),
-  componentDoc("Layer Card", "/components/layer-card.md"),
-  componentDoc("Link", "/components/link.md"),
-  componentDoc("Loader", "/components/loader.md"),
-  componentDoc("MenuBar", "/components/menu-bar.md"),
-  componentDoc("Meter", "/components/meter.md"),
-  componentDoc("Pagination", "/components/pagination.md"),
-  componentDoc("Popover", "/components/popover.md"),
-  componentDoc("Radio", "/components/radio.md"),
-  componentDoc("Select", "/components/select.md"),
-  componentDoc("Sensitive Input", "/components/sensitive-input.md"),
-  componentDoc("Sidebar", "/components/sidebar.md"),
-  componentDoc("Skeleton Line", "/components/skeleton-line.md"),
-  componentDoc("Switch", "/components/switch.md"),
-  componentDoc("Table", "/components/table.md"),
-  componentDoc("Table of Contents", "/components/table-of-contents.md"),
-  componentDoc("Tabs", "/components/tabs.md"),
-  componentDoc("Text", "/components/text.md"),
-  componentDoc("Toast", "/components/toast.md"),
-  componentDoc("Tooltip", "/components/tooltip.md"),
-];
+function slugFromRegistryName(name: string) {
+  return (
+    registryRouteOverrides[name] ??
+    name
+      .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+      .toLowerCase()
+  );
+}
+
+function titleFromSlug(slug: string) {
+  return (
+    titleOverrides[slug] ??
+    slug
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ")
+  );
+}
+
+function descriptionSummary(description: string) {
+  const normalized = description.replace(/\s+/g, " ").trim();
+  const [firstSentence] = normalized.split(/\.\s+/);
+  const summary =
+    firstSentence.length > 180
+      ? `${firstSentence.slice(0, 177)}...`
+      : firstSentence;
+  return summary.endsWith(".") ? summary : `${summary}.`;
+}
+
+function registryDocs(
+  pagePaths: Record<string, unknown>,
+  registryItems: RegistryItem[],
+  routePrefix: "blocks" | "components",
+) {
+  const documentedSlugs = new Set(Object.keys(pagePaths).map(slugFromPagePath));
+  const registryLinks = registryItems
+    .map((item) => ({ item, slug: slugFromRegistryName(item.name) }))
+    .filter(({ slug }) => documentedSlugs.has(slug));
+  const registrySlugs = new Set(registryLinks.map(({ slug }) => slug));
+  const fallbackLinks = [...documentedSlugs]
+    .filter((slug) => !registrySlugs.has(slug))
+    .map((slug) => ({
+      title: titleFromSlug(slug),
+      path: `/${routePrefix}/${slug}.md`,
+      description: `${titleFromSlug(slug)} docs, usage, and examples.`,
+    }));
+  const links = registryLinks.map(({ item, slug }) => ({
+    title: titleFromSlug(slug),
+    path: `/${routePrefix}/${slug}.md`,
+    description: descriptionSummary(item.description),
+  }));
+
+  return [...links, ...fallbackLinks].toSorted((a, b) =>
+    a.title.localeCompare(b.title),
+  );
+}
+
+const components = registryDocs(
+  componentDocPages,
+  Object.values(componentRegistry.components),
+  "components",
+);
 
 const charts: LlmLink[] = [
   {
@@ -143,23 +186,11 @@ const charts: LlmLink[] = [
   },
 ];
 
-const blocks: LlmLink[] = [
-  {
-    title: "Page Header",
-    path: "/blocks/page-header.md",
-    description: "CLI-installed page header block docs.",
-  },
-  {
-    title: "Resource List",
-    path: "/blocks/resource-list.md",
-    description: "CLI-installed resource list block docs.",
-  },
-  {
-    title: "Delete Resource",
-    path: "/blocks/delete-resource.md",
-    description: "CLI-installed delete resource block docs.",
-  },
-];
+const blocks = registryDocs(
+  blockDocPages,
+  Object.values(componentRegistry.blocks),
+  "blocks",
+);
 
 function formatSection(title: string, links: LlmLink[]) {
   return [

--- a/packages/kumo-docs-astro/src/pages/llms.txt.ts
+++ b/packages/kumo-docs-astro/src/pages/llms.txt.ts
@@ -1,0 +1,199 @@
+import type { APIRoute } from "astro";
+
+const SITE_URL = "https://kumo-ui.com";
+
+interface LlmLink {
+  title: string;
+  path: string;
+  description: string;
+}
+
+const coreDocs: LlmLink[] = [
+  {
+    title: "Installation",
+    path: "/installation.md",
+    description: "Install Kumo and configure styles in an application.",
+  },
+  {
+    title: "Components vs Blocks",
+    path: "/components-vs-blocks.md",
+    description:
+      "Understand reusable package components versus CLI-installed blocks.",
+  },
+  {
+    title: "CLI",
+    path: "/cli.md",
+    description:
+      "Use the Kumo command-line tools for project setup and blocks.",
+  },
+  {
+    title: "Contributing",
+    path: "/contributing.md",
+    description: "Contribution workflow and development guidelines.",
+  },
+  {
+    title: "Accessibility",
+    path: "/accessibility.md",
+    description: "Accessibility guidance for building with Kumo components.",
+  },
+  {
+    title: "Colors",
+    path: "/colors.md",
+    description: "Semantic color tokens and theme behavior.",
+  },
+  {
+    title: "Figma Resources",
+    path: "/figma.md",
+    description: "Design resources and Figma integration notes.",
+  },
+  {
+    title: "Streaming",
+    path: "/streaming.md",
+    description: "Streaming interface patterns and examples.",
+  },
+  {
+    title: "Registry",
+    path: "/registry.md",
+    description: "Component registry reference and metadata.",
+  },
+  {
+    title: "Changelog",
+    path: "/changelog.md",
+    description: "Release notes for Kumo.",
+  },
+];
+
+function componentDoc(title: string, path: string): LlmLink {
+  return {
+    title,
+    path,
+    description: `${title} component docs, usage, and examples.`,
+  };
+}
+
+const components: LlmLink[] = [
+  componentDoc("Autocomplete", "/components/autocomplete.md"),
+  componentDoc("Badge", "/components/badge.md"),
+  componentDoc("Banner", "/components/banner.md"),
+  componentDoc("Breadcrumbs", "/components/breadcrumbs.md"),
+  componentDoc("Button", "/components/button.md"),
+  componentDoc("Checkbox", "/components/checkbox.md"),
+  componentDoc("Clipboard Text", "/components/clipboard-text.md"),
+  componentDoc("Cloudflare Logo", "/components/cloudflare-logo.md"),
+  componentDoc("CodeHighlighted", "/components/code-highlighted.md"),
+  componentDoc("Collapsible", "/components/collapsible.md"),
+  componentDoc("Combobox", "/components/combobox.md"),
+  componentDoc("Command Palette", "/components/command-palette.md"),
+  componentDoc("Date Picker", "/components/date-picker.md"),
+  componentDoc("Dialog", "/components/dialog.md"),
+  componentDoc("Dropdown", "/components/dropdown.md"),
+  componentDoc("Empty", "/components/empty.md"),
+  componentDoc("Flow", "/components/flow.md"),
+  componentDoc("Grid", "/components/grid.md"),
+  componentDoc("Input", "/components/input.md"),
+  componentDoc("InputArea", "/components/input-area.md"),
+  componentDoc("InputGroup", "/components/input-group.md"),
+  componentDoc("Label", "/components/label.md"),
+  componentDoc("Layer Card", "/components/layer-card.md"),
+  componentDoc("Link", "/components/link.md"),
+  componentDoc("Loader", "/components/loader.md"),
+  componentDoc("MenuBar", "/components/menu-bar.md"),
+  componentDoc("Meter", "/components/meter.md"),
+  componentDoc("Pagination", "/components/pagination.md"),
+  componentDoc("Popover", "/components/popover.md"),
+  componentDoc("Radio", "/components/radio.md"),
+  componentDoc("Select", "/components/select.md"),
+  componentDoc("Sensitive Input", "/components/sensitive-input.md"),
+  componentDoc("Sidebar", "/components/sidebar.md"),
+  componentDoc("Skeleton Line", "/components/skeleton-line.md"),
+  componentDoc("Switch", "/components/switch.md"),
+  componentDoc("Table", "/components/table.md"),
+  componentDoc("Table of Contents", "/components/table-of-contents.md"),
+  componentDoc("Tabs", "/components/tabs.md"),
+  componentDoc("Text", "/components/text.md"),
+  componentDoc("Toast", "/components/toast.md"),
+  componentDoc("Tooltip", "/components/tooltip.md"),
+];
+
+const charts: LlmLink[] = [
+  {
+    title: "Charts",
+    path: "/charts.md",
+    description: "Overview of Kumo charting patterns.",
+  },
+  {
+    title: "Chart Colors",
+    path: "/charts/colors.md",
+    description: "Chart color tokens and palette guidance.",
+  },
+  {
+    title: "Timeseries",
+    path: "/charts/timeseries.md",
+    description: "Timeseries chart usage and examples.",
+  },
+  {
+    title: "Sankey",
+    path: "/charts/sankey.md",
+    description: "Sankey chart usage and examples.",
+  },
+  {
+    title: "Custom Chart",
+    path: "/charts/custom.md",
+    description: "Guidance for custom chart implementations.",
+  },
+];
+
+const blocks: LlmLink[] = [
+  {
+    title: "Page Header",
+    path: "/blocks/page-header.md",
+    description: "CLI-installed page header block docs.",
+  },
+  {
+    title: "Resource List",
+    path: "/blocks/resource-list.md",
+    description: "CLI-installed resource list block docs.",
+  },
+  {
+    title: "Delete Resource",
+    path: "/blocks/delete-resource.md",
+    description: "CLI-installed delete resource block docs.",
+  },
+];
+
+function formatSection(title: string, links: LlmLink[]) {
+  return [
+    `## ${title}`,
+    "",
+    ...links.map(
+      (link) =>
+        `- [${link.title}](${SITE_URL}${link.path}): ${link.description}`,
+    ),
+  ].join("\n");
+}
+
+const content = [
+  "# Kumo",
+  "",
+  "> Cloudflare's React component library for building product interfaces.",
+  "",
+  "This file is a curated index for LLMs. It links to markdown versions of Kumo docs pages instead of embedding the full documentation inline.",
+  "",
+  formatSection("Core Docs", coreDocs),
+  "",
+  formatSection("Components", components),
+  "",
+  formatSection("Charts", charts),
+  "",
+  formatSection("Blocks", blocks),
+  "",
+].join("\n");
+
+export const GET: APIRoute = () => {
+  return new Response(content, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/packages/kumo-docs-astro/src/pages/llms.txt.ts
+++ b/packages/kumo-docs-astro/src/pages/llms.txt.ts
@@ -117,13 +117,23 @@ function titleFromSlug(slug: string) {
 }
 
 function descriptionSummary(description: string) {
-  const normalized = description.replace(/\s+/g, " ").trim();
+  const normalized = plainAscii(description).replace(/\s+/g, " ").trim();
   const [firstSentence] = normalized.split(/\.\s+/);
   const summary =
     firstSentence.length > 180
       ? `${firstSentence.slice(0, 177)}...`
       : firstSentence;
   return summary.endsWith(".") ? summary : `${summary}.`;
+}
+
+function plainAscii(value: string) {
+  return value
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/\u2026/g, "...")
+    .replace(/\u00A0/g, " ")
+    .replace(/[^\x20-\x7E\n]/g, "");
 }
 
 function registryDocs(

--- a/packages/kumo-docs-astro/src/pages/llms.txt.ts
+++ b/packages/kumo-docs-astro/src/pages/llms.txt.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
 import componentRegistry from "@cloudflare/kumo/ai/component-registry.json";
 
+export const prerender = true;
+
 const SITE_URL = "https://kumo-ui.com";
 
 const componentDocPages = import.meta.glob("./components/*.{astro,mdx}");

--- a/packages/kumo-docs-astro/src/pages/llms.txt.ts
+++ b/packages/kumo-docs-astro/src/pages/llms.txt.ts
@@ -7,7 +7,9 @@ const SITE_URL = "https://kumo-ui.com";
 
 const componentDocPages = import.meta.glob("./components/*.{astro,mdx}");
 const blockDocPages = import.meta.glob("./blocks/*.{astro,mdx}");
+const chartDocPages = import.meta.glob("./charts/*.{astro,mdx}");
 
+// Add an override when the registry component name does not match its docs page slug.
 const registryRouteOverrides: Record<string, string> = {
   Code: "code-highlighted",
   DropdownMenu: "dropdown",
@@ -15,6 +17,7 @@ const registryRouteOverrides: Record<string, string> = {
   Toasty: "toast",
 };
 
+// Add an override when the docs page slug needs custom capitalization or spacing.
 const titleOverrides: Record<string, string> = {
   "code-highlighted": "CodeHighlighted",
   "input-area": "InputArea",
@@ -22,6 +25,20 @@ const titleOverrides: Record<string, string> = {
   "menu-bar": "MenuBar",
   "resource-list": "Resource List",
   "table-of-contents": "Table of Contents",
+};
+
+const chartTitleOverrides: Record<string, string> = {
+  colors: "Chart Colors",
+  custom: "Custom Chart",
+  index: "Charts",
+};
+
+const chartDescriptions: Record<string, string> = {
+  colors: "Chart color tokens and palette guidance.",
+  custom: "Guidance for custom chart implementations.",
+  index: "Overview of Kumo charting patterns.",
+  sankey: "Sankey chart usage and examples.",
+  timeseries: "Timeseries chart usage and examples.",
 };
 
 interface LlmLink {
@@ -92,7 +109,7 @@ const coreDocs: LlmLink[] = [
 
 function slugFromPagePath(pagePath: string) {
   return pagePath
-    .replace(/^\.\/(components|blocks)\//, "")
+    .replace(/^\.\/(components|blocks|charts)\//, "")
     .replace(/\.(astro|mdx)$/, "");
 }
 
@@ -118,7 +135,9 @@ function titleFromSlug(slug: string) {
 
 function descriptionSummary(description: string) {
   const normalized = plainAscii(description).replace(/\s+/g, " ").trim();
-  const [firstSentence] = normalized.split(/\.\s+/);
+  if (!normalized) return "";
+
+  const [firstSentence] = normalized.split(/\.\s+(?=[A-Z])/);
   const summary =
     firstSentence.length > 180
       ? `${firstSentence.slice(0, 177)}...`
@@ -164,39 +183,41 @@ function registryDocs(
   );
 }
 
+function pageDocs(
+  pagePaths: Record<string, unknown>,
+  routePrefix: "charts",
+  descriptions: Record<string, string>,
+  titles: Record<string, string>,
+) {
+  return Object.keys(pagePaths)
+    .map(slugFromPagePath)
+    .map((slug) => ({
+      title: titles[slug] ?? titleFromSlug(slug),
+      path:
+        slug === "index" ? `/${routePrefix}.md` : `/${routePrefix}/${slug}.md`,
+      description:
+        descriptions[slug] ??
+        `${titles[slug] ?? titleFromSlug(slug)} docs, usage, and examples.`,
+    }))
+    .toSorted((a, b) => {
+      if (a.path === `/${routePrefix}.md`) return -1;
+      if (b.path === `/${routePrefix}.md`) return 1;
+      return a.title.localeCompare(b.title);
+    });
+}
+
 const components = registryDocs(
   componentDocPages,
   Object.values(componentRegistry.components),
   "components",
 );
 
-const charts: LlmLink[] = [
-  {
-    title: "Charts",
-    path: "/charts.md",
-    description: "Overview of Kumo charting patterns.",
-  },
-  {
-    title: "Chart Colors",
-    path: "/charts/colors.md",
-    description: "Chart color tokens and palette guidance.",
-  },
-  {
-    title: "Timeseries",
-    path: "/charts/timeseries.md",
-    description: "Timeseries chart usage and examples.",
-  },
-  {
-    title: "Sankey",
-    path: "/charts/sankey.md",
-    description: "Sankey chart usage and examples.",
-  },
-  {
-    title: "Custom Chart",
-    path: "/charts/custom.md",
-    description: "Guidance for custom chart implementations.",
-  },
-];
+const charts = pageDocs(
+  chartDocPages,
+  "charts",
+  chartDescriptions,
+  chartTitleOverrides,
+);
 
 const blocks = registryDocs(
   blockDocPages,


### PR DESCRIPTION
## Summary

Adds a curated `/llms.txt` route to the Kumo docs site.

The file acts as a high-signal index for LLMs, linking to existing markdown versions of docs pages instead of embedding the full documentation inline. It includes core docs, components, charts, and blocks with short descriptions.

## Testing

- `pnpm --filter @cloudflare/kumo build && pnpm --filter @cloudflare/kumo-docs-astro build`
- `pnpm --filter @cloudflare/kumo-docs-astro build`
- `pnpm --filter @cloudflare/kumo-docs-astro test`
- `pnpm exec oxlint "packages/kumo-docs-astro/src/pages/llms.txt.ts" "packages/kumo-docs-astro/src/lib/astro-markdown-pages.test.ts"`

Note: full docs lint currently fails on existing unrelated demo lint/a11y issues.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a docs-only route addition and no automated review has run yet
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable
