### PR TITLE
feat(input): add RichTextInputArea

### DIFF
--- a/.changeset/input-area-toolbar.md
+++ b/.changeset/input-area-toolbar.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add RichTextInputArea for composing formatted content with built-in toolbar controls, plus toolbar slots for InputArea.

--- a/packages/kumo-docs-astro/src/components/demos/InputAreaDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/InputAreaDemo.tsx
@@ -1,4 +1,4 @@
-import { InputArea } from "@cloudflare/kumo";
+import { InputArea, RichTextInputArea } from "@cloudflare/kumo";
 
 export function InputAreaBasicDemo() {
   return (
@@ -76,6 +76,18 @@ export function InputAreaRowsDemo() {
       <InputArea label="2 rows" placeholder="Small area" rows={2} />
       <InputArea label="4 rows (default)" placeholder="Medium area" rows={4} />
       <InputArea label="8 rows" placeholder="Large area" rows={8} />
+    </div>
+  );
+}
+
+export function InputAreaToolbarDemo() {
+  return (
+    <div className="w-full max-w-3xl">
+      <RichTextInputArea
+        editorClassName="min-h-[180px]"
+        label="Reply"
+        placeholder="Write a reply..."
+      />
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -17,6 +17,7 @@ import {
   InputAreaDisabledDemo,
   InputAreaBareDemo,
   InputAreaRowsDemo,
+  InputAreaToolbarDemo,
   InputAreaOptionalFieldDemo,
   InputAreaLabelTooltipDemo,
   InputAreaReactNodeLabelDemo,
@@ -113,6 +114,16 @@ export default function Example() {
 <p>Use the `rows` prop to control the initial height.</p>
 <ComponentExample demo="InputAreaRowsDemo">
   <InputAreaRowsDemo client:visible />
+</ComponentExample>
+
+### Rich Text Formatting
+
+<p>
+  Use `RichTextInputArea` when formatting controls should apply live rich text
+  inside the editable box. `InputArea` remains a native textarea for plain text.
+</p>
+<ComponentExample demo="InputAreaToolbarDemo">
+  <InputAreaToolbarDemo client:visible />
 </ComponentExample>
 
 ### Error State (String)

--- a/packages/kumo/src/components/input/index.ts
+++ b/packages/kumo/src/components/input/index.ts
@@ -1,5 +1,13 @@
 export { Input, inputVariants, type InputProps } from "./input";
-export { InputArea, Textarea, type InputAreaProps } from "./input-area";
+export {
+  InputArea,
+  RichTextInputArea,
+  Textarea,
+  type InputAreaProps,
+  type InputAreaToolbarPlacement,
+  type RichTextInputAreaControl,
+  type RichTextInputAreaProps,
+} from "./input-area";
 
 // Re-export InputGroup from its new dedicated directory so that the subpath
 // `@cloudflare/kumo/components/input` continues to resolve InputGroup.

--- a/packages/kumo/src/components/input/input-area.tsx
+++ b/packages/kumo/src/components/input/input-area.tsx
@@ -4,6 +4,147 @@ import { useCallback, type ReactNode } from "react";
 import * as React from "react";
 import { Field as FieldBase } from "@base-ui/react/field";
 import { Field as KumoField, normalizeFieldError, type FieldErrorMatch } from "../field/field";
+import { Popover } from "../popover";
+import { Tooltip } from "../tooltip";
+import {
+  CodeBlockIcon,
+  CodeIcon,
+  LinkIcon,
+  ListBulletsIcon,
+  ListNumbersIcon,
+  Quotes,
+  TextBIcon,
+  TextHIcon,
+  TextItalicIcon,
+  TextUnderlineIcon,
+  type Icon,
+} from "@phosphor-icons/react";
+
+type RichTextControlDefinition = {
+  id:
+    | "bold"
+    | "italic"
+    | "underline"
+    | "heading"
+    | "bulletList"
+    | "numberedList"
+    | "quote"
+    | "inlineCode"
+    | "codeBlock"
+    | "link";
+  icon: Icon;
+  ariaLabel: string;
+  command: string;
+  value?: string;
+};
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function normalizeUrl(value: string) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value) ? value : `https://${value}`;
+}
+
+function selectedLines(value: string) {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function closestElement(node: Node) {
+  return node.nodeType === Node.ELEMENT_NODE
+    ? (node as Element)
+    : node.parentElement;
+}
+
+function selectedList(range: Range, editor: HTMLElement) {
+  const containers = [
+    closestElement(range.startContainer),
+    closestElement(range.endContainer),
+    closestElement(range.commonAncestorContainer),
+  ];
+
+  for (const container of containers) {
+    const list = container?.closest("ul, ol");
+    if (list && editor.contains(list)) return list as HTMLUListElement | HTMLOListElement;
+  }
+
+  for (const list of editor.querySelectorAll("ul, ol")) {
+    if (range.intersectsNode(list)) return list as HTMLUListElement | HTMLOListElement;
+  }
+
+  return null;
+}
+
+const RICH_TEXT_LINK_CLASS =
+  "text-kumo-link underline underline-offset-[0.15em] decoration-[0.0625em] link-current transition-colors";
+
+const RICH_TEXT_CONTROLS: readonly RichTextControlDefinition[] = [
+  { id: "bold", icon: TextBIcon, ariaLabel: "Bold", command: "bold" },
+  {
+    id: "italic",
+    icon: TextItalicIcon,
+    ariaLabel: "Italic",
+    command: "italic",
+  },
+  {
+    id: "underline",
+    icon: TextUnderlineIcon,
+    ariaLabel: "Underline",
+    command: "underline",
+  },
+  {
+    id: "heading",
+    icon: TextHIcon,
+    ariaLabel: "Heading",
+    command: "formatBlock",
+    value: "h3",
+  },
+  {
+    id: "bulletList",
+    icon: ListBulletsIcon,
+    ariaLabel: "Bulleted list",
+    command: "insertUnorderedList",
+  },
+  {
+    id: "numberedList",
+    icon: ListNumbersIcon,
+    ariaLabel: "Numbered list",
+    command: "insertOrderedList",
+  },
+  {
+    id: "quote",
+    icon: Quotes,
+    ariaLabel: "Quote",
+    command: "formatBlock",
+    value: "blockquote",
+  },
+  {
+    id: "inlineCode",
+    icon: CodeIcon,
+    ariaLabel: "Inline code",
+    command: "insertHTML",
+  },
+  {
+    id: "codeBlock",
+    icon: CodeBlockIcon,
+    ariaLabel: "Code block",
+    command: "insertHTML",
+  },
+  {
+    id: "link",
+    icon: LinkIcon,
+    ariaLabel: "Insert link",
+    command: "createLink",
+  },
+] as const;
 
 export const InputArea = React.forwardRef<HTMLTextAreaElement, InputAreaProps>(
   (props, ref) => {
@@ -17,6 +158,8 @@ export const InputArea = React.forwardRef<HTMLTextAreaElement, InputAreaProps>(
       labelTooltip,
       description,
       error,
+      toolbar,
+      toolbarPlacement = "top",
       ...inputProps
     } = props;
 
@@ -49,6 +192,69 @@ export const InputArea = React.forwardRef<HTMLTextAreaElement, InputAreaProps>(
       className,
     );
 
+    const toolbarTextareaClassName = cn(
+      "min-w-0 w-full resize-y border-0 bg-transparent text-kumo-default outline-none ring-0 focus:outline-none focus:ring-0",
+      "kumo-input-placeholder disabled:text-kumo-disabled",
+      {
+        xs: "px-1.5 pb-2 text-xs",
+        sm: "px-2 pb-2 text-xs",
+        base: "px-3 pb-3 text-base",
+        lg: "px-4 pb-4 text-base",
+      }[size],
+      toolbarPlacement === "top" ? "pt-1" : "pt-2",
+    );
+
+    const renderControl = (
+      controlProps?: React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    ) => {
+      if (!toolbar) {
+        return (
+          <textarea
+            {...controlProps}
+            ref={ref}
+            className={textareaClassName}
+            onChange={handleChange}
+            {...inputProps}
+          />
+        );
+      }
+
+      return (
+        <div
+          data-kumo-component="InputArea.Control"
+          className={cn(
+            inputVariants({ size, variant, parentFocusIndicator: true }),
+            "grid h-auto gap-0 overflow-hidden p-0 bg-kumo-control",
+            className,
+          )}
+        >
+          {toolbarPlacement === "top" && (
+            <div
+              data-kumo-component="InputArea.Toolbar"
+              className="overflow-x-auto border-b border-kumo-line bg-kumo-elevated p-1"
+            >
+              {toolbar}
+            </div>
+          )}
+          <textarea
+            {...controlProps}
+            ref={ref}
+            className={toolbarTextareaClassName}
+            onChange={handleChange}
+            {...inputProps}
+          />
+          {toolbarPlacement === "bottom" && (
+            <div
+              data-kumo-component="InputArea.Toolbar"
+              className="overflow-x-auto border-t border-kumo-line bg-kumo-elevated p-1"
+            >
+              {toolbar}
+            </div>
+          )}
+        </div>
+      );
+    };
+
     // Render with Field wrapper if label, error, or description is provided
     // Use FieldBase.Control with render callback to ensure proper label-textarea association.
     // The render callback receives props with the correct id/aria-labelledby from Field context.
@@ -62,29 +268,14 @@ export const InputArea = React.forwardRef<HTMLTextAreaElement, InputAreaProps>(
           error={normalizeFieldError(error)}
         >
           <FieldBase.Control
-            render={(controlProps) => (
-              <textarea
-                {...controlProps}
-                ref={ref}
-                className={textareaClassName}
-                onChange={handleChange}
-                {...inputProps}
-              />
-            )}
+            render={(controlProps) => renderControl(controlProps)}
           />
         </KumoField>
       );
     }
 
     // Render bare textarea without Field wrapper
-    return (
-      <textarea
-        ref={ref}
-        className={textareaClassName}
-        onChange={handleChange}
-        {...inputProps}
-      />
-    );
+    return renderControl();
   },
 );
 
@@ -99,6 +290,8 @@ export const Textarea = InputArea;
  * @property {ReactNode} [description] - Helper text displayed below the textarea
  * @property {string | { message: ReactNode, match: FieldErrorMatch }} [error] - Error message or validation error object
  */
+export type InputAreaToolbarPlacement = "top" | "bottom";
+
 export type InputAreaProps = {
   onValueChange?: (value: string) => void;
   variant?: "default" | "error";
@@ -114,6 +307,479 @@ export type InputAreaProps = {
   description?: ReactNode;
   /** Error message or validation error object */
   error?: string | { message: ReactNode; match: FieldErrorMatch };
+  /** Inline controls rendered inside the textarea shell. */
+  toolbar?: ReactNode;
+  /** Where to render inline controls when `toolbar` is provided. Defaults to `"top"`. */
+  toolbarPlacement?: InputAreaToolbarPlacement;
 
   // Finally, spread the native input props (least important)
 } & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "size">;
+
+export type RichTextInputAreaControl = (typeof RICH_TEXT_CONTROLS)[number]["id"];
+
+export const RichTextInputArea = React.forwardRef<
+  HTMLDivElement,
+  RichTextInputAreaProps
+>((props, ref) => {
+  const {
+    className,
+    editorClassName,
+    onValueChange,
+    size = "base",
+    variant: variantProp,
+    label,
+    labelTooltip,
+    description,
+    error,
+    required,
+    value,
+    defaultValue,
+    placeholder,
+    disabled,
+    controls = RICH_TEXT_CONTROLS.map((control) => control.id),
+    onClick,
+    onInput,
+    onKeyDown,
+    ...rootProps
+  } = props;
+  const editorRef = React.useRef<HTMLDivElement>(null);
+  const linkInputRef = React.useRef<HTMLInputElement>(null);
+  const initializedRef = React.useRef(false);
+  const savedSelectionRef = React.useRef<Range | null>(null);
+  const [linkPopoverOpen, setLinkPopoverOpen] = React.useState(false);
+  const [linkUrl, setLinkUrl] = React.useState("");
+  const [linkText, setLinkText] = React.useState("");
+  const linkUrlId = React.useId();
+  const linkTextId = React.useId();
+
+  React.useImperativeHandle(ref, () => editorRef.current as HTMLDivElement);
+
+  React.useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    if (value !== undefined) {
+      if (editor.innerHTML !== value) editor.innerHTML = value;
+      return;
+    }
+
+    if (!initializedRef.current) {
+      editor.innerHTML = defaultValue ?? "";
+      initializedRef.current = true;
+    }
+  }, [defaultValue, value]);
+
+  React.useEffect(() => {
+    if (!linkPopoverOpen) return;
+
+    requestAnimationFrame(() => {
+      linkInputRef.current?.focus({ preventScroll: true });
+    });
+  }, [linkPopoverOpen]);
+
+  const variant = variantProp ?? (error ? "error" : "default");
+
+  const handleInput = useCallback(
+    (event: React.FormEvent<HTMLDivElement>) => {
+      onInput?.(event);
+      onValueChange?.(event.currentTarget.innerHTML);
+    },
+    [onInput, onValueChange],
+  );
+
+  const handleEditorClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented || (!event.metaKey && !event.ctrlKey)) return;
+
+      const link = (event.target as Element | null)?.closest("a[href]");
+      if (!link) return;
+
+      event.preventDefault();
+      window.open(
+        (link as HTMLAnchorElement).href,
+        "_blank",
+        "noopener,noreferrer",
+      );
+    },
+    [onClick],
+  );
+
+  const handleEditorKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(event);
+    },
+    [onKeyDown],
+  );
+
+  const saveSelection = useCallback(() => {
+    const selection = window.getSelection();
+    const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+    const editor = editorRef.current;
+
+    if (!range || !editor || !editor.contains(range.commonAncestorContainer)) {
+      savedSelectionRef.current = null;
+      return;
+    }
+
+    savedSelectionRef.current = range.cloneRange();
+  }, []);
+
+  const restoreSelection = useCallback(() => {
+    const selection = window.getSelection();
+    if (!selection || !savedSelectionRef.current) return;
+
+    selection.removeAllRanges();
+    selection.addRange(savedSelectionRef.current);
+  }, []);
+
+  const insertHtmlAtSelection = useCallback(
+    (html: string) => {
+      const editor = editorRef.current;
+      if (!editor) return;
+
+      editor.focus();
+      restoreSelection();
+
+      const selection = window.getSelection();
+      const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+      if (!selection || !range) return;
+
+      range.deleteContents();
+
+      const template = document.createElement("template");
+      template.innerHTML = html;
+      const fragment = template.content;
+      const lastChild = fragment.lastChild;
+
+      range.insertNode(fragment);
+
+      if (lastChild) {
+        range.setStartAfter(lastChild);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      savedSelectionRef.current = null;
+      onValueChange?.(editor.innerHTML);
+    },
+    [onValueChange, restoreSelection],
+  );
+
+  const runCommand = useCallback(
+    (control: (typeof RICH_TEXT_CONTROLS)[number]) => {
+      if (disabled) return;
+
+      editorRef.current?.focus();
+      restoreSelection();
+
+      if (control.id === "inlineCode") {
+        const selectedText = window.getSelection()?.toString() ?? "code";
+        document.execCommand(
+          control.command,
+          false,
+          `<code>${escapeHtml(selectedText || "code")}</code>`,
+        );
+      } else if (control.id === "codeBlock") {
+        const selectedText = window.getSelection()?.toString() ?? "code";
+        document.execCommand(
+          control.command,
+          false,
+          `<pre><code>${escapeHtml(selectedText || "code")}</code></pre><div><br></div>`,
+        );
+      } else if (control.id === "bulletList" || control.id === "numberedList") {
+        const editor = editorRef.current;
+        const selection = window.getSelection();
+        const range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+        const listTag = control.id === "bulletList" ? "ul" : "ol";
+
+        if (editor && range) {
+          const list = selectedList(range, editor);
+
+          if (list) {
+            if (list.localName !== listTag) {
+              const replacement = document.createElement(listTag);
+              replacement.innerHTML = list.innerHTML;
+              list.replaceWith(replacement);
+              onValueChange?.(editor.innerHTML);
+            }
+
+            savedSelectionRef.current = null;
+            return;
+          }
+        }
+
+        const selectedText = window.getSelection()?.toString() ?? "";
+        const lines = selectedLines(selectedText);
+        const items = lines.length
+          ? lines.map((line) => `<li>${escapeHtml(line)}</li>`).join("")
+          : "<li><br></li>";
+
+        insertHtmlAtSelection(`<${listTag}>${items}</${listTag}><div><br></div>`);
+        return;
+      } else if (control.id === "quote") {
+        const selectedText = window.getSelection()?.toString() ?? "";
+        const quote = selectedText
+          ? escapeHtml(selectedText).replaceAll("\n", "<br>")
+          : "<br>";
+
+        insertHtmlAtSelection(`<blockquote>${quote}</blockquote><div><br></div>`);
+        return;
+      } else {
+        document.execCommand(
+          control.command,
+          false,
+          "value" in control ? control.value : undefined,
+        );
+      }
+
+      if (editorRef.current) onValueChange?.(editorRef.current.innerHTML);
+    },
+    [disabled, insertHtmlAtSelection, onValueChange, restoreSelection],
+  );
+
+  const insertLink = useCallback(
+    (url: string, displayText?: string) => {
+      const editor = editorRef.current;
+      if (!editor) return;
+
+      editor.focus();
+
+      const selection = window.getSelection();
+      if (selection && savedSelectionRef.current) {
+        selection.removeAllRanges();
+        selection.addRange(savedSelectionRef.current);
+      }
+
+      const selectedText = displayText || selection?.toString() || url;
+      document.execCommand(
+        "insertHTML",
+        false,
+        `<a class="${RICH_TEXT_LINK_CLASS}" href="${escapeHtml(url)}">${escapeHtml(selectedText)}</a>`,
+      );
+
+      onValueChange?.(editor.innerHTML);
+    },
+    [onValueChange],
+  );
+
+  const submitLink = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const url = linkUrl.trim();
+      if (!url) return;
+
+      insertLink(normalizeUrl(url), linkText.trim() || undefined);
+      setLinkPopoverOpen(false);
+      setLinkUrl("");
+      setLinkText("");
+    },
+    [insertLink, linkText, linkUrl],
+  );
+
+  const editorClass = cn(
+    "min-w-0 w-full overflow-auto bg-kumo-control text-kumo-default outline-none",
+    "empty:before:pointer-events-none empty:before:content-[attr(data-placeholder)] empty:before:text-kumo-placeholder",
+    "[&_code]:rounded-sm [&_code]:bg-kumo-recessed [&_code]:px-1 [&_code]:font-mono [&_code]:text-sm",
+    "[&_a]:text-kumo-link [&_a]:underline [&_a]:underline-offset-[0.15em] [&_a]:decoration-[0.0625em]",
+    "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-kumo-line [&_blockquote]:pl-3 [&_blockquote]:text-kumo-muted",
+    "[&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-6 [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-6",
+    "[&_pre]:my-2 [&_pre]:rounded-md [&_pre]:bg-kumo-recessed [&_pre]:p-2 [&_pre]:font-mono [&_pre]:text-sm",
+    "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
+    disabled && "cursor-not-allowed opacity-50",
+    {
+      xs: "min-h-[60px] px-1.5 py-2 text-xs",
+      sm: "min-h-[72px] px-2 py-2 text-xs",
+      base: "min-h-[88px] px-3 py-3 text-base",
+      lg: "min-h-[100px] px-4 py-4 text-base",
+    }[size],
+    editorClassName,
+  );
+
+  const control = (
+    <div
+      className={cn(
+        inputVariants({ size, variant, parentFocusIndicator: true }),
+        "grid h-auto gap-0 overflow-hidden p-0 bg-kumo-control",
+        className,
+      )}
+    >
+      <div className="flex overflow-x-auto border-b border-kumo-line bg-kumo-elevated p-1">
+        {RICH_TEXT_CONTROLS.filter((item) => controls.includes(item.id)).map(
+          (item) => {
+            const IconComponent = item.icon;
+
+            const button = (
+              <button
+                aria-label={item.ariaLabel}
+                className={cn(
+                  "inline-flex h-7 w-8 shrink-0 cursor-pointer items-center justify-center text-kumo-default",
+                  "not-first:border-l not-first:border-kumo-line hover:bg-kumo-base focus:z-2 focus:outline-none focus:ring-[1.5px] focus:ring-kumo-focus/50",
+                  disabled &&
+                    "cursor-not-allowed pointer-events-none opacity-50",
+                )}
+                disabled={disabled}
+                onMouseDown={(event) => {
+                  saveSelection();
+                  event.preventDefault();
+                }}
+                onClick={() => {
+                  if (item.id === "link") {
+                    saveSelection();
+                    setLinkText(window.getSelection()?.toString() ?? "");
+                    setLinkPopoverOpen(true);
+                    return;
+                  }
+
+                  runCommand(item);
+                }}
+                type="button"
+              >
+                <IconComponent aria-hidden size={16} />
+              </button>
+            );
+
+            if (item.id === "link") {
+              return (
+                <Popover
+                  key={item.id}
+                  open={linkPopoverOpen}
+                  onOpenChange={setLinkPopoverOpen}
+                >
+                  <Tooltip
+                    className={disabled ? "cursor-not-allowed" : "cursor-pointer"}
+                    content={item.ariaLabel}
+                    delay={300}
+                    render={<Popover.Trigger render={button} />}
+                  />
+                  <Popover.Content align="start" className="w-72 gap-3" side="bottom">
+                    <Popover.Title>Insert link</Popover.Title>
+                    <form className="grid gap-3" onSubmit={submitLink}>
+                      <label
+                        className="grid gap-1 text-sm font-medium text-kumo-default"
+                        htmlFor={linkUrlId}
+                      >
+                        URL
+                        <input
+                          aria-label="URL"
+                          id={linkUrlId}
+                          ref={linkInputRef}
+                          className="h-8 rounded-md border-0 bg-kumo-control px-2 text-sm text-kumo-default ring ring-kumo-line outline-none focus:ring-[1.5px] focus:ring-kumo-focus/50"
+                          onChange={(event) => setLinkUrl(event.target.value)}
+                          placeholder="https://example.com"
+                          type="text"
+                          value={linkUrl}
+                        />
+                      </label>
+                      <label
+                        className="grid gap-1 text-sm font-medium text-kumo-default"
+                        htmlFor={linkTextId}
+                      >
+                        Display text
+                        <input
+                          aria-label="Display text"
+                          id={linkTextId}
+                          className="h-8 rounded-md border-0 bg-kumo-control px-2 text-sm text-kumo-default ring ring-kumo-line outline-none focus:ring-[1.5px] focus:ring-kumo-focus/50"
+                          onChange={(event) => setLinkText(event.target.value)}
+                          placeholder="Link text"
+                          type="text"
+                          value={linkText}
+                        />
+                      </label>
+                      <div className="flex justify-end gap-2">
+                        <button
+                          className="h-7 cursor-pointer rounded-md px-2 text-sm text-kumo-default hover:bg-kumo-elevated"
+                          onClick={() => {
+                            setLinkPopoverOpen(false);
+                            setLinkUrl("");
+                            setLinkText("");
+                          }}
+                          type="button"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          className="h-7 cursor-pointer rounded-md bg-kumo-contrast px-2 text-sm text-kumo-inverse hover:opacity-90"
+                          type="submit"
+                        >
+                          Insert
+                        </button>
+                      </div>
+                    </form>
+                  </Popover.Content>
+                </Popover>
+              );
+            }
+
+            return (
+              <Tooltip
+                key={item.id}
+                className={disabled ? "cursor-not-allowed" : "cursor-pointer"}
+                content={item.ariaLabel}
+                delay={300}
+                render={button}
+              />
+            );
+          },
+        )}
+      </div>
+      <div
+        {...rootProps}
+        ref={editorRef}
+        aria-disabled={disabled || undefined}
+        aria-multiline="true"
+        className={editorClass}
+        contentEditable={!disabled}
+        data-placeholder={placeholder}
+        onClick={handleEditorClick}
+        onInput={handleInput}
+        onKeyDown={handleEditorKeyDown}
+        role="textbox"
+        suppressContentEditableWarning
+        tabIndex={rootProps.tabIndex ?? 0}
+      />
+    </div>
+  );
+
+  if (label || error || description) {
+    return (
+      <KumoField
+        label={label}
+        required={required}
+        labelTooltip={labelTooltip}
+        description={description}
+        error={normalizeFieldError(error)}
+      >
+        {control}
+      </KumoField>
+    );
+  }
+
+  return control;
+});
+
+RichTextInputArea.displayName = "RichTextInputArea";
+
+export type RichTextInputAreaProps = {
+  onValueChange?: (value: string) => void;
+  variant?: "default" | "error";
+  size?: "xs" | "sm" | "base" | "lg";
+  className?: string;
+  editorClassName?: string;
+  label?: ReactNode;
+  labelTooltip?: ReactNode;
+  description?: ReactNode;
+  error?: string | { message: ReactNode; match: FieldErrorMatch };
+  required?: boolean;
+  value?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  controls?: RichTextInputAreaControl[];
+  onInput?: React.FormEventHandler<HTMLDivElement>;
+} & Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children" | "defaultValue" | "onInput"
+>;

