### PR TITLE
fix(button): show title tooltip when disabled

### DIFF
--- a/.changeset/tidy-buttons-tooltip.md
+++ b/.changeset/tidy-buttons-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Show Button title tooltips when the button is disabled or loading.

--- a/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
@@ -105,7 +105,7 @@ export function ButtonUsageDemo() {
   return <Button variant="secondary">Click me</Button>;
 }
 
-/** Demonstrates the title prop which wraps the button in a Tooltip. */
+/** Demonstrates title tooltips on enabled, icon-only, and disabled buttons. */
 export function ButtonTitleDemo() {
   return (
     <div className="flex flex-wrap items-center gap-3">
@@ -119,6 +119,13 @@ export function ButtonTitleDemo() {
         aria-label="Add item"
         title="Add item"
       />
+      <Button
+        variant="secondary"
+        title="You need edit access to create a Worker"
+        disabled
+      >
+        Create Worker
+      </Button>
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/button.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/button.mdx
@@ -207,8 +207,8 @@ export default function Example() {
 
   <p>
     Use the `title` prop to wrap the button in a tooltip. This is useful for
-    icon-only buttons or whenever additional context helps the user understand
-    the action.
+    icon-only buttons, disabled buttons, or whenever additional context helps
+    the user understand the action.
   </p>
   <ComponentExample
     demo="ButtonTitleDemo"

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -113,6 +113,37 @@ describe("Button", () => {
     expect(button.getAttribute("title")).toBeNull();
   });
 
+  it("uses an enabled tooltip trigger around a disabled button", () => {
+    render(
+      <Button title="Saving is unavailable" disabled>
+        Save
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Save" });
+    const trigger = button.parentElement;
+
+    expect(button.hasAttribute("disabled")).toBe(true);
+    expect(trigger?.tagName).toBe("SPAN");
+    expect(trigger?.hasAttribute("data-base-ui-tooltip-trigger")).toBe(true);
+    expect(trigger?.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("uses an enabled tooltip trigger around a loading button", () => {
+    render(
+      <Button title="Saving changes" loading>
+        Save
+      </Button>,
+    );
+
+    const button = screen.getByRole("button");
+    const trigger = button.parentElement;
+
+    expect(button.hasAttribute("disabled")).toBe(true);
+    expect(trigger?.tagName).toBe("SPAN");
+    expect(trigger?.hasAttribute("data-base-ui-tooltip-trigger")).toBe(true);
+  });
+
   it("keeps emphasized variant rings color-matched when pressed or focused", () => {
     for (const variant of ["primary", "destructive"] as const) {
       const className = buttonVariants({ variant });

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -142,6 +142,7 @@ describe("Button", () => {
     expect(button.hasAttribute("disabled")).toBe(true);
     expect(trigger?.tagName).toBe("SPAN");
     expect(trigger?.hasAttribute("data-base-ui-tooltip-trigger")).toBe(true);
+    expect(trigger?.hasAttribute("disabled")).toBe(false);
   });
 
   it("keeps emphasized variant rings color-matched when pressed or focused", () => {

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -334,6 +334,14 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       </button>
     );
 
+    if (title && (disabled || loading)) {
+      return (
+        <Tooltip content={title} render={<span className="inline-flex" />}>
+          {button}
+        </Tooltip>
+      );
+    }
+
     if (title) {
       return <Tooltip content={title} render={button} />;
     }


### PR DESCRIPTION
## Summary

- render an enabled tooltip trigger wrapper around disabled and loading buttons
- preserve the native disabled button and forwarded ref
- add regression coverage and a disabled-title docs example

## Tests

- `pnpm exec vitest run --project=unit src/components/button/button.test.tsx`
- `pnpm typecheck` (`packages/kumo`)
- `pnpm lint:oxlint` (`packages/kumo`, existing unrelated warnings only)
- `pnpm codegen:demos`
- targeted `oxlint` for `ButtonDemo.tsx`

Full docs lint/typecheck remain blocked by unrelated existing errors elsewhere in the docs package.

- Reviews
- [x] bonk has reviewed the change
- [ ] automated review not possible because: not applicable
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable