### PR TITLE
feat(radio): add generic value type support

### DIFF
--- a/.changeset/giant-showers-decide.md
+++ b/.changeset/giant-showers-decide.md
@@ -1,6 +1,6 @@
 ---
-"@cloudflare/kumo-docs-astro": minor
-"@cloudflare/kumo": minor
+"@cloudflare/kumo-docs-astro": patch
+"@cloudflare/kumo": patch
 ---
 
 feat(radio): add generic value type support to Radio.Group and Radio.Item

--- a/.changeset/giant-showers-decide.md
+++ b/.changeset/giant-showers-decide.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/kumo-docs-astro": minor
+"@cloudflare/kumo": minor
+---
+
+feat(radio): add generic value type support to Radio.Group and Radio.Item

--- a/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
@@ -242,6 +242,40 @@ export function RadioCardControlStartDemo() {
   );
 }
 
+enum ThemeType {
+  dark = "dark",
+  light = "light",
+  system = "system",
+}
+
+/** Shows Radio.Group with typed values: a numeric union and a TypeScript enum. */
+export function RadioTypedValueDemo() {
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [theme, setTheme] = useState<ThemeType>(ThemeType.system);
+  return (
+    <div className="grid grid-cols-2 gap-6">
+      <Radio.Group<number>
+        legend="Items per page"
+        value={pageSize}
+        onValueChange={setPageSize}
+      >
+        <Radio.Item<number> label="10" value={10} />
+        <Radio.Item<number> label="25" value={25} />
+        <Radio.Item<number> label="50" value={50} />
+      </Radio.Group>
+      <Radio.Group<ThemeType>
+        legend="Theme"
+        value={theme}
+        onValueChange={setTheme}
+      >
+        <Radio.Item<ThemeType> label="Light" value={ThemeType.light} />
+        <Radio.Item<ThemeType> label="Dark" value={ThemeType.dark} />
+        <Radio.Item<ThemeType> label="System" value={ThemeType.system} />
+      </Radio.Group>
+    </div>
+  );
+}
+
 /** Shows Radio.Item labels with rich ReactNode content (icons, badges, or additional markup) */
 export function RadioRichLabelDemo() {
   const [value, setValue] = useState("pro");

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -23,6 +23,7 @@ import {
   RadioRichLabelDemo,
   RadioLegendSrOnlyDemo,
   RadioLegendCustomDemo,
+  RadioTypedValueDemo,
 } from "~/components/demos/RadioDemo";
 
 {/* Hero Demo */}
@@ -189,6 +190,53 @@ export default function Example() {
 </p>
 <ComponentExample demo="RadioLegendCustomDemo">
   <RadioLegendCustomDemo client:visible />
+</ComponentExample>
+
+### Typed Values
+
+<p>
+  `Radio.Group` and `Radio.Item` support generic types. Pass a type parameter
+  (e.g. `<number>` or an enum) to constrain the type of `value` on both sub-components, 
+  and `defaultValue` and `onValueChange` on `Radio.Group`. Defaults to `string` 
+  when omitted.
+</p>
+<ComponentExample
+  vrSection="radio-typed-value"
+  vrTitle="Radio Typed Value"
+  code={`enum ThemeType {
+    dark = "dark",
+    light = "light",
+    system = "system",
+}
+
+export function RadioTypedValueDemo() {
+    const [pageSize, setPageSize] = useState<number>(10);
+    const [theme, setTheme] = useState<ThemeType>(ThemeType.system);
+    return (
+      <div className="grid grid-cols-2 gap-6">
+        <Radio.Group<number>
+          legend="Items per page"
+          value={pageSize}
+          onValueChange={setPageSize}
+        >
+          <Radio.Item<number> label="10" value={10} />
+          <Radio.Item<number> label="25" value={25} />
+          <Radio.Item<number> label="50" value={50} />
+        </Radio.Group>
+        <Radio.Group<ThemeType>
+          legend="Theme"
+          value={theme}
+          onValueChange={setTheme}
+        >
+          <Radio.Item<ThemeType> label="Light" value={ThemeType.light} />
+          <Radio.Item<ThemeType> label="Dark" value={ThemeType.dark} />
+          <Radio.Item<ThemeType> label="System" value={ThemeType.system} />
+        </Radio.Group>
+      </div>
+    );
+}`}
+>
+  <RadioTypedValueDemo client:visible />
 </ComponentExample>
 
 </ComponentSection>

--- a/packages/kumo/scripts/component-registry/metadata.ts
+++ b/packages/kumo/scripts/component-registry/metadata.ts
@@ -328,6 +328,36 @@ export const ADDITIONAL_COMPONENT_PROPS: Record<
       description: "Callback when active tab changes",
     },
   },
