### PR TITLE
feat(chart): add enableLegendSelection prop to TimeseriesChart

### DIFF
--- a/.changeset/quick-legends-isolate.md
+++ b/.changeset/quick-legends-isolate.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(chart): add `enableLegendSelection` prop to `TimeseriesChart`
+
+Opt-in (default `false`) hidden ECharts legend that lets consumers drive series
+visibility imperatively via the `legendSelect` / `legendUnSelect` /
+`legendToggleSelect` actions — useful for building a custom interactive legend
+with `ChartLegend`. Series toggled off via the legend are also excluded from the
+tooltip. Requires registering ECharts' `LegendComponent`
+(`echarts.use([LegendComponent])`). When disabled, behaviour is unchanged.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -695,20 +695,25 @@ export function LegendOnClickDemo() {
     const chart = chartRef.current;
     if (!chart) return;
 
-    const isIsolated = series.every((s) =>
-      s.name === name ? !hiddenSeries[s.name] : hiddenSeries[s.name],
-    );
+    // Functional update so each click works from the latest state — rapid
+    // clicks won't race with React's state batching.
+    setHiddenSeries((prev) => {
+      // Already isolated to this series? (only it visible, everything else hidden)
+      const isIsolated = series.every((s) =>
+        s.name === name ? !prev[s.name] : prev[s.name],
+      );
 
-    const nextHidden: Record<string, boolean> = {};
-    for (const s of series) {
-      const shouldHide = isIsolated ? false : s.name !== name;
-      nextHidden[s.name] = shouldHide;
-      chart.dispatchAction({
-        type: shouldHide ? "legendUnSelect" : "legendSelect",
-        name: s.name,
-      });
-    }
-    setHiddenSeries(nextHidden);
+      const nextHidden: Record<string, boolean> = {};
+      for (const s of series) {
+        const shouldHide = isIsolated ? false : s.name !== name;
+        nextHidden[s.name] = shouldHide;
+        chart.dispatchAction({
+          type: shouldHide ? "legendUnSelect" : "legendSelect",
+          name: s.name,
+        });
+      }
+      return nextHidden;
+    });
   };
 
   return (

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -9,7 +9,7 @@ import {
 import * as echarts from "echarts/core";
 import type { EChartsOption } from "echarts";
 import { BarChart, LineChart, PieChart } from "echarts/charts";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIsDarkMode } from "~/lib/use-is-dark-mode";
 import {
   AriaComponent,
@@ -689,14 +689,18 @@ export function LegendOnClickDemo() {
     [series],
   );
 
+  // A theme switch re-inits the ECharts instance, resetting legend selection to
+  // all-visible. Reset our state to match so the legend doesn't desync.
+  useEffect(() => {
+    setHiddenSeries({});
+  }, [isDarkMode]);
+
   // Click isolates a series: show only the clicked one and hide the rest via the
   // (hidden) ECharts legend. Clicking the already-isolated series restores all.
   const handleClick = (name: string) => {
     const chart = chartRef.current;
     if (!chart) return;
 
-    // Functional update so each click works from the latest state — rapid
-    // clicks won't race with React's state batching.
     setHiddenSeries((prev) => {
       // Already isolated to this series? (only it visible, everything else hidden)
       const isIsolated = series.every((s) =>

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -598,7 +598,7 @@ export function LegendHighlightDemo() {
     <LayerCard>
       <LayerCard.Secondary>Read latency</LayerCard.Secondary>
       <LayerCard.Primary>
-        <div className="flex divide-x divide-kumo-line gap-4 px-2 mb-2">
+        <div className="flex divide-x divide-kumo-line px-2 mb-2">
           {series.map((s) => (
             <ChartLegend.LargeItem
               key={s.name}
@@ -621,6 +621,7 @@ export function LegendHighlightDemo() {
                   seriesName: s.name,
                 });
               }}
+              className="not-first:pl-4"
             />
           ))}
         </div>
@@ -714,7 +715,7 @@ export function LegendOnClickDemo() {
     <LayerCard>
       <LayerCard.Secondary>Read latency</LayerCard.Secondary>
       <LayerCard.Primary>
-        <div className="flex divide-x divide-kumo-line gap-4 px-2 mb-2">
+        <div className="flex divide-x divide-kumo-line px-2 mb-2">
           {series.map((s) => (
             <ChartLegend.LargeItem
               key={s.name}
@@ -724,6 +725,7 @@ export function LegendOnClickDemo() {
               unit={s.unit}
               inactive={hiddenSeries[s.name] ?? false}
               onClick={() => handleClick(s.name)}
+              className="not-first:pl-4"
             />
           ))}
         </div>

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -16,6 +16,7 @@ import {
   AxisPointerComponent,
   BrushComponent,
   GridComponent,
+  LegendComponent,
   ToolboxComponent,
   TooltipComponent,
 } from "echarts/components";
@@ -29,6 +30,7 @@ echarts.use([
   AxisPointerComponent,
   BrushComponent,
   GridComponent,
+  LegendComponent,
   ToolboxComponent,
   TooltipComponent,
   AriaComponent,
@@ -636,6 +638,110 @@ export function LegendHighlightDemo() {
 }
 
 /**
+ * Timeseries chart where the legend isolates a series on click. Clicking a
+ * `ChartLegend` item shows only that series and hides the rest; clicking the
+ * already-isolated series restores all. Visibility is driven through a hidden
+ * ECharts legend via the `legendSelect` / `legendUnSelect` actions.
+ */
+export function LegendOnClickDemo() {
+  const isDarkMode = useIsDarkMode();
+  const chartRef = useRef<echarts.ECharts>(null);
+  const [hiddenSeries, setHiddenSeries] = useState<Record<string, boolean>>({});
+
+  const series = useMemo(
+    () => [
+      {
+        name: "P99",
+        color: ChartPalette.semantic("Attention", isDarkMode),
+        value: "124",
+        unit: "ms",
+      },
+      {
+        name: "P95",
+        color: ChartPalette.semantic("Warning", isDarkMode),
+        value: "76",
+        unit: "ms",
+      },
+      {
+        name: "P75",
+        color: ChartPalette.semantic("Neutral", isDarkMode),
+        value: "32",
+        unit: "ms",
+      },
+      {
+        name: "P50",
+        color: ChartPalette.semantic("Neutral", isDarkMode),
+        value: "10",
+        unit: "ms",
+      },
+    ],
+    [isDarkMode],
+  );
+
+  const data = useMemo(
+    () =>
+      series.map((s, i) => ({
+        name: s.name,
+        data: buildSeriesData(3 - i, 30, 60_000, 1 - i * 0.2),
+        color: s.color,
+      })),
+    [series],
+  );
+
+  // Click isolates a series: show only the clicked one and hide the rest via the
+  // (hidden) ECharts legend. Clicking the already-isolated series restores all.
+  const handleClick = (name: string) => {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    const isIsolated = series.every((s) =>
+      s.name === name ? !hiddenSeries[s.name] : hiddenSeries[s.name],
+    );
+
+    const nextHidden: Record<string, boolean> = {};
+    for (const s of series) {
+      const shouldHide = isIsolated ? false : s.name !== name;
+      nextHidden[s.name] = shouldHide;
+      chart.dispatchAction({
+        type: shouldHide ? "legendUnSelect" : "legendSelect",
+        name: s.name,
+      });
+    }
+    setHiddenSeries(nextHidden);
+  };
+
+  return (
+    <LayerCard>
+      <LayerCard.Secondary>Read latency</LayerCard.Secondary>
+      <LayerCard.Primary>
+        <div className="flex divide-x divide-kumo-line gap-4 px-2 mb-2">
+          {series.map((s) => (
+            <ChartLegend.LargeItem
+              key={s.name}
+              name={s.name}
+              color={s.color}
+              value={s.value}
+              unit={s.unit}
+              inactive={hiddenSeries[s.name] ?? false}
+              onClick={() => handleClick(s.name)}
+            />
+          ))}
+        </div>
+        <TimeseriesChart
+          ref={chartRef}
+          xAxisName="Time (UTC)"
+          echarts={echarts}
+          isDarkMode={isDarkMode}
+          data={data}
+          height={300}
+          enableLegendSelection
+        />
+      </LayerCard.Primary>
+    </LayerCard>
+  );
+}
+
+/**
  * Custom chart with HTML tooltip using dangerousHtmlFormatter.
  * USE WITH CAUTION: Only use dangerousHtmlFormatter for trusted HTML content.
  * Always sanitize any user-provided data using echarts.format.encodeHTML
@@ -715,7 +821,9 @@ const FOLLOW_CURSOR_OPTIONS: FollowCursorOption[] = [
  */
 export function TooltipFollowCursorDemo() {
   const isDarkMode = useIsDarkMode();
-  const [selected, setSelected] = useState<FollowCursorOption>(FOLLOW_CURSOR_OPTIONS[0]);
+  const [selected, setSelected] = useState<FollowCursorOption>(
+    FOLLOW_CURSOR_OPTIONS[0],
+  );
 
   const data = useMemo(
     () => [
@@ -738,7 +846,9 @@ export function TooltipFollowCursorDemo() {
       <Select
         label="Tooltip follow cursor"
         value={selected}
-        onValueChange={(v) => { if (v) setSelected(v); }}
+        onValueChange={(v) => {
+          if (v) setSelected(v);
+        }}
         renderValue={(v) => v.label}
       >
         {FOLLOW_CURSOR_OPTIONS.map((opt) => (
@@ -767,7 +877,10 @@ export function TooltipFollowCursorDemo() {
 export function TooltipBoundaryDemo() {
   const isDarkMode = useIsDarkMode();
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null);
-  const boundaryRef = useCallback((el: HTMLDivElement | null) => setBoundary(el), []);
+  const boundaryRef = useCallback(
+    (el: HTMLDivElement | null) => setBoundary(el),
+    [],
+  );
 
   const data = useMemo(
     () => [

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -14,6 +14,7 @@ import {
   GradientLineChartDemo,
   IncompleteDataChartDemo,
   LegendHighlightDemo,
+  LegendOnClickDemo,
   LoadingChartDemo,
   TimeRangeSelectionChartDemo,
   TooltipFollowCursorDemo,
@@ -155,6 +156,21 @@ import {
 
   <ComponentExample demo="LegendHighlightDemo">
     <LegendHighlightDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+## Legend Click
+
+<p>
+  Clicking a <code>ChartLegend</code> item isolates that series, showing only
+  it and hiding the rest. Clicking the already-isolated series restores them
+  all.
+</p>
+
+  <ComponentExample demo="LegendOnClickDemo">
+    <LegendOnClickDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/chart/EChart.tsx
+++ b/packages/kumo/src/components/chart/EChart.tsx
@@ -71,14 +71,22 @@ export interface ChartEvents {
   contextmenu: (params: any) => void;
 
   // Legend events
-  /** Fired when any legend item's selected state changes */
+  /** Map of series name → selected state for all legend items */
+  /** Fired on legend toggle (`legendToggleSelect` action or a legend UI click) */
   legendselectchanged: (params: {
     name: string;
-    /** Map of series name → selected state for all legend items */
     selected: Record<string, boolean>;
   }) => void;
-  legendselected: (params: any) => void;
-  legendunselected: (params: any) => void;
+  /** Fired by the `legendSelect` action. Carries the full `selected` map. */
+  legendselected: (params: {
+    name: string;
+    selected: Record<string, boolean>;
+  }) => void;
+  /** Fired by the `legendUnSelect` action. Carries the full `selected` map. */
+  legendunselected: (params: {
+    name: string;
+    selected: Record<string, boolean>;
+  }) => void;
   legendscroll: (params: any) => void;
 
   // Data zoom / timeline events

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -253,12 +253,14 @@ export const TimeseriesChart = forwardRef<
   dataRef.current = data;
   // Tracks legend selection (series name → visible) so the tooltip can skip toggled-off series
   const legendSelectedRef = useRef<Record<string, boolean> | null>(null);
-  // Clear stale selection when legend selection is disabled so it can't keep
-  // filtering the tooltip after the hidden legend is removed. Done in an effect
-  // (not during render) to stay safe under concurrent rendering.
+  // Clear stale selection so it can't keep filtering the tooltip when:
+  // - legend selection is disabled (hidden legend removed), or
+  // - the theme toggles (`isDarkMode` change re-inits the ECharts instance,
+  //   which resets legend selection to all-visible).
+  // Done in an effect (not during render) to stay safe under concurrent rendering.
   useEffect(() => {
-    if (!enableLegendSelection) legendSelectedRef.current = null;
-  }, [enableLegendSelection]);
+    legendSelectedRef.current = null;
+  }, [enableLegendSelection, isDarkMode]);
 
   const tooltipModeRef = useRef(tooltipMode);
   tooltipModeRef.current = tooltipMode;

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -254,8 +254,12 @@ export const TimeseriesChart = forwardRef<
   // Tracks legend selection (series name → visible) so the tooltip can skip toggled-off series
   const legendSelectedRef = useRef<Record<string, boolean> | null>(null);
   // Clear stale selection when legend selection is disabled so it can't keep
-  // filtering the tooltip after the hidden legend is removed.
-  if (!enableLegendSelection) legendSelectedRef.current = null;
+  // filtering the tooltip after the hidden legend is removed. Done in an effect
+  // (not during render) to stay safe under concurrent rendering.
+  useEffect(() => {
+    if (!enableLegendSelection) legendSelectedRef.current = null;
+  }, [enableLegendSelection]);
+
   const tooltipModeRef = useRef(tooltipMode);
   tooltipModeRef.current = tooltipMode;
   const tooltipMaxItemsRef = useRef(tooltipMaxItems);

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -1,7 +1,15 @@
 import type * as echarts from "echarts/core";
 import type { LineSeriesOption, BarSeriesOption } from "echarts/charts";
 import type { EChartsOption, SeriesOption, SetOptionOpts } from "echarts";
-import { forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import { Chart, ChartEvents, KumoChartOption } from "./EChart";
 
@@ -103,6 +111,20 @@ export interface TimeseriesChartProps {
   tooltipFollowCursor?: "both" | "x";
   /** Indicates incomplete data periods with optional before/after timestamps in ms */
   incomplete?: { before?: number; after?: number };
+  /**
+   * When `true`, adds a hidden ECharts legend so consumers can drive series
+   * visibility imperatively via the `legendSelect` / `legendUnSelect` /
+   * `legendToggleSelect` actions (e.g. to build a custom interactive legend).
+   * Toggled-off series are also excluded from the tooltip.
+   *
+   * Requires the consumer to register ECharts' `LegendComponent`
+   * (`echarts.use([LegendComponent])`); otherwise the legend actions no-op and,
+   * in development, ECharts logs a "component legend is used but not imported"
+   * warning.
+   *
+   * @default false
+   */
+  enableLegendSelection?: boolean;
   /** Height of the chart in pixels. Defaults to `350`. */
   height?: number;
   /** Callback fired when user selects a time range via brush selection */
@@ -198,6 +220,7 @@ export const TimeseriesChart = forwardRef<
     onTimeRangeChange,
     height = 350,
     incomplete,
+    enableLegendSelection = false,
     isDarkMode,
     gradient,
     loading,
@@ -228,6 +251,11 @@ export const TimeseriesChart = forwardRef<
   // Keep latest props accessible inside event handlers without stale closures
   const dataRef = useRef(data);
   dataRef.current = data;
+  // Tracks legend selection (series name → visible) so the tooltip can skip toggled-off series
+  const legendSelectedRef = useRef<Record<string, boolean> | null>(null);
+  // Clear stale selection when legend selection is disabled so it can't keep
+  // filtering the tooltip after the hidden legend is removed.
+  if (!enableLegendSelection) legendSelectedRef.current = null;
   const tooltipModeRef = useRef(tooltipMode);
   tooltipModeRef.current = tooltipMode;
   const tooltipMaxItemsRef = useRef(tooltipMaxItems);
@@ -242,7 +270,10 @@ export const TimeseriesChart = forwardRef<
     if (!container) return;
     const onMove = (e: MouseEvent) => {
       const rect = container.getBoundingClientRect();
-      mousePosRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      mousePosRef.current = {
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top,
+      };
     };
     container.addEventListener("mousemove", onMove);
     return () => container.removeEventListener("mousemove", onMove);
@@ -348,6 +379,7 @@ export const TimeseriesChart = forwardRef<
       },
       backgroundColor: "transparent",
       toolbox: { show: false },
+      ...(enableLegendSelection ? { legend: { show: false } } : {}),
       xAxis: {
         name: xAxisName,
         nameLocation: "middle" as const,
@@ -402,6 +434,7 @@ export const TimeseriesChart = forwardRef<
     incompleteAfter,
     type,
     gradient,
+    enableLegendSelection,
     echarts,
     ariaDescription,
   ]);
@@ -415,11 +448,19 @@ export const TimeseriesChart = forwardRef<
         const seenNames = new Set<string>();
         const allRows: TooltipRow[] = [];
 
+        // Respect legend selection: series toggled off via the legend
+        // (legendUnSelect / legendToggleSelect) should not appear in the tooltip.
+        // Read from a ref kept in sync by `legendselectchanged` — avoids the
+        // expensive `getOption()` deep-clone on every pointer move.
+        const legendSelected = legendSelectedRef.current;
+
         for (const s of dataRef.current) {
           if (seenNames.has(s.name)) continue;
+          if (legendSelected && legendSelected[s.name] === false) continue;
           seenNames.add(s.name);
           const value = findNearest(s.data, ts);
-          if (value != null) allRows.push({ name: s.name, value, color: s.color });
+          if (value != null)
+            allRows.push({ name: s.name, value, color: s.color });
         }
 
         // Sort by value descending so highest series appears first
@@ -432,11 +473,19 @@ export const TimeseriesChart = forwardRef<
           // Find the series whose value is closest to the cursor's y position
           const chart = chartRef.current;
           const cursorValue = chart
-            ? (chart.convertFromPixel("grid", [0, mousePosRef.current.y]) as [number, number])?.[1]
+            ? (
+                chart.convertFromPixel("grid", [0, mousePosRef.current.y]) as [
+                  number,
+                  number,
+                ]
+              )?.[1]
             : null;
           if (cursorValue != null && allRows.length > 0) {
             const nearest = allRows.reduce((best, row) =>
-              Math.abs(row.value - cursorValue) < Math.abs(best.value - cursorValue) ? row : best,
+              Math.abs(row.value - cursorValue) <
+              Math.abs(best.value - cursorValue)
+                ? row
+                : best,
             );
             rows = [nearest];
           } else {
@@ -456,6 +505,16 @@ export const TimeseriesChart = forwardRef<
       },
       globalout: () => {
         setTooltipState(null);
+      },
+      // Keep the tooltip in sync with legend selection.
+      legendselectchanged: (params: any) => {
+        if (params?.selected) legendSelectedRef.current = params.selected;
+      },
+      legendselected: (params: any) => {
+        if (params?.selected) legendSelectedRef.current = params.selected;
+      },
+      legendunselected: (params: any) => {
+        if (params?.selected) legendSelectedRef.current = params.selected;
       },
       ...(onTimeRangeChange && {
         brushend: (params: any) => {
@@ -500,11 +559,19 @@ export const TimeseriesChart = forwardRef<
   const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat;
   const tooltipOpen = tooltipState !== null;
 
-
   return (
-    <TooltipPrimitive.Root open={tooltipOpen} trackCursorAxis={tooltipFollowCursor}>
+    <TooltipPrimitive.Root
+      open={tooltipOpen}
+      trackCursorAxis={tooltipFollowCursor}
+    >
       <TooltipPrimitive.Trigger
-        render={<div ref={containerRef} className="relative w-full" style={{ height }} />}
+        render={
+          <div
+            ref={containerRef}
+            className="relative w-full"
+            style={{ height }}
+          />
+        }
       >
         {loading && <ChartWaveLoader height={height} isDarkMode={isDarkMode} />}
         {!loading && (
@@ -556,7 +623,10 @@ interface TooltipContentProps {
   formatValue?: (v: number) => string;
 }
 
-const TooltipContent = memo(function TooltipContent({ state, formatValue }: TooltipContentProps) {
+const TooltipContent = memo(function TooltipContent({
+  state,
+  formatValue,
+}: TooltipContentProps) {
   const { ts, rows, hiddenCount } = state;
 
   return (
@@ -565,25 +635,31 @@ const TooltipContent = memo(function TooltipContent({ state, formatValue }: Tool
         {formatTimestamp(ts)}
       </div>
       {rows.map((row) => (
-        <div key={row.name} className="flex items-center justify-between gap-4 py-0.5">
+        <div
+          key={row.name}
+          className="flex items-center justify-between gap-4 py-0.5"
+        >
           <div className="flex items-center gap-2 min-w-0">
             <span
               className="w-3 h-3 rounded-full shrink-0"
               style={{ backgroundColor: row.color }}
             />
-            <span className="text-xs font-medium text-kumo-default truncate" title={row.name}>
+            <span
+              className="text-xs font-medium text-kumo-default truncate"
+              title={row.name}
+            >
               {row.name}
             </span>
           </div>
           <span className="text-xs font-semibold text-kumo-default shrink-0">
-            {formatValue ? formatValue(row.value) : formatDefaultValue(row.value)}
+            {formatValue
+              ? formatValue(row.value)
+              : formatDefaultValue(row.value)}
           </span>
         </div>
       ))}
       {hiddenCount > 0 && (
-        <div className="text-xs text-kumo-subtle mt-1">
-          +{hiddenCount} more
-        </div>
+        <div className="text-xs text-kumo-subtle mt-1">+{hiddenCount} more</div>
       )}
     </>
   );
@@ -594,25 +670,36 @@ const TooltipContent = memo(function TooltipContent({ state, formatValue }: Tool
 /** Binary search for the value in `data` whose timestamp is closest to `ts`. */
 function findNearest(data: [number, number][], ts: number): number | null {
   if (data.length === 0) return null;
-  let lo = 0, hi = data.length - 1;
+  let lo = 0,
+    hi = data.length - 1;
   while (lo < hi) {
     const mid = (lo + hi) >> 1;
     if (data[mid][0] < ts) lo = mid + 1;
     else hi = mid;
   }
   // Check both neighbours and return the closer one
-  if (lo > 0 && Math.abs(data[lo - 1][0] - ts) < Math.abs(data[lo][0] - ts)) lo--;
+  if (lo > 0 && Math.abs(data[lo - 1][0] - ts) < Math.abs(data[lo][0] - ts))
+    lo--;
   return data[lo][1];
 }
 
 /** Shallow-compare two tooltip states so React can skip renders when nothing changed. */
 function isSameTooltipState(a: TooltipState | null, b: TooltipState): boolean {
-  if (!a || a.ts !== b.ts || a.hiddenCount !== b.hiddenCount || a.rows.length !== b.rows.length) {
+  if (
+    !a ||
+    a.ts !== b.ts ||
+    a.hiddenCount !== b.hiddenCount ||
+    a.rows.length !== b.rows.length
+  ) {
     return false;
   }
   return a.rows.every((row, i) => {
     const next = b.rows[i];
-    return row.name === next.name && row.value === next.value && row.color === next.color;
+    return (
+      row.name === next.name &&
+      row.value === next.value &&
+      row.color === next.color
+    );
   });
 }
 

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -506,15 +506,19 @@ export const TimeseriesChart = forwardRef<
       globalout: () => {
         setTooltipState(null);
       },
-      // Keep the tooltip in sync with legend selection.
-      legendselectchanged: (params: any) => {
-        if (params?.selected) legendSelectedRef.current = params.selected;
+      // Keep the tooltip in sync with legend selection. Each action fires a
+      // different event — `legendToggleSelect` → `legendselectchanged`,
+      // `legendSelect` → `legendselected`, `legendUnSelect` → `legendunselected`
+      // — and all three carry the full `selected` map, so we listen to all of
+      // them (params type inferred from `ChartEvents`).
+      legendselectchanged: (params) => {
+        legendSelectedRef.current = params.selected;
       },
-      legendselected: (params: any) => {
-        if (params?.selected) legendSelectedRef.current = params.selected;
+      legendselected: (params) => {
+        legendSelectedRef.current = params.selected;
       },
-      legendunselected: (params: any) => {
-        if (params?.selected) legendSelectedRef.current = params.selected;
+      legendunselected: (params) => {
+        legendSelectedRef.current = params.selected;
       },
       ...(onTimeRangeChange && {
         brushend: (params: any) => {


### PR DESCRIPTION
### Summary
Adds an opt-in enableLegendSelection prop (default false) to TimeseriesChart. When enabled, it includes a hidden ECharts legend so consumers can drive series visibility imperatively via the legendSelect / legendUnSelect / legendToggleSelect actions — enabling custom interactive legends built with ChartLegend. Series toggled off via the legend are also excluded from the tooltip.

### Changes
- TimeseriesChart
- New enableLegendSelection?: boolean prop (default false); only adds legend: { show: false } when enabled.
- Tooltip now omits legend-deselected series, synced via legend events (legendselectchanged / legendselected / legendunselected) into a ref, avoids calling getOption() on the pointer-move hot path.
- Resets the selection ref when the prop is disabled so stale state can't filter the tooltip.

### Notes / Requirements
- Requires consumers to register ECharts' LegendComponent (echarts.use([LegendComponent])) when enableLegendSelection is on; otherwise the legend actions no-op (and dev logs a warning).
- Backward compatible: with the default false, no legend is added and tooltip behavior is unchanged.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: click through preview URL
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
