### PR TITLE
fix: generate chart component registry

### DIFF
--- a/.changeset/fix-chart-registry.md
+++ b/.changeset/fix-chart-registry.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Include chart components exported from multi-component barrel directories in the generated component registry, with complete props metadata for generic interfaces.

--- a/packages/kumo/scripts/component-registry/discovery.ts
+++ b/packages/kumo/scripts/component-registry/discovery.ts
@@ -34,6 +34,7 @@ export const CATEGORY_MAP: Record<string, string> = {
   // Display
   badge: "Display",
   breadcrumbs: "Display",
+  chart: "Data Visualization",
   code: "Display",
   collapsible: "Display",
   empty: "Display",
@@ -180,6 +181,56 @@ export function detectExportsFromIndex(dirPath: string): DetectedExports {
   } catch {
     return result;
   }
+}
+
+interface BarrelComponentExport extends DetectedExports {
+  componentName: string;
+  propsType: string;
+  sourceFile: string;
+}
+
+/**
+ * Detect components in a barrel directory that does not have a conventional
+ * `{directory}/{directory}.tsx` entry point.
+ */
+export function detectComponentExportsFromIndex(
+  dirPath: string,
+): BarrelComponentExport[] {
+  const indexPath = join(dirPath, "index.ts");
+  if (!existsSync(indexPath)) return [];
+
+  const content = readFileSync(indexPath, "utf-8");
+  const exports: BarrelComponentExport[] = [];
+  const exportPattern = /export\s*\{([^}]+)\}\s*from\s*["'](.+?)["']/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = exportPattern.exec(content)) !== null) {
+    const sourceFile = `${match[2].replace(/^\.\//, "")}.tsx`;
+    if (!existsSync(join(dirPath, sourceFile))) continue;
+
+    const namedExports: string[] = [];
+    const typeExports: string[] = [];
+
+    for (const item of match[1].split(",").map((value) => value.trim())) {
+      const typeMatch = item.match(/^type\s+(\w+)(?:\s+as\s+(\w+))?/);
+      if (typeMatch) {
+        typeExports.push(typeMatch[2] || typeMatch[1]);
+        continue;
+      }
+
+      const nameMatch = item.match(/^(\w+)(?:\s+as\s+(\w+))?/);
+      if (nameMatch) namedExports.push(nameMatch[2] || nameMatch[1]);
+    }
+
+    for (const componentName of namedExports) {
+      const propsType = `${componentName}Props`;
+      if (typeExports.includes(propsType)) {
+        exports.push({ componentName, propsType, sourceFile });
+      }
+    }
+  }
+
+  return exports;
 }
 
 /**
@@ -433,6 +484,39 @@ export async function discoverFromDir(
       ...(styling && { styling }),
       // Note: subComponents are added later by processComponent in index.ts
     });
+  }
+
+  for (const entry of readdirSync(sourceDir)) {
+    const dirPath = join(sourceDir, entry);
+    if (!statSync(dirPath).isDirectory()) continue;
+    if (existsSync(join(dirPath, `${entry}.tsx`))) continue;
+
+    for (const detected of detectComponentExportsFromIndex(dirPath)) {
+      const mainFile = join(dirPath, detected.sourceFile);
+      const variantsData = extractVariantsFromFile(mainFile);
+      const styling = extractStylingFromFile(mainFile);
+
+      console.log(
+        `  ${entry}/${detected.sourceFile} → ${detected.componentName} (props: ${detected.propsType}, type: ${type})`,
+      );
+
+      configs.push({
+        name: detected.componentName,
+        propsType: detected.propsType,
+        sourceFile: `${entry}/${detected.sourceFile}`,
+        dirName: entry,
+        sourceDir,
+        type,
+        description: extractDescription(mainFile, detected.componentName),
+        category: CATEGORY_MAP[entry] || "Other",
+        variants: variantsData?.variants ?? {},
+        defaults: variantsData?.defaults ?? {},
+        ...(variantsData?.baseStyles && {
+          baseStyles: variantsData.baseStyles,
+        }),
+        ...(styling && { styling }),
+      });
+    }
   }
 
   return configs;

--- a/packages/kumo/scripts/component-registry/discovery.ts
+++ b/packages/kumo/scripts/component-registry/discovery.ts
@@ -205,8 +205,11 @@ export function detectComponentExportsFromIndex(
   let match: RegExpExecArray | null;
 
   while ((match = exportPattern.exec(content)) !== null) {
-    const sourceFile = `${match[2].replace(/^\.\//, "")}.tsx`;
-    if (!existsSync(join(dirPath, sourceFile))) continue;
+    const sourceName = match[2].replace(/^\.\//, "");
+    const sourceFile = [`${sourceName}.tsx`, `${sourceName}.ts`].find((file) =>
+      existsSync(join(dirPath, file)),
+    );
+    if (!sourceFile) continue;
 
     const namedExports: string[] = [];
     const typeExports: string[] = [];

--- a/packages/kumo/scripts/component-registry/index.test.ts
+++ b/packages/kumo/scripts/component-registry/index.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { detectComponentExportsFromIndex } from "./discovery.js";
 
 // =============================================================================
 // Tests for string transformation utilities
@@ -580,6 +581,40 @@ describe("getComponentNameFromPath", () => {
   });
 });
 
+describe("detectComponentExportsFromIndex", () => {
+  it("detects multiple components with matching props from a barrel", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kumo-barrel-test-"));
+    try {
+      writeFileSync(
+        join(dir, "index.ts"),
+        `export {
+        BubbleMap,
+        ChoroplethMap,
+        type MapGeoJson,
+        type BubbleMapProps,
+        type ChoroplethMapProps,
+      } from "./Maps";`,
+      );
+      writeFileSync(join(dir, "Maps.tsx"), "export const placeholder = true;");
+
+      expect(detectComponentExportsFromIndex(dir)).toEqual([
+        {
+          componentName: "BubbleMap",
+          propsType: "BubbleMapProps",
+          sourceFile: "Maps.tsx",
+        },
+        {
+          componentName: "ChoroplethMap",
+          propsType: "ChoroplethMapProps",
+          sourceFile: "Maps.tsx",
+        },
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+
 // =============================================================================
 // Tests for JSON Schema type conversion
 // =============================================================================
@@ -681,7 +716,7 @@ describe("jsonSchemaTypeToString", () => {
 
 // Tests for sub-component detection utilities
 
-import { writeFileSync, unlinkSync, mkdtempSync } from "node:fs";
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -941,6 +976,37 @@ interface GroupProps extends BaseProps {
     const content = "interface OtherProps { foo: string; }";
     const props = extractPropsFromInterface(content, "MyProps", cliFlags);
     expect(props).toEqual({});
+  });
+
+  it("extracts documented props from a generic interface", () => {
+    const content = `
+interface MapProps<T> {
+  /** Raw data rows. */
+  data: T[];
+  /** Value accessor. */
+  value: MapAccessor<T, number>;
+  /** Show the tooltip. Default: true. */
+  showTooltip?: boolean;
+}
+`;
+    const props = extractPropsFromInterface(content, "MapProps", cliFlags);
+    expect(props).toEqual({
+      data: {
+        type: "T[]",
+        required: true,
+        description: "Raw data rows.",
+      },
+      value: {
+        type: "MapAccessor<T, number>",
+        required: true,
+        description: "Value accessor.",
+      },
+      showTooltip: {
+        type: "boolean",
+        optional: true,
+        description: "Show the tooltip. Default: true.",
+      },
+    });
   });
 });
 

--- a/packages/kumo/scripts/component-registry/index.test.ts
+++ b/packages/kumo/scripts/component-registry/index.test.ts
@@ -587,15 +587,25 @@ describe("detectComponentExportsFromIndex", () => {
     try {
       writeFileSync(
         join(dir, "index.ts"),
-        `export {
-        BubbleMap,
-        ChoroplethMap,
-        type MapGeoJson,
-        type BubbleMapProps,
-        type ChoroplethMapProps,
-      } from "./Maps";`,
+        `
+        export {
+          BubbleMap,
+          ChoroplethMap,
+          type MapGeoJson,
+          type BubbleMapProps,
+          type ChoroplethMapProps,
+        } from "./Maps";
+        export {
+          ServerChart,
+          type ServerChartProps,
+        } from "./ServerChart";
+        `,
       );
       writeFileSync(join(dir, "Maps.tsx"), "export const placeholder = true;");
+      writeFileSync(
+        join(dir, "ServerChart.ts"),
+        "export const placeholder = true;",
+      );
 
       expect(detectComponentExportsFromIndex(dir)).toEqual([
         {
@@ -607,6 +617,11 @@ describe("detectComponentExportsFromIndex", () => {
           componentName: "ChoroplethMap",
           propsType: "ChoroplethMapProps",
           sourceFile: "Maps.tsx",
+        },
+        {
+          componentName: "ServerChart",
+          propsType: "ServerChartProps",
+          sourceFile: "ServerChart.ts",
         },
       ]);
     } finally {
@@ -980,13 +995,15 @@ interface GroupProps extends BaseProps {
 
   it("extracts documented props from a generic interface", () => {
     const content = `
