### PR TITLE
Prevent Generated Chart Search Results from Pointing to Nonexistent Docs

### DIFF
--- a/packages/kumo-docs-astro/src/components/SearchDialog.tsx
+++ b/packages/kumo-docs-astro/src/components/SearchDialog.tsx
@@ -25,6 +25,9 @@ const COMPONENTS_WITHOUT_DOCS = new Set([
   "Field",
   "Icon",
   "Surface", // Deprecated compatibility export; no dedicated docs page
+  "Chart",
+  "SankeyChart",
+  "TimeseriesChart",
 ]);
 
 /**
@@ -35,6 +38,11 @@ const SLUG_OVERRIDES: Record<string, string> = {
   CodeHighlighted: "code-highlighted",
   DropdownMenu: "dropdown",
   Toasty: "toast",
+};
+
+const URL_OVERRIDES: Record<string, string> = {
+  BubbleMap: "/charts/maps",
+  ChoroplethMap: "/charts/maps",
 };
 
 /**
@@ -243,6 +251,8 @@ interface SearchDialogProps {
 
 /** Build URL path from component type and name */
 function getComponentUrl(type: string, name: string): string {
+  if (URL_OVERRIDES[name]) return URL_OVERRIDES[name];
+
   const slug =
     SLUG_OVERRIDES[name] ??
     name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();


### PR DESCRIPTION
Currently the auto-generated search results for Chart components point to nonexistent paths: `/components/chart`, `/components/bubble-map`, etc. Most of these have guides already, so the generated search results were redundant, so removing them was sufficient. `BubbleMap` and `ChoroplethMap`, however, are documented in the "Maps" guide, which is not listed as a result when searching for those components. In those cases, add overrides that direct them to `/charts/maps`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
