### PR TITLE
perf(docs): prefetch + view-transition soft nav for snappier navigation

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,19 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.3"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "@opencode-ai/plugin": "1.15.11"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -99,20 +87,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.3.tgz",
-      "integrity": "sha512-hAm/hZkSCsMSNHVy9DKmFtZAve/qYoIWpduNPcvXnnKK7NMlJEOQitA6CQC67Ym5DFKypDW1TC9YO6S1WdGtpg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.11.tgz",
+      "integrity": "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ==",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.3",
-        "effect": "4.0.0-beta.83",
+        "@opencode-ai/sdk": "1.15.11",
+        "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.4.3",
-        "@opentui/keymap": ">=0.4.3",
-        "@opentui/solid": ">=0.4.3"
+        "@opentui/core": ">=0.2.15",
+        "@opentui/keymap": ">=0.2.15",
+        "@opentui/solid": ">=0.2.15"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -127,9 +114,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.3.tgz",
-      "integrity": "sha512-Mevo4e6kQwbvto9E+42KSIVMhp+JBu+SwQhC5AomAvrV6Xkio3U249T+xDILDCXhl5Z/Hi/DlAuVLzpGnuh0gg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.11.tgz",
+      "integrity": "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -166,21 +153,21 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.83",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
-      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "version": "4.0.0-beta.66",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
+      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.8.0",
+        "fast-check": "^4.6.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^7.0.0",
+        "ini": "^6.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^2.0.1",
+        "msgpackr": "^1.11.9",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.9.0"
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/fast-check": {
@@ -212,12 +199,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
-      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "license": "ISC",
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/isexe": {
@@ -226,12 +213,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -239,12 +220,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
-      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.4"
+        "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -346,9 +327,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/packages/kumo-docs-astro/astro.config.mjs
+++ b/packages/kumo-docs-astro/astro.config.mjs
@@ -79,6 +79,13 @@ export default defineConfig({
     markdownPages({ passthroughPaths: ["/skill.md"] }),
   ],
   site: "https://kumo-ui.com/",
+  // Prefetch linked pages so navigation feels instant. `hover` fetches the
+  // target page's HTML + assets as soon as a link is hovered/focused, so by
+  // the time the user clicks it's usually already cached.
+  prefetch: {
+    prefetchAll: true,
+    defaultStrategy: "hover",
+  },
   markdown: {
     shikiConfig: {
       themes: {

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -121,7 +121,18 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
   const [chartsOpen, setChartsOpen] = useState(true);
   const [blocksOpen, setBlocksOpen] = useState(true);
 
-  const activePath = normalizePathname(currentPath);
+  // The sidebar is persisted across view-transition navigations
+  // (`transition:persist`), so the `currentPath` prop is only correct for the
+  // first render. Track the live pathname client-side and update it on each
+  // soft navigation so the active-link highlight stays in sync.
+  const [livePath, setLivePath] = useState(currentPath);
+  useEffect(() => {
+    const sync = () => setLivePath(window.location.pathname);
+    sync();
+    document.addEventListener("astro:page-load", sync);
+    return () => document.removeEventListener("astro:page-load", sync);
+  }, []);
+  const activePath = normalizePathname(livePath);
 
   const [searchOpen, setSearchOpen] = useState(false);
 
@@ -297,7 +308,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
                 className={cn(
                   LI_STYLE,
                   "pl-4",
-                  currentPath === item.href && LI_ACTIVE_STYLE,
+                  livePath === item.href && LI_ACTIVE_STYLE,
                 )}
               >
                 {item.label}

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -50,6 +50,14 @@ const buildDate =
     />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <ClientRouter />
+    <style is:global>
+      /* Keep soft navigation + prefetch, but drop Astro's default cross-fade
+         so pages swap instantly instead of fading in/out. */
+      ::view-transition-old(root),
+      ::view-transition-new(root) {
+        animation: none;
+      }
+    </style>
     <script is:inline>
       // Initialize theme from localStorage or system preference.
       // Runs immediately (blocking) to prevent flash of unstyled content, and

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import { ClientRouter } from "astro:transitions";
 
 interface Props {
   title?: string;
@@ -48,9 +49,12 @@ const buildDate =
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=optional"
     />
     <link rel="sitemap" href="/sitemap-index.xml" />
+    <ClientRouter />
     <script is:inline>
-      // Initialize theme from localStorage or system preference
-      // This runs immediately (blocking) to prevent flash of unstyled content
+      // Initialize theme from localStorage or system preference.
+      // Runs immediately (blocking) to prevent flash of unstyled content, and
+      // must be re-applied after each view-transition swap because the <html>
+      // attributes are replaced during navigation.
       (function () {
         function setTheme(theme) {
           localStorage.setItem("theme", theme);
@@ -60,38 +64,54 @@ const buildDate =
           );
         }
 
-        const stored = localStorage.getItem("theme");
-        if (stored) {
-          document.documentElement.setAttribute("data-mode", stored);
-        } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-          document.documentElement.setAttribute("data-mode", "dark");
+        function applyStoredTheme() {
+          const stored = localStorage.getItem("theme");
+          if (stored) {
+            document.documentElement.setAttribute("data-mode", stored);
+          } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            document.documentElement.setAttribute("data-mode", "dark");
+          }
         }
 
-        document.addEventListener("keydown", function (event) {
-          if (event.defaultPrevented || event.repeat) return;
-          if (event.metaKey || event.ctrlKey || event.altKey) return;
-          if (event.key?.toLowerCase() !== "d") return;
+        // Apply on this (initial or freshly-swapped) document immediately.
+        applyStoredTheme();
 
-          const target = event.target;
-          if (
-            target instanceof HTMLElement &&
-            (target.isContentEditable ||
-              target.closest("input, textarea, select, [contenteditable]"))
-          ) {
-            return;
-          }
+        // Register global listeners exactly once across soft navigations.
+        if (!window.__kumoThemeInit) {
+          window.__kumoThemeInit = true;
 
-          event.preventDefault();
-          const current = document.documentElement.getAttribute("data-mode");
-          setTheme(current === "dark" ? "light" : "dark");
-        });
+          // Reapply theme before each swap paints, so there's no light flash.
+          document.addEventListener("astro:before-swap", applyStoredTheme);
+          document.addEventListener("astro:after-swap", applyStoredTheme);
+
+          document.addEventListener("keydown", function (event) {
+            if (event.defaultPrevented || event.repeat) return;
+            if (event.metaKey || event.ctrlKey || event.altKey) return;
+            if (event.key?.toLowerCase() !== "d") return;
+
+            const target = event.target;
+            if (
+              target instanceof HTMLElement &&
+              (target.isContentEditable ||
+                target.closest("input, textarea, select, [contenteditable]"))
+            ) {
+              return;
+            }
+
+            event.preventDefault();
+            const current = document.documentElement.getAttribute("data-mode");
+            setTheme(current === "dark" ? "light" : "dark");
+          });
+        }
       })();
     </script>
   </head>
   <body>
     <slot />
     <script>
-      function initCopyButtons() {
+      // Wraps code blocks and injects a copy button. Safe to run on every page
+      // load — the `.code-block` parent check prevents double-wrapping.
+      function wrapCodeBlocks() {
         document.querySelectorAll("pre.astro-code").forEach((pre) => {
           // Skip <pre> elements already inside a .code-block parent
           if (pre.parentElement?.classList.contains("code-block")) return;
@@ -128,49 +148,53 @@ const buildDate =
           // Append button to the wrapper, as a sibling of <pre>
           wrapper.appendChild(button);
         });
-
-        // Click handler via event delegation
-        const timers = new WeakMap<Element, ReturnType<typeof setTimeout>>();
-        document.addEventListener("click", async (e) => {
-          const btn = (e.target as Element).closest(".code-block-copy-btn");
-
-          if (!btn) return;
-
-          const pre = btn.closest(".code-block")?.querySelector("pre");
-
-          if (!pre) return;
-
-          const code = pre.textContent || "";
-
-          const existingTimer = timers.get(btn);
-
-          if (existingTimer) clearTimeout(existingTimer);
-
-          // Set animation immediately (optimistic)
-          btn.setAttribute("data-copied", "");
-          btn.setAttribute("aria-label", "Copied!");
-
-          try {
-            await navigator.clipboard.writeText(code);
-          } catch {
-            // Roll back on failure
-            btn.removeAttribute("data-copied");
-            btn.setAttribute("aria-label", "Copy code to clipboard");
-            return;
-          }
-
-          timers.set(
-            btn,
-            setTimeout(() => {
-              btn.removeAttribute("data-copied");
-              btn.setAttribute("aria-label", "Copy code to clipboard");
-              timers.delete(btn);
-            }, 1500),
-          );
-        });
       }
 
-      initCopyButtons();
+      // Click handler via event delegation — registered ONCE for the lifetime
+      // of the document (survives soft navigations), so it must live outside
+      // wrapCodeBlocks() to avoid stacking duplicate listeners on each nav.
+      const timers = new WeakMap<Element, ReturnType<typeof setTimeout>>();
+      document.addEventListener("click", async (e) => {
+        const btn = (e.target as Element).closest(".code-block-copy-btn");
+
+        if (!btn) return;
+
+        const pre = btn.closest(".code-block")?.querySelector("pre");
+
+        if (!pre) return;
+
+        const code = pre.textContent || "";
+
+        const existingTimer = timers.get(btn);
+
+        if (existingTimer) clearTimeout(existingTimer);
+
+        // Set animation immediately (optimistic)
+        btn.setAttribute("data-copied", "");
+        btn.setAttribute("aria-label", "Copied!");
+
+        try {
+          await navigator.clipboard.writeText(code);
+        } catch {
+          // Roll back on failure
+          btn.removeAttribute("data-copied");
+          btn.setAttribute("aria-label", "Copy code to clipboard");
+          return;
+        }
+
+        timers.set(
+          btn,
+          setTimeout(() => {
+            btn.removeAttribute("data-copied");
+            btn.setAttribute("aria-label", "Copy code to clipboard");
+            timers.delete(btn);
+          }, 1500),
+        );
+      });
+
+      // Re-wrap code blocks after every navigation. `astro:page-load` fires on
+      // the initial load and after each ClientRouter soft navigation.
+      document.addEventListener("astro:page-load", wrapCodeBlocks);
     </script>
   </body>
 </html>

--- a/packages/kumo-docs-astro/src/layouts/MainLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/MainLayout.astro
@@ -13,7 +13,7 @@ const currentPath = Astro.url.pathname;
 
 <BaseLayout title={title} description={description}>
   <div class="isolate">
-    <SidebarNav currentPath={currentPath} client:load />
+    <SidebarNav currentPath={currentPath} client:load transition:persist />
 
     <script is:inline>
       (function () {


### PR DESCRIPTION
## Summary

The docs site (`kumo-ui.com`) felt sluggish to navigate. It turns out the site is **already fully static** (`output: "static"`, no SSR adapter, `dist/` served as Cloudflare static assets) — the slowness wasn't server rendering. It came from:

- Classic full-page reloads on every link click
- **No prefetch** — each navigation was a cold fetch
- Heavy React island hydration (**113 `client:load` + 331 `client:visible`**) re-booting on every page load

This PR makes navigation feel instant without changing the static output.

## Changes

- **Hover prefetch** (`astro.config.mjs`): `prefetch: { prefetchAll: true, defaultStrategy: "hover" }` — target pages are fetched the moment a link is hovered/focused.
- **Soft navigation** via `<ClientRouter />` (`BaseLayout.astro`) — view-transition navigation instead of cold document reloads. (`MainLayout` already had an `astro:after-swap` scroll-restore handler written in anticipation of this; it was dead until now.)
- **View-transition-safe scripts** (`BaseLayout.astro`):
  - Theme init reapplies on `astro:before-swap`/`astro:after-swap`; keydown listener registered once behind a guard.
  - Copy-button logic split so the click delegation registers once and `wrapCodeBlocks()` re-runs on `astro:page-load` (prevents lost buttons / stacked listeners).
- **Persisted sidebar** (`MainLayout.astro` + `SidebarNav.tsx`): `transition:persist` keeps the heavy `SidebarNav` island mounted across navigations. Since a persisted island won't receive a fresh `currentPath` prop, it now tracks the live pathname via `astro:page-load` so the active-link highlight stays correct.

## Notes

- Docs-only change — no `@cloudflare/kumo` library changes, so no changeset.
- Follow-up idea (separate PR): audit the 113 `client:load` islands and downgrade non-critical ones to `client:visible`/`client:idle` to cut initial JS.

## Test in preview

Navigate around the docs (sidebar links, component pages) — clicks should feel instant, theme toggle + copy buttons should still work across soft navigations, and the active sidebar link should track the current page.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: perceived-performance / navigation UX change best verified by a human in the preview link
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: docs-only navigation enhancement with no library/API changes; build passes (71 static pages) and behavior is verified interactively in the preview deploy
