### PR TITLE
fix(chart): preserve BubbleMap view on data refresh

### DIFF
--- a/.changeset/choropleth-map.md
+++ b/.changeset/choropleth-map.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `ChoroplethMap`, a GeoJSON region choropleth chart component that joins data rows to features by `name`/`nameProperty` and shades regions with a continuous `visualMap` scale. Includes Kumo light/dark map colours, tooltip formatting, optional legend, hover/click callbacks, roam controls, docs, and demos.

--- a/.changeset/tame-maps-walk.md
+++ b/.changeset/tame-maps-walk.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update BubbleMap viewport behavior to avoid resetting user pan and zoom while refreshing bubble data.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChoroplethMapDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChoroplethMapDemo.tsx
@@ -1,0 +1,64 @@
+import { ChoroplethMap, type MapGeoJson } from "@cloudflare/kumo";
+import * as echarts from "echarts/core";
+import { MapChart } from "echarts/charts";
+import { VisualMapComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import { useIsDarkMode } from "~/lib/use-is-dark-mode";
+
+echarts.use([MapChart, VisualMapComponent, TooltipComponent, CanvasRenderer]);
+
+interface ChoroplethMapDemoProps {
+  geoJson: MapGeoJson | null;
+}
+
+/** A country-level traffic row — joined to GeoJSON features by `country`. */
+interface CountryTraffic {
+  /** Must match the GeoJSON feature's `name` property. */
+  country: string;
+  requests: number;
+}
+
+// Country-level traffic. The colour scale is continuous; if your data is
+// skewed, shape it in the parent (e.g. a transformed value) before passing it in.
+const countries: CountryTraffic[] = [
+  { country: "United States of America", requests: 4200 },
+  { country: "Germany", requests: 3100 },
+  { country: "United Kingdom", requests: 2800 },
+  { country: "Japan", requests: 2500 },
+  { country: "France", requests: 2200 },
+  { country: "Brazil", requests: 1700 },
+  { country: "India", requests: 1500 },
+  { country: "Canada", requests: 1300 },
+  { country: "Australia", requests: 1100 },
+  { country: "Spain", requests: 900 },
+  { country: "Netherlands", requests: 700 },
+  { country: "Mexico", requests: 600 },
+  { country: "Argentina", requests: 420 },
+  { country: "Nigeria", requests: 300 },
+  { country: "South Africa", requests: 220 },
+];
+
+const fmt = (n: number) =>
+  `${n >= 1000 ? `${(n / 1000).toLocaleString()}k` : n.toString()} requests`;
+
+/**
+ * Choropleth map — regions shaded by value, joined to GeoJSON features by name.
+ * Uses the default continuous linear colour scale.
+ */
+export function ChoroplethMapBasicDemo({ geoJson }: ChoroplethMapDemoProps) {
+  const isDarkMode = useIsDarkMode();
+
+  if (!geoJson) return null;
+
+  return (
+    <ChoroplethMap<CountryTraffic>
+      echarts={echarts}
+      geoJson={geoJson}
+      data={countries}
+      name="country"
+      value="requests"
+      valueFormat={fmt}
+      isDarkMode={isDarkMode}
+    />
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/charts/maps.astro
+++ b/packages/kumo-docs-astro/src/pages/charts/maps.astro
@@ -6,6 +6,7 @@ import ComponentExample from "../../components/docs/ComponentExample.astro";
 import CodeBlock from "../../components/docs/CodeBlock.astro";
 import PropsTable from "../../components/docs/PropsTable.astro";
 import { BubbleMapBasicDemo } from "~/components/demos/Chart/BubbleMapDemo";
+import { ChoroplethMapBasicDemo } from "~/components/demos/Chart/ChoroplethMapDemo";
 import type { MapGeoJson } from "@cloudflare/kumo";
 
 const WORLD_GEO_JSON_URL =
@@ -50,15 +51,15 @@ try {
   <ComponentSection>
     <Heading level={2}>Installation</Heading>
     <p class="mb-4 text-kumo-subtle">
-      <code class="text-kumo-default">BubbleMap</code> requires <code class="text-kumo-default">echarts</code> as a peer dependency. Consumers provide the GeoJSON feature collection; the component does not fetch map data or use map tiles.
+      <code class="text-kumo-default">BubbleMap</code> and <code class="text-kumo-default">ChoroplethMap</code> require <code class="text-kumo-default">echarts</code> as a peer dependency. Consumers provide the GeoJSON feature collection; map components do not fetch map data or use map tiles.
     </p>
     <CodeBlock code={`npm install echarts`} lang="bash" />
 
     <Heading level={3} class="mb-2 mt-6 text-lg">Barrel</Heading>
-    <CodeBlock code={`import { BubbleMap } from "@cloudflare/kumo";`} lang="tsx" />
+    <CodeBlock code={`import { BubbleMap, ChoroplethMap } from "@cloudflare/kumo";`} lang="tsx" />
     <Heading level={3} class="mb-2 mt-4 text-lg">Granular</Heading>
     <CodeBlock
-      code={`import { BubbleMap } from "@cloudflare/kumo/components/chart";`}
+      code={`import { BubbleMap, ChoroplethMap } from "@cloudflare/kumo/components/chart";`}
       lang="tsx"
     />
   </ComponentSection>
@@ -66,15 +67,21 @@ try {
   <ComponentSection>
     <Heading level={2}>Usage</Heading>
     <CodeBlock
-      code={`import { BubbleMap, type MapGeoJson } from "@cloudflare/kumo";
+      code={`import { BubbleMap, ChoroplethMap, type MapGeoJson } from "@cloudflare/kumo";
 import * as echarts from "echarts/core";
 import { MapChart, ScatterChart } from "echarts/charts";
-import { TooltipComponent } from "echarts/components";
+import { TooltipComponent, VisualMapComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 
-echarts.use([MapChart, ScatterChart, TooltipComponent, CanvasRenderer]);
+echarts.use([
+  MapChart,
+  ScatterChart,
+  TooltipComponent,
+  VisualMapComponent,
+  CanvasRenderer,
+]);
 
-// Load GeoJSON in your app and pass it to BubbleMap.
+// Load GeoJSON in your app and pass it to map components.
 const geoJson = world as MapGeoJson;
 
 const colos = [
@@ -82,17 +89,32 @@ const colos = [
   { iata: "LHR", city: "London", lat: 51.5, lon: -0.12, requests: 1500 },
 ];
 
+const countries = [
+  { country: "United States of America", requests: 4200 },
+  { country: "Germany", requests: 3100 },
+];
+
 export default function Example() {
   return (
-    <BubbleMap
-      echarts={echarts}
-      geoJson={geoJson}
-      data={colos}
-      lng="lon"
-      lat="lat"
-      name="city"
-      value="requests"
-    />
+    <>
+      <BubbleMap
+        echarts={echarts}
+        geoJson={geoJson}
+        data={colos}
+        lng="lon"
+        lat="lat"
+        name="city"
+        value="requests"
+      />
+
+      <ChoroplethMap
+        echarts={echarts}
+        geoJson={geoJson}
+        data={countries}
+        name="country"
+        value="requests"
+      />
+    </>
   );
 }`}
       lang="tsx"
@@ -143,11 +165,28 @@ export default function Example() {
           lang="tsx"
         />
       </div>
+
+      <div>
+        <Heading level={3}>Choropleth Map</Heading>
+        <p class="mb-4 text-kumo-subtle">
+          Shade regions by value. Data rows are joined to GeoJSON features by <code class="text-kumo-default">name</code> (matched against the feature's <code class="text-kumo-default">nameProperty</code>, default <code class="text-kumo-default">"name"</code>).
+        </p>
+        <ComponentExample code={`<ChoroplethMap
+  echarts={echarts}
+  geoJson={geoJson}
+  data={countries}
+  name="country"
+  value="requests"
+/>`}>
+          <ChoroplethMapBasicDemo geoJson={geoJson} client:visible />
+        </ComponentExample>
+      </div>
     </div>
   </ComponentSection>
 
   <ComponentSection>
     <Heading level={2}>API Reference</Heading>
+    <Heading level={3} class="mb-2 mt-4 text-lg">BubbleMap</Heading>
     <PropsTable component="BubbleMap" />
   </ComponentSection>
 </DocLayout>

--- a/packages/kumo-docs-astro/src/pages/tests/map.astro
+++ b/packages/kumo-docs-astro/src/pages/tests/map.astro
@@ -4,6 +4,7 @@ import {
   BubbleMapBasicDemo,
   BubbleMapManyPointsDemo,
 } from "../../components/demos/Chart/BubbleMapDemo";
+import { ChoroplethMapBasicDemo } from "../../components/demos/Chart/ChoroplethMapDemo";
 import type { MapGeoJson } from "@cloudflare/kumo";
 
 const WORLD_GEO_JSON_URL =
@@ -58,6 +59,15 @@ try {
       </div>
       <div class="p-4 rounded-lg border border-kumo-hairline bg-kumo-base">
         <BubbleMapManyPointsDemo geoJson={geoJson} client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-4">
+      <div>
+        <h2 class="text-xl font-semibold text-kumo-default">ChoroplethMapBasicDemo</h2>
+      </div>
+      <div class="p-4 rounded-lg border border-kumo-hairline bg-kumo-base">
+        <ChoroplethMapBasicDemo geoJson={geoJson} client:visible />
       </div>
     </section>
   </div>

--- a/packages/kumo/src/components/chart/Color.ts
+++ b/packages/kumo/src/components/chart/Color.ts
@@ -72,16 +72,42 @@ const sequentialDark = {
 
 /** Colours for GeoJSON-based map charts. */
 export interface MapColors {
-  /** Fill for land regions. */
+  /** Fill for land / no-data regions. */
   area: string;
   /** Default bubble fill (the chart palette blue). */
   bubble: string;
+  /** Seam / border between regions (used by choropleth maps). */
+  line: string;
+  /**
+   * Sequential ramp (low → high) for shading choropleth regions. Tuned so the
+   * lowest band stays clearly distinct from the neutral no-data fill in both
+   * modes (light: low = light blue → high = deep blue; dark: low = deep blue →
+   * high = bright blue, so higher values read brighter against the dark base).
+   */
+  scale: string[];
 }
 
 /** Neutral land fill per mode; bubbles use the shared categorical palette. */
 const mapAreaByMode = {
   light: "#E5E7EB",
   dark: "#2B2C31",
+} as const;
+
+/** Region seam colour per mode — keeps adjacent choropleth regions distinct. */
+const mapLineByMode = {
+  light: "#FFFFFF",
+  dark: "#1F2024",
+} as const;
+
+/**
+ * Choropleth shading ramp per mode (ordered low → high), anchored on the shared
+ * chart blue `#4290F0` (same as BubbleMap and `categorical(0)`) so the maps read
+ * as one family. Every step stays clearly blue, and the low ends are kept
+ * distinct from the neutral no-data fill in both modes.
+ */
+const mapScaleByMode = {
+  light: ["#C8DEFB", "#8FBDF6", "#4290F0", "#1E60BE", "#0A3A7A"],
+  dark: ["#26456C", "#2C68BE", "#4290F0", "#79AEF4", "#BBD6FA"],
 } as const;
 
 /**
@@ -193,6 +219,8 @@ export namespace ChartPalette {
     return {
       area: mapAreaByMode[mode],
       bubble: categorical(0, isDarkMode),
+      line: mapLineByMode[mode],
+      scale: [...mapScaleByMode[mode]],
     };
   }
 }

--- a/packages/kumo/src/components/chart/Maps.tsx
+++ b/packages/kumo/src/components/chart/Maps.tsx
@@ -3,6 +3,7 @@ import type { ForwardedRef, ReactElement, RefAttributes } from "react";
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -96,8 +97,6 @@ function buildGeo(opts: {
     zoom: opts.zoom,
     aspectScale: 1,
     silent: true,
-    layoutCenter: ["50%", "50%"],
-    layoutSize: "180%",
     itemStyle: {
       areaColor: opts.areaColor,
       // Stroke the seams in the fill colour so the land reads as one seamless
@@ -158,7 +157,7 @@ export interface BubbleMapProps<T> {
   center?: [number, number];
   /** Zoom level — multiplies the auto-fit scale. Default: `1.25`. */
   zoom?: number;
-  /** Enable drag-to-pan and scroll-to-zoom. Default: `true`. */
+  /** Enable drag-to-pan and scroll-to-zoom. Default: `false`. */
   roam?: boolean;
 
   /** Show the tooltip. Default: `true`. */
@@ -233,7 +232,7 @@ function BubbleMapRoot<T>(
     bubbleBorderWidth = 0,
     center,
     zoom = 1.25,
-    roam = true,
+    roam = false,
     showTooltip = true,
     valueFormat = defaultValueFormat,
     tooltipFormatter,
@@ -253,6 +252,41 @@ function BubbleMapRoot<T>(
   );
   useRegisterMap(ec, mapName, geoJson);
 
+  const palette = useMemo(
+    () => ChartPalette.mapColors(isDarkMode),
+    [isDarkMode],
+  );
+
+  // Rebuild `geo` only when the map data or view changes. Depend on `center`'s
+  // components, not the array ref, so an inline `center={[x, y]}` doesn't rebuild
+  // `geo` (and reset the view) every render.
+  const centerX = center?.[0];
+  const centerY = center?.[1];
+  const geo = useMemo(
+    () =>
+      buildGeo({
+        mapName,
+        areaColor: palette.area,
+        center:
+          centerX !== undefined && centerY !== undefined
+            ? [centerX, centerY]
+            : undefined,
+        zoom,
+        roam,
+      }),
+    [mapName, geoJson, palette, centerX, centerY, zoom, roam],
+  );
+
+  // Apply `geo` only when its identity changes, so refetches don't reset a
+  // roamed/zoomed view. The ref is updated post-commit (not during render) so
+  // discarded render passes (StrictMode/concurrent) can't mark `geo` applied
+  // before it reaches the chart.
+  const appliedGeoRef = useRef<typeof geo | undefined>(undefined);
+  const shouldIncludeGeo = appliedGeoRef.current !== geo;
+  useEffect(() => {
+    appliedGeoRef.current = geo;
+  }, [geo]);
+
   // Keep the latest hover callback without re-binding chart events.
   const hoverRef = useRef(onBubbleHover);
   hoverRef.current = onBubbleHover;
@@ -269,16 +303,13 @@ function BubbleMapRoot<T>(
   );
 
   const options = useMemo<KumoChartOption>(() => {
-    const palette = ChartPalette.mapColors(isDarkMode);
-
     const values = data.map((row) => resolve(row, value));
-    const vmin = values.length ? Math.min(...values) : 0;
     const vmax = values.length ? Math.max(...values) : 1;
 
     const radiusFor = (v: number) => {
       if (bubbleSize) return bubbleSize(v);
-      if (vmax <= vmin) return maxRadius;
-      const t = Math.sqrt((v - vmin) / (vmax - vmin));
+      if (vmax <= 0) return minRadius;
+      const t = Math.sqrt(Math.max(0, v) / vmax);
       return minRadius + t * (maxRadius - minRadius);
     };
 
@@ -301,7 +332,8 @@ function BubbleMapRoot<T>(
       backgroundColor: "transparent",
       animation: true,
       animationDuration: 500,
-      geo: buildGeo({ mapName, areaColor: palette.area, center, zoom, roam }),
+      animationDurationUpdate: 0,
+      ...(shouldIncludeGeo ? { geo } : {}),
       tooltip: showTooltip
         ? {
             trigger: "item",
@@ -341,6 +373,7 @@ function BubbleMapRoot<T>(
         : undefined,
       series: [
         {
+          id: "bubbles",
           type: "scatter",
           coordinateSystem: "geo",
           data: points,
@@ -351,10 +384,9 @@ function BubbleMapRoot<T>(
       ],
     };
   }, [
-    isDarkMode,
-    geoJson,
-    mapNameProp,
-    mapName,
+    palette,
+    geo,
+    shouldIncludeGeo,
     data,
     lng,
     lat,
@@ -366,9 +398,6 @@ function BubbleMapRoot<T>(
     bubbleColor,
     bubbleBorderColor,
     bubbleBorderWidth,
-    center,
-    zoom,
-    roam,
     showTooltip,
     tooltipFormatter,
     valueFormat,

--- a/packages/kumo/src/components/chart/Maps.tsx
+++ b/packages/kumo/src/components/chart/Maps.tsx
@@ -462,6 +462,399 @@ export const BubbleMap = forwardRef(BubbleMapRoot) as (<T>(
 
 BubbleMap.displayName = "BubbleMap";
 
+// ===========================================================================
+// ChoroplethMap — GeoJSON regions shaded by value
+// ===========================================================================
+
+export interface ChoroplethMapProps<T> {
+  /**
+   * The ECharts core instance imported by the consumer (passed in for
+   * tree-shaking). Requires `MapChart`, `VisualMapComponent`, `TooltipComponent`,
+   * and a renderer registered via `echarts.use([...])`.
+   */
+  echarts: typeof echarts;
+  /** GeoJSON `FeatureCollection` whose regions are shaded by value. */
+  geoJson: MapGeoJson;
+  /**
+   * Optional stable ECharts map registry name. Set this when the same GeoJSON is
+   * parsed into new object instances across mounts and should reuse one global
+   * ECharts registration.
+   */
+  mapName?: string;
+  /** Raw data rows. The region key and value are read via the accessors below. */
+  data: T[];
+  /**
+   * Region-key accessor (key of `T` or `(row) => string`). Each row is joined to
+   * a GeoJSON feature whose `nameProperty` equals this value.
+   */
+  name: MapAccessor<T, string>;
+  /** Value accessor — drives the region's fill colour. */
+  value: MapAccessor<T, number>;
+  /**
+   * GeoJSON feature property to join on. Default: `"name"`. Real-world data is
+   * often more reliably matched on an ISO-code property (e.g. `"iso_a2"`).
+   */
+  nameProperty?: string;
+
+  /**
+   * Sequential colour ramp (low → high). Defaults to the Kumo choropleth blues,
+   * tuned to stay distinct from the no-data fill. Distributed across the
+   * continuous gradient.
+   */
+  colorRange?: string[];
+  /** Lower bound of the continuous scale. Default: data minimum. */
+  min?: number;
+  /** Upper bound of the continuous scale. Default: data maximum. */
+  max?: number;
+  /** Fill for regions with no matching data row. Defaults to the neutral land grey. */
+  noDataColor?: string;
+  /** Show the visualMap colour legend. Default: `false`. */
+  showLegend?: boolean;
+
+  /** Show the tooltip. Default: `true`. */
+  showTooltip?: boolean;
+  /** Format the value for the default tooltip. Default: `toLocaleString()`. */
+  valueFormat?: (value: number) => string;
+  /**
+   * Override the tooltip content for a row. Returns an HTML string rendered by
+   * ECharts' own tooltip.
+   *
+   * USE WITH CAUTION: the return value is injected as HTML. Escape any
+   * user-provided strings to avoid XSS.
+   */
+  tooltipFormatter?: (row: T) => string;
+
+  /** Called as the pointer enters/leaves a region with data. */
+  onRegionHover?: (row: T | undefined) => void;
+  /** Called when a region with data is clicked. */
+  onRegionClick?: (row: T) => void;
+
+  /** Map center as `[longitude, latitude]`. Defaults to auto-fit. */
+  center?: [number, number];
+  /** Zoom level — multiplies the auto-fit scale. Default: `1.25`. */
+  zoom?: number;
+  /** Enable drag-to-pan and scroll-to-zoom. Default: `false`. */
+  roam?: boolean;
+
+  /** Height of the chart in pixels. Default: `400`. */
+  height?: number;
+  className?: string;
+  isDarkMode?: boolean;
+}
+
+interface ChoroplethRegion<T> {
+  name: string;
+  value: number;
+  datum: T;
+}
+
+/**
+ * ChoroplethMap — shades GeoJSON regions by value, joining data rows to features
+ * by `name`/`nameProperty`. A continuous `visualMap` legend maps value → colour.
+ * Regions without a matching row render in `noDataColor`. For skewed data, scale
+ * the `value` in the parent (e.g. log) before passing it in.
+ *
+ * @example
+ * ```tsx
+ * import * as echarts from "echarts/core";
+ * import { MapChart } from "echarts/charts";
+ * import { VisualMapComponent, TooltipComponent } from "echarts/components";
+ * import { CanvasRenderer } from "echarts/renderers";
+ * echarts.use([MapChart, VisualMapComponent, TooltipComponent, CanvasRenderer]);
+ *
+ * <ChoroplethMap
+ *   echarts={echarts}
+ *   geoJson={world}
+ *   data={countries}
+ *   name="country" value="requests"
+ * />
+ * ```
+ */
+function ChoroplethMapRoot<T>(
+  {
+    echarts: ec,
+    geoJson,
+    mapName: mapNameProp,
+    data,
+    name,
+    value,
+    nameProperty = "name",
+    colorRange,
+    min,
+    max,
+    noDataColor,
+    showLegend = false,
+    showTooltip = true,
+    valueFormat = defaultValueFormat,
+    tooltipFormatter,
+    onRegionHover,
+    onRegionClick,
+    center,
+    zoom = 1.25,
+    roam = false,
+    height = 400,
+    className,
+    isDarkMode,
+  }: ChoroplethMapProps<T>,
+  ref: ForwardedRef<echarts.ECharts | null>,
+) {
+  // ECharts has no public unregisterMap API, so reuse a deterministic
+  // registration name for equivalent GeoJSON instead of creating one per mount.
+  const mapName = useMemo(
+    () => getMapName(geoJson, mapNameProp),
+    [geoJson, mapNameProp],
+  );
+  useRegisterMap(ec, mapName, geoJson);
+
+  const palette = useMemo(
+    () => ChartPalette.mapColors(isDarkMode),
+    [isDarkMode],
+  );
+
+  // The view fields (roam/zoom/center) reset the map when re-sent, so memoise
+  // them on their primitive components and only re-apply on change — a data
+  // refetch must not snap a roamed/zoomed map back to its initial view.
+  // `isDarkMode` is a dependency because toggling the theme destroys and
+  // recreates the ECharts instance (see EChart init effect); the fresh instance
+  // needs the view re-applied or it resets aspectScale/zoom/center to defaults.
+  const centerX = center?.[0];
+  const centerY = center?.[1];
+  const view = useMemo(
+    () => ({
+      roam,
+      ...(roam
+        ? {
+            scaleLimit: {
+              min: Math.min(1, zoom),
+              max: zoom * MAX_ZOOM_FACTOR,
+            },
+          }
+        : {}),
+      center:
+        centerX !== undefined && centerY !== undefined
+          ? [centerX, centerY]
+          : undefined,
+      zoom,
+      aspectScale: 1,
+    }),
+    [centerX, centerY, zoom, roam, isDarkMode],
+  );
+
+  // Update the applied-view ref post-commit (not during render) so discarded
+  // render passes (StrictMode/concurrent) can't mark the view applied early.
+  const appliedViewRef = useRef<typeof view | undefined>(undefined);
+  const shouldIncludeView = appliedViewRef.current !== view;
+  useEffect(() => {
+    appliedViewRef.current = view;
+  }, [view]);
+
+  // Keep the latest hover callback without re-binding chart events.
+  const hoverRef = useRef(onRegionHover);
+  hoverRef.current = onRegionHover;
+
+  const mergedRef = useCallback(
+    (instance: echarts.ECharts | null) => {
+      if (typeof ref === "function") {
+        ref(instance);
+      } else if (ref) {
+        ref.current = instance;
+      }
+    },
+    [ref],
+  );
+
+  const options = useMemo<KumoChartOption>(() => {
+    const colors = colorRange ?? palette.scale;
+    const noData = noDataColor ?? palette.area;
+
+    const regions: ChoroplethRegion<T>[] = data.map((row) => ({
+      name: resolve(row, name),
+      value: resolve(row, value),
+      datum: row,
+    }));
+
+    const values = regions.map((r) => r.value);
+    const vmin = values.length ? Math.min(...values) : 0;
+    const vmax = values.length ? Math.max(...values) : 1;
+    const resolvedMin = min ?? vmin;
+    const resolvedMax = max ?? (vmax > vmin ? vmax : vmin + 1);
+
+    const visualMap = {
+      type: "continuous" as const,
+      show: showLegend,
+      min: resolvedMin,
+      max: resolvedMax,
+      calculable: false,
+      hoverLink: false,
+      inRange: { color: colors },
+      orient: "horizontal" as const,
+      text: ["High", "Low"],
+      left: 0,
+      bottom: 8,
+      textStyle: {
+        color: ChartPalette.text("primary", isDarkMode),
+        fontSize: 11,
+      },
+    };
+
+    return {
+      backgroundColor: "transparent",
+      animation: true,
+      animationDuration: 500,
+      animationDurationUpdate: 0,
+      visualMap,
+      tooltip: showTooltip
+        ? {
+            trigger: "item",
+            triggerOn: "mousemove",
+            backgroundColor: "var(--color-kumo-base)",
+            borderColor: "var(--color-kumo-line)",
+            borderWidth: 1,
+            padding: 8,
+            textStyle: {
+              color: "var(--text-color-kumo-default)",
+              fontSize: 13,
+            },
+            extraCssText: "border-radius: 0.5rem;",
+            dangerousHtmlFormatter: (params: unknown) => {
+              const p = params as {
+                name?: string;
+                value?: number;
+                data?: { datum?: T };
+              };
+              const row = p.data?.datum;
+              // Suppress the tooltip for regions with no matching data row.
+              if (row === undefined) return "";
+              if (tooltipFormatter) return tooltipFormatter(row);
+              const v =
+                typeof p.value === "number" && !Number.isNaN(p.value)
+                  ? p.value
+                  : undefined;
+              const nameStr = p.name
+                ? `<strong>${escapeHtml(p.name)}</strong>`
+                : "";
+              const valueStr =
+                v !== undefined
+                  ? `<span style="color:var(--text-color-kumo-subtle)">${escapeHtml(valueFormat(v))}</span>`
+                  : "";
+              return `<div style="display:flex;flex-direction:column;gap:2px;">${nameStr}${valueStr}</div>`;
+            },
+          }
+        : undefined,
+      series: [
+        {
+          id: "regions",
+          type: "map",
+          map: mapName,
+          nameProperty,
+          ...(shouldIncludeView ? view : {}),
+          data: regions,
+          itemStyle: {
+            areaColor: noData,
+            borderColor: palette.line,
+            borderWidth: 0.5,
+          },
+          label: { show: false },
+          // Hover affordance: keep the region's own value colour and dim the
+          // rest (focus + blur), instead of recolouring to a loud accent.
+          emphasis: {
+            focus: "self" as const,
+            label: { show: false },
+            itemStyle: {
+              areaColor: "inherit",
+              borderColor: palette.line,
+              borderWidth: 1.5,
+            },
+          },
+          blur: {
+            label: { show: false },
+            itemStyle: { opacity: 0.45 },
+          },
+          select: { disabled: true },
+          z: 1,
+        },
+      ],
+    };
+  }, [
+    isDarkMode,
+    palette,
+    geoJson,
+    mapName,
+    view,
+    shouldIncludeView,
+    data,
+    name,
+    value,
+    nameProperty,
+    colorRange,
+    min,
+    max,
+    noDataColor,
+    showLegend,
+    showTooltip,
+    tooltipFormatter,
+    valueFormat,
+  ]);
+
+  const handleMouseOver = useCallback(
+    (params: Parameters<ChartEvents["mouseover"]>[0]) => {
+      const datum = (params.data as { datum?: T } | undefined)?.datum;
+      if (datum !== undefined) hoverRef.current?.(datum);
+    },
+    [],
+  );
+
+  const handleMouseOut = useCallback(() => {
+    hoverRef.current?.(undefined);
+  }, []);
+
+  const handleClick = useCallback(
+    (params: Parameters<ChartEvents["click"]>[0]) => {
+      const datum = (params.data as { datum?: T } | undefined)?.datum;
+      if (datum !== undefined) onRegionClick?.(datum);
+    },
+    [onRegionClick],
+  );
+
+  const onEvents = useMemo<Partial<ChartEvents>>(
+    () => ({
+      ...(onRegionHover
+        ? {
+            mouseover: handleMouseOver,
+            mouseout: handleMouseOut,
+            globalout: handleMouseOut,
+          }
+        : {}),
+      ...(onRegionClick ? { click: handleClick } : {}),
+    }),
+    [
+      onRegionHover,
+      handleMouseOver,
+      handleMouseOut,
+      handleClick,
+      onRegionClick,
+    ],
+  );
+
+  return (
+    <Chart
+      echarts={ec}
+      ref={mergedRef}
+      options={options}
+      className={className}
+      isDarkMode={isDarkMode}
+      height={height}
+      onEvents={onEvents}
+    />
+  );
+}
+
+export const ChoroplethMap = forwardRef(ChoroplethMapRoot) as (<T>(
+  props: ChoroplethMapProps<T> & RefAttributes<echarts.ECharts | null>,
+) => ReactElement | null) & { displayName?: string };
+
+ChoroplethMap.displayName = "ChoroplethMap";
+
 /** Register the GeoJSON with ECharts before the child Chart's setOption runs. */
 function useRegisterMap(
   ec: typeof echarts,

--- a/packages/kumo/src/components/chart/index.ts
+++ b/packages/kumo/src/components/chart/index.ts
@@ -21,10 +21,12 @@ export {
 } from "./SankeyChart";
 export {
   BubbleMap,
+  ChoroplethMap,
   type MapGeoJson,
   type MapAccessor,
   type MapStyle,
   type BubbleMapProps,
+  type ChoroplethMapProps,
 } from "./Maps";
 // Re-export color utilities for consumers who need to match chart colors outside of a chart instance
 export { ChartPalette } from "./Color";

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -250,6 +250,7 @@ export {
   TimeseriesChart,
   ChartLegend,
   BubbleMap,
+  ChoroplethMap,
   type KumoChartOption,
   type SankeyChartProps,
   type SankeyNodeData,
@@ -259,6 +260,7 @@ export {
   type MapAccessor,
   type MapStyle,
   type BubbleMapProps,
+  type ChoroplethMapProps,
 } from "./components/chart";
 export {
   Autocomplete,


### PR DESCRIPTION
Updates `BubbleMap` so bubble data refreshes do not reset the current map view. The chart now only resends the `geo` option when map data or view-related props change, while regular data updates can update the bubble series without resetting pan or zoom state.

Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a small chart interaction behavior change that needs reviewer validation in context

Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