--- a/packages/kumo/src/components/input/input.test.tsx
+++ b/packages/kumo/src/components/input/input.test.tsx
@@ -1,12 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import { createRef } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import {
   Input,
   inputVariants,
   KUMO_INPUT_VARIANTS,
   KUMO_INPUT_DEFAULT_VARIANTS,
 } from "./input";
+import { InputArea, RichTextInputArea } from "./input-area";
+
+function selectEditorContents(editor: HTMLElement) {
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
 
 describe("Input", () => {
   // Rendering
@@ -226,5 +236,279 @@ describe("Input", () => {
   it("exports KUMO_INPUT_DEFAULT_VARIANTS with correct defaults", () => {
     expect(KUMO_INPUT_DEFAULT_VARIANTS.size).toBe("base");
     expect(KUMO_INPUT_DEFAULT_VARIANTS.variant).toBe("default");
+  });
+});
+
+describe("InputArea", () => {
+  it("renders toolbar controls inside the textarea shell", () => {
+    const { container } = render(
+      <InputArea
+        aria-label="Comment"
+        toolbar={<button type="button">Bold</button>}
+      />,
+    );
+
+    expect(screen.getByRole("textbox")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Bold" })).toBeTruthy();
+    expect(
+      container.querySelector('[data-kumo-component="InputArea.Control"]'),
+    ).toBeTruthy();
+  });
+
+  it("renders toolbar controls above the textarea by default", () => {
+    const { container } = render(
+      <InputArea
+        aria-label="Comment"
+        toolbar={<button type="button">Bold</button>}
+      />,
+    );
+
+    const control = container.querySelector(
+      '[data-kumo-component="InputArea.Control"]',
+    );
+    expect(
+      control?.firstElementChild?.getAttribute("data-kumo-component"),
+    ).toBe("InputArea.Toolbar");
+    expect(control?.firstElementChild?.className).toContain("border-b");
+  });
+
+  it("supports rendering toolbar controls below the textarea", () => {
+    const { container } = render(
+      <InputArea
+        aria-label="Comment"
+        toolbar={<button type="button">Bold</button>}
+        toolbarPlacement="bottom"
+      />,
+    );
+
+    const control = container.querySelector(
+      '[data-kumo-component="InputArea.Control"]',
+    );
+    expect(
+      control?.lastElementChild?.getAttribute("data-kumo-component"),
+    ).toBe("InputArea.Toolbar");
+    expect(control?.lastElementChild?.className).toContain("border-t");
+  });
+});
+
+describe("RichTextInputArea", () => {
+  it("renders a hard formatting toolbar above the editable box", () => {
+    render(<RichTextInputArea aria-label="Reply" />);
+
+    expect(screen.getByRole("textbox")).toHaveProperty(
+      "contentEditable",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Bold" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Italic" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Bulleted list" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Inline code" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Code block" })).toBeTruthy();
+  });
+
+  it("applies formatting commands from toolbar buttons", () => {
+    document.execCommand = vi.fn(() => true);
+    const execCommand = vi
+      .spyOn(document, "execCommand")
+      .mockImplementation(() => true);
+    render(<RichTextInputArea aria-label="Reply" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Bold" }));
+
+    expect(execCommand).toHaveBeenCalledWith("bold", false, undefined);
+    execCommand.mockRestore();
+  });
+
+  it("applies inline code formatting", () => {
+    document.execCommand = vi.fn(() => true);
+    const execCommand = vi
+      .spyOn(document, "execCommand")
+      .mockImplementation(() => true);
+    render(<RichTextInputArea aria-label="Reply" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Inline code" }));
+
+    expect(execCommand).toHaveBeenCalledWith(
+      "insertHTML",
+      false,
+      "<code>code</code>",
+    );
+    execCommand.mockRestore();
+  });
+
+  it("applies code block formatting", () => {
+    document.execCommand = vi.fn(() => true);
+    const execCommand = vi
+      .spyOn(document, "execCommand")
+      .mockImplementation(() => true);
+    render(<RichTextInputArea aria-label="Reply" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Code block" }));
+
+    expect(execCommand).toHaveBeenCalledWith(
+      "insertHTML",
+      false,
+      "<pre><code>code</code></pre><div><br></div>",
+    );
+    execCommand.mockRestore();
+  });
+
+  it("inserts bulleted list markup from selected lines", () => {
+    render(<RichTextInputArea aria-label="Reply" defaultValue={"One\nTwo"} />);
+
+    const editor = screen.getByRole("textbox");
+    selectEditorContents(editor);
+    const button = screen.getByRole("button", { name: "Bulleted list" });
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    expect(editor.innerHTML).toContain("<ul>");
+    expect(editor.innerHTML).toContain("<li>One</li>");
+    expect(editor.innerHTML).toContain("<li>Two</li>");
+  });
+
+  it("inserts numbered list markup from selected lines", () => {
+    render(<RichTextInputArea aria-label="Reply" defaultValue={"One\nTwo"} />);
+
+    const editor = screen.getByRole("textbox");
+    selectEditorContents(editor);
+    const button = screen.getByRole("button", { name: "Numbered list" });
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    expect(editor.innerHTML).toContain("<ol>");
+    expect(editor.innerHTML).toContain("<li>One</li>");
+    expect(editor.innerHTML).toContain("<li>Two</li>");
+  });
+
+  it("converts selected bulleted lists to numbered lists", () => {
+    render(
+      <RichTextInputArea
+        aria-label="Reply"
+        defaultValue="<ul><li>One</li><li>Two</li></ul>"
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    selectEditorContents(editor);
+    const button = screen.getByRole("button", { name: "Numbered list" });
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    expect(editor.querySelector("ul")).toBeNull();
+    expect(editor.querySelector("ol")?.innerHTML).toBe(
+      "<li>One</li><li>Two</li>",
+    );
+  });
+
+  it("converts selected numbered lists to bulleted lists", () => {
+    render(
+      <RichTextInputArea
+        aria-label="Reply"
+        defaultValue="<ol><li>One</li><li>Two</li></ol>"
+      />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    selectEditorContents(editor);
+    const button = screen.getByRole("button", { name: "Bulleted list" });
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    expect(editor.querySelector("ol")).toBeNull();
+    expect(editor.querySelector("ul")?.innerHTML).toBe(
+      "<li>One</li><li>Two</li>",
+    );
+  });
+
+  it("inserts quote markup from selected text", () => {
+    render(<RichTextInputArea aria-label="Reply" defaultValue="Quoted text" />);
+
+    const editor = screen.getByRole("textbox");
+    selectEditorContents(editor);
+    const button = screen.getByRole("button", { name: "Quote" });
+    fireEvent.mouseDown(button);
+    fireEvent.click(button);
+
+    expect(editor.innerHTML).toContain("<blockquote>Quoted text</blockquote>");
+  });
+
+  it("inserts inline links from the link toolbar button", () => {
+    document.execCommand = vi.fn(() => true);
+    const execCommand = vi
+      .spyOn(document, "execCommand")
+      .mockImplementation(() => true);
+    render(<RichTextInputArea aria-label="Reply" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "https://example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+
+    expect(execCommand).toHaveBeenCalledWith(
+      "insertHTML",
+      false,
+      '<a class="text-kumo-link underline underline-offset-[0.15em] decoration-[0.0625em] link-current transition-colors" href="https://example.com">https://example.com</a>',
+    );
+    execCommand.mockRestore();
+  });
+
+  it("inserts inline links with display text and normalizes bare domains", () => {
+    document.execCommand = vi.fn(() => true);
+    const execCommand = vi
+      .spyOn(document, "execCommand")
+      .mockImplementation(() => true);
+    render(<RichTextInputArea aria-label="Reply" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "www.google.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Display text"), {
+      target: { value: "Google" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+
+    expect(execCommand).toHaveBeenCalledWith(
+      "insertHTML",
+      false,
+      '<a class="text-kumo-link underline underline-offset-[0.15em] decoration-[0.0625em] link-current transition-colors" href="https://www.google.com">Google</a>',
+    );
+    execCommand.mockRestore();
+  });
+
+  it("opens editor links on modifier click", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(
+      <RichTextInputArea
+        aria-label="Reply"
+        defaultValue={'<a href="https://example.com">Example</a>'}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Example" }), {
+      metaKey: true,
+    });
+
+    expect(open).toHaveBeenCalledWith(
+      "https://example.com/",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    open.mockRestore();
+  });
+
+  it("reports edited HTML through onValueChange", () => {
+    const onValueChange = vi.fn();
+    render(
+      <RichTextInputArea aria-label="Reply" onValueChange={onValueChange} />,
+    );
+
+    const editor = screen.getByRole("textbox");
+    editor.innerHTML = "<strong>Hello</strong>";
+    fireEvent.input(editor);
+
+    expect(onValueChange).toHaveBeenCalledWith("<strong>Hello</strong>");
   });
 });

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -107,8 +107,12 @@ export {
   inputVariants,
   type InputProps,
   InputArea,
+  RichTextInputArea,
   Textarea,
   type InputAreaProps,
+  type InputAreaToolbarPlacement,
+  type RichTextInputAreaControl,
+  type RichTextInputAreaProps,
 } from "./components/input";
 export {
   InputGroup,


### PR DESCRIPTION
## Summary

- Adds `RichTextInputArea` with a top formatting toolbar for bold, italic, underline, heading, lists, quote, code, code block, and links.
- Adds link insertion with URL and display text fields, normalized bare domains, Kumo link styling, and modifier-click opening.
- Adds `InputArea` toolbar slots, exports, tests, docs, and a changeset.

## Tests

- `pnpm --filter @cloudflare/kumo exec vitest run --project=unit src/components/input/input.test.tsx`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo build`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: automated review has not run yet for this new PR
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable
