### PR TITLE
fix(button): keep emphasis active ring color

### DIFF
--- a/.changeset/blue-red-button-rings.md
+++ b/.changeset/blue-red-button-rings.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Keep primary and destructive button active/focus rings matched to their variant color.

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Plus } from "@phosphor-icons/react";
-import { Button, RefreshButton, LinkButton } from "./button";
+import { Button, RefreshButton, LinkButton, buttonVariants } from "./button";
 
 describe("Button", () => {
   describe("children wrapper", () => {
@@ -111,6 +111,21 @@ describe("Button", () => {
     const button = screen.getByRole("button", { name: "Save" });
     // title is intercepted by Tooltip wrapper, not set as native attribute
     expect(button.getAttribute("title")).toBeNull();
+  });
+
+  it("keeps emphasized variant rings color-matched when pressed or focused", () => {
+    for (const variant of ["primary", "destructive"] as const) {
+      const className = buttonVariants({ variant });
+
+      expect(className).toContain("ring-(--kumo-button-emphasis-ring)");
+      expect(className).toContain("focus:ring-(--kumo-button-emphasis-ring)");
+      expect(className).toContain(
+        "focus-visible:ring-(--kumo-button-emphasis-ring)",
+      );
+      expect(className).toContain("active:ring-(--kumo-button-emphasis-ring)");
+      expect(className).not.toContain("focus:ring-kumo-focus/50");
+      expect(className).not.toContain("focus-visible:ring-kumo-brand");
+    }
   });
 });
 

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -49,7 +49,7 @@ export const KUMO_BUTTON_VARIANTS = {
   variant: {
     primary: {
       classes:
-        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
+        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) focus:ring-(--kumo-button-emphasis-ring) focus-visible:ring-(--kumo-button-emphasis-ring) active:ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
       description: "High-emphasis button for primary actions",
     },
     secondary: {
@@ -63,7 +63,7 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     destructive: {
       classes:
-        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
+        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) focus:ring-(--kumo-button-emphasis-ring) focus-visible:ring-(--kumo-button-emphasis-ring) active:ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
       description: "Danger button for destructive actions like delete",
     },
     "secondary-destructive": {


### PR DESCRIPTION
## Summary

- Keep primary and destructive button focus/active rings matched to their emphasis color
- Add a regression test for emphasized button ring classes
- Add a patch changeset for @cloudflare/kumo

## Testing

- `pnpm --filter @cloudflare/kumo test -- button`
- `pnpm --filter @cloudflare/kumo test -- src/components/button/button.test.tsx`
- `pnpm --filter @cloudflare/kumo lint` (passes with existing unrelated warnings)

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: small visual state fix with targeted regression coverage
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: 
- [ ] Additional testing not necessary because: 