### PR TITLE
[kumo] Fix horizontal scroll in Sidebar.Content

### DIFF
--- a/.changeset/fix-sidebar-horizontal-scroll.md
+++ b/.changeset/fix-sidebar-horizontal-scroll.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix horizontal scroll in `Sidebar.Content`: always apply `overflow-x: hidden` on the scroll viewport, not just when collapsed. Base UI's `ScrollArea.Viewport` sets `overflow: scroll` as an inline style, which allowed ~14px of horizontal overflow when consumer content (e.g. search buttons with keyboard shortcuts) exceeded the sidebar width.

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -792,7 +792,7 @@ const SidebarContent = forwardRef<
       className={cn(
         "h-full px-[11px] py-3 group-not-data-[state=collapsed]/sidebar:px-3.5",
         "transition-[padding] duration-(--sidebar-animation-duration)",
-        "group-data-[state=collapsed]/sidebar:overflow-x-hidden!",
+        "overflow-x-hidden!",
         // Scroll fade via CSS mask driven by Base UI overflow CSS variables
         "[mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]",
       )}


### PR DESCRIPTION
## Fix horizontal scroll in `Sidebar.Content`

### Problem

`Sidebar.Content` wraps Base UI's `ScrollArea`. The scroll viewport (`[data-sidebar="content"] > div`) receives `overflow: scroll` as an inline style from Base UI, and the inner content div gets `style="min-width: fit-content"`. Together, these create ~14px of horizontal overflow in sidebar panes, allowing users to scroll horizontally when they shouldn't be able to.

This is observable in the Cloudflare dashboard sidebar where consumer content (search buttons with `⌘K` keyboard shortcuts, shortcut items with pin buttons, etc.) pushes the intrinsic content width slightly beyond the viewport.

### Root Cause

The existing `overflow-x-hidden!` override on the viewport was scoped to collapsed state only (`group-data-[state=collapsed]/sidebar:overflow-x-hidden!`), leaving horizontal scrolling enabled in the expanded state.

### Fix

Apply `overflow-x-hidden!` unconditionally on the `ScrollArea.Viewport`, so `overflow-x: hidden !important` always overrides Base UI's inline `overflow: scroll` regardless of sidebar state. The `ScrollArea.Scrollbar` was already set to `orientation="vertical"` and the `ScrollArea.Content` already had `min-w-0!` — this change completes the fix.

One-line change: `group-data-[state=collapsed]/sidebar:overflow-x-hidden!` → `overflow-x-hidden!`

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: single-line CSS class change, no logic or API surface affected
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: CSS-only change that broadens an existing `!important` override from collapsed-only to all states. Existing sidebar tests (701 passing) cover component behavior. The overflow is caused by Base UI's inline styles interacting with consumer content and cannot be reproduced with Kumo's own sidebar components alone.