### PR TITLE
fix(button): refine hover states

### DIFF
--- a/.changeset/button-hover-states.md
+++ b/.changeset/button-hover-states.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Refine outline and secondary destructive button hover states.

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -67,12 +67,13 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     "secondary-destructive": {
       classes:
-        "bg-kumo-base !text-kumo-danger ring not-disabled:hover:bg-kumo-base disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
+        "bg-kumo-base !text-kumo-danger ring not-disabled:hover:!text-kumo-danger not-disabled:hover:ring-kumo-danger/30 disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
       description:
         "Secondary button with destructive text for less prominent dangerous actions",
     },
     outline: {
-      classes: "bg-transparent text-kumo-default ring ring-kumo-hairline",
+      classes:
+        "bg-transparent text-kumo-default ring ring-kumo-hairline transition-colors not-disabled:hover:text-kumo-strong not-disabled:hover:ring-kumo-focus/25",
       description: "Bordered button with transparent background",
     },
   },


### PR DESCRIPTION
## Summary
- Add a transparent hover affordance for outline buttons using stronger text and ring tokens
- Add a subtle danger ring hover state for secondary destructive buttons
- Add a patch changeset for @cloudflare/kumo

## Testing
- pnpm --filter @cloudflare/kumo test button
- pnpm --filter @cloudflare/kumo lint

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: small visual token-only button variant update
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: covered by existing button tests and manual local visual review