### PR TITLE
fix(badge): add green badge token

### DIFF
--- a/.changeset/green-badges-appear.md
+++ b/.changeset/green-badges-appear.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix the green Badge variant missing its background color token.

--- a/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BadgeDemo.tsx
@@ -20,6 +20,7 @@ export function BadgeColorVariantsDemo() {
     <div className="flex flex-wrap items-center gap-2">
       <Badge variant="neutral">Neutral</Badge>
       <Badge variant="red">Red</Badge>
+      <Badge variant="green">Green</Badge>
       <Badge variant="orange">Orange</Badge>
       <Badge variant="teal">Teal</Badge>
       <Badge variant="blue">Blue</Badge>

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -498,6 +498,18 @@ export const THEME_CONFIG: ThemeConfig = {
       },
     },
 
+    // Green
+    "kumo-badge-green": {
+      newName: "",
+      description: "Green badge background",
+      theme: {
+        kumo: {
+          light: "var(--color-emerald-600, oklch(59.6% 0.145 163.225))",
+          dark: "var(--color-emerald-700, oklch(50.8% 0.118 165.612))",
+        },
+      },
+    },
+
     // Orange
     "kumo-badge-orange": {
       newName: "",

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -246,6 +246,11 @@
     var(--color-red-700, oklch(50.5% 0.213 27.518))
   );
 
+  --color-kumo-badge-green: light-dark(
+    var(--color-emerald-600, oklch(59.6% 0.145 163.225)),
+    var(--color-emerald-700, oklch(50.8% 0.118 165.612))
+  );
+
   --color-kumo-badge-orange: light-dark(
     var(--color-orange-650, oklch(81.5% 0.197 76)),
     var(--color-orange-650, oklch(81.5% 0.197 76))
@@ -339,6 +344,7 @@
     --color-kumo-banner-info: oklch(93.2% 0.032 255.585 / 0.7);
     --color-kumo-banner-warning: var(--color-yellow-100, oklch(97.3% 0.071 103.193));
     --color-kumo-badge-red: var(--color-red-600, oklch(57.7% 0.245 27.325));
+    --color-kumo-badge-green: var(--color-emerald-600, oklch(59.6% 0.145 163.225));
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-purple: var(--color-purple-600, oklch(60% 0.118 184.704));
     --color-kumo-badge-teal: var(--color-teal-650, oklch(54.9% 0.096 184.565));
@@ -395,6 +401,7 @@
     --color-kumo-banner-info: oklch(37.9% 0.146 265.522 / 0.5);
     --color-kumo-banner-warning: oklch(55.4% 0.135 66.442 / 0.5);
     --color-kumo-badge-red: var(--color-red-700, oklch(50.5% 0.213 27.518));
+    --color-kumo-badge-green: var(--color-emerald-700, oklch(50.8% 0.118 165.612));
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-purple: var(--color-purple-700, oklch(50.8% 0.118 165.612));
     --color-kumo-badge-teal: var(--color-teal-700, oklch(51.1% 0.096 186.391));


### PR DESCRIPTION
## Summary

- Add the missing `kumo-badge-green` theme token used by `Badge variant="green"`
- Regenerate `theme-kumo.css` so the green badge has a background color
- Add the green badge to the docs "Other color variants" example

Fixes https://github.com/cloudflare/kumo/issues/587

## Verification

- `pnpm --filter @cloudflare/kumo codegen:themes`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo-docs-astro exec oxlint src/components/demos/BadgeDemo.tsx`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a small generated theme-token and docs example fix
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: verified generated CSS contains the missing token and linted the updated docs example
- [x] Additional testing not necessary because: lint and typecheck cover this token-only package fix