### PR TITLE
fix(dialog): use fixed width instead of min-width for size prop

### DIFF
--- a/.changeset/fix-dialog-size-width.md
+++ b/.changeset/fix-dialog-size-width.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Dialog `size` prop to set a fixed width instead of only a minimum width. Previously, dialog content could stretch the dialog beyond its intended size.

--- a/packages/kumo-docs-astro/src/components/demos/DialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DialogDemo.tsx
@@ -6,6 +6,7 @@ import {
   Combobox,
   DropdownMenu,
 } from "@cloudflare/kumo";
+import type { DialogProps } from "@cloudflare/kumo";
 import { Warning, X } from "@phosphor-icons/react";
 
 export function DialogBasicDemo() {
@@ -381,5 +382,99 @@ export function DialogWithDropdownDemo() {
         </div>
       </Dialog>
     </Dialog.Root>
+  );
+}
+
+/**
+ * Demonstrates that each dialog size holds its fixed width regardless of
+ * content. Each dialog contains a wide table that would previously cause the
+ * dialog to stretch beyond its intended size.
+ */
+export function DialogSizesDemo() {
+  const sizes: { size: NonNullable<DialogProps["size"]>; label: string; width: string }[] = [
+    { size: "sm", label: "Small", width: "288px" },
+    { size: "base", label: "Base", width: "384px" },
+    { size: "lg", label: "Large", width: "512px" },
+    { size: "xl", label: "Extra Large", width: "768px" },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {sizes.map(({ size, label, width }) => (
+        <Dialog.Root key={size}>
+          <Dialog.Trigger
+            render={(p) => (
+              <Button variant="secondary" {...p}>
+                {label} ({width})
+              </Button>
+            )}
+          />
+          <Dialog size={size} className="p-8">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <Dialog.Title className="text-2xl font-semibold">
+                {label} Dialog
+              </Dialog.Title>
+              <Dialog.Close
+                aria-label="Close"
+                render={(props) => (
+                  <Button
+                    {...props}
+                    variant="secondary"
+                    shape="square"
+                    icon={<X />}
+                    aria-label="Close"
+                  />
+                )}
+              />
+            </div>
+            <Dialog.Description className="text-kumo-subtle">
+              This <code>size="{size}"</code> dialog should stay at {width} wide
+              regardless of the content below.
+            </Dialog.Description>
+            <div className="mt-4 overflow-auto rounded-md border border-kumo-line">
+              <table className="w-max text-sm">
+                <thead className="bg-kumo-elevated text-left">
+                  <tr>
+                    <th className="px-3 py-2">Resource</th>
+                    <th className="px-3 py-2">Region</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2">Latency</th>
+                    <th className="px-3 py-2">Requests</th>
+                    <th className="px-3 py-2">Last Deployed</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-kumo-hairline">
+                  <tr>
+                    <td className="px-3 py-2">api-gateway-prod</td>
+                    <td className="px-3 py-2">us-east-1</td>
+                    <td className="px-3 py-2 text-kumo-success">Healthy</td>
+                    <td className="px-3 py-2">12ms</td>
+                    <td className="px-3 py-2">1,234,567</td>
+                    <td className="px-3 py-2">2026-06-23</td>
+                  </tr>
+                  <tr>
+                    <td className="px-3 py-2">worker-analytics</td>
+                    <td className="px-3 py-2">eu-west-1</td>
+                    <td className="px-3 py-2 text-kumo-warning">Degraded</td>
+                    <td className="px-3 py-2">89ms</td>
+                    <td className="px-3 py-2">456,789</td>
+                    <td className="px-3 py-2">2026-06-22</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <Dialog.Close
+                render={(props) => (
+                  <Button variant="secondary" {...props}>
+                    Close
+                  </Button>
+                )}
+              />
+            </div>
+          </Dialog>
+        </Dialog.Root>
+      ))}
+    </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/dialog.mdx
@@ -16,6 +16,7 @@ import {
   DialogConfirmationDemo,
   DialogAlertDemo,
   DialogMaxWidthDemo,
+  DialogSizesDemo,
   DialogWithSelectDemo,
   DialogWithComboboxDemo,
   DialogWithDropdownDemo,
@@ -133,6 +134,17 @@ export default function Example() {
 
 <ComponentExample demo="DialogBasicDemo">
   <DialogBasicDemo client:load />
+</ComponentExample>
+
+### Sizes
+
+<p>
+  The `size` prop controls the fixed width of the dialog on desktop. Content
+  that overflows the dialog width will scroll horizontally within the dialog
+  rather than stretching it.
+</p>
+<ComponentExample demo="DialogSizesDemo">
+  <DialogSizesDemo client:load />
 </ComponentExample>
 
 ### Alert Dialog (`role="alertdialog"`)

--- a/packages/kumo/src/components/dialog/dialog.tsx
+++ b/packages/kumo/src/components/dialog/dialog.tsx
@@ -19,20 +19,20 @@ import {
 export const KUMO_DIALOG_VARIANTS = {
   size: {
     base: {
-      classes: "sm:min-w-96",
-      description: "Default dialog width",
+      classes: "sm:w-96",
+      description: "Default dialog width (384px)",
     },
     sm: {
-      classes: "min-w-72",
-      description: "Small dialog for simple confirmations",
+      classes: "sm:w-72",
+      description: "Small dialog for simple confirmations (288px)",
     },
     lg: {
-      classes: "min-w-[32rem]",
-      description: "Large dialog for complex content",
+      classes: "sm:w-[32rem]",
+      description: "Large dialog for complex content (512px)",
     },
     xl: {
-      classes: "min-w-[48rem]",
-      description: "Extra large dialog for detailed views",
+      classes: "sm:w-[48rem]",
+      description: "Extra large dialog for detailed views (768px)",
     },
   },
   role: {
@@ -119,10 +119,10 @@ export type KumoDialogRole = keyof typeof KUMO_DIALOG_VARIANTS.role;
 export interface KumoDialogVariantsProps {
   /**
    * Dialog width.
-   * - `"sm"` — Small (min 288px) for simple confirmations
-   * - `"base"` — Default (min 384px)
-   * - `"lg"` — Large (min 512px) for complex content
-   * - `"xl"` — Extra large (min 768px) for detailed views
+   * - `"sm"` — Small (288px) for simple confirmations
+   * - `"base"` — Default (384px)
+   * - `"lg"` — Large (512px) for complex content
+   * - `"xl"` — Extra large (768px) for detailed views
    * @default "base"
    */
   size?: KumoDialogSize;
@@ -143,7 +143,7 @@ export function dialogVariants({
 }: KumoDialogVariantsProps = {}) {
   return cn(
     // Base styles
-    "shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full sm:w-auto max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
+    "shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
     // Apply size from KUMO_DIALOG_VARIANTS
     resolveVariant(KUMO_DIALOG_VARIANTS.size, size, KUMO_DIALOG_DEFAULT_VARIANTS.size).classes,
   );


### PR DESCRIPTION
## Summary

The Dialog `size` prop only controlled `min-width`, so content wider than the minimum would stretch the dialog. This changes the size variants to set a fixed `width` on desktop, making the `size` prop behave as expected.

### Root cause

- Base styles included `sm:w-auto` which made the dialog shrink-to-fit content
- Size variants used `min-w-*` classes (floor only, no ceiling)
- Any wide content (tables, long text) pushed the dialog past its intended size

### Fix

- Removed `sm:w-auto` from base dialog styles
- Changed size variants from `min-w-*` to `sm:w-*` (fixed width on desktop)
- Mobile stays `w-full` via the `sm:` breakpoint prefix
- `max-w-[calc(100vw-2rem)]` still prevents viewport overflow

| Size | Before | After |
|------|--------|-------|
| `sm` | `min-w-72` | `sm:w-72` (288px) |
| `base` | `sm:min-w-96` | `sm:w-96` (384px) |
| `lg` | `min-w-[32rem]` | `sm:w-[32rem]` (512px) |
| `xl` | `min-w-[48rem]` | `sm:w-[48rem]` (768px) |

### Demo

Added a "Sizes" demo to the docs site showing all four sizes with a wide table inside each dialog, so you can verify the dialog holds its width.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual/CSS change requires manual inspection
- Tests
- [x] Additional testing not necessary because: CSS-only change with docs demo for manual verification