### PR TITLE
fix(design-skill): add installation instructions

### DIFF
--- a/packages/kumo-docs-astro/src/components/docs/Heading.astro
+++ b/packages/kumo-docs-astro/src/components/docs/Heading.astro
@@ -35,7 +35,7 @@ const baseStyles = levelStyles[level];
 
 <Element
   id={slug}
-  class:list={["group relative scroll-mt-24 tracking-tight", baseStyles, className]}
+  class:list={["group relative scroll-mt-24", baseStyles, className]}
 >
   <a
     href={`#${slug}`}

--- a/packages/kumo-docs-astro/src/pages/skill.astro
+++ b/packages/kumo-docs-astro/src/pages/skill.astro
@@ -1,5 +1,7 @@
 ---
 import { parseInline } from "marked";
+import CodeBlock from "~/components/docs/CodeBlock.astro";
+import Heading from "~/components/docs/Heading.astro";
 import { DesignTips } from "~/components/skill/DesignTips";
 import { designTips } from "~/components/skill/design-tips";
 import DocLayout from "~/layouts/DocLayout.astro";
@@ -11,11 +13,15 @@ const renderedTips = designTips.map(({ title, description }) => ({
     : {}),
 }));
 
-const headings = designTips.map(({ id, title }) => ({
-  depth: 2,
-  slug: id,
-  text: title,
-}));
+const headings = [
+  { depth: 2, slug: "installation", text: "Installation" },
+  { depth: 2, slug: "rules", text: "Rules" },
+  ...designTips.map(({ id, title }) => ({
+    depth: 3,
+    slug: id,
+    text: title,
+  })),
+];
 ---
 
 <DocLayout
@@ -23,7 +29,16 @@ const headings = designTips.map(({ id, title }) => ({
   description="Cloudflare product design guidance for building and reviewing Kumo interfaces."
   headings={headings}
 >
-  <div class="not-prose grid gap-16">
-    <DesignTips client:load renderedTips={renderedTips} />
+  <div>
+    <section>
+      <Heading level={2} class="mt-0">Installation</Heading>
+      <CodeBlock code="npx skills add cloudflare/kumo@kumo-design" lang="bash" />
+    </section>
+    <section>
+      <Heading level={2}>Rules</Heading>
+      <div class="not-prose grid gap-16">
+        <DesignTips client:load renderedTips={renderedTips} />
+      </div>
+    </section>
   </div>
 </DocLayout>


### PR DESCRIPTION
## Summary

- add Skills CLI installation command to design skill page
- group design guidance under Rules and nest rule links in table of contents
- let documentation headings use natural letter spacing

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: documentation-only content and styling changes
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [x] Additional testing not necessary because: documentation-only content and styling changes