### PR TITLE
chore(kumo): update Base UI to 1.6.0

### DIFF
--- a/.changeset/fresh-otters-draw.md
+++ b/.changeset/fresh-otters-draw.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update Base UI to 1.6.0.

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -469,7 +469,7 @@
     }
   },
   "dependencies": {
-    "@base-ui/react": "^1.5.0",
+    "@base-ui/react": "^1.6.0",
     "@shikijs/langs": "^4.0.0",
     "@shikijs/themes": "^4.0.0",
     "clsx": "^2.1.1",

--- a/packages/kumo/scripts/generate-primitives.ts
+++ b/packages/kumo/scripts/generate-primitives.ts
@@ -33,6 +33,12 @@ const EXCLUDED_EXPORTS = new Set([
   "./use-render", // Internal hook
 ]);
 
+const COMPATIBILITY_EXPORTS: Record<string, string[]> = {
+  "otp-field": [
+    'export { OTPField as OTPFieldPreview } from "@base-ui/react/otp-field";',
+  ],
+};
+
 function main() {
   // Read base-ui package.json
   if (!existsSync(BASE_UI_PACKAGE)) {
@@ -97,6 +103,7 @@ function generateBarrelExport(subpaths: string[]) {
   for (const subpath of subpaths) {
     const modulePath = `@base-ui/react/${subpath.replace("./", "")}`;
     lines.push(`export * from "${modulePath}";`);
+    lines.push(...(COMPATIBILITY_EXPORTS[subpath.replace("./", "")] ?? []));
   }
   lines.push("");
 
@@ -109,6 +116,7 @@ function generateIndividualPrimitives(subpaths: string[]) {
     const primitiveFile = join(PRIMITIVES_DIR, `${primitiveName}.ts`);
     const modulePath = `@base-ui/react/${primitiveName}`;
 
+    const compatibilityExports = COMPATIBILITY_EXPORTS[primitiveName] ?? [];
     const content = [
       "/**",
       ` * ${primitiveName} primitive`,
@@ -123,6 +131,7 @@ function generateIndividualPrimitives(subpaths: string[]) {
       " */",
       "",
       `export * from "${modulePath}";`,
+      ...compatibilityExports,
       "",
     ].join("\n");
 

--- a/packages/kumo/src/primitives/index.ts
+++ b/packages/kumo/src/primitives/index.ts
@@ -37,6 +37,7 @@ export * from "@base-ui/react/meter";
 export * from "@base-ui/react/navigation-menu";
 export * from "@base-ui/react/number-field";
 export * from "@base-ui/react/otp-field";
+export { OTPField as OTPFieldPreview } from "@base-ui/react/otp-field";
 export * from "@base-ui/react/popover";
 export * from "@base-ui/react/preview-card";
 export * from "@base-ui/react/progress";

--- a/packages/kumo/src/primitives/otp-field.ts
+++ b/packages/kumo/src/primitives/otp-field.ts
@@ -11,3 +11,4 @@
  */
 
 export * from "@base-ui/react/otp-field";
+export { OTPField as OTPFieldPreview } from "@base-ui/react/otp-field";

--- a/packages/kumo/tests/imports/primitives.test.ts
+++ b/packages/kumo/tests/imports/primitives.test.ts
@@ -27,7 +27,7 @@ try {
 const EXPORT_NAME_OVERRIDES: Record<string, string> = {
   "csp-provider": "CSPProvider", // All caps CSP
   drawer: "Drawer", // Stable in base-ui 1.4.0
-  "otp-field": "OTPFieldPreview", // Preview component with all caps OTP
+  "otp-field": "OTPField", // Stable component with all caps OTP
 };
 
 // Exports excluded by generate-primitives.ts

--- a/packages/kumo/tests/imports/primitives.test.ts
+++ b/packages/kumo/tests/imports/primitives.test.ts
@@ -123,6 +123,14 @@ describe("Primitives Export", () => {
       expect(missingExports).toEqual([]);
     });
 
+    it("should keep OTPFieldPreview as a compatibility alias", async () => {
+      const barrelPrimitives = await import("../../src/primitives/index.ts");
+      const otpFieldPrimitives = await import("../../src/primitives/otp-field.ts");
+
+      expect(barrelPrimitives.OTPFieldPreview).toBe(barrelPrimitives.OTPField);
+      expect(otpFieldPrimitives.OTPFieldPreview).toBe(otpFieldPrimitives.OTPField);
+    });
+
     it("should re-export all non-excluded base-ui exports", () => {
       const baseUiPackage = JSON.parse(
         readFileSync(baseUiPackagePath, "utf-8"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/kumo:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.5.0
-        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^1.6.0
+        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -602,8 +602,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.5.0':
-    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -619,8 +619,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.2.9':
-    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -5258,8 +5258,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
@@ -6742,10 +6742,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@base-ui/react@1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.4)(date-fns@4.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.9(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@base-ui/utils': 0.3.1(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@floating-ui/utils': 0.2.11
       react: 19.2.0
@@ -6756,13 +6756,13 @@ snapshots:
       '@types/react': 19.2.4
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.9(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@base-ui/utils@0.3.1(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      reselect: 5.1.1
+      reselect: 5.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.4
@@ -11769,7 +11769,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  reselect@5.1.1: {}
+  reselect@5.2.0: {}
 
   resolve-dir@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Update `@base-ui/react` from 1.5.0 to 1.6.0.
- Refresh the lockfile for `@base-ui/utils` 0.3.1 and `reselect` 5.2.0.
- Update the primitive sync test for stable `OTPField` now that `otp-field` no longer exports `OTPFieldPreview` upstream.
- Preserve `OTPFieldPreview` as a backwards-compatible Kumo alias for both `@cloudflare/kumo/primitives` and `@cloudflare/kumo/primitives/otp-field`.

## Base UI 1.6.0 Notes

- OTPField is now stable.
- Accordion keyboard navigation aligns with APG.
- Combobox includes a performance improvement.
- Drawer adds a new `Drawer.VirtualKeyboardProvider` part for mobile drawers.
- Drawer swipe gesture performance is improved.

## Verification

- `pnpm --filter @cloudflare/kumo codegen:primitives`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo build`
- `pnpm --filter @cloudflare/kumo test`
- `pnpm --filter @cloudflare/kumo validate:build`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm install --frozen-lockfile`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: dependency update has not been reviewed by bonk yet
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: 
- [ ] Additional testing not necessary because: 
