### PR TITLE
feat(chart): add BubbleMap chart component

### DIFF
--- a/.changeset/spicy-maps-glow.md
+++ b/.changeset/spicy-maps-glow.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/kumo": minor
+---
+
+feat(chart): add `BubbleMap` chart component
+
+New `BubbleMap` component renders proportional bubbles over a registered
+geographic map using ECharts' scatter series. Includes value-based radius
+scaling, a `mapColors` palette addition to `ChartPalette`, and supporting
+types. Also extracts `escapeHtml` / `defaultValueFormat` tooltip helpers into a
+shared `tooltip-utils` module reused by `SankeyChart`.

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -86,6 +86,7 @@ const chartItems: NavItem[] = [
   { label: "Charts", href: "/charts" },
   { label: "Colors", href: "/charts/colors" },
   { label: "Timeseries", href: "/charts/timeseries" },
+  { label: "Maps", href: "/charts/maps" },
   { label: "Sankey", href: "/charts/sankey" },
   { label: "Custom Chart", href: "/charts/custom" },
 ];

--- a/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
+++ b/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
@@ -7,13 +7,33 @@ export function ThemeToggle() {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    const getCurrentTheme = () => {
+      const mode = document.documentElement.getAttribute("data-mode");
+      if (mode === "dark" || mode === "light") return mode;
+
+      const stored = localStorage.getItem("theme");
+      if (stored === "dark" || stored === "light") return stored;
+
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    };
+
+    const handleThemeChange = (event: Event) => {
+      const nextTheme = (event as CustomEvent<{ theme?: "light" | "dark" }>)
+        .detail?.theme;
+      if (nextTheme === "dark" || nextTheme === "light") {
+        setTheme(nextTheme);
+      }
+    };
+
     setMounted(true);
-    const stored = localStorage.getItem("theme");
-    if (stored === "dark" || stored === "light") {
-      setTheme(stored);
-    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      setTheme("dark");
-    }
+    setTheme(getCurrentTheme());
+    window.addEventListener("kumo:theme-change", handleThemeChange);
+
+    return () => {
+      window.removeEventListener("kumo:theme-change", handleThemeChange);
+    };
   }, []);
 
   const toggleTheme = () => {
@@ -21,6 +41,9 @@ export function ThemeToggle() {
     setTheme(newTheme);
     localStorage.setItem("theme", newTheme);
     document.documentElement.setAttribute("data-mode", newTheme);
+    window.dispatchEvent(
+      new CustomEvent("kumo:theme-change", { detail: { theme: newTheme } }),
+    );
   };
 
   // Prevent hydration mismatch
@@ -37,6 +60,7 @@ export function ThemeToggle() {
       variant="ghost"
       shape="square"
       aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+      title="Toggle theme (D)"
       onClick={toggleTheme}
     >
       {theme === "light" ? <MoonIcon size={20} /> : <SunIcon size={20} />}

--- a/packages/kumo-docs-astro/src/components/demos/Chart/BubbleMapDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/BubbleMapDemo.tsx
@@ -1,0 +1,364 @@
+import { BubbleMap, type MapGeoJson } from "@cloudflare/kumo";
+import * as echarts from "echarts/core";
+import { MapChart, ScatterChart } from "echarts/charts";
+import { TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import { useIsDarkMode } from "~/lib/use-is-dark-mode";
+
+echarts.use([MapChart, ScatterChart, TooltipComponent, CanvasRenderer]);
+
+interface BubbleMapDemoProps {
+  geoJson: MapGeoJson | null;
+}
+
+/** A point-of-presence row — the kind of raw shape these maps consume. */
+interface Colo {
+  iata: string;
+  city: string;
+  lat: number;
+  lon: number;
+  requests: number;
+  country?: string;
+}
+
+const colos: Colo[] = [
+  { iata: "SFO", city: "San Francisco", country: "US", lat: 37.77, lon: -122.42, requests: 1200 }, // prettier-ignore
+  { iata: "EWR", city: "New York", country: "US", lat: 40.71, lon: -74.0, requests: 980 }, // prettier-ignore
+  { iata: "GRU", city: "São Paulo", country: "BR", lat: -23.55, lon: -46.63, requests: 540 }, // prettier-ignore
+  { iata: "LHR", city: "London", country: "GB", lat: 51.5, lon: -0.12, requests: 1500 }, // prettier-ignore
+  { iata: "LOS", city: "Lagos", country: "NG", lat: 6.52, lon: 3.38, requests: 320 }, // prettier-ignore
+  { iata: "FRA", city: "Frankfurt", country: "DE", lat: 50.11, lon: 8.68, requests: 760 }, // prettier-ignore
+  { iata: "BOM", city: "Mumbai", country: "IN", lat: 19.07, lon: 72.87, requests: 640 }, // prettier-ignore
+  { iata: "SIN", city: "Singapore", country: "SG", lat: 1.35, lon: 103.82, requests: 880 }, // prettier-ignore
+  { iata: "NRT", city: "Tokyo", country: "JP", lat: 35.68, lon: 139.69, requests: 1100 }, // prettier-ignore
+  { iata: "SYD", city: "Sydney", country: "AU", lat: -33.86, lon: 151.21, requests: 410 }, // prettier-ignore
+];
+
+const fmt = (n: number) =>
+  `${n > 1000 ? `${(n / 1000).toLocaleString()}k` : n.toString()} requests`;
+
+/**
+ * Bubble map — raw rows + dimension accessors, radius scaling, a tooltip
+ */
+export function BubbleMapBasicDemo({ geoJson }: BubbleMapDemoProps) {
+  const isDarkMode = useIsDarkMode();
+
+  if (!geoJson) return null;
+
+  return (
+    <BubbleMap<Colo>
+      echarts={echarts}
+      geoJson={geoJson}
+      data={colos}
+      lng="lon"
+      lat="lat"
+      name="city"
+      value="requests"
+      valueFormat={fmt}
+      minRadius={8}
+      isDarkMode={isDarkMode}
+    />
+  );
+}
+
+export function BubbleMapManyPointsDemo({ geoJson }: BubbleMapDemoProps) {
+  const isDarkMode = useIsDarkMode();
+
+  if (!geoJson) return null;
+
+  return (
+    <BubbleMap<Colo>
+      echarts={echarts}
+      geoJson={geoJson}
+      data={colos2}
+      lng="lon"
+      lat="lat"
+      name="city"
+      value="requests"
+      valueFormat={fmt}
+      isDarkMode={isDarkMode}
+    />
+  );
+}
+
+const colos2 = [
+  {
+    requests: 1455,
+    iata: "CDG",
+    lat: 49.012798,
+    lon: 2.55,
+    cca2: "FR",
+    region: "Europe",
+    city: "Paris",
+  },
+  {
+    requests: 3,
+    iata: "SEA",
+    lat: 47.449001,
+    lon: -122.308998,
+    cca2: "US",
+    region: "North America",
+    city: "Seattle",
+  },
+  {
+    requests: 1,
+    iata: "DAC",
+    lat: 23.843347,
+    lon: 90.397783,
+    cca2: "BD",
+    region: "Asia Pacific",
+    city: "Dhaka",
+  },
+  {
+    requests: 13,
+    iata: "SIN",
+    lat: 1.35019,
+    lon: 103.994003,
+    cca2: "SG",
+    region: "Asia Pacific",
+    city: "Singapore",
+  },
+  {
+    requests: 1,
+    iata: "DUS",
+    lat: 51.289501,
+    lon: 6.76678,
+    cca2: "DE",
+    region: "Europe",
+    city: "Dusseldorf",
+  },
+  {
+    requests: 1443,
+    iata: "MAD",
+    lat: 40.4936,
+    lon: -3.56676,
+    cca2: "ES",
+    region: "Europe",
+    city: "Madrid",
+  },
+  {
+    requests: 5,
+    iata: "ATL",
+    lat: 33.6367,
+    lon: -84.428101,
+    cca2: "US",
+    region: "North America",
+    city: "Atlanta",
+  },
+  {
+    requests: 1,
+    iata: "MCT",
+    lat: 23.5933,
+    lon: 58.284401,
+    cca2: "OM",
+    region: "Middle East",
+    city: "Muscat",
+  },
+  {
+    requests: 1515,
+    iata: "LAX",
+    lat: 33.942501,
+    lon: -118.407997,
+    cca2: "US",
+    region: "North America",
+    city: "Los Angeles",
+  },
+  {
+    requests: 23,
+    iata: "YYZ",
+    lat: 43.6772,
+    lon: -79.6306,
+    cca2: "CA",
+    region: "North America",
+    city: "Toronto",
+  },
+  {
+    requests: 11,
+    iata: "AMS",
+    lat: 52.308601,
+    lon: 4.76389,
+    cca2: "NL",
+    region: "Europe",
+    city: "Amsterdam",
+  },
+  {
+    requests: 1,
+    iata: "DME",
+    lat: 55.408798,
+    lon: 37.9063,
+    cca2: "RU",
+    region: "Europe",
+    city: "Moscow",
+  },
+  {
+    requests: 1,
+    iata: "CGK",
+    lat: -6.12557,
+    lon: 106.655998,
+    cca2: "ID",
+    region: "Asia Pacific",
+    city: "Jakarta",
+  },
+  {
+    requests: 2,
+    iata: "EWR",
+    lat: 40.692501,
+    lon: -74.168701,
+    cca2: "US",
+    region: "North America",
+    city: "Newark",
+  },
+  {
+    requests: 1,
+    iata: "TPA",
+    lat: 27.9755,
+    lon: -82.533203,
+    cca2: "US",
+    region: "North America",
+    city: "Tampa",
+  },
+  {
+    requests: 2,
+    iata: "DEL",
+    lat: 28.5665,
+    lon: 77.103104,
+    cca2: "IN",
+    region: "Asia Pacific",
+    city: "New Delhi",
+  },
+  {
+    requests: 4,
+    iata: "MIA",
+    lat: 25.7932,
+    lon: -80.290604,
+    cca2: "US",
+    region: "North America",
+    city: "Miami",
+  },
+  {
+    requests: 3,
+    iata: "EZE",
+    lat: -34.8222,
+    lon: -58.5358,
+    cca2: "AR",
+    region: "South America",
+    city: "Ezeiza",
+  },
+  {
+    requests: 1,
+    iata: "LHR",
+    lat: 51.4706,
+    lon: -0.461941,
+    cca2: "GB",
+    region: "Europe",
+    city: "London",
+  },
+  {
+    requests: 13,
+    iata: "ZRH",
+    lat: 47.464699,
+    lon: 8.54917,
+    cca2: "CH",
+    region: "Europe",
+    city: "Zurich",
+  },
+  {
+    requests: 3,
+    iata: "FRA",
+    lat: 50.026402,
+    lon: 8.54313,
+    cca2: "DE",
+    region: "Europe",
+    city: "Frankfurt-am-Main",
+  },
+  {
+    requests: 1,
+    iata: "IAD",
+    lat: 38.9445,
+    lon: -77.455803,
+    cca2: "US",
+    region: "North America",
+    city: "Dulles",
+  },
+  {
+    requests: 1460,
+    iata: "DFW",
+    lat: 32.896801,
+    lon: -97.038002,
+    cca2: "US",
+    region: "North America",
+    city: "Dallas-Fort Worth",
+  },
+  {
+    requests: 1413,
+    iata: "SJC",
+    lat: 37.362598,
+    lon: -121.929001,
+    cca2: "US",
+    region: "North America",
+    city: "San Jose",
+  },
+  {
+    requests: 1,
+    iata: "AMM",
+    lat: 31.722601,
+    lon: 35.993198,
+    cca2: "JO",
+    region: "Middle East",
+    city: "Amman",
+  },
+  {
+    requests: 1,
+    iata: "GYE",
+    lat: -2.15742,
+    lon: -79.883598,
+    cca2: "EC",
+    region: "South America",
+    city: "Guayaquil",
+  },
+  {
+    requests: 5,
+    iata: "GRU",
+    lat: -23.435556,
+    lon: -46.473057,
+    cca2: "BR",
+    region: "South America",
+    city: "Sao Paulo",
+  },
+  {
+    requests: 1437,
+    iata: "BOD",
+    lat: 44.8283,
+    lon: -0.715556,
+    cca2: "FR",
+    region: "Europe",
+    city: "Bordeaux/Merignac",
+  },
+  {
+    requests: 1,
+    iata: "GUA",
+    lat: 14.5833,
+    lon: -90.527496,
+    cca2: "GT",
+    region: "North America",
+    city: "Guatemala City",
+  },
+  {
+    requests: 1,
+    iata: "SCL",
+    lat: -33.393002,
+    lon: -70.785797,
+    cca2: "CL",
+    region: "South America",
+    city: "Santiago",
+  },
+  {
+    requests: 1,
+    iata: "HKG",
+    lat: 22.308901,
+    lon: 113.915001,
+    cca2: "HK",
+    region: "Asia Pacific",
+    city: "Hong Kong",
+  },
+];

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -52,12 +52,39 @@ const buildDate =
       // Initialize theme from localStorage or system preference
       // This runs immediately (blocking) to prevent flash of unstyled content
       (function () {
+        function setTheme(theme) {
+          localStorage.setItem("theme", theme);
+          document.documentElement.setAttribute("data-mode", theme);
+          window.dispatchEvent(
+            new CustomEvent("kumo:theme-change", { detail: { theme } }),
+          );
+        }
+
         const stored = localStorage.getItem("theme");
         if (stored) {
           document.documentElement.setAttribute("data-mode", stored);
         } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
           document.documentElement.setAttribute("data-mode", "dark");
         }
+
+        document.addEventListener("keydown", function (event) {
+          if (event.defaultPrevented || event.repeat) return;
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          if (event.key?.toLowerCase() !== "d") return;
+
+          const target = event.target;
+          if (
+            target instanceof HTMLElement &&
+            (target.isContentEditable ||
+              target.closest("input, textarea, select, [contenteditable]"))
+          ) {
+            return;
+          }
+
+          event.preventDefault();
+          const current = document.documentElement.getAttribute("data-mode");
+          setTheme(current === "dark" ? "light" : "dark");
+        });
       })();
     </script>
   </head>

--- a/packages/kumo-docs-astro/src/pages/charts/maps.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/maps.astro
@@ -17,8 +17,13 @@ try {
   const response = await fetch(WORLD_GEO_JSON_URL);
   if (response.ok) {
     geoJson = (await response.json()) as MapGeoJson;
+  } else {
+    console.warn(
+      `Failed to fetch BubbleMap GeoJSON: ${response.status} ${response.statusText}`,
+    );
   }
-} catch {
+} catch (error) {
+  console.warn("Failed to fetch BubbleMap GeoJSON", error);
   geoJson = null;
 }
 ---

--- a/packages/kumo-docs-astro/src/pages/charts/maps.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/maps.astro
@@ -1,0 +1,148 @@
+---
+import DocLayout from "../../layouts/DocLayout.astro";
+import Heading from "../../components/docs/Heading.astro";
+import ComponentSection from "../../components/docs/ComponentSection.astro";
+import ComponentExample from "../../components/docs/ComponentExample.astro";
+import CodeBlock from "../../components/docs/CodeBlock.astro";
+import PropsTable from "../../components/docs/PropsTable.astro";
+import { BubbleMapBasicDemo } from "~/components/demos/Chart/BubbleMapDemo";
+import type { MapGeoJson } from "@cloudflare/kumo";
+
+const WORLD_GEO_JSON_URL =
+  "https://cdn.jsdelivr.net/gh/johan/world.geo.json@master/countries.geo.json";
+
+let geoJson: MapGeoJson | null = null;
+
+try {
+  const response = await fetch(WORLD_GEO_JSON_URL);
+  if (response.ok) {
+    geoJson = (await response.json()) as MapGeoJson;
+  }
+} catch {
+  geoJson = null;
+}
+---
+
+<DocLayout
+  title="Maps"
+  description="Map chart components for visualizing geographic data with GeoJSON."
+  sourceFile="components/chart"
+>
+  <ComponentSection>
+    <ComponentExample code={`<BubbleMap
+  echarts={echarts}
+  geoJson={geoJson}
+  data={colos}
+  lng="lon"
+  lat="lat"
+  name="city"
+  value="requests"
+/>`}>
+      <BubbleMapBasicDemo geoJson={geoJson} client:visible />
+    </ComponentExample>
+  </ComponentSection>
+
+  <ComponentSection>
+    <Heading level={2}>Installation</Heading>
+    <p class="mb-4 text-kumo-subtle">
+      <code class="text-kumo-default">BubbleMap</code> requires <code class="text-kumo-default">echarts</code> as a peer dependency. Consumers provide the GeoJSON feature collection; the component does not fetch map data or use map tiles.
+    </p>
+    <CodeBlock code={`npm install echarts`} lang="bash" />
+
+    <Heading level={3} class="mb-2 mt-6 text-lg">Barrel</Heading>
+    <CodeBlock code={`import { BubbleMap } from "@cloudflare/kumo";`} lang="tsx" />
+    <Heading level={3} class="mb-2 mt-4 text-lg">Granular</Heading>
+    <CodeBlock
+      code={`import { BubbleMap } from "@cloudflare/kumo/components/chart";`}
+      lang="tsx"
+    />
+  </ComponentSection>
+
+  <ComponentSection>
+    <Heading level={2}>Usage</Heading>
+    <CodeBlock
+      code={`import { BubbleMap, type MapGeoJson } from "@cloudflare/kumo";
+import * as echarts from "echarts/core";
+import { MapChart, ScatterChart } from "echarts/charts";
+import { TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([MapChart, ScatterChart, TooltipComponent, CanvasRenderer]);
+
+// Load GeoJSON in your app and pass it to BubbleMap.
+const geoJson = world as MapGeoJson;
+
+const colos = [
+  { iata: "SFO", city: "San Francisco", lat: 37.77, lon: -122.42, requests: 1200 },
+  { iata: "LHR", city: "London", lat: 51.5, lon: -0.12, requests: 1500 },
+];
+
+export default function Example() {
+  return (
+    <BubbleMap
+      echarts={echarts}
+      geoJson={geoJson}
+      data={colos}
+      lng="lon"
+      lat="lat"
+      name="city"
+      value="requests"
+    />
+  );
+}`}
+      lang="tsx"
+    />
+  </ComponentSection>
+
+  <ComponentSection>
+    <Heading level={2} class="mb-6">Examples</Heading>
+
+    <div class="space-y-8">
+      <div>
+        <Heading level={3}>Bubble Map</Heading>
+        <p class="mb-4 text-kumo-subtle">
+          Plot raw rows by longitude and latitude. The <code class="text-kumo-default">value</code> accessor controls proportional bubble size.
+        </p>
+        <ComponentExample code={`<BubbleMap
+  echarts={echarts}
+  geoJson={geoJson}
+  data={colos}
+  lng="lon"
+  lat="lat"
+  name="city"
+  value="requests"
+  minRadius={8}
+/>`}>
+          <BubbleMapBasicDemo geoJson={geoJson} client:visible />
+        </ComponentExample>
+      </div>
+
+      <div>
+        <Heading level={3}>Custom Tooltips</Heading>
+        <p class="mb-4 text-kumo-subtle">
+          Provide <code class="text-kumo-default">tooltipFormatter</code> when the default name/value tooltip is not enough. The formatter returns HTML rendered by ECharts, so escape user-provided values.
+        </p>
+        <CodeBlock
+          code={`<BubbleMap
+  echarts={echarts}
+  geoJson={geoJson}
+  data={colos}
+  lng="lon"
+  lat="lat"
+  name="city"
+  value="requests"
+  tooltipFormatter={(row) =>
+    "<strong>" + row.city + "</strong><br />" + row.requests.toLocaleString()
+  }
+/>`}
+          lang="tsx"
+        />
+      </div>
+    </div>
+  </ComponentSection>
+
+  <ComponentSection>
+    <Heading level={2}>API Reference</Heading>
+    <PropsTable component="BubbleMap" />
+  </ComponentSection>
+</DocLayout>

--- a/packages/kumo-docs-astro/src/pages/tests/map.astro
+++ b/packages/kumo-docs-astro/src/pages/tests/map.astro
@@ -15,8 +15,13 @@ try {
   const response = await fetch(WORLD_GEO_JSON_URL);
   if (response.ok) {
     geoJson = (await response.json()) as MapGeoJson;
+  } else {
+    console.warn(
+      `Failed to fetch BubbleMap GeoJSON: ${response.status} ${response.statusText}`,
+    );
   }
-} catch {
+} catch (error) {
+  console.warn("Failed to fetch BubbleMap GeoJSON", error);
   geoJson = null;
 }
 ---

--- a/packages/kumo-docs-astro/src/pages/tests/map.astro
+++ b/packages/kumo-docs-astro/src/pages/tests/map.astro
@@ -1,0 +1,59 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import {
+  BubbleMapBasicDemo,
+  BubbleMapManyPointsDemo,
+} from "../../components/demos/Chart/BubbleMapDemo";
+import type { MapGeoJson } from "@cloudflare/kumo";
+
+const WORLD_GEO_JSON_URL =
+  "https://cdn.jsdelivr.net/gh/johan/world.geo.json@master/countries.geo.json";
+
+let geoJson: MapGeoJson | null = null;
+
+try {
+  const response = await fetch(WORLD_GEO_JSON_URL);
+  if (response.ok) {
+    geoJson = (await response.json()) as MapGeoJson;
+  }
+} catch {
+  geoJson = null;
+}
+---
+
+<BaseLayout title="Geo Map Test Page">
+  <div class="p-16 space-y-12 max-w-[1000px] mx-auto mb-64">
+    <div>
+      <h1 class="text-2xl font-bold text-kumo-strong">Geo Map Demo Components</h1>
+      <p class="mt-2 text-kumo-subtle">
+        Test page for validating BubbleMap rendering, point scaling, tooltips,
+        and hover styles across light and dark modes.
+      </p>
+    </div>
+
+    <section class="space-y-4">
+      <div>
+        <h2 class="text-xl font-semibold text-kumo-default">BubbleMapBasicDemo</h2>
+        <p class="text-kumo-subtle">
+          Bubble map using raw colo rows, dimension accessors, radius scaling,
+          and formatted request values.
+        </p>
+      </div>
+      <div class="p-4 rounded-lg border border-kumo-hairline bg-kumo-base">
+        <BubbleMapBasicDemo geoJson={geoJson} client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <div>
+        <h2 class="text-xl font-semibold text-kumo-default">BubbleMapManyPointsDemo</h2>
+        <p class="text-kumo-subtle">
+          Larger point dataset with request values across global locations.
+        </p>
+      </div>
+      <div class="p-4 rounded-lg border border-kumo-hairline bg-kumo-base">
+        <BubbleMapManyPointsDemo geoJson={geoJson} client:visible />
+      </div>
+    </section>
+  </div>
+</BaseLayout>

--- a/packages/kumo/src/components/chart/Color.ts
+++ b/packages/kumo/src/components/chart/Color.ts
@@ -70,6 +70,20 @@ const sequentialDark = {
   blues: ["#03254F", "#0E58B4", "#4290F0", "#A6BFDD", "#E1EAF4"],
 };
 
+/** Colours for GeoJSON-based map charts. */
+export interface MapColors {
+  /** Fill for land regions. */
+  area: string;
+  /** Default bubble fill (the chart palette blue). */
+  bubble: string;
+}
+
+/** Neutral land fill per mode; bubbles use the shared categorical palette. */
+const mapAreaByMode = {
+  light: "#E5E7EB",
+  dark: "#2B2C31",
+} as const;
+
 /**
  * Ordered list of categorical colors for light mode, indexed by series position.
  * Used as the default ECharts color palette when `isDarkMode` is `false`.
@@ -170,5 +184,15 @@ export namespace ChartPalette {
       dark: { primary: "#9CA3AF", secondary: "#6B7280" },
     };
     return isDarkMode ? colors.dark[variant] : colors.light[variant];
+  }
+
+  /** Returns colors for GeoJSON-based map charts. */
+  export function mapColors(isDarkMode = false): MapColors {
+    const mode = isDarkMode ? "dark" : "light";
+
+    return {
+      area: mapAreaByMode[mode],
+      bubble: categorical(0, isDarkMode),
+    };
   }
 }

--- a/packages/kumo/src/components/chart/Maps.test.tsx
+++ b/packages/kumo/src/components/chart/Maps.test.tsx
@@ -1,0 +1,141 @@
+import { createRef } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BubbleMap, type MapGeoJson } from "./Maps";
+
+const createMockChart = () => ({
+  setOption: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  resize: vi.fn(),
+  dispose: vi.fn(),
+});
+
+const createMockEcharts = (mockChart = createMockChart()) => ({
+  init: vi.fn(() => mockChart),
+  registerMap: vi.fn(),
+});
+
+const geoJson: MapGeoJson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      id: "US",
+      properties: { name: "United States" },
+      geometry: { type: "Polygon", coordinates: [] },
+    },
+  ],
+};
+
+const data = [
+  { city: "San Francisco", lat: 37.77, lon: -122.42, requests: 10 },
+  { city: "London", lat: 51.5, lon: -0.12, requests: 20 },
+];
+
+describe("BubbleMap", () => {
+  it("reuses the generated map name across remounts for the same GeoJSON", () => {
+    const mockEcharts = createMockEcharts();
+
+    const first = render(
+      <BubbleMap
+        echarts={mockEcharts as any}
+        geoJson={geoJson}
+        data={data}
+        lng="lon"
+        lat="lat"
+        name="city"
+        value="requests"
+      />,
+    );
+    first.unmount();
+
+    render(
+      <BubbleMap
+        echarts={mockEcharts as any}
+        geoJson={geoJson}
+        data={data}
+        lng="lon"
+        lat="lat"
+        name="city"
+        value="requests"
+      />,
+    );
+
+    expect(mockEcharts.registerMap).toHaveBeenCalledTimes(2);
+    expect(mockEcharts.registerMap.mock.calls[0][0]).toBe(
+      mockEcharts.registerMap.mock.calls[1][0],
+    );
+  });
+
+  it("sanitizes custom map names before registering them", () => {
+    const mockEcharts = createMockEcharts();
+
+    render(
+      <BubbleMap
+        echarts={mockEcharts as any}
+        geoJson={geoJson}
+        mapName="world:traffic/map"
+        data={data}
+        lng="lon"
+        lat="lat"
+        name="city"
+        value="requests"
+      />,
+    );
+
+    expect(mockEcharts.registerMap).toHaveBeenCalledWith(
+      "world-traffic-map",
+      geoJson,
+    );
+  });
+
+  it("uses bubbleSize when provided", async () => {
+    const mockChart = createMockChart();
+    const mockEcharts = createMockEcharts(mockChart);
+
+    render(
+      <BubbleMap
+        echarts={mockEcharts as any}
+        geoJson={geoJson}
+        data={data}
+        lng="lon"
+        lat="lat"
+        name="city"
+        value="requests"
+        bubbleSize={(value) => value / 2}
+      />,
+    );
+
+    await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+    const options = mockChart.setOption.mock.calls[0][0];
+
+    expect(options.series[0].data[0].symbolSize).toBe(5);
+    expect(options.series[0].data[1].symbolSize).toBe(10);
+  });
+
+  it("forwards the ECharts instance ref", async () => {
+    const mockChart = createMockChart();
+    const mockEcharts = createMockEcharts(mockChart);
+    const ref = createRef<typeof mockChart | null>();
+
+    const { unmount } = render(
+      <BubbleMap
+        ref={ref as any}
+        echarts={mockEcharts as any}
+        geoJson={geoJson}
+        data={data}
+        lng="lon"
+        lat="lat"
+        name="city"
+        value="requests"
+      />,
+    );
+
+    await waitFor(() => expect(ref.current).toBe(mockChart));
+
+    unmount();
+
+    expect(ref.current).toBeNull();
+  });
+});

