### PR TITLE
feat(lint): add Flow.Node render rule

### DIFF
--- a/.changeset/flow-node-render-lint.md
+++ b/.changeset/flow-node-render-lint.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add a lint rule that verifies custom components used with `Flow.Node`'s `render` prop forward refs and spread received props.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,6 +8,7 @@
   "rules": {
     "kumo/no-cross-package-imports": "error",
     "kumo/no-primitive-colors": "error",
-    "kumo/no-tailwind-dark-variant": "error"
+    "kumo/no-tailwind-dark-variant": "error",
+    "kumo/no-flow-node-custom-render": "error"
   }
 }

--- a/lint/kumo-plugin.js
+++ b/lint/kumo-plugin.js
@@ -2,6 +2,7 @@ import { noTailwindDarkVariantRule } from "./no-tailwind-dark-variant.js";
 import { noPrimitiveColorsRule } from "./no-primitive-colors.js";
 import { enforceVariantStandardRule } from "./enforce-variant-standard.js";
 import { noCrossPackageImportsRule } from "./no-cross-package-imports.js";
+import { noFlowNodeCustomRenderRule } from "./no-flow-node-custom-render.js";
 
 const plugin = {
   meta: {
@@ -12,6 +13,7 @@ const plugin = {
     "no-primitive-colors": noPrimitiveColorsRule,
     "enforce-variant-standard": enforceVariantStandardRule,
     "no-cross-package-imports": noCrossPackageImportsRule,
+    "no-flow-node-custom-render": noFlowNodeCustomRenderRule,
   },
 };
 

--- a/lint/no-flow-node-custom-render.js
+++ b/lint/no-flow-node-custom-render.js
@@ -1,0 +1,376 @@
+import { defineRule } from "oxlint";
+
+function traverse(node, visitors, seen = new WeakSet()) {
+  if (!node || typeof node !== "object" || seen.has(node)) {
+    return;
+  }
+
+  seen.add(node);
+
+  const visitor = visitors[node.type];
+  if (visitor) {
+    visitor(node);
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (
+      key === "parent" ||
+      key === "loc" ||
+      key === "range" ||
+      key === "start" ||
+      key === "end"
+    ) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        traverse(child, visitors, seen);
+      }
+    } else if (value && typeof value === "object") {
+      traverse(value, visitors, seen);
+    }
+  }
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    current &&
+    (current.type === "TSAsExpression" ||
+      current.type === "TSSatisfiesExpression" ||
+      current.type === "TSNonNullExpression" ||
+      current.type === "ChainExpression")
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function getLiteralValue(node) {
+  if (node?.type === "Literal" || node?.type === "StringLiteral") {
+    return node.value;
+  }
+  return null;
+}
+
+function getIdentifierName(node) {
+  if (node?.type === "Identifier" || node?.type === "JSXIdentifier") {
+    return node.name;
+  }
+  return null;
+}
+
+function getPropertyName(node) {
+  if (!node) return null;
+  if (node.type === "Identifier" || node.type === "PrivateIdentifier") {
+    return node.name;
+  }
+  if (node.type === "Literal" || node.type === "StringLiteral") {
+    return node.value;
+  }
+  return null;
+}
+
+function getJSXName(node) {
+  if (node?.type === "JSXIdentifier") {
+    return node.name;
+  }
+  if (node?.type === "JSXMemberExpression") {
+    const objectName = getJSXName(node.object);
+    const propertyName = getJSXName(node.property);
+    return objectName && propertyName ? `${objectName}.${propertyName}` : null;
+  }
+  return null;
+}
+
+function isComponentName(name) {
+  return typeof name === "string" && /^[A-Z]/.test(name);
+}
+
+function getJSXAttributeName(attr) {
+  return attr?.name?.type === "JSXIdentifier" ? attr.name.name : null;
+}
+
+function getJSXExpression(value) {
+  if (value?.type === "JSXExpressionContainer") {
+    return value.expression;
+  }
+  return value;
+}
+
+function getFlowNodeRenderComponentName(node) {
+  if (getJSXName(node.name) !== "Flow.Node") {
+    return null;
+  }
+
+  for (const attr of node.attributes ?? []) {
+    if (
+      attr.type !== "JSXAttribute" ||
+      getJSXAttributeName(attr) !== "render"
+    ) {
+      continue;
+    }
+
+    const renderExpression = getJSXExpression(attr.value);
+    if (renderExpression?.type !== "JSXElement") {
+      return null;
+    }
+
+    const componentName = getJSXName(renderExpression.openingElement?.name);
+    if (isComponentName(componentName)) {
+      return { componentName, node: attr };
+    }
+  }
+
+  return null;
+}
+
+function isForwardRefCallee(callee, forwardRefNames) {
+  const unwrapped = unwrapExpression(callee);
+  const identifierName = getIdentifierName(unwrapped);
+  if (identifierName && forwardRefNames.has(identifierName)) {
+    return true;
+  }
+
+  if (unwrapped?.type === "MemberExpression") {
+    return getPropertyName(unwrapped.property) === "forwardRef";
+  }
+
+  return false;
+}
+
+function getFirstFunctionArgument(node) {
+  for (const arg of node.arguments ?? []) {
+    if (arg.type === "SpreadElement") continue;
+    const unwrapped = unwrapExpression(arg);
+    if (
+      unwrapped?.type === "FunctionExpression" ||
+      unwrapped?.type === "ArrowFunctionExpression"
+    ) {
+      return unwrapped;
+    }
+  }
+  return null;
+}
+
+function findForwardRefRenderFunction(node, forwardRefNames) {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped?.type !== "CallExpression") {
+    return null;
+  }
+
+  if (isForwardRefCallee(unwrapped.callee, forwardRefNames)) {
+    return getFirstFunctionArgument(unwrapped);
+  }
+
+  for (const arg of unwrapped.arguments ?? []) {
+    if (arg.type === "SpreadElement") continue;
+    const found = findForwardRefRenderFunction(arg, forwardRefNames);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+function getPropsParamNames(param) {
+  const names = new Set();
+  const unwrapped = unwrapExpression(param);
+
+  if (unwrapped?.type === "Identifier") {
+    names.add(unwrapped.name);
+  } else if (unwrapped?.type === "AssignmentPattern") {
+    for (const name of getPropsParamNames(unwrapped.left)) {
+      names.add(name);
+    }
+  } else if (unwrapped?.type === "ObjectPattern") {
+    for (const prop of unwrapped.properties ?? []) {
+      if (prop.type === "RestElement" && prop.argument?.type === "Identifier") {
+        names.add(prop.argument.name);
+      }
+    }
+  }
+
+  return names;
+}
+
+function getRefParamNames(param) {
+  const names = new Set();
+  const unwrapped = unwrapExpression(param);
+
+  if (unwrapped?.type === "Identifier") {
+    names.add(unwrapped.name);
+  } else if (unwrapped?.type === "AssignmentPattern") {
+    for (const name of getRefParamNames(unwrapped.left)) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+function expressionContainsIdentifier(node, names) {
+  let found = false;
+  traverse(node, {
+    Identifier(identifier) {
+      if (names.has(identifier.name)) {
+        found = true;
+      }
+    },
+  });
+  return found;
+}
+
+function analyzeRenderFunction(fn, usesForwardRef) {
+  const propsNames = getPropsParamNames(fn.params?.[0]);
+  const refNames = usesForwardRef
+    ? getRefParamNames(fn.params?.[1])
+    : new Set();
+  let spreadsProps = false;
+  let forwardsRef = false;
+
+  traverse(fn.body, {
+    JSXSpreadAttribute(node) {
+      const argumentName = getIdentifierName(unwrapExpression(node.argument));
+      if (argumentName && propsNames.has(argumentName)) {
+        spreadsProps = true;
+      }
+    },
+    JSXAttribute(node) {
+      if (getJSXAttributeName(node) !== "ref") {
+        return;
+      }
+
+      const expression = getJSXExpression(node.value);
+      if (expressionContainsIdentifier(expression, refNames)) {
+        forwardsRef = true;
+      }
+    },
+  });
+
+  return {
+    forwardsRef: usesForwardRef && forwardsRef,
+    spreadsProps,
+  };
+}
+
+function getComponentInfoFromVariable(node, forwardRefNames) {
+  const componentName = getIdentifierName(node.id);
+  if (!isComponentName(componentName)) {
+    return null;
+  }
+
+  const forwardRefRenderFunction = findForwardRefRenderFunction(
+    node.init,
+    forwardRefNames,
+  );
+  if (forwardRefRenderFunction) {
+    return {
+      componentName,
+      info: analyzeRenderFunction(forwardRefRenderFunction, true),
+    };
+  }
+
+  const init = unwrapExpression(node.init);
+  if (
+    init?.type === "FunctionExpression" ||
+    init?.type === "ArrowFunctionExpression"
+  ) {
+    return {
+      componentName,
+      info: analyzeRenderFunction(init, false),
+    };
+  }
+
+  return null;
+}
+
+export const noFlowNodeCustomRenderRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Ensure custom components used in Flow.Node render forward refs and spread props.",
+    },
+    messages: {
+      missingRef:
+        "<{{component}}> used in Flow.Node render must forward the ref it receives.",
+      missingProps:
+        "<{{component}}> used in Flow.Node render must spread received props onto its root element.",
+      missingRefAndProps:
+        "<{{component}}> used in Flow.Node render must forward its ref and spread received props onto its root element.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  createOnce(context) {
+    const forwardRefNames = new Set(["forwardRef"]);
+    const components = new Map();
+    const usages = [];
+
+    return {
+      ImportDeclaration(node) {
+        if (getLiteralValue(node.source) !== "react") {
+          return;
+        }
+
+        for (const specifier of node.specifiers ?? []) {
+          if (
+            specifier.type === "ImportSpecifier" &&
+            getIdentifierName(specifier.imported) === "forwardRef"
+          ) {
+            forwardRefNames.add(
+              getIdentifierName(specifier.local) ?? "forwardRef",
+            );
+          }
+        }
+      },
+      FunctionDeclaration(node) {
+        const componentName = getIdentifierName(node.id);
+        if (isComponentName(componentName)) {
+          components.set(componentName, analyzeRenderFunction(node, false));
+        }
+      },
+      VariableDeclarator(node) {
+        const result = getComponentInfoFromVariable(node, forwardRefNames);
+        if (result) {
+          components.set(result.componentName, result.info);
+        }
+      },
+      JSXOpeningElement(node) {
+        const usage = getFlowNodeRenderComponentName(node);
+        if (usage) {
+          usages.push(usage);
+        }
+      },
+      "Program:exit"() {
+        for (const usage of usages) {
+          const info = components.get(usage.componentName);
+          if (!info) {
+            continue;
+          }
+
+          const missingRef = !info.forwardsRef;
+          const missingProps = !info.spreadsProps;
+
+          if (!missingRef && !missingProps) {
+            continue;
+          }
+
+          context.report({
+            node: usage.node,
+            messageId:
+              missingRef && missingProps
+                ? "missingRefAndProps"
+                : missingRef
+                  ? "missingRef"
+                  : "missingProps",
+            data: {
+              component: usage.componentName,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/lint/no-flow-node-custom-render.js
+++ b/lint/no-flow-node-custom-render.js
@@ -1,6 +1,12 @@
 import { defineRule } from "oxlint";
 
-function traverse(node, visitors, seen = new WeakSet()) {
+function traverse(
+  node,
+  visitors,
+  seen = new WeakSet(),
+  parent = null,
+  parentKey = null,
+) {
   if (!node || typeof node !== "object" || seen.has(node)) {
     return;
   }
@@ -9,7 +15,7 @@ function traverse(node, visitors, seen = new WeakSet()) {
 
   const visitor = visitors[node.type];
   if (visitor) {
-    visitor(node);
+    visitor(node, parent, parentKey);
   }
 
   for (const [key, value] of Object.entries(node)) {
@@ -25,10 +31,10 @@ function traverse(node, visitors, seen = new WeakSet()) {
 
     if (Array.isArray(value)) {
       for (const child of value) {
-        traverse(child, visitors, seen);
+        traverse(child, visitors, seen, node, key);
       }
     } else if (value && typeof value === "object") {
-      traverse(value, visitors, seen);
+      traverse(value, visitors, seen, node, key);
     }
   }
 }
@@ -209,11 +215,23 @@ function getRefParamNames(param) {
   return names;
 }
 
+function isNonComputedMemberProperty(identifier, parent, parentKey) {
+  return (
+    parent?.type === "MemberExpression" &&
+    parentKey === "property" &&
+    parent.property === identifier &&
+    !parent.computed
+  );
+}
+
 function expressionContainsIdentifier(node, names) {
   let found = false;
   traverse(node, {
-    Identifier(identifier) {
-      if (names.has(identifier.name)) {
+    Identifier(identifier, parent, parentKey) {
+      if (
+        names.has(identifier.name) &&
+        !isNonComputedMemberProperty(identifier, parent, parentKey)
+      ) {
         found = true;
       }
     },

--- a/packages/kumo-docs-astro/.oxlintrc.json
+++ b/packages/kumo-docs-astro/.oxlintrc.json
@@ -9,6 +9,7 @@
     "kumo/no-tailwind-dark-variant": "error",
     "kumo/no-primitive-colors": "error",
     "kumo/no-cross-package-imports": "error",
+    "kumo/no-flow-node-custom-render": "error",
     "typescript/no-unsafe-type-assertion": "off",
     "typescript/no-unnecessary-template-expression": "off",
     "typescript/no-unnecessary-type-assertion": "off"

--- a/packages/kumo/.oxlintrc.json
+++ b/packages/kumo/.oxlintrc.json
@@ -17,6 +17,7 @@
     "kumo/enforce-variant-standard": "error",
     "kumo/no-deprecated-props": "error",
     "kumo/no-cross-package-imports": "error",
+    "kumo/no-flow-node-custom-render": "error",
     "typescript/no-unsafe-type-assertion": "off",
     "typescript/no-unnecessary-template-expression": "off",
     "typescript/no-unnecessary-type-assertion": "off",

--- a/packages/kumo/lint/kumo-plugin.js
+++ b/packages/kumo/lint/kumo-plugin.js
@@ -3,6 +3,7 @@ import { noPrimitiveColorsRule } from "./no-primitive-colors.js";
 import { enforceVariantStandardRule } from "./enforce-variant-standard.js";
 import { noDeprecatedPropsRule } from "./no-deprecated-props.js";
 import { noCrossPackageImportsRule } from "./no-cross-package-imports.js";
+import { noFlowNodeCustomRenderRule } from "./no-flow-node-custom-render.js";
 
 const plugin = {
   meta: {
@@ -14,6 +15,7 @@ const plugin = {
     "enforce-variant-standard": enforceVariantStandardRule,
     "no-deprecated-props": noDeprecatedPropsRule,
     "no-cross-package-imports": noCrossPackageImportsRule,
+    "no-flow-node-custom-render": noFlowNodeCustomRenderRule,
   },
 };
 

--- a/packages/kumo/lint/no-flow-node-custom-render.js
+++ b/packages/kumo/lint/no-flow-node-custom-render.js
@@ -1,0 +1,376 @@
+import { defineRule } from "oxlint";
+
+function traverse(node, visitors, seen = new WeakSet()) {
+  if (!node || typeof node !== "object" || seen.has(node)) {
+    return;
+  }
+
+  seen.add(node);
+
+  const visitor = visitors[node.type];
+  if (visitor) {
+    visitor(node);
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (
+      key === "parent" ||
+      key === "loc" ||
+      key === "range" ||
+      key === "start" ||
+      key === "end"
+    ) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        traverse(child, visitors, seen);
+      }
+    } else if (value && typeof value === "object") {
+      traverse(value, visitors, seen);
+    }
+  }
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    current &&
+    (current.type === "TSAsExpression" ||
+      current.type === "TSSatisfiesExpression" ||
+      current.type === "TSNonNullExpression" ||
+      current.type === "ChainExpression")
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function getLiteralValue(node) {
+  if (node?.type === "Literal" || node?.type === "StringLiteral") {
+    return node.value;
+  }
+  return null;
+}
+
+function getIdentifierName(node) {
+  if (node?.type === "Identifier" || node?.type === "JSXIdentifier") {
+    return node.name;
+  }
+  return null;
+}
+
+function getPropertyName(node) {
+  if (!node) return null;
+  if (node.type === "Identifier" || node.type === "PrivateIdentifier") {
+    return node.name;
+  }
+  if (node.type === "Literal" || node.type === "StringLiteral") {
+    return node.value;
+  }
+  return null;
+}
+
+function getJSXName(node) {
+  if (node?.type === "JSXIdentifier") {
+    return node.name;
+  }
+  if (node?.type === "JSXMemberExpression") {
+    const objectName = getJSXName(node.object);
+    const propertyName = getJSXName(node.property);
+    return objectName && propertyName ? `${objectName}.${propertyName}` : null;
+  }
+  return null;
+}
+
+function isComponentName(name) {
+  return typeof name === "string" && /^[A-Z]/.test(name);
+}
+
+function getJSXAttributeName(attr) {
+  return attr?.name?.type === "JSXIdentifier" ? attr.name.name : null;
+}
+
+function getJSXExpression(value) {
+  if (value?.type === "JSXExpressionContainer") {
+    return value.expression;
+  }
+  return value;
+}
+
+function getFlowNodeRenderComponentName(node) {
+  if (getJSXName(node.name) !== "Flow.Node") {
+    return null;
+  }
+
+  for (const attr of node.attributes ?? []) {
+    if (
+      attr.type !== "JSXAttribute" ||
+      getJSXAttributeName(attr) !== "render"
+    ) {
+      continue;
+    }
+
+    const renderExpression = getJSXExpression(attr.value);
+    if (renderExpression?.type !== "JSXElement") {
+      return null;
+    }
+
+    const componentName = getJSXName(renderExpression.openingElement?.name);
+    if (isComponentName(componentName)) {
+      return { componentName, node: attr };
+    }
+  }
+
+  return null;
+}
+
+function isForwardRefCallee(callee, forwardRefNames) {
+  const unwrapped = unwrapExpression(callee);
+  const identifierName = getIdentifierName(unwrapped);
+  if (identifierName && forwardRefNames.has(identifierName)) {
+    return true;
+  }
+
+  if (unwrapped?.type === "MemberExpression") {
+    return getPropertyName(unwrapped.property) === "forwardRef";
+  }
+
+  return false;
+}
+
+function getFirstFunctionArgument(node) {
+  for (const arg of node.arguments ?? []) {
+    if (arg.type === "SpreadElement") continue;
+    const unwrapped = unwrapExpression(arg);
+    if (
+      unwrapped?.type === "FunctionExpression" ||
+      unwrapped?.type === "ArrowFunctionExpression"
+    ) {
+      return unwrapped;
+    }
+  }
+  return null;
+}
+
+function findForwardRefRenderFunction(node, forwardRefNames) {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped?.type !== "CallExpression") {
+    return null;
+  }
+
+  if (isForwardRefCallee(unwrapped.callee, forwardRefNames)) {
+    return getFirstFunctionArgument(unwrapped);
+  }
+
+  for (const arg of unwrapped.arguments ?? []) {
+    if (arg.type === "SpreadElement") continue;
+    const found = findForwardRefRenderFunction(arg, forwardRefNames);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+function getPropsParamNames(param) {
+  const names = new Set();
+  const unwrapped = unwrapExpression(param);
+
+  if (unwrapped?.type === "Identifier") {
+    names.add(unwrapped.name);
+  } else if (unwrapped?.type === "AssignmentPattern") {
+    for (const name of getPropsParamNames(unwrapped.left)) {
+      names.add(name);
+    }
+  } else if (unwrapped?.type === "ObjectPattern") {
+    for (const prop of unwrapped.properties ?? []) {
+      if (prop.type === "RestElement" && prop.argument?.type === "Identifier") {
+        names.add(prop.argument.name);
+      }
+    }
+  }
+
+  return names;
+}
+
+function getRefParamNames(param) {
+  const names = new Set();
+  const unwrapped = unwrapExpression(param);
+
+  if (unwrapped?.type === "Identifier") {
+    names.add(unwrapped.name);
+  } else if (unwrapped?.type === "AssignmentPattern") {
+    for (const name of getRefParamNames(unwrapped.left)) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+function expressionContainsIdentifier(node, names) {
+  let found = false;
+  traverse(node, {
+    Identifier(identifier) {
+      if (names.has(identifier.name)) {
+        found = true;
+      }
+    },
+  });
+  return found;
+}
+
+function analyzeRenderFunction(fn, usesForwardRef) {
+  const propsNames = getPropsParamNames(fn.params?.[0]);
+  const refNames = usesForwardRef
+    ? getRefParamNames(fn.params?.[1])
+    : new Set();
+  let spreadsProps = false;
+  let forwardsRef = false;
+
+  traverse(fn.body, {
+    JSXSpreadAttribute(node) {
+      const argumentName = getIdentifierName(unwrapExpression(node.argument));
+      if (argumentName && propsNames.has(argumentName)) {
+        spreadsProps = true;
+      }
+    },
+    JSXAttribute(node) {
+      if (getJSXAttributeName(node) !== "ref") {
+        return;
+      }
+
+      const expression = getJSXExpression(node.value);
+      if (expressionContainsIdentifier(expression, refNames)) {
+        forwardsRef = true;
+      }
+    },
+  });
+
+  return {
+    forwardsRef: usesForwardRef && forwardsRef,
+    spreadsProps,
+  };
+}
+
+function getComponentInfoFromVariable(node, forwardRefNames) {
+  const componentName = getIdentifierName(node.id);
+  if (!isComponentName(componentName)) {
+    return null;
+  }
+
+  const forwardRefRenderFunction = findForwardRefRenderFunction(
+    node.init,
+    forwardRefNames,
+  );
+  if (forwardRefRenderFunction) {
+    return {
+      componentName,
+      info: analyzeRenderFunction(forwardRefRenderFunction, true),
+    };
+  }
+
+  const init = unwrapExpression(node.init);
+  if (
+    init?.type === "FunctionExpression" ||
+    init?.type === "ArrowFunctionExpression"
+  ) {
+    return {
+      componentName,
+      info: analyzeRenderFunction(init, false),
+    };
+  }
+
+  return null;
+}
+
+export const noFlowNodeCustomRenderRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Ensure custom components used in Flow.Node render forward refs and spread props.",
+    },
+    messages: {
+      missingRef:
+        "<{{component}}> used in Flow.Node render must forward the ref it receives.",
+      missingProps:
+        "<{{component}}> used in Flow.Node render must spread received props onto its root element.",
+      missingRefAndProps:
+        "<{{component}}> used in Flow.Node render must forward its ref and spread received props onto its root element.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  createOnce(context) {
+    const forwardRefNames = new Set(["forwardRef"]);
+    const components = new Map();
+    const usages = [];
+
+    return {
+      ImportDeclaration(node) {
+        if (getLiteralValue(node.source) !== "react") {
+          return;
+        }
+
+        for (const specifier of node.specifiers ?? []) {
+          if (
+            specifier.type === "ImportSpecifier" &&
+            getIdentifierName(specifier.imported) === "forwardRef"
+          ) {
+            forwardRefNames.add(
+              getIdentifierName(specifier.local) ?? "forwardRef",
+            );
+          }
+        }
+      },
+      FunctionDeclaration(node) {
+        const componentName = getIdentifierName(node.id);
+        if (isComponentName(componentName)) {
+          components.set(componentName, analyzeRenderFunction(node, false));
+        }
+      },
+      VariableDeclarator(node) {
+        const result = getComponentInfoFromVariable(node, forwardRefNames);
+        if (result) {
+          components.set(result.componentName, result.info);
+        }
+      },
+      JSXOpeningElement(node) {
+        const usage = getFlowNodeRenderComponentName(node);
+        if (usage) {
+          usages.push(usage);
+        }
+      },
+      "Program:exit"() {
+        for (const usage of usages) {
+          const info = components.get(usage.componentName);
+          if (!info) {
+            continue;
+          }
+
+          const missingRef = !info.forwardsRef;
+          const missingProps = !info.spreadsProps;
+
+          if (!missingRef && !missingProps) {
+            continue;
+          }
+
+          context.report({
+            node: usage.node,
+            messageId:
+              missingRef && missingProps
+                ? "missingRefAndProps"
+                : missingRef
+                  ? "missingRef"
+                  : "missingProps",
+            data: {
+              component: usage.componentName,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/kumo/lint/no-flow-node-custom-render.js
+++ b/packages/kumo/lint/no-flow-node-custom-render.js
@@ -1,6 +1,12 @@
 import { defineRule } from "oxlint";
 
-function traverse(node, visitors, seen = new WeakSet()) {
+function traverse(
+  node,
+  visitors,
+  seen = new WeakSet(),
+  parent = null,
+  parentKey = null,
+) {
   if (!node || typeof node !== "object" || seen.has(node)) {
     return;
   }
@@ -9,7 +15,7 @@ function traverse(node, visitors, seen = new WeakSet()) {
 
   const visitor = visitors[node.type];
   if (visitor) {
-    visitor(node);
+    visitor(node, parent, parentKey);
   }
 
   for (const [key, value] of Object.entries(node)) {
@@ -25,10 +31,10 @@ function traverse(node, visitors, seen = new WeakSet()) {
 
     if (Array.isArray(value)) {
       for (const child of value) {
-        traverse(child, visitors, seen);
+        traverse(child, visitors, seen, node, key);
       }
     } else if (value && typeof value === "object") {
-      traverse(value, visitors, seen);
+      traverse(value, visitors, seen, node, key);
     }
   }
 }
@@ -209,11 +215,23 @@ function getRefParamNames(param) {
   return names;
 }
 
+function isNonComputedMemberProperty(identifier, parent, parentKey) {
+  return (
+    parent?.type === "MemberExpression" &&
+    parentKey === "property" &&
+    parent.property === identifier &&
+    !parent.computed
+  );
+}
+
 function expressionContainsIdentifier(node, names) {
   let found = false;
   traverse(node, {
-    Identifier(identifier) {
-      if (names.has(identifier.name)) {
+    Identifier(identifier, parent, parentKey) {
+      if (
+        names.has(identifier.name) &&
+        !isNonComputedMemberProperty(identifier, parent, parentKey)
+      ) {
         found = true;
       }
     },

--- a/packages/kumo/tests/lint/no-flow-node-custom-render.test.ts
+++ b/packages/kumo/tests/lint/no-flow-node-custom-render.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi } from "vitest";
+import { noFlowNodeCustomRenderRule } from "../../lint/no-flow-node-custom-render.js";
+
+interface Report {
+  node: any;
+  messageId: string;
+  data?: Record<string, any>;
+}
+
+function createMockContext() {
+  const reports: Report[] = [];
+  return {
+    report: vi.fn((report: Report) => reports.push(report)),
+    getReports: () => reports,
+  };
+}
+
+function id(name: string) {
+  return { type: "Identifier", name };
+}
+
+function jsxId(name: string) {
+  return { type: "JSXIdentifier", name };
+}
+
+function jsxMember(object: string, property: string) {
+  return {
+    type: "JSXMemberExpression",
+    object: jsxId(object),
+    property: jsxId(property),
+  };
+}
+
+function member(object: string, property: string) {
+  return {
+    type: "MemberExpression",
+    object: id(object),
+    property: id(property),
+    computed: false,
+  };
+}
+
+function expression(value: any) {
+  return { type: "JSXExpressionContainer", expression: value };
+}
+
+function attr(name: string, value: any) {
+  return {
+    type: "JSXAttribute",
+    name: jsxId(name),
+    value,
+  };
+}
+
+function refAttr(name = "ref") {
+  return attr("ref", expression(id(name)));
+}
+
+function propsSpread(name = "props") {
+  return {
+    type: "JSXSpreadAttribute",
+    argument: id(name),
+  };
+}
+
+function jsxElement(name: string, attributes: any[] = []) {
+  return {
+    type: "JSXElement",
+    openingElement: {
+      type: "JSXOpeningElement",
+      name: jsxId(name),
+      attributes,
+    },
+    children: [],
+  };
+}
+
+function flowNodeWithRender(componentName: string) {
+  return {
+    type: "JSXOpeningElement",
+    name: jsxMember("Flow", "Node"),
+    attributes: [attr("render", expression(jsxElement(componentName)))],
+  };
+}
+
+function nodeWithRender(componentName: string) {
+  return {
+    type: "JSXOpeningElement",
+    name: jsxMember("Other", "Node"),
+    attributes: [attr("render", expression(jsxElement(componentName)))],
+  };
+}
+
+function functionExpression({
+  propsParam = id("props"),
+  refParam = id("ref"),
+  attributes = [],
+}: {
+  propsParam?: any;
+  refParam?: any;
+  attributes?: any[];
+} = {}) {
+  return {
+    type: "ArrowFunctionExpression",
+    params: [propsParam, refParam],
+    body: jsxElement("li", attributes),
+  };
+}
+
+function functionDeclaration(name: string, attributes: any[] = []) {
+  return {
+    type: "FunctionDeclaration",
+    id: id(name),
+    params: [id("props")],
+    body: {
+      type: "BlockStatement",
+      body: [
+        {
+          type: "ReturnStatement",
+          argument: jsxElement("li", attributes),
+        },
+      ],
+    },
+  };
+}
+
+function forwardRefCall(fn: any, callee: any = id("forwardRef")) {
+  return {
+    type: "CallExpression",
+    callee,
+    arguments: [fn],
+  };
+}
+
+function variableDeclarator(name: string, init: any) {
+  return {
+    type: "VariableDeclarator",
+    id: id(name),
+    init,
+  };
+}
+
+function objectPatternWithRest(restName: string) {
+  return {
+    type: "ObjectPattern",
+    properties: [
+      {
+        type: "Property",
+        key: id("children"),
+        value: id("children"),
+      },
+      {
+        type: "RestElement",
+        argument: id(restName),
+      },
+    ],
+  };
+}
+
+function runRule(nodes: any[]): Report[] {
+  const context = createMockContext();
+  const rule = (noFlowNodeCustomRenderRule as any).createOnce(context);
+
+  for (const node of nodes) {
+    if (node.type === "ImportDeclaration") {
+      rule.ImportDeclaration(node);
+    } else if (node.type === "FunctionDeclaration") {
+      rule.FunctionDeclaration(node);
+    } else if (node.type === "VariableDeclarator") {
+      rule.VariableDeclarator(node);
+    } else if (node.type === "JSXOpeningElement") {
+      rule.JSXOpeningElement(node);
+    }
+  }
+
+  rule["Program:exit"]();
+
+  return context.getReports();
+}
+
+describe("no-flow-node-custom-render", () => {
+  it("allows custom components that forward refs and spread props", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(
+        functionExpression({ attributes: [refAttr(), propsSpread()] }),
+      ),
+    );
+
+    expect(runRule([component, flowNodeWithRender("CustomNode")])).toHaveLength(
+      0,
+    );
+  });
+
+  it("allows React.forwardRef with destructured props rest", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(
+        functionExpression({
+          propsParam: objectPatternWithRest("restProps"),
+          refParam: id("forwardedRef"),
+          attributes: [refAttr("forwardedRef"), propsSpread("restProps")],
+        }),
+        member("React", "forwardRef"),
+      ),
+    );
+
+    expect(runRule([component, flowNodeWithRender("CustomNode")])).toHaveLength(
+      0,
+    );
+  });
+
+  it("ignores intrinsic render elements", () => {
+    const reports = runRule([
+      {
+        type: "JSXOpeningElement",
+        name: jsxMember("Flow", "Node"),
+        attributes: [attr("render", expression(jsxElement("li")))],
+      },
+    ]);
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it("ignores custom components defined outside the current file", () => {
+    expect(runRule([flowNodeWithRender("ImportedNode")])).toHaveLength(0);
+  });
+
+  it("reports custom components that neither forward refs nor spread props", () => {
+    const component = functionDeclaration("CustomNode");
+    const reports = runRule([component, flowNodeWithRender("CustomNode")]);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe("missingRefAndProps");
+    expect(reports[0].data).toEqual({ component: "CustomNode" });
+  });
+
+  it("reports custom components that spread props without forwarding refs", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      functionExpression({ refParam: undefined, attributes: [propsSpread()] }),
+    );
+    const reports = runRule([component, flowNodeWithRender("CustomNode")]);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe("missingRef");
+  });
+
+  it("reports forwardRef components that do not spread props", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(functionExpression({ attributes: [refAttr()] })),
+    );
+    const reports = runRule([component, flowNodeWithRender("CustomNode")]);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe("missingProps");
+  });
+
+  it("checks components declared after Flow.Node usage", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(functionExpression({ attributes: [refAttr()] })),
+    );
+    const reports = runRule([flowNodeWithRender("CustomNode"), component]);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe("missingProps");
+  });
+
+  it("ignores render props on other components", () => {
+    const component = functionDeclaration("CustomNode");
+
+    expect(runRule([component, nodeWithRender("CustomNode")])).toHaveLength(0);
+  });
+});

--- a/packages/kumo/tests/lint/no-flow-node-custom-render.test.ts
+++ b/packages/kumo/tests/lint/no-flow-node-custom-render.test.ts
@@ -53,7 +53,11 @@ function attr(name: string, value: any) {
 }
 
 function refAttr(name = "ref") {
-  return attr("ref", expression(id(name)));
+  return refAttrExpression(id(name));
+}
+
+function refAttrExpression(value: any) {
+  return attr("ref", expression(value));
 }
 
 function propsSpread(name = "props") {
@@ -132,6 +136,31 @@ function forwardRefCall(fn: any, callee: any = id("forwardRef")) {
   };
 }
 
+function callExpression(callee: any, args: any[]) {
+  return {
+    type: "CallExpression",
+    callee,
+    arguments: args,
+  };
+}
+
+function reactForwardRefImport(localName = "forwardRef") {
+  return {
+    type: "ImportDeclaration",
+    source: {
+      type: "Literal",
+      value: "react",
+    },
+    specifiers: [
+      {
+        type: "ImportSpecifier",
+        imported: id("forwardRef"),
+        local: id(localName),
+      },
+    ],
+  };
+}
+
 function variableDeclarator(name: string, init: any) {
   return {
     type: "VariableDeclarator",
@@ -154,6 +183,17 @@ function objectPatternWithRest(restName: string) {
         argument: id(restName),
       },
     ],
+  };
+}
+
+function assignmentPattern(left: any) {
+  return {
+    type: "AssignmentPattern",
+    left,
+    right: {
+      type: "ObjectExpression",
+      properties: [],
+    },
   };
 }
 
@@ -210,6 +250,55 @@ describe("no-flow-node-custom-render", () => {
     );
   });
 
+  it("allows default destructured props rest", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(
+        functionExpression({
+          propsParam: assignmentPattern(objectPatternWithRest("restProps")),
+          attributes: [refAttr(), propsSpread("restProps")],
+        }),
+      ),
+    );
+
+    expect(runRule([component, flowNodeWithRender("CustomNode")])).toHaveLength(
+      0,
+    );
+  });
+
+  it("allows HOC-wrapped forwardRef components", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      callExpression(id("memo"), [
+        forwardRefCall(
+          functionExpression({ attributes: [refAttr(), propsSpread()] }),
+        ),
+      ]),
+    );
+
+    expect(runRule([component, flowNodeWithRender("CustomNode")])).toHaveLength(
+      0,
+    );
+  });
+
+  it("allows aliased forwardRef imports", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(
+        functionExpression({ attributes: [refAttr(), propsSpread()] }),
+        id("fr"),
+      ),
+    );
+
+    expect(
+      runRule([
+        reactForwardRefImport("fr"),
+        component,
+        flowNodeWithRender("CustomNode"),
+      ]),
+    ).toHaveLength(0);
+  });
+
   it("ignores intrinsic render elements", () => {
     const reports = runRule([
       {
@@ -255,6 +344,24 @@ describe("no-flow-node-custom-render", () => {
 
     expect(reports).toHaveLength(1);
     expect(reports[0].messageId).toBe("missingProps");
+  });
+
+  it("does not count member property names as forwarded refs", () => {
+    const component = variableDeclarator(
+      "CustomNode",
+      forwardRefCall(
+        functionExpression({
+          attributes: [
+            refAttrExpression(member("callbacks", "ref")),
+            propsSpread(),
+          ],
+        }),
+      ),
+    );
+    const reports = runRule([component, flowNodeWithRender("CustomNode")]);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].messageId).toBe("missingRef");
   });
 
   it("checks components declared after Flow.Node usage", () => {


### PR DESCRIPTION
## Summary

- Add `kumo/no-flow-node-custom-render` to enforce `Flow.Node render={<CustomComponent />}` passthrough requirements.
- Verify local custom render components forward refs and spread received props.
- Enable the rule in root, package, and docs oxlint configs.

## Tests

- `pnpm --filter @cloudflare/kumo exec vitest run --project=unit tests/lint/no-flow-node-custom-render.test.ts`
- `pnpm exec tsc --noEmit --target ES2022 --module ES2022 --moduleResolution bundler --jsx react-jsx --strict --skipLibCheck --types vitest --allowJs --checkJs false tests/lint/no-flow-node-custom-render.test.ts lint/no-flow-node-custom-render.js`
- `pnpm exec oxlint --config /var/folders/bj/9s0glzp52jvf5230xw5lk1rc0000gn/T/opencode/oxlint-touched.json lint/no-flow-node-custom-render.js lint/kumo-plugin.js packages/kumo/lint/no-flow-node-custom-render.js packages/kumo/lint/kumo-plugin.js packages/kumo/tests/lint/no-flow-node-custom-render.test.ts`
- `pnpm exec prettier --check .oxlintrc.json .changeset/flow-node-render-lint.md lint/kumo-plugin.js lint/no-flow-node-custom-render.js packages/kumo/.oxlintrc.json packages/kumo/lint/kumo-plugin.js packages/kumo/lint/no-flow-node-custom-render.js packages/kumo/tests/lint/no-flow-node-custom-render.test.ts packages/kumo-docs-astro/.oxlintrc.json`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: bonk has not reviewed this change yet
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: n/a
- [ ] Additional testing not necessary because: n/a
