### PR TITLE
fix(button): resolve Firefox rendering artifact when Turnstile is pre…

### DIFF
--- a/.changeset/fix-button-firefox-turnstile.md
+++ b/.changeset/fix-button-firefox-turnstile.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(button): resolve Firefox rendering artifact when Turnstile is present
+
+Replace `translate-y-px` with `box-shadow: inset 0 1px 0 0 var(--kumo-button-emphasis-bg)` on the primary/destructive button emphasis overlay span. The transform triggered a rendering bug in Firefox on pages with Turnstile's `contain: strict` CSS. The box-shadow achieves the same visual depth effect without the rendering issue.

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -208,7 +208,7 @@ const renderButtonContent = (
     <>
       <span
         aria-hidden="true"
-        className="absolute inset-0 rounded-[inherit] bg-linear-to-b from-(--kumo-button-emphasis-gradient-start) to-(--kumo-button-emphasis-gradient-end) translate-y-px group-hover:from-(--kumo-button-emphasis-bg)"
+        className="absolute inset-0 rounded-[inherit] bg-linear-to-b from-(--kumo-button-emphasis-gradient-start) to-(--kumo-button-emphasis-gradient-end) shadow-[inset_0_1px_0_0_var(--kumo-button-emphasis-bg)] group-hover:from-(--kumo-button-emphasis-bg)"
       />
       <span className="relative flex items-center gap-1.5">
         {iconNode}


### PR DESCRIPTION
…sent

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._
Fixes a rendering issue on the button with pages that have Turnstile.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Additional testing not necessary because: visual-only fix for Firefox rendering artifact; manual QA verified in Firefox and Chrome
 
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
