### PR TITLE
fix(sidebar): disable menu button tooltips when expanded

### DIFF
--- a/.changeset/sidebar-tooltip-expanded.md
+++ b/.changeset/sidebar-tooltip-expanded.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Disable Sidebar.MenuButton tooltips while the sidebar is expanded or peeking.

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1221,7 +1221,8 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
     if (tooltip) {
       button = (
         <Tooltip
-          content={showTooltip ? tooltip : null}
+          content={tooltip}
+          disabled={!showTooltip}
           side="right"
           render={button}
         />


### PR DESCRIPTION
## Summary

Fixes a bug where an empty tooltip may appear

<img width="346" height="273" alt="Screenshot 2026-07-08 at 1 01 10 PM" src="https://github.com/user-attachments/assets/5d5f1e2f-bb41-498f-8171-aaec802c25ce" />

- Disable Sidebar.MenuButton tooltips when the sidebar is expanded or peeking
- Keep tooltip content intact and use the Base UI disabled prop to prevent empty tooltip popups

Fixes #619

## Testing

- pnpm --filter @cloudflare/kumo test -- src/components/sidebar/sidebar.test.tsx
- pnpm --filter @cloudflare/kumo lint

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this PR is a targeted one-line behavior fix and will receive normal PR review
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: existing docs sidebar demos reproduce the expanded and collapsed tooltip states
- [x] Additional testing not necessary because: existing sidebar unit tests and package lint pass for this targeted tooltip behavior change