### PR TITLE
fix: correct map changeset bump

### DIFF
--- a/.changeset/choropleth-map.md
+++ b/.changeset/choropleth-map.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/kumo": major
+"@cloudflare/kumo": minor
 ---
 
 Add `ChoroplethMap`, a GeoJSON region choropleth chart component that joins data rows to features by `name`/`nameProperty` and shades regions with a continuous `visualMap` scale. Includes Kumo light/dark map colours, tooltip formatting, optional legend, hover/click callbacks, roam controls, docs, and demos.
@@ -8,4 +8,4 @@ Both `BubbleMap` and `ChoroplethMap` now apply a d3-geo `projection` (latitude-c
 
 Update `BubbleMap` viewport behavior to avoid resetting user pan and zoom while refreshing bubble data.
 
-Breaking interaction change: `BubbleMap` now defaults `roam` to `false`, so maps no longer allow drag-to-pan or scroll-to-zoom unless consumers pass `roam={true}`.
+`BubbleMap` now defaults `roam` to `false` to avoid accidental pan and zoom interactions. Consumers that want drag-to-pan or scroll-to-zoom can pass `roam={true}`.


### PR DESCRIPTION
## Summary

- Change the ChoroplethMap changeset from major to minor
- Reword the BubbleMap roam default note so the release PR does not present it as a breaking change

## Why

The release PR should not publish @cloudflare/kumo as 3.0.0 for this map update. After this merges, the changesets release PR should regenerate with this entry under Minor Changes.

## Tests

- Not run; changeset metadata only.
