### PR TITLE
feat(button): revise colored button styles

### DIFF
--- a/.changeset/blue-primary-buttons.md
+++ b/.changeset/blue-primary-buttons.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update the Button primary and destructive variants with token-derived gradient treatments.

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -295,7 +295,7 @@ export const THEME_CONFIG: ThemeConfig = {
       theme: {
         kumo: {
           light: "oklch(0.5772 0.2324 260)",
-          dark: "oklch(0.5772 0.2324 260)",
+          dark: "color-mix(in oklch, oklch(0.5772 0.2324 260), black 10%)",
         },
       },
     },
@@ -431,7 +431,7 @@ export const THEME_CONFIG: ThemeConfig = {
       theme: {
         kumo: {
           light: "var(--color-red-500, oklch(63.7% 0.237 25.331))",
-          dark: "var(--color-red-400, oklch(70.4% 0.191 22.216))",
+          dark: "var(--color-red-600, oklch(57.7% 0.245 27.325))",
         },
       },
     },

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -22,51 +22,6 @@ describe("Button", () => {
     });
   });
 
-  describe("emphasis variants", () => {
-    it.each([
-      ["primary", "var(--color-kumo-brand)"],
-      ["destructive", "var(--color-kumo-danger)"],
-    ] as const)(
-      "renders the %s gradient overlay and relative content wrapper",
-      (variant, token) => {
-        render(<Button variant={variant}>Save</Button>);
-        const button = screen.getByRole("button", { name: "Save" });
-
-        expect(button.className).toContain("bg-(--kumo-button-emphasis-bg)");
-        expect(button.className).toContain(
-          "ring-(--kumo-button-emphasis-ring)",
-        );
-        expect(button.getAttribute("style")).toContain(
-          `--kumo-button-emphasis-ring: color-mix(in oklch, ${token}, black 10%)`,
-        );
-        expect(button.getAttribute("style")).toContain(
-          `--kumo-button-emphasis-bg: color-mix(in oklch, ${token}, white 30%)`,
-        );
-        expect(button.getAttribute("style")).toContain(
-          `--kumo-button-emphasis-gradient-start: color-mix(in oklch, ${token}, white 15%)`,
-        );
-        expect(button.getAttribute("style")).toContain(
-          `--kumo-button-emphasis-gradient-end: ${token}`,
-        );
-
-        const overlay = button.querySelector('span[aria-hidden="true"]');
-        expect(overlay?.className).toContain("bg-linear-to-b");
-        expect(overlay?.className).toContain(
-          "from-(--kumo-button-emphasis-gradient-start)",
-        );
-        expect(overlay?.className).toContain(
-          "to-(--kumo-button-emphasis-gradient-end)",
-        );
-        expect(overlay?.className).toContain(
-          "group-hover:from-(--kumo-button-emphasis-bg)",
-        );
-
-        const content = button.querySelector("span.relative.flex.items-center");
-        expect(content?.textContent).toBe("Save");
-      },
-    );
-  });
-
   describe("loading state transitions", () => {
     it("transitions from non-loading to loading and back", () => {
       const { rerender } = render(<Button loading={false}>Submit</Button>);

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -22,6 +22,51 @@ describe("Button", () => {
     });
   });
 
+  describe("emphasis variants", () => {
+    it.each([
+      ["primary", "var(--color-kumo-brand)"],
+      ["destructive", "var(--color-kumo-danger)"],
+    ] as const)(
+      "renders the %s gradient overlay and relative content wrapper",
+      (variant, token) => {
+        render(<Button variant={variant}>Save</Button>);
+        const button = screen.getByRole("button", { name: "Save" });
+
+        expect(button.className).toContain("bg-(--kumo-button-emphasis-bg)");
+        expect(button.className).toContain(
+          "ring-(--kumo-button-emphasis-ring)",
+        );
+        expect(button.getAttribute("style")).toContain(
+          `--kumo-button-emphasis-ring: color-mix(in oklch, ${token}, black 10%)`,
+        );
+        expect(button.getAttribute("style")).toContain(
+          `--kumo-button-emphasis-bg: color-mix(in oklch, ${token}, white 30%)`,
+        );
+        expect(button.getAttribute("style")).toContain(
+          `--kumo-button-emphasis-gradient-start: color-mix(in oklch, ${token}, white 15%)`,
+        );
+        expect(button.getAttribute("style")).toContain(
+          `--kumo-button-emphasis-gradient-end: ${token}`,
+        );
+
+        const overlay = button.querySelector('span[aria-hidden="true"]');
+        expect(overlay?.className).toContain("bg-linear-to-b");
+        expect(overlay?.className).toContain(
+          "from-(--kumo-button-emphasis-gradient-start)",
+        );
+        expect(overlay?.className).toContain(
+          "to-(--kumo-button-emphasis-gradient-end)",
+        );
+        expect(overlay?.className).toContain(
+          "group-hover:from-(--kumo-button-emphasis-bg)",
+        );
+
+        const content = button.querySelector("span.relative.flex.items-center");
+        expect(content?.textContent).toBe("Save");
+      },
+    );
+  });
+
   describe("loading state transitions", () => {
     it("transitions from non-loading to loading and back", () => {
       const { rerender } = render(<Button loading={false}>Submit</Button>);

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -49,7 +49,7 @@ export const KUMO_BUTTON_VARIANTS = {
   variant: {
     primary: {
       classes:
-        "bg-kumo-brand !text-white hover:bg-kumo-brand-hover disabled:bg-kumo-brand/50",
+        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
       description: "High-emphasis button for primary actions",
     },
     secondary: {
@@ -62,7 +62,8 @@ export const KUMO_BUTTON_VARIANTS = {
       description: "Minimal button with no background",
     },
     destructive: {
-      classes: "bg-kumo-danger !text-white hover:bg-kumo-danger/70",
+      classes:
+        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
       description: "Danger button for destructive actions like delete",
     },
     "secondary-destructive": {
@@ -136,12 +137,6 @@ export function buttonVariants({
     "cursor-pointer",
     // Disabled state
     "disabled:cursor-not-allowed disabled:text-kumo-subtle",
-    // Apply variant, size, shape styles from KUMO_BUTTON_VARIANTS
-    resolveVariant(
-      KUMO_BUTTON_VARIANTS.variant,
-      variant,
-      KUMO_BUTTON_DEFAULT_VARIANTS.variant,
-    ).classes,
     resolveVariant(
       KUMO_BUTTON_VARIANTS.size,
       size,
@@ -158,6 +153,11 @@ export function buttonVariants({
         size,
         KUMO_BUTTON_DEFAULT_VARIANTS.size,
       ).classes,
+    resolveVariant(
+      KUMO_BUTTON_VARIANTS.variant,
+      variant,
+      KUMO_BUTTON_DEFAULT_VARIANTS.variant,
+    ).classes,
   );
 }
 
@@ -167,6 +167,55 @@ const renderIconNode = (IconComponent?: Icon | React.ReactNode) => {
   if (React.isValidElement(IconComponent)) return IconComponent;
   const Comp = IconComponent as React.ComponentType<Record<string, unknown>>;
   return <Comp />;
+};
+
+const getEmphasisToken = (variant: KumoButtonVariant) => {
+  if (variant === "primary") return "var(--color-kumo-brand)";
+  if (variant === "destructive") return "var(--color-kumo-danger)";
+  return undefined;
+};
+
+const getEmphasisStyle = (variant: KumoButtonVariant) => {
+  const token = getEmphasisToken(variant);
+  if (!token) return undefined;
+
+  return {
+    "--kumo-button-emphasis-ring": `color-mix(in oklch, ${token}, black 10%)`,
+    "--kumo-button-emphasis-bg": `color-mix(in oklch, ${token}, white 30%)`,
+    "--kumo-button-emphasis-gradient-start": `color-mix(in oklch, ${token}, white 15%)`,
+    "--kumo-button-emphasis-gradient-end": token,
+  } satisfies React.CSSProperties & Record<`--${string}`, string>;
+};
+
+const renderButtonContent = (
+  variant: KumoButtonVariant,
+  iconNode: React.ReactNode,
+  children: React.ReactNode,
+) => {
+  const childNode =
+    children != null ? <span className="contents">{children}</span> : null;
+
+  if (!getEmphasisToken(variant)) {
+    return (
+      <>
+        {iconNode}
+        {childNode}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className="absolute inset-0 rounded-[inherit] bg-linear-to-b from-(--kumo-button-emphasis-gradient-start) to-(--kumo-button-emphasis-gradient-end) translate-y-px group-hover:from-(--kumo-button-emphasis-bg)"
+      />
+      <span className="relative flex items-center gap-1.5">
+        {iconNode}
+        {childNode}
+      </span>
+    </>
+  );
 };
 
 /**
@@ -253,12 +302,20 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size = "base",
       variant = "secondary",
       icon: IconComponent,
+      style,
       title,
       ...props
     },
     ref,
   ) => {
     const { type, ...restProps } = props;
+    const emphasisStyle = getEmphasisStyle(variant);
+    const iconNode = loading ? (
+      <Loader size={size === "lg" ? 16 : 14} />
+    ) : (
+      renderIconNode(IconComponent)
+    );
+
     const button = (
       <button
         ref={ref}
@@ -269,15 +326,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           className,
         )}
         disabled={loading || disabled}
+        style={emphasisStyle ? { ...emphasisStyle, ...style } : style}
         type={type ?? "button"}
         {...restProps}
       >
-        {loading ? (
-          <Loader size={size === "lg" ? 16 : 14} />
-        ) : (
-          renderIconNode(IconComponent)
-        )}
-        {children != null && <span className="contents">{children}</span>}
+        {renderButtonContent(variant, iconNode, children)}
       </button>
     );
 
@@ -335,12 +388,14 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
       size = "base",
       variant = "ghost",
       icon: IconComponent,
+      style,
       // linksExternal = false,
       ...props
     },
     ref,
   ) => {
     const LinkComponent = useLinkComponent();
+    const emphasisStyle = getEmphasisStyle(variant);
     const externalProps = external
       ? { target: "_blank", rel: "noopener noreferrer" }
       : {};
@@ -355,12 +410,12 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
           className,
         )}
         href={href}
+        style={emphasisStyle ? { ...emphasisStyle, ...style } : style}
         to={typeof href === "string" ? href : undefined}
         {...externalProps}
         {...props}
       >
-        {renderIconNode(IconComponent)}
-        {children}
+        {renderButtonContent(variant, renderIconNode(IconComponent), children)}
       </LinkComponent>
     );
   },

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -148,7 +148,7 @@
 
   --color-kumo-brand: light-dark(
     oklch(0.5772 0.2324 260),
-    oklch(0.5772 0.2324 260)
+    color-mix(in oklch, oklch(0.5772 0.2324 260), black 10%)
   );
 
   --color-kumo-brand-hover: light-dark(
@@ -218,7 +218,7 @@
 
   --color-kumo-danger: light-dark(
     var(--color-red-500, oklch(63.7% 0.237 25.331)),
-    var(--color-red-400, oklch(70.4% 0.191 22.216))
+    var(--color-red-600, oklch(57.7% 0.245 27.325))
   );
 
   --color-kumo-success-tint: light-dark(
@@ -381,7 +381,7 @@
     --color-kumo-interact: var(--color-neutral-700, oklch(37.1% 0 0));
     --color-kumo-fill: var(--color-neutral-800, oklch(26.9% 0 0));
     --color-kumo-fill-hover: var(--color-neutral-800, oklch(37.1% 0 0));
-    --color-kumo-brand: oklch(0.5772 0.2324 260);
+    --color-kumo-brand: color-mix(in oklch, oklch(0.5772 0.2324 260), black 10%);
     --color-kumo-brand-hover: var(--color-blue-700, oklch(48.8% 0.243 264.376));
     --color-kumo-line: var(--color-kumo-neutral-750, oklch(32% 0 0));
     --color-kumo-hairline: var(--color-neutral-800, oklch(26.9% 0 0));
@@ -395,7 +395,7 @@
     --color-kumo-warning-tint: var(--color-yellow-700, oklch(55.4% 0.135 66.442));
     --color-kumo-warning: var(--color-yellow-400, oklch(85.2% 0.199 91.936));
     --color-kumo-danger-tint: var(--color-red-900, oklch(39.6% 0.141 25.723));
-    --color-kumo-danger: var(--color-red-400, oklch(70.4% 0.191 22.216));
+    --color-kumo-danger: var(--color-red-600, oklch(57.7% 0.245 27.325));
     --color-kumo-success-tint: var(--color-emerald-900, oklch(37.8% 0.077 168.94));
     --color-kumo-success: var(--color-emerald-400, oklch(76.5% 0.177 163.223));
     --color-kumo-banner-info: oklch(37.9% 0.146 265.522 / 0.5);


### PR DESCRIPTION
## Summary

- Updates Button primary and destructive variants with token-derived gradient/ring treatments.
- Adjusts dark-mode brand and danger tokens used by the emphasized button variants.
- Adds focused Button tests and a patch changeset.

| Before | After |
| --- | --- |
| <img width="530" height="358" alt="CleanShot 2026-06-19 at 11 54 13@2x" src="https://github.com/user-attachments/assets/7e92b5cd-785b-4430-9403-d5836bfa34d3" />  | <img width="530" height="358" alt="CleanShot 2026-06-19 at 11 54 05@2x" src="https://github.com/user-attachments/assets/246ad3b4-84e0-4e3f-8213-9aca6d576e93" /> |
| <img width="554" height="292" alt="CleanShot 2026-06-19 at 11 54 28@2x" src="https://github.com/user-attachments/assets/32e17c91-dcd0-43b0-8171-5c4b136986d3" /> | <img width="554" height="292" alt="CleanShot 2026-06-19 at 11 54 21@2x" src="https://github.com/user-attachments/assets/20604c76-8f88-4366-8551-81dc32db84d1" /> |



## Testing

- pnpm --filter @cloudflare/kumo exec vitest run --project=unit src/components/button/button.test.tsx
- pnpm --filter @cloudflare/kumo typecheck
- pnpm --filter @cloudflare/kumo lint
- pnpm --filter @cloudflare/kumo codegen:themes

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: implemented and verified locally with focused tests, typecheck, lint, and theme codegen
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable