### PR TITLE
fix(sidebar): correct GroupLabel top margin from mt-6 to mt-4

### DIFF
--- a/.changeset/open-bottles-do.md
+++ b/.changeset/open-bottles-do.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(sidebar): correct GroupLabel top margin from mt-6 to mt-4

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -930,7 +930,7 @@ const SidebarGroupLabel = forwardRef<
     <div className="min-h-0 min-w-0">
       <div
         className={cn(
-          "truncate px-3 mt-6 mb-2 text-sm font-medium text-kumo-subtle",
+          "truncate px-3 mt-4 mb-2 text-sm font-medium text-kumo-subtle",
           // First group: less top margin
           "[[data-sidebar=group]:first-child_&]:mt-2",
         )}


### PR DESCRIPTION
Fixes incorrect `Sidebar.GroupLabel` top margin.

The inner label div had `mt-6` which created too much spacing between sidebar group sections. This corrects it to `mt-4` to match the design spec.

Single-line CSS class change in `SidebarGroupLabel` — `mt-6` → `mt-4`.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: single-line CSS token change, no logic affected
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: purely cosmetic spacing change (mt-6 → mt-4), no behavioral or API impact