### PR TITLE
fix(button): use line ring token

### DIFF
--- a/.changeset/bright-rings-wait.md
+++ b/.changeset/bright-rings-wait.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(button): use ring-kumo-line for default secondary button ring

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -54,7 +54,7 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     secondary: {
       classes:
-        "bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-hairline data-[state=open]:bg-kumo-base",
+        "bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-base",
       description: "Default button style for most actions",
     },
     ghost: {


### PR DESCRIPTION
Updates the default secondary Button ring token from `ring-kumo-hairline` to `ring-kumo-line`. This makes buttons use the same rings as most other elements on the page.

Before:
<img width="2248" height="764" alt="CleanShot 2026-06-09 at 22 37 01@2x" src="https://github.com/user-attachments/assets/7da17a82-3fe8-4239-baa9-30fce2031e8c" />

After:
<img width="2248" height="764" alt="CleanShot 2026-06-09 at 22 38 00@2x" src="https://github.com/user-attachments/assets/6affc930-2769-46cd-810b-5039722fd2d5" />

Verification:
`pnpm --filter @cloudflare/kumo exec vitest run --project=unit src/components/button/button.test.tsx`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: small token-only style update
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: n/a
- [ ] Additional testing not necessary because: n/a