### PR TITLE
fix(typography): use 1.5 line heights

### DIFF
--- a/.changeset/quiet-lines-rest.md
+++ b/.changeset/quiet-lines-rest.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Set default `text-base` and `text-lg` line heights to 1.5.

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -626,7 +626,7 @@ export const THEME_CONFIG: ThemeConfig = {
     "base--line-height": {
       newName: "",
       theme: {
-        kumo: "calc(1.25 / 0.875)",
+        kumo: "1.5",
       },
     },
     lg: {
@@ -638,7 +638,7 @@ export const THEME_CONFIG: ThemeConfig = {
     "lg--line-height": {
       newName: "",
       theme: {
-        kumo: "calc(1.25 / 1)",
+        kumo: "1.5",
       },
     },
   },

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -290,9 +290,9 @@
   --text-sm: 13px;
   --text-sm--line-height: calc(1 / 0.85);
   --text-base: 14px;
-  --text-base--line-height: calc(1.25 / 0.875);
+  --text-base--line-height: 1.5;
   --text-lg: 16px;
-  --text-lg--line-height: calc(1.25 / 1);
+  --text-lg--line-height: 1.5;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

- set default `text-base` and `text-lg` line heights to `1.5`
- regenerate Kumo theme CSS and add patch changeset
- track work in [DESENG-1058](https://jira.cfdata.org/browse/DESENG-1058)

## Validation

- `pnpm exec vitest run --project=unit scripts/theme-generator/generate-css.test.ts`
- touched-file oxlint: 0 warnings, 0 errors

## Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: straightforward typography token update

## Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [x] Additional testing not necessary because: existing theme generator tests pass