### PR TITLE
docs: prefer hosted Kumo docs for agent lookup

### DIFF
--- a/.changeset/tidy-ravens-yawn.md
+++ b/.changeset/tidy-ravens-yawn.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Improve Kumo documentation lookup guidance for AI agents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,10 @@ kumo/
 
 | Task                 | Location                                         | Notes                                                    |
 | -------------------- | ------------------------------------------------ | -------------------------------------------------------- |
-| Component API        | `packages/kumo/ai/component-registry.{json,md}`  | Source of truth. Query with `jq` or CLI                  |
+| Usage/API docs       | `https://kumo-ui.com/llms.txt`                   | Start here for user-facing Kumo questions                |
+| Component docs       | `https://kumo-ui.com/components/{name}.md`       | Fast markdown docs with examples and API tables          |
+| Hosted registry      | `https://kumo-ui.com/api/component-registry`     | Structured component metadata                            |
+| Component API        | `packages/kumo/ai/component-registry.{json,md}`  | Local development source of truth. Query with `jq` or CLI |
 | Component source     | `packages/kumo/src/components/{name}/{name}.tsx` | Standard pattern                                         |
 | Blocks (installable) | `packages/kumo/src/blocks/`                      | NOT library exports; installed via CLI                   |
 | Semantic tokens      | `packages/kumo/src/styles/theme-kumo.css`        | AUTO-GENERATED; edit `scripts/theme-generator/config.ts` |
@@ -49,8 +52,10 @@ kumo/
 
 ### Components
 
+- **Docs first for usage questions**: For user-facing Kumo API, installation, styling, component, or block questions, start with `https://kumo-ui.com/llms.txt` or the matching `.md` docs page before searching package files.
 - **Scaffold new**: `pnpm --filter @cloudflare/kumo new:component` (never create manually)
-- **Registry first**: Always check `component-registry.json` before using/modifying a component
+- **Registry/source for development**: Check `component-registry.json` and source files when modifying Kumo itself or verifying implementation details.
+- **Avoid dependency spelunking**: Do not inspect `node_modules/@cloudflare/kumo` for normal usage/API answers unless debugging the installed package version, build output, or package resolution.
 - See `packages/kumo/AGENTS.md` for component conventions (variants, forwardRef, displayName)
 
 ### Imports

--- a/packages/kumo/AGENTS.md
+++ b/packages/kumo/AGENTS.md
@@ -35,8 +35,11 @@ kumo/
 
 | Task                     | Location                                        | Notes                                                                      |
 | ------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------- |
-| Component implementation | `src/components/{name}/{name}.tsx`              | Always check registry first                                                |
-| Component API reference  | `ai/component-registry.json`                    | Source of truth for props/variants                                         |
+| Usage/API docs           | `https://kumo-ui.com/llms.txt`                  | Start here for user-facing Kumo questions                                  |
+| Component docs           | `https://kumo-ui.com/components/{name}.md`      | Fast markdown docs with examples and API tables                            |
+| Hosted registry          | `https://kumo-ui.com/api/component-registry`    | Structured component metadata                                              |
+| Component implementation | `src/components/{name}/{name}.tsx`              | Use for implementation changes                                             |
+| Component API reference  | `ai/component-registry.json`                    | Local development source of truth for props/variants                       |
 | Variant definitions      | `KUMO_{NAME}_VARIANTS` export in component file | Machine-readable + lint-enforced                                           |
 | CLI commands             | `src/command-line/commands/`                    | `ls`, `doc`, `add`, `blocks`, `init`, `migrate`                            |
 | Catalog runtime          | `src/catalog/`                                  | JSON pointer resolution, visibility conditions                             |
@@ -47,6 +50,14 @@ kumo/
 | Registry codegen         | `scripts/component-registry/index.ts`           | 13 sub-modules; pipeline: discovery → cache → type extraction → enrichment |
 
 ## CONVENTIONS
+
+### Agent Lookup Order
+
+- For user-facing Kumo usage, installation, styling, component, or block questions, start with `https://kumo-ui.com/llms.txt` or the matching `.md` docs page.
+- Use the hosted registry at `https://kumo-ui.com/api/component-registry` for structured metadata when a docs page is not enough.
+- Use local `ai/component-registry.json` and `src/components/{name}/{name}.tsx` when modifying Kumo itself or verifying implementation details.
+- Do not inspect `node_modules/@cloudflare/kumo` for normal usage/API answers unless debugging the installed package version, build output, or package resolution.
+- In consumer projects, prefer `pnpm exec kumo doc <ComponentName>` or `npx @cloudflare/kumo doc <ComponentName>` over bare `kumo`.
 
 ### Build System
 

--- a/packages/kumo/README.md
+++ b/packages/kumo/README.md
@@ -18,7 +18,13 @@ pnpm add react react-dom @phosphor-icons/react
 
 ## Component Documentation
 
-Kumo includes a built-in CLI for quick component reference:
+Hosted documentation is the fastest way to answer usage and API questions:
+
+- Docs index for agents: <https://kumo-ui.com/llms.txt>
+- Component docs: `https://kumo-ui.com/components/{component}.md`
+- Structured registry: <https://kumo-ui.com/api/component-registry>
+
+Kumo also includes a built-in CLI for quick local component reference:
 
 ```bash
 npx @cloudflare/kumo ls         # List all components

--- a/packages/kumo/ai/USAGE.md
+++ b/packages/kumo/ai/USAGE.md
@@ -2,6 +2,16 @@
 
 > Cloudflare's React component library built on [Base UI](https://base-ui.com) + Tailwind CSS v4.
 
+## Documentation Lookup
+
+For user-facing usage/API questions, start with the hosted docs instead of reading installed package files:
+
+- LLM index: `https://kumo-ui.com/llms.txt`
+- Component docs: `https://kumo-ui.com/components/{component}.md`
+- Structured registry: `https://kumo-ui.com/api/component-registry`
+
+Use `@cloudflare/kumo/ai/component-registry.json` from the installed package only when the exact installed package version matters or when debugging package resolution/build output. In consumer projects, use `pnpm exec kumo doc <ComponentName>` or `npx @cloudflare/kumo doc <ComponentName>` instead of bare `kumo`.
+
 ## Quick Start
 
 ### CSS setup (required)
@@ -192,7 +202,13 @@ Some components accept an `as` prop or Base UI's `render` prop:
 
 ## Full Registry
 
-For complete prop details, variant values, Tailwind classes, and code examples for every component, see:
+For complete prop details, variant values, Tailwind classes, and code examples for every component, prefer the hosted registry:
+
+```
+https://kumo-ui.com/api/component-registry
+```
+
+The same structured metadata is also included in the package for version-specific debugging:
 
 ```
 @cloudflare/kumo/ai/component-registry.json


### PR DESCRIPTION
## Summary

- Add docs-first lookup guidance for Kumo usage/API questions.
- Point agents to the hosted LLM index, component markdown pages, and hosted registry before local package files.
- Clarify that installed package registry lookup is for version-specific debugging or package/build investigation.
- Document consumer CLI usage with `pnpm exec kumo doc <ComponentName>` or `npx @cloudflare/kumo doc <ComponentName>`.

## Testing

- Ran a local behavioral check with temporary consumer fixtures and confirmed docs-first guidance made the first lookup use hosted Kumo component markdown instead of installed package files.
- Ran `git diff --check`.
- Pre-push changeset validation passed.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: documentation-only guidance update
- Tests
- [ ] Tests included/updated
- [x] Automated tests not possible - manual testing has been completed as follows: local behavioral check for lookup source selection plus git diff whitespace validation
- [ ] Additional testing not necessary because: documentation-only guidance update