### PR TITLE
feat(chart): add hideXAxisLabels and hideYAxisLabels props to TimeseriesChart

### DIFF
--- a/.changeset/hide-axis-labels.md
+++ b/.changeset/hide-axis-labels.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `hideXAxisLabels` and `hideYAxisLabels` props to TimeseriesChart for hiding axis tick labels.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -420,6 +420,39 @@ export function LegendCompactDemo() {
 }
 
 /**
+ * Timeseries chart with axis labels hidden using `hideXAxisLabels` and `hideYAxisLabels`.
+ */
+export function HiddenAxisLabelsDemo() {
+  const isDarkMode = useIsDarkMode();
+
+  const data = useMemo(
+    () => [
+      {
+        name: "Requests",
+        data: buildSeriesData(0, 50, 60_000, 1),
+        color: ChartPalette.semantic("Neutral", isDarkMode),
+      },
+      {
+        name: "Errors",
+        data: buildSeriesData(1, 50, 60_000, 0.3),
+        color: ChartPalette.semantic("Attention", isDarkMode),
+      },
+    ],
+    [isDarkMode],
+  );
+
+  return (
+    <TimeseriesChart
+      echarts={echarts}
+      isDarkMode={isDarkMode}
+      data={data}
+      hideXAxisLabels
+      hideYAxisLabels
+    />
+  );
+}
+
+/**
  * Timeseries chart rendered as a stacked bar chart.
  */
 export function BarChartDemo() {

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -19,6 +19,7 @@ import {
   TimeRangeSelectionChartDemo,
   TooltipFollowCursorDemo,
   TooltipBoundaryDemo,
+  HiddenAxisLabelsDemo,
 } from "~/components/demos/Chart/ChartDemo";
 
 <p>
@@ -49,6 +50,20 @@ import {
 
   <ComponentExample demo="CustomAxisLabelFormatDemo">
     <CustomAxisLabelFormatDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+## Hidden Axis Labels
+
+<p>
+  Use <code>hideXAxisLabels</code> and <code>hideYAxisLabels</code> to hide
+  the tick labels on either axis. The axis lines and grid are unaffected.
+</p>
+
+  <ComponentExample demo="HiddenAxisLabelsDemo">
+    <HiddenAxisLabelsDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -409,6 +409,7 @@ export const TimeseriesChart = forwardRef<
           show: false,
         },
         axisLine: { show: false },
+        axisTick: { show: !hideXAxisLabels },
         splitNumber: xAxisTickCount ?? 5,
         axisLabel: {
           show: !hideXAxisLabels,
@@ -422,7 +423,7 @@ export const TimeseriesChart = forwardRef<
         nameLocation: "middle" as const,
         nameGap: 40,
         type: "value" as const,
-        axisTick: { show: true },
+        axisTick: { show: !hideYAxisLabels },
         axisLabel: {
           show: !hideYAxisLabels,
           margin: 15,

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -56,8 +56,20 @@ export interface TimeseriesChartProps {
    * values, not y-axis tick labels. It will be removed in a future major version.
    */
   yAxisTickLabelFormat?: (value: number) => string;
+  /**
+   * When `true`, hides the x-axis tick labels (timestamps).
+   * The axis line and grid are unaffected.
+   * @default false
+   */
+  hideXAxisLabels?: boolean;
   /** Label for the y-axis (value axis) */
   yAxisName?: string;
+  /**
+   * When `true`, hides the y-axis tick labels (values).
+   * The axis line and grid are unaffected.
+   * @default false
+   */
+  hideYAxisLabels?: boolean;
   /** Number of ticks to display on the y-axis */
   yAxisTickCount?: number;
   /**
@@ -212,9 +224,11 @@ export const TimeseriesChart = forwardRef<
     xAxisName,
     xAxisTickCount,
     xAxisTickFormat,
+    hideXAxisLabels,
     yAxisTickFormat,
     yAxisTickLabelFormat,
     yAxisName,
+    hideYAxisLabels,
     yAxisTickCount,
     tooltipValueFormat,
     onTimeRangeChange,
@@ -396,11 +410,12 @@ export const TimeseriesChart = forwardRef<
         },
         axisLine: { show: false },
         splitNumber: xAxisTickCount ?? 5,
-        ...(xAxisTickFormat && {
-          axisLabel: {
+        axisLabel: {
+          show: !hideXAxisLabels,
+          ...(xAxisTickFormat && {
             formatter: (value: number) => xAxisTickFormat(value),
-          },
-        }),
+          }),
+        },
       },
       yAxis: {
         name: yAxisName,
@@ -409,6 +424,7 @@ export const TimeseriesChart = forwardRef<
         type: "value" as const,
         axisTick: { show: true },
         axisLabel: {
+          show: !hideYAxisLabels,
           margin: 15,
           ...(yAxisTickFormat && {
             formatter: (value: number) => yAxisTickFormat(value),
@@ -433,8 +449,10 @@ export const TimeseriesChart = forwardRef<
     xAxisName,
     xAxisTickCount,
     xAxisTickFormat,
+    hideXAxisLabels,
     yAxisTickFormat,
     yAxisName,
+    hideYAxisLabels,
     yAxisTickCount,
     incompleteBefore,
     incompleteAfter,


### PR DESCRIPTION
Adds two new boolean props to `TimeseriesChart` that allow consumers to hide axis tick labels:

- `hideXAxisLabels` — hides x-axis timestamp labels
- `hideYAxisLabels` — hides y-axis value labels

Both default to `false` (labels visible). Axis lines and grid lines are unaffected.

### Usage

```tsx
<TimeseriesChart
  echarts={echarts}
  data={data}
  hideXAxisLabels
  hideYAxisLabels
/>
```

Passes through to ECharts' `axisLabel.show` on the respective axis config.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: trivial prop passthrough to ECharts
- Tests
  - [x] Additional testing not necessary because: passthrough boolean props with no logic beyond negation