### PR TITLE
feat(sidebar): add target prop to Sidebar.MenuSubButton

### DIFF
--- a/.changeset/sidebar-menusubbutton-target.md
+++ b/.changeset/sidebar-menusubbutton-target.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `target` prop to `Sidebar.MenuSubButton` for parity with `Sidebar.MenuButton` — forwarded to the link when `href` is set, so link sub-items can control where they open (e.g. same-tab cross-origin navigation).

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -579,6 +579,41 @@ describe("Sidebar.MenuButton", () => {
   });
 });
 
+describe("Sidebar.MenuSubButton", () => {
+  it("should render as link when href provided", () => {
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuSubButton href="/observability">
+              Observability
+            </SidebarMenuSubButton>
+          </SidebarMenu>
+        </SidebarContent>
+      </TestSidebar>,
+    );
+    const link = screen.getByText("Observability").closest("a");
+    expect(link).toBeTruthy();
+    expect(link!.getAttribute("href")).toBe("/observability");
+  });
+
+  it("should forward target to the link when href provided", () => {
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuSubButton href="https://example.com" target="_self">
+              External
+            </SidebarMenuSubButton>
+          </SidebarMenu>
+        </SidebarContent>
+      </TestSidebar>,
+    );
+    const link = screen.getByText("External").closest("a");
+    expect(link!.getAttribute("target")).toBe("_self");
+  });
+});
+
 // ============================================================================
 // Contained mode
 // ============================================================================

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1350,6 +1350,8 @@ export interface SidebarMenuSubButtonProps
   active?: boolean;
   /** Navigation URL. When set, renders as a link via LinkProvider. */
   href?: string;
+  /** Link target — only meaningful when `href` is provided. */
+  target?: React.HTMLAttributeAnchorTarget;
 }
 
 /**
@@ -1369,7 +1371,7 @@ export interface SidebarMenuSubButtonProps
 const SidebarMenuSubButton = forwardRef<
   HTMLButtonElement,
   SidebarMenuSubButtonProps
->(({ className, active = false, href, children, ...props }, ref) => {
+>(({ className, active = false, href, target, children, ...props }, ref) => {
   const LinkComponent = useLinkComponent();
   const isInsideMenuSubItem = useContext(MenuSubItemContext);
 
@@ -1404,6 +1406,7 @@ const SidebarMenuSubButton = forwardRef<
         className={cn(buttonClasses, "no-underline!")}
         href={href}
         to={href}
+        target={target}
         data-active={active || undefined}
         data-sidebar="menu-sub-button"
         data-kumo-component="Sidebar"


### PR DESCRIPTION
Adds an optional `target` prop to `Sidebar.MenuSubButton`, forwarded to the anchor when `href` is set.

## Why

`Sidebar.MenuButton` and `Sidebar.MenuSubButton` both render a real link (via `LinkProvider`) when `href` is set, but only `MenuButton` exposes a `target` prop. This brings `MenuSubButton` to parity so link sub-items can control where they open — following the same approach as `DropdownMenu.LinkItem` (letting consumers control link attributes rather than the component assuming intent).

**Where it helps:** the Cloudflare dashboard's Universal Nav shares one sidebar across apps; some sub-items link to another origin and should open in the same tab. With `target="_self"` that's declarative, instead of an imperative `window.location.href` workaround that breaks native anchor behavior (cmd/middle-click, copy-link).

## Change

- Add `target?: React.HTMLAttributeAnchorTarget` to `SidebarMenuSubButtonProps` (JSDoc mirrors `MenuButton`)
- Destructure `target` and forward it to `<LinkComponent>`
- Added a minor changeset

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: small, self-contained additive prop mirroring `MenuButton`; requesting standard human review
- Tests
  - [x] Tests included/updated
