### PR TITLE
Add Missing Chart Pages to SearchDialog

### DIFF
--- a/packages/kumo-docs-astro/src/components/SearchDialog.tsx
+++ b/packages/kumo-docs-astro/src/components/SearchDialog.tsx
@@ -80,11 +80,43 @@ const STATIC_PAGES: Array<{
     category: "Guides",
   },
   {
+    name: "Charts",
+    description: "Charts built on ECharts.",
+    url: "/charts",
+    category: "Charts",
+  },
+  {
     name: "Chart Colors",
     description:
       "Semantic, categorical, and sequential color guidance for charts.",
     url: "/charts/colors",
-    category: "Guides",
+    category: "Charts",
+  },
+  {
+    name: "Timeseries Chart",
+    description: "A specialized chart for displaying time-based data.",
+    url: "/charts/timeseries",
+    category: "Charts",
+  },
+  {
+    name: "Maps",
+    description:
+      "Map chart components for visualizing geographic data with GeoJSON.",
+    url: "/charts/maps",
+    category: "Charts",
+  },
+  {
+    name: "Sankey Chart",
+    description:
+      "A Sankey diagram component for visualizing flow data between nodes using ECharts.",
+    url: "/charts/sankey",
+    category: "Charts",
+  },
+  {
+    name: "Custom Chart",
+    description: "Example charts using the Chart component.",
+    url: "/charts/custom",
+    category: "Charts",
   },
   {
     name: "CLI",


### PR DESCRIPTION
## Why
Searching for "Chart" in the docs currently only yields the Chart Colors guide.

## Impact
+ All chart-related results added to search
+ Added search category "Charts" for all chart-related pages
    + As a result of this, Chart Colors no longer shows when when searching for "Guides".

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: Tested that search behaves as expected for new and existing search terms.
  - [ ] Additional testing not necessary because: <!-- explain why -->
