### PR TITLE
[kumo] Fix registry description summaries

### DIFF
--- a/.changeset/quiet-registry-descriptions.md
+++ b/.changeset/quiet-registry-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Keep generated component registry descriptions to JSDoc summaries before markdown sections or code examples.

--- a/packages/kumo/scripts/component-registry/discovery.ts
+++ b/packages/kumo/scripts/component-registry/discovery.ts
@@ -237,7 +237,7 @@ export function detectPropsTypeFromFile(
 
 /**
  * Extract description text from JSDoc content.
- * Stops at first @tag (like @example, @see, @param, etc.)
+ * Stops at first @tag, markdown heading, or fenced code block.
  */
 function extractDescriptionFromJSDoc(jsdocContent: string): string | null {
   const lines: string[] = [];
@@ -245,24 +245,29 @@ function extractDescriptionFromJSDoc(jsdocContent: string): string | null {
   for (const rawLine of jsdocContent.split("\n")) {
     const line = rawLine.replace(/^\s*\*\s?/, "").trim();
 
-    // Stop at any @tag
-    if (line.startsWith("@")) {
+    // Stop before structured documentation that should not become the summary.
+    if (
+      line.startsWith("@") ||
+      /^#{1,6}\s/.test(line) ||
+      line.startsWith("```") ||
+      line.startsWith("~~~")
+    ) {
       break;
     }
 
-    // Skip empty lines at the start, but allow them in the middle
-    if (line.length > 0 || lines.length > 0) {
-      lines.push(line);
+    // Keep the summary to the first paragraph.
+    if (line.length === 0) {
+      if (lines.length > 0) {
+        break;
+      }
+      continue;
     }
-  }
 
-  // Trim trailing empty lines and join
-  while (lines.length > 0 && lines[lines.length - 1] === "") {
-    lines.pop();
+    lines.push(line);
   }
 
   if (lines.length > 0) {
-    return lines.join(" ").trim();
+    return lines.join(" ").replace(/\s+/g, " ").trim();
   }
 
   return null;


### PR DESCRIPTION
Fixes generated component registry descriptions so they use only the JSDoc summary paragraph.

Previously, regenerated registry descriptions could include markdown headings, code examples, and compound component details. This showed up in downstream surfaces like the docs registry cards and CLI/registry metadata.

## Screenshot

<img width="2676" height="2662" alt="Before and after registry card descriptions showing Collapsible summary cleanup" src="https://github.com/user-attachments/assets/9283d0cf-2fe2-4b37-94be-e2c577a3df96" />


## Testing

- Ran `pnpm --filter @cloudflare/kumo codegen:registry -- --no-cache`
- Compared generated descriptions before/after with:
  `jq '.components.Collapsible.description, .components.DropdownMenu.description, .components.Autocomplete.description, .components.Sidebar.description' packages/kumo/ai/component-registry.json`
- Verified the fixed output only includes the one-line summaries.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: small registry metadata extraction fix reviewed manually
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: regenerated the component registry with no cache and compared Collapsible, DropdownMenu, Autocomplete, and Sidebar descriptions before/after with jq
  - [ ] Additional testing not necessary because: