### PR TITLE
feat: add timeseries thresholds

### DIFF
--- a/.changeset/timeseries-thresholds.md
+++ b/.changeset/timeseries-thresholds.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add horizontal threshold lines to TimeseriesChart.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -168,6 +168,38 @@ export function ReferenceMarkersChartDemo() {
   );
 }
 
+export function ThresholdsChartDemo() {
+  const isDarkMode = useIsDarkMode();
+
+  const data = useMemo(
+    () => [
+      {
+        name: "Memory used",
+        data: buildSeriesData(0, 50, 60_000, 1),
+        color: ChartPalette.semantic("Neutral", isDarkMode),
+      },
+    ],
+    [isDarkMode],
+  );
+
+  return (
+    <TimeseriesChart
+      echarts={echarts}
+      isDarkMode={isDarkMode}
+      data={data}
+      thresholds={[
+        {
+          value: 55,
+          label: "Memory limit",
+          color: ChartPalette.semantic("Attention", isDarkMode),
+        },
+      ]}
+      xAxisName="Time (UTC)"
+      yAxisName="Memory (MB)"
+    />
+  );
+}
+
 /**
  * Timeseries chart with custom axis tick label formats for both x-axis (HH:MM) and y-axis (compact numbers).
  */

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -11,6 +11,7 @@ import {
   BasicLineChartDemo,
   BarChartDemo,
   ReferenceMarkersChartDemo,
+  ThresholdsChartDemo,
   CustomAxisLabelFormatDemo,
   GradientLineChartDemo,
   IncompleteDataChartDemo,
@@ -50,6 +51,21 @@ import {
 
   <ComponentExample demo="ReferenceMarkersChartDemo">
     <ReferenceMarkersChartDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+## Thresholds
+
+<p>
+  Use the <code>thresholds</code> prop to render horizontal reference lines on the
+  value axis, such as memory limits or quota boundaries. Thresholds include a
+  value and color, with an optional label.
+</p>
+
+  <ComponentExample demo="ThresholdsChartDemo">
+    <ThresholdsChartDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -25,8 +25,14 @@ import {
   type TooltipRow,
   type TooltipState,
 } from "./timeseries-tooltip";
+import {
+  buildTimeseriesThresholdAnnotations,
+  getThresholdValueExtent,
+  type TimeseriesThreshold,
+} from "./timeseries-thresholds";
 
 export type { TimeseriesMarker } from "./timeseries-markers";
+export type { TimeseriesThreshold } from "./timeseries-thresholds";
 
 /** A single data series rendered on a `TimeseriesChart` */
 export interface TimeseriesData {
@@ -52,6 +58,8 @@ export interface TimeseriesChartProps {
   data: TimeseriesData[];
   /** Vertical reference markers rendered on the time axis. */
   markers?: TimeseriesMarker[];
+  /** Horizontal threshold lines rendered on the value axis. */
+  thresholds?: TimeseriesThreshold[];
   /** Label for the x-axis (time axis) */
   xAxisName?: string;
   /** Number of ticks to display on the x-axis */
@@ -217,6 +225,7 @@ export const TimeseriesChart = forwardRef<
     type = "line",
     data,
     markers,
+    thresholds,
     xAxisName,
     xAxisTickCount,
     xAxisTickFormat,
@@ -312,6 +321,9 @@ export const TimeseriesChart = forwardRef<
         ? ({ type: "bar", stack: "total" } as const)
         : ({ type: "line", showSymbol: false } as const);
 
+    const thresholdAnnotations = buildTimeseriesThresholdAnnotations(thresholds);
+    const thresholdExtent = getThresholdValueExtent(thresholds);
+
     const markerClusters = clusterTimeseriesMarkers(
       markers,
       getApproximateMarkerClusterInterval(
@@ -398,6 +410,16 @@ export const TimeseriesChart = forwardRef<
       });
     }
 
+    if (thresholdAnnotations) {
+      transformSeries.push({
+        data: [],
+        name: "Thresholds",
+        type: type === "bar" ? "bar" : "line",
+        animation: false,
+        markLine: thresholdAnnotations.markLine,
+      });
+    }
+
     return {
       aria: {
         enabled: true,
@@ -457,6 +479,12 @@ export const TimeseriesChart = forwardRef<
           lineStyle: { type: "dashed" as const, width: 1 },
         },
         splitNumber: yAxisTickCount,
+        ...(thresholdExtent && {
+          min: (value: { min: number }) =>
+            Math.min(value.min, thresholdExtent.min),
+          max: (value: { max: number }) =>
+            Math.max(value.max, thresholdExtent.max),
+        }),
       },
       grid: {
         left: yAxisName ? 30 : 24,
@@ -482,6 +510,7 @@ export const TimeseriesChart = forwardRef<
     echarts,
     ariaDescription,
     markers,
+    thresholds,
     markerColor,
     markerLabelBackgroundColor,
   ]);

--- a/packages/kumo/src/components/chart/index.ts
+++ b/packages/kumo/src/components/chart/index.ts
@@ -3,6 +3,7 @@ export {
   type TimeseriesChartProps,
   type TimeseriesData,
   type TimeseriesMarker,
+  type TimeseriesThreshold,
 } from "./TimeseriesChart";
 
 export {

--- a/packages/kumo/src/components/chart/timeseries-markers.ts
+++ b/packages/kumo/src/components/chart/timeseries-markers.ts
@@ -134,9 +134,7 @@ export function getTimeseriesMarkerFromEvent(params: {
   componentType?: string;
   data?: { tooltip?: { marker?: TimeseriesMarkerCluster } };
 }): TimeseriesMarkerCluster | undefined {
-  if (
-    params.componentType !== "markLine"
-  ) {
+  if (params.componentType !== "markLine") {
     return undefined;
   }
   return params.data?.tooltip?.marker;

--- a/packages/kumo/src/components/chart/timeseries-thresholds.ts
+++ b/packages/kumo/src/components/chart/timeseries-thresholds.ts
@@ -1,0 +1,65 @@
+export interface TimeseriesThreshold {
+  /** Y-axis value where the threshold line is rendered. */
+  value: number;
+  /** Optional label shown on/near the threshold line. */
+  label?: string;
+  /** Threshold line and label color. */
+  color: string;
+}
+
+export function buildTimeseriesThresholdAnnotations(
+  thresholds: TimeseriesThreshold[] | undefined,
+) {
+  if (!thresholds?.length) return undefined;
+
+  return {
+    markLine: {
+      symbol: "none" as const,
+      silent: true,
+      animation: false,
+      z: 9,
+      lineStyle: {
+        type: "dashed" as const,
+        width: 1,
+      },
+      blur: {
+        lineStyle: { opacity: 1 },
+        label: { opacity: 1 },
+      },
+      label: {
+        show: true,
+        position: "insideEndTop" as const,
+        formatter: (params: { name?: string }) => params.name ?? "",
+      },
+      data: thresholds.map((threshold) => ({
+        name: threshold.label,
+        yAxis: threshold.value,
+        lineStyle: {
+          color: threshold.color,
+          width: 1,
+          type: "dashed" as const,
+        },
+        blur: {
+          lineStyle: { opacity: 1 },
+          label: { opacity: 1 },
+        },
+        label: {
+          show: Boolean(threshold.label),
+          color: threshold.color,
+        },
+      })),
+    },
+  };
+}
+
+export function getThresholdValueExtent(
+  thresholds: TimeseriesThreshold[] | undefined,
+): { min: number; max: number } | undefined {
+  if (!thresholds?.length) return undefined;
+
+  const values = thresholds.map((threshold) => threshold.value);
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+  };
+}


### PR DESCRIPTION
Adds a first-class `thresholds` API to `TimeseriesChart` for horizontal value-axis reference lines, e.g. memory limits or quota boundaries. Thresholds require a value and color; labels are optional for cases where an unlabeled reference line is useful.

This keeps threshold rendering inside the high-level chart abstraction and uses ECharts `markLine` through a small dedicated helper, matching the marker implementation without adding tooltip-specific behaviour. Threshold values also participate in y-axis extent calculation so limits above/below the current data remain visible.

<img width="652" height="535" alt="image" src="https://github.com/user-attachments/assets/158229ca-1a93-48ab-9fed-fe953b527e54" />


- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual chart annotation behaviour needs human review
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: checked docs demo locally
- [x] Additional testing not necessary because: existing chart behaviour is unchanged when no thresholds are provided