-interface MapProps<T> {
+interface MapProps<T extends { id: string }> {
   /** Raw data rows. */
   data: T[];
   /** Value accessor. */
   value: MapAccessor<T, number>;
   /** Show the tooltip. Default: true. */
   showTooltip?: boolean;
+  /** Nested configuration. */
+  config?: { item: { id: string }; enabled: boolean };
 }
 `;
     const props = extractPropsFromInterface(content, "MapProps", cliFlags);
@@ -1005,6 +1022,11 @@ interface MapProps<T> {
         type: "boolean",
         optional: true,
         description: "Show the tooltip. Default: true.",
+      },
+      config: {
+        type: "{ item: { id: string }; enabled: boolean }",
+        optional: true,
+        description: "Nested configuration.",
       },
     });
   });

--- a/packages/kumo/scripts/component-registry/index.ts
+++ b/packages/kumo/scripts/component-registry/index.ts
@@ -54,6 +54,7 @@ import { discoverComponents, discoverBlocks } from "./discovery.js";
 import { shouldSkipProp } from "./props-filter.js";
 import {
   detectSubComponents,
+  extractPropsFromInterface,
   extractSubComponentProps,
 } from "./sub-components.js";
 import { generateAIContext } from "./markdown-generator.js";
@@ -433,8 +434,23 @@ function generatePropsFromType(
       `Warning: Could not generate schema for ${getPropsType(config)}:`,
       error,
     );
-    // Fallback: generate props from variants only
-    return generatePropsFromVariantsOnly(config);
+    const interfaceProps = extractPropsFromInterface(
+      readFileSync(sourcePath, "utf-8"),
+      propsType,
+      CLI_FLAGS,
+    );
+    const fallbackProps = generatePropsFromVariantsOnly(config);
+
+    if (Object.keys(interfaceProps).length > 0) {
+      delete fallbackProps.className;
+      delete fallbackProps.children;
+      console.log(
+        `  → Fallback: extracted ${Object.keys(interfaceProps).length} props from interface`,
+      );
+      return { ...fallbackProps, ...interfaceProps };
+    }
+
+    return fallbackProps;
   }
 }
 

--- a/packages/kumo/scripts/component-registry/index.ts
+++ b/packages/kumo/scripts/component-registry/index.ts
@@ -434,12 +434,21 @@ function generatePropsFromType(
       `Warning: Could not generate schema for ${getPropsType(config)}:`,
       error,
     );
-    const interfaceProps = extractPropsFromInterface(
-      readFileSync(sourcePath, "utf-8"),
-      propsType,
-      CLI_FLAGS,
-    );
     const fallbackProps = generatePropsFromVariantsOnly(config);
+    let interfaceProps: Record<string, PropSchema> = {};
+
+    try {
+      interfaceProps = extractPropsFromInterface(
+        readFileSync(sourcePath, "utf-8"),
+        propsType,
+        CLI_FLAGS,
+      );
+    } catch (readError) {
+      console.warn(
+        `Warning: Could not read ${sourcePath} for interface fallback:`,
+        readError,
+      );
+    }
 
     if (Object.keys(interfaceProps).length > 0) {
       delete fallbackProps.className;

--- a/packages/kumo/scripts/component-registry/sub-components.ts
+++ b/packages/kumo/scripts/component-registry/sub-components.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import * as ts from "typescript";
 import type { SubComponentConfig, PropSchema } from "./types.js";
 import { extractBalancedBraces } from "./utils.js";
 import { shouldSkipProp } from "./props-filter.js";
@@ -348,56 +349,44 @@ export function extractPropsFromInterface(
   cliFlags: CLIFlags,
 ): Record<string, PropSchema> {
   const props: Record<string, PropSchema> = {};
-
-  // Match interface definitions, including generic interfaces such as FooProps<T>.
-  const interfacePattern = new RegExp(
-    `interface\\s+${interfaceName}(?:<[^>{}]+>)?\\s*(?:extends[^{]*)?\\{([^}]+)\\}`,
+  const sourceFile = ts.createSourceFile(
+    "component.tsx",
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
   );
-  const match = content.match(interfacePattern);
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.InterfaceDeclaration =>
+      ts.isInterfaceDeclaration(statement) &&
+      statement.name.text === interfaceName,
+  );
+  if (!declaration) return props;
 
-  if (match) {
-    const propsBlock = match[1];
-    const undocumentedPropsBlock = propsBlock.replace(
-      /\/\*\*[\s\S]*?\*\//g,
-      "",
-    );
-    const documentedPropPattern =
-      /\/\*\*([\s\S]*?)\*\/\s*(\w+)(\?)?:\s*([^;\n}]+)/g;
-    const propPattern = /(\w+)(\?)?:\s*([^;\n}]+)/g;
-    const documentedProps = new Set<string>();
-    let propMatch: RegExpExecArray | null;
-
-    while ((propMatch = documentedPropPattern.exec(propsBlock)) !== null) {
-      const propName = propMatch[2];
-      if (shouldSkipProp(propName, cliFlags)) continue;
-
-      documentedProps.add(propName);
-      props[propName] = {
-        type: propMatch[4].trim(),
-        ...(propMatch[3] ? { optional: true } : { required: true }),
-        description: propMatch[1]
-          .split("\n")
-          .map((line) => line.replace(/^\s*\*\s?/, "").trim())
-          .filter(Boolean)
-          .join(" "),
-      };
+  for (const member of declaration.members) {
+    if (!ts.isPropertySignature(member) || !member.type) continue;
+    if (!ts.isIdentifier(member.name) && !ts.isStringLiteral(member.name)) {
+      continue;
     }
 
-    while ((propMatch = propPattern.exec(undocumentedPropsBlock)) !== null) {
-      const propName = propMatch[1];
-      if (documentedProps.has(propName)) continue;
-      const isOptional = propMatch[2] === "?";
-      let propType = propMatch[3].trim();
+    const propName = member.name.text;
+    if (shouldSkipProp(propName, cliFlags)) continue;
 
-      propType = propType.replace(/[,;]$/, "").trim();
+    const descriptions = ts
+      .getJSDocCommentsAndTags(member)
+      .filter(ts.isJSDoc)
+      .flatMap((doc) => {
+        if (typeof doc.comment === "string") return [doc.comment];
+        return doc.comment?.map((part) => part.text).filter(Boolean) ?? [];
+      });
 
-      if (shouldSkipProp(propName, cliFlags)) continue;
-
-      props[propName] = {
-        type: propType,
-        ...(isOptional ? { optional: true } : { required: true }),
-      };
-    }
+    props[propName] = {
+      type: member.type.getText(sourceFile),
+      ...(member.questionToken ? { optional: true } : { required: true }),
+      ...(descriptions.length > 0 && {
+        description: descriptions.join(" ").replace(/\s+/g, " ").trim(),
+      }),
+    };
   }
 
   return props;

--- a/packages/kumo/scripts/component-registry/sub-components.ts
+++ b/packages/kumo/scripts/component-registry/sub-components.ts
@@ -349,19 +349,43 @@ export function extractPropsFromInterface(
 ): Record<string, PropSchema> {
   const props: Record<string, PropSchema> = {};
 
-  // Match interface definition
+  // Match interface definitions, including generic interfaces such as FooProps<T>.
   const interfacePattern = new RegExp(
-    `interface\\s+${interfaceName}\\s*(?:extends[^{]*)?\\{([^}]+)\\}`,
+    `interface\\s+${interfaceName}(?:<[^>{}]+>)?\\s*(?:extends[^{]*)?\\{([^}]+)\\}`,
   );
   const match = content.match(interfacePattern);
 
   if (match) {
     const propsBlock = match[1];
-    const propPattern = /(\w+)(\?)?:\s*([^;,\n}]+)/g;
+    const undocumentedPropsBlock = propsBlock.replace(
+      /\/\*\*[\s\S]*?\*\//g,
+      "",
+    );
+    const documentedPropPattern =
+      /\/\*\*([\s\S]*?)\*\/\s*(\w+)(\?)?:\s*([^;\n}]+)/g;
+    const propPattern = /(\w+)(\?)?:\s*([^;\n}]+)/g;
+    const documentedProps = new Set<string>();
     let propMatch: RegExpExecArray | null;
 
-    while ((propMatch = propPattern.exec(propsBlock)) !== null) {
+    while ((propMatch = documentedPropPattern.exec(propsBlock)) !== null) {
+      const propName = propMatch[2];
+      if (shouldSkipProp(propName, cliFlags)) continue;
+
+      documentedProps.add(propName);
+      props[propName] = {
+        type: propMatch[4].trim(),
+        ...(propMatch[3] ? { optional: true } : { required: true }),
+        description: propMatch[1]
+          .split("\n")
+          .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+          .filter(Boolean)
+          .join(" "),
+      };
+    }
+
+    while ((propMatch = propPattern.exec(undocumentedPropsBlock)) !== null) {
       const propName = propMatch[1];
+      if (documentedProps.has(propName)) continue;
       const isOptional = propMatch[2] === "?";
       let propType = propMatch[3].trim();
 


### PR DESCRIPTION
## Summary

Fixes missing API reference tables for chart components, including `BubbleMap` and `ChoroplethMap`, on the maps documentation page.

## Changes

- Discover components exported from multi-component barrel directories when matching props types are exported.
- Categorize chart entries under Data Visualization.
- Extract complete props metadata and JSDoc descriptions from generic interfaces when schema generation cannot process the root type.
- Add regression coverage for barrel discovery and generic interface extraction.
- Add a patch changeset for `@cloudflare/kumo`.

## Validation

- `pnpm --filter @cloudflare/kumo test:unit --run scripts/component-registry/index.test.ts`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo build`
- `pnpm --filter @cloudflare/kumo-docs-astro build`
- Verified `/charts/maps/` renders both API tables without registry error banners.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: registry generation and static documentation output require repository build context
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->