### PR TITLE
fix: keep mobile sidebar open for portaled focus

### DIFF
--- a/.changeset/sidebar-mobile-portal-focus.md
+++ b/.changeset/sidebar-mobile-portal-focus.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Keep the mobile Sidebar open when focus moves to portaled interactive content.

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -683,7 +683,7 @@ describe("Sidebar mobile behavior", () => {
     await waitFor(() => expect(document.activeElement).toBe(toggle));
   });
 
-  it("should close on focus leave without stealing focus back", async () => {
+  it("should NOT close when focus moves outside the sidebar (e.g. to portaled content)", async () => {
     setMobileMatchMedia(true);
     const user = userEvent.setup();
     render(<MobileTest />);
@@ -700,7 +700,7 @@ describe("Sidebar mobile behavior", () => {
     afterSidebar.focus();
     fireEvent.focusOut(nav, { relatedTarget: afterSidebar });
 
-    await waitFor(() => expect(nav.getAttribute("aria-hidden")).toBe("true"));
-    expect(document.activeElement).toBe(afterSidebar);
+    expect(nav.getAttribute("aria-hidden")).toBe("false");
+    expect(nav.hasAttribute("inert")).toBe(false);
   });
 });

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -477,27 +477,18 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
     const mobileNodeRef = useRef<HTMLElement | null>(null);
     const shouldRestoreFocusRef = useRef(false);
 
-    // Escape key and focus-leave close the mobile sidebar
+    // Escape key closes the mobile sidebar
     useEffect(() => {
       if (!isMobile || !openMobile) return;
-      const node = mobileNodeRef.current;
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
           shouldRestoreFocusRef.current = true;
           setOpenMobile(false);
         }
       };
-      const handleFocusOut = (e: FocusEvent) => {
-        if (node && !node.contains(e.relatedTarget as Node)) {
-          shouldRestoreFocusRef.current = false;
-          setOpenMobile(false);
-        }
-      };
       document.addEventListener("keydown", handleKeyDown);
-      node?.addEventListener("focusout", handleFocusOut);
       return () => {
         document.removeEventListener("keydown", handleKeyDown);
-        node?.removeEventListener("focusout", handleFocusOut);
       };
     }, [isMobile, openMobile, setOpenMobile]);
 


### PR DESCRIPTION
Fixes [#604](https://github.com/cloudflare/kumo/issues/604)

## Summary

Fixes the mobile Sidebar closing unexpectedly when focus moves outside the sidebar into portaled interactive content, such as dropdown menus or popovers rendered from inside the sidebar.

The mobile Sidebar now closes on explicit dismissal actions only:
- Escape key
- Backdrop click

## Changes

- Removed the mobile Sidebar `focusout` listener that closed the drawer when focus moved outside the sidebar DOM subtree.
- Updated the mobile Sidebar regression test to verify the drawer stays open when focus moves outside, matching portaled nested interactive behavior.
- Added a patch changeset for `@cloudflare/kumo`.

## Validation

- `pnpm --filter @cloudflare/kumo test:unit src/components/sidebar/sidebar.test.tsx`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: targeted behavioral fix for mobile focus handling
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->