+  Radio: {
+    value: {
+      type: "T",
+      description: "The controlled value of the selected radio item.",
+    },
+    defaultValue: {
+      type: "T",
+      description: "The uncontrolled initial value of the selected radio item.",
+    },
+    onValueChange: {
+      type: "(value: T, eventDetails: RadioGroupChangeEventDetails) => void",
+      description:
+        "Callback fired when the selected value changes. The second argument carries native event details about the interaction.",
+    },
+  },
+  "Radio.Group": {
+    value: {
+      type: "T",
+      description: "The controlled value of the selected radio item.",
+    },
+    defaultValue: {
+      type: "T",
+      description: "The uncontrolled initial value of the selected radio item.",
+    },
+    onValueChange: {
+      type: "(value: T, eventDetails: RadioGroupChangeEventDetails) => void",
+      description:
+        "Callback fired when the selected value changes. The second argument carries native event details about the interaction.",
+    },
+  },
   Collapsible: {
     onOpenChange: {
       type: "(open: boolean) => void",

--- a/packages/kumo/src/components/radio/index.ts
+++ b/packages/kumo/src/components/radio/index.ts
@@ -5,6 +5,7 @@ export {
   KUMO_RADIO_DEFAULT_VARIANTS,
   radioVariants,
   type RadioGroupProps,
+  type RadioGroupChangeEventDetails,
   type RadioLegendProps,
   type RadioItemProps,
   type RadioControlPosition,

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -1,9 +1,24 @@
-import { forwardRef, createContext, useContext, type ReactNode } from "react";
+import {
+  forwardRef,
+  createContext,
+  useContext,
+  type ReactNode,
+  type ReactElement,
+  type ForwardedRef,
+} from "react";
 import { cn } from "../../utils/cn";
 import { resolveVariant } from "../../utils/resolve-variant";
 import { Fieldset } from "@base-ui/react/fieldset";
 import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
 import { Radio as BaseRadio } from "@base-ui/react/radio";
+
+/**
+ * Event details passed as the second argument to `onValueChange`. Carries the
+ * native event and interaction metadata. Re-exported from Base UI.
+ */
+export type RadioGroupChangeEventDetails = Parameters<
+  NonNullable<BaseRadioGroup.Props<unknown>["onValueChange"]>
+>[1];
 
 /** Radio variant definitions mapping variant names to their Tailwind classes. */
 export const KUMO_RADIO_VARIANTS = {
@@ -62,8 +77,16 @@ export function radioVariants({
   appearance = KUMO_RADIO_DEFAULT_VARIANTS.appearance,
 }: KumoRadioVariantsProps = {}) {
   return cn(
-    resolveVariant(KUMO_RADIO_VARIANTS.variant, variant, KUMO_RADIO_DEFAULT_VARIANTS.variant).classes,
-    resolveVariant(KUMO_RADIO_VARIANTS.appearance, appearance, KUMO_RADIO_DEFAULT_VARIANTS.appearance).classes,
+    resolveVariant(
+      KUMO_RADIO_VARIANTS.variant,
+      variant,
+      KUMO_RADIO_DEFAULT_VARIANTS.variant,
+    ).classes,
+    resolveVariant(
+      KUMO_RADIO_VARIANTS.appearance,
+      appearance,
+      KUMO_RADIO_DEFAULT_VARIANTS.appearance,
+    ).classes,
   );
 }
 
@@ -138,6 +161,15 @@ const RadioGroupContext = createContext<{
  *   <Radio.Item label="Option B" value="b" />
  * </Radio.Group>
  * ```
+ *
+ * @example
+ * // Typed values — pass a type parameter to constrain `value`
+ * ```tsx
+ * <Radio.Group<number> legend="Items per page" defaultValue={10}>
+ *   <Radio.Item<number> label="10" value={10} />
+ *   <Radio.Item<number> label="25" value={25} />
+ * </Radio.Group>
+ * ```
  */
 /**
  * Props for Radio.Legend — a composable sub-component for labeling a Radio.Group.
@@ -160,7 +192,19 @@ export interface RadioLegendProps {
   className?: string;
 }
 
-export interface RadioGroupProps {
+/**
+ * Radio.Group component props.
+ *
+ * Parameterised by the radio value type `Value` (defaults to `string`). Pass a
+ * type argument — e.g. `<Radio.Group<number>>` — to type `value`,
+ * `defaultValue`, and the value passed to `onValueChange`.
+ *
+ * Note: the generic only types the group-level value props. It does **not**
+ * guarantee that the `value` of each `Radio.Item` child conforms to `Value`,
+ * since children are passed as `ReactNode` and are not cross-checked at compile
+ * time. Annotate items (`<Radio.Item<number>>`) for matching inference.
+ */
+export interface RadioGroupProps<Value = string> {
   /**
    * Legend text for the group (required for accessibility).
    * For more control over legend styling, omit this prop and use `<Radio.Legend>` as a child instead.
@@ -184,11 +228,17 @@ export interface RadioGroupProps {
   /** Helper text for the group */
   description?: ReactNode;
   /** Value of the radio that should be initially selected (uncontrolled) */
-  defaultValue?: string;
+  defaultValue?: Value;
   /** Value of the radio that should be selected (controlled) */
-  value?: string;
-  /** Event handler called when radio value changes */
-  onValueChange?: (value: string) => void;
+  value?: Value;
+  /**
+   * Event handler called when the radio value changes. The second argument
+   * carries native event details about the interaction.
+   */
+  onValueChange?: (
+    value: Value,
+    eventDetails: RadioGroupChangeEventDetails,
+  ) => void;
   /** Whether all radios in the group are disabled */
   disabled?: boolean;
   /** Position of radio control relative to label: "start" puts radio before label, "end" puts label before radio. Defaults to "start" for default appearance and "end" for card appearance. */
@@ -213,7 +263,14 @@ export interface RadioGroupProps {
  * <Radio.Item label="Unavailable" value="unavailable" disabled />
  * ```
  */
-export type RadioItemProps = {
+/**
+ * Radio.Item component props.
+ *
+ * Parameterised by the radio value type `Value` (defaults to `string`). Pass a
+ * type argument — e.g. `<Radio.Item<number>>` — to type `value` to match the
+ * enclosing `Radio.Group`'s value type.
+ */
+export type RadioItemProps<Value = string> = {
   /** Visual variant: "default" or "error" for validation failures */
   variant?: RadioVariant;
   /**
@@ -230,7 +287,7 @@ export type RadioItemProps = {
   /** Description text displayed below the label (only visible in card appearance) */
   description?: ReactNode;
   /** Value of the radio (required) */
-  value: string;
+  value: Value;
   /** Additional CSS classes for the label wrapper */
   className?: string;
   /** Whether the radio is disabled */
@@ -238,101 +295,58 @@ export type RadioItemProps = {
 };
 
 // Radio.Item for use within Radio.Group
-const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
-  (
-    {
-      className,
-      disabled,
-      variant = "default",
-      appearance: appearanceProp,
-      label,
-      description,
-      value,
-    },
-    ref,
-  ) => {
-    const { controlPosition, appearance: groupAppearance } =
-      useContext(RadioGroupContext);
-    const appearance = appearanceProp ?? groupAppearance;
-    const isCard = appearance === "card";
+function _RadioItem<T = string>(
+  {
+    className,
+    disabled,
+    variant = "default",
+    appearance: appearanceProp,
+    label,
+    description,
+    value,
+  }: RadioItemProps<T>,
+  ref: ForwardedRef<HTMLButtonElement>,
+) {
+  const { controlPosition, appearance: groupAppearance } =
+    useContext(RadioGroupContext);
+  const appearance = appearanceProp ?? groupAppearance;
+  const isCard = appearance === "card";
 
-    // Fall back to an appearance-appropriate default when controlPosition is
-    // not provided: card defaults to "end" (radio on the right), default
-    // appearance defaults to "start" (radio on the left).
-    const effectiveControlPosition: RadioControlPosition =
-      controlPosition ?? (isCard ? "end" : "start");
+  // Fall back to an appearance-appropriate default when controlPosition is
+  // not provided: card defaults to "end" (radio on the right), default
+  // appearance defaults to "start" (radio on the left).
+  const effectiveControlPosition: RadioControlPosition =
+    controlPosition ?? (isCard ? "end" : "start");
 
-    if (isCard) {
-      const controlAtStart = effectiveControlPosition === "start";
-      return (
-        <label
-          data-kumo-component="Radio"
-          data-kumo-part="item-label"
-          className={cn(
-            "m-0 group relative flex items-start gap-3 rounded-lg border border-kumo-hairline bg-kumo-base p-3 transition-colors has-[[data-checked]]:border-kumo-interact has-[[data-checked]]:bg-kumo-tint",
-            controlAtStart && "flex-row-reverse",
-            variant === "error" &&
-              "border-kumo-danger has-[[data-checked]]:border-kumo-danger has-[[data-checked]]:bg-kumo-base",
-            disabled
-              ? "cursor-not-allowed opacity-50"
-              : cn(
-                  "has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-50 cursor-pointer",
-                  variant !== "error" &&
-                    "hover:not-has-[[data-disabled]]:bg-kumo-tint",
-                ),
-            className,
-          )}
-        >
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="text-base font-medium text-kumo-default">
-              {label}
-            </span>
-            {description && (
-              <span className="text-sm text-kumo-subtle">{description}</span>
-            )}
-          </div>
-          <BaseRadio.Root
-            ref={ref}
-            data-kumo-component="Radio"
-            data-kumo-part="item"
-            value={value}
-            disabled={disabled}
-            className={cn(
-              "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring ring-2 focus:outline-none focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand",
-              variant === "error" ? "ring-kumo-danger" : "ring-kumo-line",
-              !disabled &&
-                variant !== "error" &&
-                "group-hover:ring-kumo-hairline focus-visible:outline-offset-3",
-              !disabled &&
-                variant === "error" &&
-                "focus-visible:outline-offset-3",
-              "data-[checked]:bg-kumo-contrast",
-            )}
-          >
-            <BaseRadio.Indicator
-              keepMounted
-              className="flex items-center justify-center"
-            >
-              <span className="h-2 w-2 rounded-full bg-kumo-base" />
-            </BaseRadio.Indicator>
-          </BaseRadio.Root>
-        </label>
-      );
-    }
-
+  if (isCard) {
+    const controlAtStart = effectiveControlPosition === "start";
     return (
       <label
         data-kumo-component="Radio"
         data-kumo-part="item-label"
         className={cn(
-          "m-0 group relative inline-flex items-start gap-2",
-          // "start" (default): radio before label
-          // "end": label before radio using flex-row-reverse
-          effectiveControlPosition === "end" && "flex-row-reverse justify-end",
-          disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+          "m-0 group relative flex items-start gap-3 rounded-lg border border-kumo-hairline bg-kumo-base p-3 transition-colors has-[[data-checked]]:border-kumo-interact has-[[data-checked]]:bg-kumo-tint",
+          controlAtStart && "flex-row-reverse",
+          variant === "error" &&
+            "border-kumo-danger has-[[data-checked]]:border-kumo-danger has-[[data-checked]]:bg-kumo-base",
+          disabled
+            ? "cursor-not-allowed opacity-50"
+            : cn(
+                "has-[[data-disabled]]:cursor-not-allowed has-[[data-disabled]]:opacity-50 cursor-pointer",
+                variant !== "error" &&
+                  "hover:not-has-[[data-disabled]]:bg-kumo-tint",
+              ),
           className,
         )}
       >
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="text-base font-medium text-kumo-default">
+            {label}
+          </span>
+          {description && (
+            <span className="text-sm text-kumo-subtle">{description}</span>
+          )}
+        </div>
         <BaseRadio.Root
           ref={ref}
           data-kumo-component="Radio"
@@ -340,14 +354,14 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
           value={value}
           disabled={disabled}
           className={cn(
-            "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
+            "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring ring-2 focus:outline-none focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand",
             variant === "error" ? "ring-kumo-danger" : "ring-kumo-line",
             !disabled &&
               variant !== "error" &&
-              "group-hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:outline-offset-3",
+              "group-hover:ring-kumo-hairline focus-visible:outline-offset-3",
             !disabled &&
               variant === "error" &&
-              "focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:outline-offset-3",
+              "focus-visible:outline-offset-3",
             "data-[checked]:bg-kumo-contrast",
           )}
         >
@@ -358,13 +372,61 @@ const RadioItem = forwardRef<HTMLButtonElement, RadioItemProps>(
             <span className="h-2 w-2 rounded-full bg-kumo-base" />
           </BaseRadio.Indicator>
         </BaseRadio.Root>
-        <span className="text-base text-kumo-default">{label}</span>
       </label>
     );
-  },
-);
+  }
 
-RadioItem.displayName = "Radio.Item";
+  return (
+    <label
+      data-kumo-component="Radio"
+      data-kumo-part="item-label"
+      className={cn(
+        "m-0 group relative inline-flex items-start gap-2",
+        // "start" (default): radio before label
+        // "end": label before radio using flex-row-reverse
+        effectiveControlPosition === "end" && "flex-row-reverse justify-end",
+        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        className,
+      )}
+    >
+      <BaseRadio.Root
+        ref={ref}
+        data-kumo-component="Radio"
+        data-kumo-part="item"
+        value={value}
+        disabled={disabled}
+        className={cn(
+          "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2",
+          variant === "error" ? "ring-kumo-danger" : "ring-kumo-line",
+          !disabled &&
+            variant !== "error" &&
+            "group-hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:outline-offset-3",
+          !disabled &&
+            variant === "error" &&
+            "focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:outline-offset-3",
+          "data-[checked]:bg-kumo-contrast",
+        )}
+      >
+        <BaseRadio.Indicator
+          keepMounted
+          className="flex items-center justify-center"
+        >
+          <span className="h-2 w-2 rounded-full bg-kumo-base" />
+        </BaseRadio.Indicator>
+      </BaseRadio.Root>
+      <span className="text-base text-kumo-default">{label}</span>
+    </label>
+  );
+}
+
+// React's `forwardRef` erases generic type parameters, so we cast the result
+// back to a generic call signature. The cast is required to support React 18
+// consumers (where function components can't receive `ref` as a plain prop).
+const RadioItem = forwardRef(_RadioItem) as <T = string>(
+  props: RadioItemProps<T> & { ref?: ForwardedRef<HTMLButtonElement> },
+) => ReactElement;
+
+(RadioItem as unknown as { displayName: string }).displayName = "Radio.Item";
 
 // Radio.Legend — composable legend sub-component for Radio.Group
 function RadioLegend({ children, className }: RadioLegendProps) {
@@ -380,7 +442,7 @@ function RadioLegend({ children, className }: RadioLegendProps) {
 RadioLegend.displayName = "Radio.Legend";
 
 // Radio.Group with built-in Fieldset and RadioGroup
-function RadioGroup({
+function RadioGroup<Value = string>({
   legend,
   children,
   orientation = "vertical",
@@ -394,13 +456,15 @@ function RadioGroup({
   controlPosition,
   name,
   className,
-}: RadioGroupProps) {
+}: RadioGroupProps<Value>) {
   return (
     <RadioGroupContext.Provider value={{ controlPosition, appearance }}>
-      <BaseRadioGroup
+      <BaseRadioGroup<Value>
         defaultValue={defaultValue}
         value={value}
-        onValueChange={(newValue) => onValueChange?.(newValue)}
+        onValueChange={(newValue, eventDetails) =>
+          onValueChange?.(newValue, eventDetails)
+        }
         disabled={disabled}
         name={name}
       >

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -9,16 +9,18 @@ import {
 import { cn } from "../../utils/cn";
 import { resolveVariant } from "../../utils/resolve-variant";
 import { Fieldset } from "@base-ui/react/fieldset";
-import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
+import {
+  RadioGroup as BaseRadioGroup,
+  type RadioGroup as BaseRadioGroupNamespace,
+} from "@base-ui/react/radio-group";
 import { Radio as BaseRadio } from "@base-ui/react/radio";
 
 /**
  * Event details passed as the second argument to `onValueChange`. Carries the
  * native event and interaction metadata. Re-exported from Base UI.
  */
-export type RadioGroupChangeEventDetails = Parameters<
-  NonNullable<BaseRadioGroup.Props<unknown>["onValueChange"]>
->[1];
+export type RadioGroupChangeEventDetails =
+  BaseRadioGroupNamespace.ChangeEventDetails;
 
 /** Radio variant definitions mapping variant names to their Tailwind classes. */
 export const KUMO_RADIO_VARIANTS = {

--- a/packages/kumo/src/components/radio/radio.type-spec.tsx
+++ b/packages/kumo/src/components/radio/radio.type-spec.tsx
@@ -1,9 +1,23 @@
+/**
+ * Type-level specification for the Radio component.
+ *
+ * This file is NOT a vitest test file (no `.test.tsx` suffix) — it lives in
+ * the regular tsconfig `include` glob so `tsc --noEmit` (i.e.
+ * `pnpm typecheck`) evaluates every `@ts-expect-error` directive. If one of
+ * the "should be a compile error" cases below stops being an error, tsc
+ * will fail with "Unused '@ts-expect-error' directive" and CI goes red.
+ */
+
 import {
   Radio,
   type RadioGroupChangeEventDetails,
   type RadioGroupProps,
   type RadioItemProps,
 } from "./radio";
+
+// ---------------------------------------------------------------------------
+// Positive cases — these MUST compile cleanly.
+// ---------------------------------------------------------------------------
 
 enum ThemeType {
   light = "light",
@@ -62,6 +76,12 @@ const numericItemProps: RadioItemProps<number> = {
   value: 50,
 };
 
+// ---------------------------------------------------------------------------
+// Negative cases — these MUST NOT compile. The `@ts-expect-error` directive
+// asserts that tsc produces an error on the following line; if it doesn't,
+// tsc itself fails the typecheck with "Unused '@ts-expect-error' directive".
+// ---------------------------------------------------------------------------
+
 // @ts-expect-error - default radio values are strings when no generic is provided.
 const defaultStringValue: RadioGroupProps = { children: stringGroup, value: 1 };
 
@@ -77,9 +97,15 @@ const mismatchedItemValue: RadioItemProps<number> = {
   value: "25",
 };
 
-void enumGroup;
-void numericGroupProps;
-void numericItemProps;
-void defaultStringValue;
-void mismatchedGroupValue;
-void mismatchedItemValue;
+// Silence unused-variable warnings for all the sentinels above.
+// This file is never executed; it exists purely for type checking.
+export const __typeSpec = {
+  numericGroup,
+  enumGroup,
+  stringGroup,
+  numericGroupProps,
+  numericItemProps,
+  defaultStringValue,
+  mismatchedGroupValue,
+  mismatchedItemValue,
+};

--- a/packages/kumo/src/components/radio/radio.typecheck.tsx
+++ b/packages/kumo/src/components/radio/radio.typecheck.tsx
@@ -1,0 +1,85 @@
+import {
+  Radio,
+  type RadioGroupChangeEventDetails,
+  type RadioGroupProps,
+  type RadioItemProps,
+} from "./radio";
+
+enum ThemeType {
+  light = "light",
+  dark = "dark",
+  system = "system",
+}
+
+const numericGroup = (
+  <Radio.Group<number>
+    legend="Items per page"
+    value={25}
+    defaultValue={10}
+    onValueChange={(value, eventDetails) => {
+      value.toFixed();
+      eventDetails.allowPropagation();
+    }}
+  >
+    <Radio.Item<number> label="10" value={10} />
+    <Radio.Item<number> label="25" value={25} />
+  </Radio.Group>
+);
+
+const enumGroup = (
+  <Radio.Group<ThemeType>
+    legend="Theme"
+    value={ThemeType.system}
+    onValueChange={(value) => {
+      const theme: ThemeType = value;
+      void theme;
+    }}
+  >
+    <Radio.Item<ThemeType> label="Light" value={ThemeType.light} />
+    <Radio.Item<ThemeType> label="System" value={ThemeType.system} />
+  </Radio.Group>
+);
+
+const stringGroup = (
+  <Radio.Group legend="Theme" value="system">
+    <Radio.Item label="Light" value="light" />
+    <Radio.Item label="System" value="system" />
+  </Radio.Group>
+);
+
+const numericGroupProps: RadioGroupProps<number> = {
+  children: numericGroup,
+  value: 50,
+  onValueChange: (value, eventDetails) => {
+    value.toFixed();
+    const details: RadioGroupChangeEventDetails = eventDetails;
+    details.cancel();
+  },
+};
+
+const numericItemProps: RadioItemProps<number> = {
+  label: "50",
+  value: 50,
+};
+
+// @ts-expect-error - default radio values are strings when no generic is provided.
+const defaultStringValue: RadioGroupProps = { children: stringGroup, value: 1 };
+
+const mismatchedGroupValue: RadioGroupProps<number> = {
+  children: numericGroup,
+  // @ts-expect-error - generic group values must match the declared value type.
+  value: "25",
+};
+
+const mismatchedItemValue: RadioItemProps<number> = {
+  label: "25",
+  // @ts-expect-error - generic item values must match the declared value type.
+  value: "25",
+};
+
+void enumGroup;
+void numericGroupProps;
+void numericItemProps;
+void defaultStringValue;
+void mismatchedGroupValue;
+void mismatchedItemValue;

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -160,6 +160,7 @@ export {
   KUMO_RADIO_DEFAULT_VARIANTS,
   radioVariants,
   type RadioGroupProps,
+  type RadioGroupChangeEventDetails,
   type RadioLegendProps,
   type RadioItemProps,
   type RadioControlPosition,


### PR DESCRIPTION
This introduces generic types for radio button values.

<img width="1094" height="991" alt="Screenshot 2026-06-10 at 18 12 18" src="https://github.com/user-attachments/assets/82674f86-d05a-427e-a5c7-01096b7a331e" />

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: this is a small type-surface refinement reviewed manually
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