--- a/packages/kumo/src/components/chart/Maps.tsx
+++ b/packages/kumo/src/components/chart/Maps.tsx
@@ -276,7 +276,7 @@ export function BubbleMap<T>({
           coordinateSystem: "geo",
           data: points,
           itemStyle: { opacity: 0.8 },
-          emphasis: { scale: 1.1, itemStyle: { opacity: 1 } },
+          emphasis: { scale: 1.2, itemStyle: { opacity: 1 } },
           z: 3,
         },
       ],

--- a/packages/kumo/src/components/chart/Maps.tsx
+++ b/packages/kumo/src/components/chart/Maps.tsx
@@ -1,5 +1,12 @@
 import type * as echarts from "echarts/core";
-import { useCallback, useId, useLayoutEffect, useMemo, useRef } from "react";
+import type { ForwardedRef, ReactElement, RefAttributes } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { Chart, type ChartEvents, type KumoChartOption } from "./EChart";
 import { ChartPalette } from "./Color";
 import { defaultValueFormat, escapeHtml } from "./tooltip-utils";
@@ -38,6 +45,31 @@ function resolveStyle<T, V>(row: T, style: MapStyle<T, V>): V {
 /** Furthest `roam` zoom-in, as a multiple of the auto-fit scale. */
 const MAX_ZOOM_FACTOR = 8;
 
+const geoJsonMapNames = new WeakMap<MapGeoJson, string>();
+
+function sanitizeMapName(name: string) {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function hashString(value: string) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = Math.imul(31, hash) + value.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function getMapName(geoJson: MapGeoJson, mapName?: string) {
+  if (mapName) return sanitizeMapName(mapName);
+
+  const existing = geoJsonMapNames.get(geoJson);
+  if (existing) return existing;
+
+  const generated = `kumo-map-${hashString(JSON.stringify(geoJson))}`;
+  geoJsonMapNames.set(geoJson, generated);
+  return generated;
+}
+
 /** Build the `geo` coordinate-system config (land base for the bubbles). */
 function buildGeo(opts: {
   mapName: string;
@@ -50,9 +82,15 @@ function buildGeo(opts: {
     map: opts.mapName,
     nameProperty: "name",
     roam: opts.roam,
-    // Constrain roam so users can't zoom out into empty space or in past context.
+    // Prevent zooming far out into empty space while still allowing users to
+    // zoom back to the lesser of ECharts' base scale and the configured zoom.
     ...(opts.roam
-      ? { scaleLimit: { min: opts.zoom, max: opts.zoom * MAX_ZOOM_FACTOR } }
+      ? {
+          scaleLimit: {
+            min: Math.min(1, opts.zoom),
+            max: opts.zoom * MAX_ZOOM_FACTOR,
+          },
+        }
       : {}),
     center: opts.center,
     zoom: opts.zoom,
@@ -84,6 +122,12 @@ export interface BubbleMapProps<T> {
   echarts: typeof echarts;
   /** GeoJSON `FeatureCollection` for the land base. */
   geoJson: MapGeoJson;
+  /**
+   * Optional stable ECharts map registry name. Set this when the same GeoJSON is
+   * parsed into new object instances across mounts and should reuse one global
+   * ECharts registration.
+   */
+  mapName?: string;
   /** Raw data rows. Coordinates/value/name are read via the accessors below. */
   data: T[];
   /** Longitude accessor (key of `T` or `(row) => number`). */
@@ -99,6 +143,11 @@ export interface BubbleMapProps<T> {
   minRadius?: number;
   /** Largest bubble radius in px. Default: `26`. */
   maxRadius?: number;
+  /**
+   * Explicit bubble radius `(value) => px`. Overrides the default
+   * `minRadius`/`maxRadius` scaling.
+   */
+  bubbleSize?: (value: number) => number;
   /** Bubble fill colour — constant or `(row) => color`. Defaults to the chart blue. */
   bubbleColor?: MapStyle<T, string>;
   /** Bubble border colour — constant or `(row) => color`. Default: `transparent`. */
@@ -166,39 +215,58 @@ interface BubblePoint<T> {
  * />
  * ```
  */
-export function BubbleMap<T>({
-  echarts: ec,
-  geoJson,
-  data,
-  lng,
-  lat,
-  value,
-  name,
-  minRadius = 6,
-  maxRadius = 26,
-  bubbleColor,
-  bubbleBorderColor = "transparent",
-  bubbleBorderWidth = 0,
-  center,
-  zoom = 1.25,
-  roam = true,
-  showTooltip = true,
-  valueFormat = defaultValueFormat,
-  tooltipFormatter,
-  onBubbleHover,
-  onBubbleClick,
-  height = 400,
-  className,
-  isDarkMode,
-}: BubbleMapProps<T>) {
-  // Per-instance map name so distinct maps don't clobber each other in
-  // ECharts' global, name-keyed registry.
-  const mapName = useId();
+function BubbleMapRoot<T>(
+  {
+    echarts: ec,
+    geoJson,
+    mapName: mapNameProp,
+    data,
+    lng,
+    lat,
+    value,
+    name,
+    minRadius = 6,
+    maxRadius = 26,
+    bubbleSize,
+    bubbleColor,
+    bubbleBorderColor = "transparent",
+    bubbleBorderWidth = 0,
+    center,
+    zoom = 1.25,
+    roam = true,
+    showTooltip = true,
+    valueFormat = defaultValueFormat,
+    tooltipFormatter,
+    onBubbleHover,
+    onBubbleClick,
+    height = 400,
+    className,
+    isDarkMode,
+  }: BubbleMapProps<T>,
+  ref: ForwardedRef<echarts.ECharts | null>,
+) {
+  // ECharts has no public unregisterMap API, so reuse a deterministic
+  // registration name for equivalent GeoJSON instead of creating one per mount.
+  const mapName = useMemo(
+    () => getMapName(geoJson, mapNameProp),
+    [geoJson, mapNameProp],
+  );
   useRegisterMap(ec, mapName, geoJson);
 
   // Keep the latest hover callback without re-binding chart events.
   const hoverRef = useRef(onBubbleHover);
   hoverRef.current = onBubbleHover;
+
+  const mergedRef = useCallback(
+    (instance: echarts.ECharts | null) => {
+      if (typeof ref === "function") {
+        ref(instance);
+      } else if (ref) {
+        ref.current = instance;
+      }
+    },
+    [ref],
+  );
 
   const options = useMemo<KumoChartOption>(() => {
     const palette = ChartPalette.mapColors(isDarkMode);
@@ -208,6 +276,7 @@ export function BubbleMap<T>({
     const vmax = values.length ? Math.max(...values) : 1;
 
     const radiusFor = (v: number) => {
+      if (bubbleSize) return bubbleSize(v);
       if (vmax <= vmin) return maxRadius;
       const t = Math.sqrt((v - vmin) / (vmax - vmin));
       return minRadius + t * (maxRadius - minRadius);
@@ -284,6 +353,7 @@ export function BubbleMap<T>({
   }, [
     isDarkMode,
     geoJson,
+    mapNameProp,
     mapName,
     data,
     lng,
@@ -292,6 +362,7 @@ export function BubbleMap<T>({
     name,
     minRadius,
     maxRadius,
+    bubbleSize,
     bubbleColor,
     bubbleBorderColor,
     bubbleBorderWidth,
@@ -346,6 +417,7 @@ export function BubbleMap<T>({
   return (
     <Chart
       echarts={ec}
+      ref={mergedRef}
       options={options}
       className={className}
       isDarkMode={isDarkMode}
@@ -354,6 +426,10 @@ export function BubbleMap<T>({
     />
   );
 }
+
+export const BubbleMap = forwardRef(BubbleMapRoot) as (<T>(
+  props: BubbleMapProps<T> & RefAttributes<echarts.ECharts | null>,
+) => ReactElement | null) & { displayName?: string };
 
 BubbleMap.displayName = "BubbleMap";
 

--- a/packages/kumo/src/components/chart/Maps.tsx
+++ b/packages/kumo/src/components/chart/Maps.tsx
@@ -1,0 +1,369 @@
+import type * as echarts from "echarts/core";
+import { useCallback, useId, useLayoutEffect, useMemo, useRef } from "react";
+import { Chart, type ChartEvents, type KumoChartOption } from "./EChart";
+import { ChartPalette } from "./Color";
+import { defaultValueFormat, escapeHtml } from "./tooltip-utils";
+
+export interface MapGeoJson {
+  type: "FeatureCollection";
+  features: Array<{
+    type: "Feature";
+    id?: string | number;
+    properties?: Record<string, unknown> | null;
+    geometry: unknown;
+  }>;
+}
+
+/** Keys of `T` whose value is assignable to `V`. */
+type KeysWithValue<T, V> = {
+  [K in keyof T]-?: T[K] extends V ? K : never;
+}[keyof T];
+
+/** Accessor for a value on a data row: a key of `T`, or a function of the row. */
+export type MapAccessor<T, V> = KeysWithValue<T, V> | ((row: T) => V);
+
+function resolve<T, V>(row: T, accessor: MapAccessor<T, V>): V {
+  return typeof accessor === "function" ? accessor(row) : (row[accessor] as V);
+}
+
+/** Per-datum style value: a constant, or a function of the row. */
+export type MapStyle<T, V> = V | ((row: T) => V);
+
+function resolveStyle<T, V>(row: T, style: MapStyle<T, V>): V {
+  return typeof style === "function"
+    ? (style as (r: T) => V)(row)
+    : (style as V);
+}
+
+/** Furthest `roam` zoom-in, as a multiple of the auto-fit scale. */
+const MAX_ZOOM_FACTOR = 8;
+
+/** Build the `geo` coordinate-system config (land base for the bubbles). */
+function buildGeo(opts: {
+  mapName: string;
+  areaColor: string;
+  center?: [number, number];
+  zoom: number;
+  roam: boolean;
+}) {
+  return {
+    map: opts.mapName,
+    nameProperty: "name",
+    roam: opts.roam,
+    // Constrain roam so users can't zoom out into empty space or in past context.
+    ...(opts.roam
+      ? { scaleLimit: { min: opts.zoom, max: opts.zoom * MAX_ZOOM_FACTOR } }
+      : {}),
+    center: opts.center,
+    zoom: opts.zoom,
+    aspectScale: 1,
+    silent: true,
+    layoutCenter: ["50%", "50%"],
+    layoutSize: "180%",
+    itemStyle: {
+      areaColor: opts.areaColor,
+      // Stroke the seams in the fill colour so the land reads as one seamless
+      // mass rather than dotted internal borders.
+      borderColor: opts.areaColor,
+      borderWidth: 0.5,
+    },
+    emphasis: { disabled: true },
+  };
+}
+
+// ===========================================================================
+// BubbleMap — proportional symbols over a blank GeoJSON base
+// ===========================================================================
+
+export interface BubbleMapProps<T> {
+  /**
+   * The ECharts core instance imported by the consumer (passed in for
+   * tree-shaking). Requires `MapChart`, `ScatterChart`, `TooltipComponent`, and
+   * a renderer registered via `echarts.use([...])`.
+   */
+  echarts: typeof echarts;
+  /** GeoJSON `FeatureCollection` for the land base. */
+  geoJson: MapGeoJson;
+  /** Raw data rows. Coordinates/value/name are read via the accessors below. */
+  data: T[];
+  /** Longitude accessor (key of `T` or `(row) => number`). */
+  lng: MapAccessor<T, number>;
+  /** Latitude accessor (key of `T` or `(row) => number`). */
+  lat: MapAccessor<T, number>;
+  /** Value accessor — drives bubble size. */
+  value: MapAccessor<T, number>;
+  /** Optional name accessor — used by the default tooltip. */
+  name?: MapAccessor<T, string>;
+
+  /** Smallest bubble radius in px. Default: `6`. */
+  minRadius?: number;
+  /** Largest bubble radius in px. Default: `26`. */
+  maxRadius?: number;
+  /** Bubble fill colour — constant or `(row) => color`. Defaults to the chart blue. */
+  bubbleColor?: MapStyle<T, string>;
+  /** Bubble border colour — constant or `(row) => color`. Default: `transparent`. */
+  bubbleBorderColor?: MapStyle<T, string>;
+  /** Bubble border width — constant or `(row) => px`. Default: `0`. */
+  bubbleBorderWidth?: MapStyle<T, number>;
+  /** Map center as `[longitude, latitude]`. Defaults to auto-fit. */
+  center?: [number, number];
+  /** Zoom level — multiplies the auto-fit scale. Default: `1.25`. */
+  zoom?: number;
+  /** Enable drag-to-pan and scroll-to-zoom. Default: `true`. */
+  roam?: boolean;
+
+  /** Show the tooltip. Default: `true`. */
+  showTooltip?: boolean;
+  /** Format the value for the default tooltip. Default: `toLocaleString()`. */
+  valueFormat?: (value: number) => string;
+  /**
+   * Override the tooltip content for a row. Returns an HTML string rendered by
+   * ECharts' own tooltip.
+   *
+   * USE WITH CAUTION: the return value is injected as HTML. Escape any
+   * user-provided strings to avoid XSS.
+   */
+  tooltipFormatter?: (row: T) => string;
+
+  /** Called as the pointer enters/leaves a bubble. */
+  onBubbleHover?: (row: T | undefined) => void;
+  /** Called when a bubble is clicked. */
+  onBubbleClick?: (row: T) => void;
+
+  /** Height of the chart in pixels. Default: `400`. */
+  height?: number;
+  className?: string;
+  isDarkMode?: boolean;
+}
+
+interface BubblePoint<T> {
+  name?: string;
+  value: [number, number, number];
+  symbolSize: number;
+  itemStyle: { color: string; borderColor: string; borderWidth: number };
+  datum: T;
+}
+
+/**
+ * BubbleMap — proportional bubbles plotted by coordinate over a blank GeoJSON
+ * base. Land is rendered seamlessly (no internal borders) so the bubbles read
+ * clearly; bubble area is proportional to value (`minRadius`…`maxRadius`).
+ *
+ * @example
+ * ```tsx
+ * import * as echarts from "echarts/core";
+ * import { MapChart, ScatterChart } from "echarts/charts";
+ * import { TooltipComponent } from "echarts/components";
+ * import { CanvasRenderer } from "echarts/renderers";
+ * echarts.use([MapChart, ScatterChart, TooltipComponent, CanvasRenderer]);
+ *
+ * <BubbleMap
+ *   echarts={echarts}
+ *   geoJson={world}
+ *   data={colos}
+ *   lng="lon" lat="lat" name="iata" value="requests"
+ *   onBubbleHover={(c) => setHovered(c?.iata)}
+ * />
+ * ```
+ */
+export function BubbleMap<T>({
+  echarts: ec,
+  geoJson,
+  data,
+  lng,
+  lat,
+  value,
+  name,
+  minRadius = 6,
+  maxRadius = 26,
+  bubbleColor,
+  bubbleBorderColor = "transparent",
+  bubbleBorderWidth = 0,
+  center,
+  zoom = 1.25,
+  roam = true,
+  showTooltip = true,
+  valueFormat = defaultValueFormat,
+  tooltipFormatter,
+  onBubbleHover,
+  onBubbleClick,
+  height = 400,
+  className,
+  isDarkMode,
+}: BubbleMapProps<T>) {
+  // Per-instance map name so distinct maps don't clobber each other in
+  // ECharts' global, name-keyed registry.
+  const mapName = useId();
+  useRegisterMap(ec, mapName, geoJson);
+
+  // Keep the latest hover callback without re-binding chart events.
+  const hoverRef = useRef(onBubbleHover);
+  hoverRef.current = onBubbleHover;
+
+  const options = useMemo<KumoChartOption>(() => {
+    const palette = ChartPalette.mapColors(isDarkMode);
+
+    const values = data.map((row) => resolve(row, value));
+    const vmin = values.length ? Math.min(...values) : 0;
+    const vmax = values.length ? Math.max(...values) : 1;
+
+    const radiusFor = (v: number) => {
+      if (vmax <= vmin) return maxRadius;
+      const t = Math.sqrt((v - vmin) / (vmax - vmin));
+      return minRadius + t * (maxRadius - minRadius);
+    };
+
+    const points: BubblePoint<T>[] = data.map((row) => {
+      const v = resolve(row, value);
+      return {
+        name: name ? resolve(row, name) : undefined,
+        value: [resolve(row, lng), resolve(row, lat), v],
+        symbolSize: radiusFor(v),
+        itemStyle: {
+          color: bubbleColor ? resolveStyle(row, bubbleColor) : palette.bubble,
+          borderColor: resolveStyle(row, bubbleBorderColor),
+          borderWidth: resolveStyle(row, bubbleBorderWidth),
+        },
+        datum: row,
+      };
+    });
+
+    return {
+      backgroundColor: "transparent",
+      animation: true,
+      animationDuration: 500,
+      geo: buildGeo({ mapName, areaColor: palette.area, center, zoom, roam }),
+      tooltip: showTooltip
+        ? {
+            trigger: "item",
+            triggerOn: "mousemove",
+            backgroundColor: "var(--color-kumo-base)",
+            borderColor: "var(--color-kumo-line)",
+            borderWidth: 1,
+            padding: 8,
+            textStyle: {
+              color: "var(--text-color-kumo-default)",
+              fontSize: 13,
+            },
+            extraCssText: "border-radius: 0.5rem;",
+            dangerousHtmlFormatter: (params: unknown) => {
+              const p = params as {
+                name?: string;
+                value?: number[];
+                data?: { datum?: T };
+              };
+              const row = p.data?.datum;
+              if (tooltipFormatter && row !== undefined) {
+                return tooltipFormatter(row);
+              }
+              const v = p.value?.[2];
+              // Two-line layout: name on top, value muted below (use
+              // `valueFormat` to add a unit, e.g. "1.2k requests").
+              const nameStr = p.name
+                ? `<strong>${escapeHtml(p.name)}</strong>`
+                : "";
+              const valueStr =
+                v !== undefined
+                  ? `<span style="color:var(--text-color-kumo-subtle)">${escapeHtml(valueFormat(v))}</span>`
+                  : "";
+              return `<div style="display:flex;flex-direction:column;gap:2px;">${nameStr}${valueStr}</div>`;
+            },
+          }
+        : undefined,
+      series: [
+        {
+          type: "scatter",
+          coordinateSystem: "geo",
+          data: points,
+          itemStyle: { opacity: 0.8 },
+          emphasis: { scale: 1.1, itemStyle: { opacity: 1 } },
+          z: 3,
+        },
+      ],
+    };
+  }, [
+    isDarkMode,
+    geoJson,
+    mapName,
+    data,
+    lng,
+    lat,
+    value,
+    name,
+    minRadius,
+    maxRadius,
+    bubbleColor,
+    bubbleBorderColor,
+    bubbleBorderWidth,
+    center,
+    zoom,
+    roam,
+    showTooltip,
+    tooltipFormatter,
+    valueFormat,
+  ]);
+
+  const handleMouseOver = useCallback(
+    (params: Parameters<ChartEvents["mouseover"]>[0]) => {
+      const datum = (params.data as { datum?: T } | undefined)?.datum;
+      if (datum !== undefined) hoverRef.current?.(datum);
+    },
+    [],
+  );
+
+  const handleMouseOut = useCallback(() => {
+    hoverRef.current?.(undefined);
+  }, []);
+
+  const handleClick = useCallback(
+    (params: Parameters<ChartEvents["click"]>[0]) => {
+      const datum = (params.data as { datum?: T } | undefined)?.datum;
+      if (datum !== undefined) onBubbleClick?.(datum);
+    },
+    [onBubbleClick],
+  );
+
+  const onEvents = useMemo<Partial<ChartEvents>>(
+    () => ({
+      ...(onBubbleHover
+        ? {
+            mouseover: handleMouseOver,
+            mouseout: handleMouseOut,
+            globalout: handleMouseOut,
+          }
+        : {}),
+      ...(onBubbleClick ? { click: handleClick } : {}),
+    }),
+    [
+      onBubbleHover,
+      handleMouseOver,
+      handleMouseOut,
+      handleClick,
+      onBubbleClick,
+    ],
+  );
+
+  return (
+    <Chart
+      echarts={ec}
+      options={options}
+      className={className}
+      isDarkMode={isDarkMode}
+      height={height}
+      onEvents={onEvents}
+    />
+  );
+}
+
+BubbleMap.displayName = "BubbleMap";
+
+/** Register the GeoJSON with ECharts before the child Chart's setOption runs. */
+function useRegisterMap(
+  ec: typeof echarts,
+  mapName: string,
+  geoJson: MapGeoJson,
+) {
+  useLayoutEffect(() => {
+    ec.registerMap(mapName, geoJson as Parameters<typeof ec.registerMap>[1]);
+  }, [ec, mapName, geoJson]);
+}

--- a/packages/kumo/src/components/chart/SankeyChart.tsx
+++ b/packages/kumo/src/components/chart/SankeyChart.tsx
@@ -3,6 +3,7 @@ import type { EChartsOption } from "echarts";
 import { useMemo, useCallback } from "react";
 import { Chart, type ChartEvents } from "./EChart";
 import { ChartPalette } from "./Color";
+import { defaultValueFormat, escapeHtml } from "./tooltip-utils";
 
 export interface SankeyNodeData {
   id?: string;
@@ -95,8 +96,6 @@ export interface SankeyChartProps {
   onLinkClick?: (link: SankeyLinkData) => void;
 }
 
-const defaultFormatValue = (value: number) => value.toLocaleString();
-
 /** Type guard for ECharts tooltip params */
 interface TooltipParams {
   dataType?: string;
@@ -109,15 +108,6 @@ interface TooltipParams {
 function isTooltipParams(params: unknown): params is TooltipParams {
   return typeof params === "object" && params !== null;
 }
-
-/** Escape HTML special characters to prevent XSS in tooltips */
-const escapeHtml = (str: string): string =>
-  str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 
 /**
  * Escape ECharts rich text metacharacters to prevent formatting issues.
@@ -175,7 +165,7 @@ export function SankeyChart({
   showTooltip: enableTooltip = true,
   showNodeValues,
   nodeLabelLayout = "stacked",
-  formatValue = defaultFormatValue,
+  formatValue = defaultValueFormat,
   tooltipFormatter,
   defaultNodeColor,
   left,

--- a/packages/kumo/src/components/chart/index.ts
+++ b/packages/kumo/src/components/chart/index.ts
@@ -19,5 +19,12 @@ export {
   type SankeyLinkData,
   type SankeyTooltipParams,
 } from "./SankeyChart";
+export {
+  BubbleMap,
+  type MapGeoJson,
+  type MapAccessor,
+  type MapStyle,
+  type BubbleMapProps,
+} from "./Maps";
 // Re-export color utilities for consumers who need to match chart colors outside of a chart instance
 export { ChartPalette } from "./Color";

--- a/packages/kumo/src/components/chart/tooltip-utils.ts
+++ b/packages/kumo/src/components/chart/tooltip-utils.ts
@@ -1,0 +1,10 @@
+export const defaultValueFormat = (value: number) => value.toLocaleString();
+
+/** Escape HTML special characters to prevent XSS in default tooltips. */
+export const escapeHtml = (str: string): string =>
+  str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -249,11 +249,16 @@ export {
   SankeyChart,
   TimeseriesChart,
   ChartLegend,
+  BubbleMap,
   type KumoChartOption,
   type SankeyChartProps,
   type SankeyNodeData,
   type SankeyLinkData,
   type SankeyTooltipParams,
+  type MapGeoJson,
+  type MapAccessor,
+  type MapStyle,
+  type BubbleMapProps,
 } from "./components/chart";
 export {
   Autocomplete,


### PR DESCRIPTION
## Summary

Add `BubbleMap` chart component that plots proportional bubbles by coordinate over a minimal, monochromatic GeoJSON base. Land renders as a single seamless neutral mass (seams stroked in the fill color, no internal borders) so the bubbles read clearly, and bubble area scales with value (`minRadius`…`maxRadius`, sqrt-scaled).

- Adds a `mapColors` helper to `ChartPalette` (neutral land fill per mode + shared categorical bubble color).
- Supports flexible accessors (`lng`/`lat`/`value`/`name`), per-datum style overrides, roam (pan/zoom) with constrained scale limits, and theme-aware tooltips.
- Extracts shared `escapeHtml` / `defaultValueFormat` tooltip helpers into `tooltip-utils`, reused by `SankeyChart`.
- Includes docs page, demo, and test page, plus a `D`-to-toggle theme shortcut with cross-component theme sync.

 #### Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: net-new component, manual review needed
#### Tests
- [ ] Tests included/updated
- [x] Automated tests not possible - manual testing has been completed as follows: verified BubbleMap rendering, radius scaling (empty/equal/varied data), tooltip output, and theme toggle on docs and test pages
- [ ] Additional testing not necessary because: