### PR TITLE
feat(sidebar): add fullScreenOnMobile prop

### DIFF
--- a/.changeset/sidebar-fullscreen-mobile.md
+++ b/.changeset/sidebar-fullscreen-mobile.md
@@ -1,0 +1,13 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `fullScreenOnMobile` prop to `Sidebar`. When set, the mobile navigation
+sheet expands to the full viewport instead of leaving a sliver of the page
+visible, giving nav items comfortable touch targets. The backdrop is suppressed
+and the divider border dropped, since neither has anything to separate. Defaults
+to `false`.
+
+Also fixes `Breadcrumbs.Link` shrinking alongside the current crumb. Flexbox
+distributed truncation across every crumb, turning the trail into unreadable
+stubs; ancestors now hold their width so only the current page truncates.

--- a/.changeset/sidebar-fullscreen-mobile.md
+++ b/.changeset/sidebar-fullscreen-mobile.md
@@ -8,6 +8,10 @@ visible, giving nav items comfortable touch targets. The backdrop is suppressed
 and the divider border dropped, since neither has anything to separate. Defaults
 to `false`.
 
+Also adds `Sidebar.Close`, a ghost button that dismisses the mobile sheet. It is
+intended for `Sidebar.Header` in full-screen mobile layouts where the backdrop is
+hidden and there is no adjacent page content to tap.
+
 Also fixes `Breadcrumbs.Link` shrinking alongside the current crumb. Flexbox
 distributed truncation across every crumb, turning the trail into unreadable
 stubs; ancestors now hold their width so only the current page truncates.

--- a/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
@@ -114,9 +114,7 @@ function AccountSwitcher() {
 function initialsFor(name: string) {
   const words = name.trim().split(/\s+/);
   return (
-    words.length > 1
-      ? words[0][0] + words[1][0]
-      : name.slice(0, 2)
+    words.length > 1 ? words[0][0] + words[1][0] : name.slice(0, 2)
   ).toUpperCase();
 }
 
@@ -135,7 +133,7 @@ function AccountAvatar({ name, size = 28 }: { name: string; size?: number }) {
       className="flex shrink-0 items-center justify-center rounded-[30%] bg-kumo-control text-kumo-default shadow-xs ring ring-kumo-line"
     >
       <span
-        className="font-semibold leading-none tracking-tight"
+        className="leading-none font-semibold tracking-tight"
         style={{ fontSize: size * 0.4 }}
       >
         {initialsFor(name)}
@@ -158,7 +156,7 @@ function CompactAccountSwitcher() {
           <button
             type="button"
             aria-label={`Account: ${active.name}`}
-            className="shrink-0 cursor-pointer rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-kumo-line"
+            className="shrink-0 cursor-pointer rounded-full transition-opacity outline-none hover:opacity-80 focus-visible:ring-2 focus-visible:ring-kumo-line"
           >
             <AccountAvatar name={active.name} />
           </button>
@@ -168,7 +166,7 @@ function CompactAccountSwitcher() {
         {accounts.map((account) => (
           <DropdownMenu.Item
             key={account.id}
-            className="gap-2 cursor-pointer"
+            className="cursor-pointer gap-2"
             onClick={() => setActive(account)}
           >
             <AccountAvatar name={account.name} size={20} />
@@ -979,7 +977,7 @@ function QuickSearch() {
   return (
     <button
       type="button"
-      className="group flex h-8 w-full shrink-0 cursor-pointer select-none items-center gap-2 overflow-x-clip rounded-lg border-0 bg-kumo-base px-3 text-left text-sm font-normal !text-kumo-default shadow-xs ring ring-kumo-line transition-[color,background,border,box-shadow] duration-250 not-disabled:hover:bg-kumo-tint focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand"
+      className="group flex h-8 w-full shrink-0 cursor-pointer items-center gap-2 overflow-x-clip rounded-lg border-0 bg-kumo-base px-3 text-left text-sm font-normal !text-kumo-default shadow-xs ring ring-kumo-line transition-[color,background,border,box-shadow] duration-250 select-none not-disabled:hover:bg-kumo-tint focus:ring-kumo-focus/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand"
     >
       <MagnifyingGlassIcon className="size-4 shrink-0" />
       <span className="flex-1 text-left">Quick search...</span>
@@ -1255,6 +1253,7 @@ export function SidebarFullScreenMobileDemo() {
                   <Breadcrumbs.Current>{current}</Breadcrumbs.Current>
                 </Breadcrumbs>
               </div>
+              <Sidebar.Close />
             </Sidebar.Header>
             <Sidebar.Content>
               <div className="pt-1 pb-2">

--- a/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
@@ -2,6 +2,7 @@ import {
   Sidebar,
   useSidebar,
   DropdownMenu,
+  Breadcrumbs,
   type SidebarState,
 } from "@cloudflare/kumo";
 import {
@@ -23,8 +24,11 @@ import {
   ArrowsLeftRightIcon,
   ArrowLeftIcon,
   MagnifyingGlassIcon,
+  ClockCounterClockwiseIcon,
+  FileMagnifyingGlassIcon,
+  ChartPieIcon,
 } from "@phosphor-icons/react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -95,6 +99,79 @@ function AccountSwitcher() {
             onClick={() => setActive(account)}
           >
             <account.icon className="size-4 text-kumo-brand" weight="duotone" />
+            {account.name}
+            {account.id === active.id && (
+              <CheckIcon className="ml-auto size-4" />
+            )}
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+/** Initials from an account name: "Workers Prod" → "WP", "Company" → "CO". */
+function initialsFor(name: string) {
+  const words = name.trim().split(/\s+/);
+  return (
+    words.length > 1
+      ? words[0][0] + words[1][0]
+      : name.slice(0, 2)
+  ).toUpperCase();
+}
+
+/**
+ * Squircle avatar with a hairline ring, so it sits on the surface rather than
+ * floating. Muted neutral fill. Reads as an identity
+ * affordance rather than decoration. Sized to the header row rather than to
+ * iOS touch-target minimums — the whole row is generous, and an oversized mark
+ * competes with the breadcrumb trail that should carry the emphasis.
+ */
+function AccountAvatar({ name, size = 28 }: { name: string; size?: number }) {
+  return (
+    <span
+      aria-hidden
+      style={{ width: size, height: size }}
+      className="flex shrink-0 items-center justify-center rounded-[30%] bg-kumo-control text-kumo-default shadow-xs ring ring-kumo-line"
+    >
+      <span
+        className="font-semibold leading-none tracking-tight"
+        style={{ fontSize: size * 0.4 }}
+      >
+        {initialsFor(name)}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Avatar account switcher. The account name lives one tap away in the dropdown,
+ * freeing the header row for the breadcrumb trail.
+ */
+function CompactAccountSwitcher() {
+  const [active, setActive] = useState(accounts[0]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger
+        render={
+          <button
+            type="button"
+            aria-label={`Account: ${active.name}`}
+            className="shrink-0 cursor-pointer rounded-full outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-kumo-line"
+          >
+            <AccountAvatar name={active.name} />
+          </button>
+        }
+      />
+      <DropdownMenu.Content align="start">
+        {accounts.map((account) => (
+          <DropdownMenu.Item
+            key={account.id}
+            className="gap-2 cursor-pointer"
+            onClick={() => setActive(account)}
+          >
+            <AccountAvatar name={account.name} size={20} />
             {account.name}
             {account.id === active.id && (
               <CheckIcon className="ml-auto size-4" />
@@ -872,6 +949,346 @@ export function SidebarMobileDemo() {
           </p>
         </DemoMain>
       </Sidebar.Provider>
+    </div>
+  );
+}
+// ---------------------------------------------------------------------------
+// 10. Full-screen mobile — nav fills the viewport, route lives in breadcrumbs
+// ---------------------------------------------------------------------------
+
+/** A node in the nav tree. Leaves are navigable; branches expand. */
+interface NavNode {
+  label: string;
+  icon?: React.ElementType;
+  /** Small status pill, e.g. "Beta" / "New". */
+  badge?: string;
+  children?: NavNode[];
+}
+
+/** Status pill used beside nav labels. */
+function NavBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="ml-1.5 shrink-0 rounded-full border border-dashed border-kumo-line px-1.5 py-px text-[10px] font-medium text-kumo-subtle">
+      {children}
+    </span>
+  );
+}
+
+/** Quick search affordance pinned above the nav list. */
+function QuickSearch() {
+  return (
+    <button
+      type="button"
+      className="group flex h-8 w-full shrink-0 cursor-pointer select-none items-center gap-2 overflow-x-clip rounded-lg border-0 bg-kumo-base px-3 text-left text-sm font-normal !text-kumo-default shadow-xs ring ring-kumo-line transition-[color,background,border,box-shadow] duration-250 not-disabled:hover:bg-kumo-tint focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand"
+    >
+      <MagnifyingGlassIcon className="size-4 shrink-0" />
+      <span className="flex-1 text-left">Quick search...</span>
+      <kbd className="shrink-0 font-sans text-xs text-kumo-subtle">⌘K</kbd>
+    </button>
+  );
+}
+
+/**
+ * The nav tree. Breadcrumbs are derived from this, so the trail can never drift
+ * out of sync with the sidebar — selecting a leaf yields its full ancestry.
+ */
+const NAV_TREE: { group: string | null; items: NavNode[] }[] = [
+  {
+    group: null,
+    items: [
+      { label: "Account home", icon: HouseIcon },
+      { label: "Recents", icon: ClockCounterClockwiseIcon },
+      { label: "Domains", icon: GlobeIcon },
+    ],
+  },
+  {
+    group: "Observe",
+    items: [
+      {
+        label: "Investigate",
+        icon: FileMagnifyingGlassIcon,
+        children: [
+          { label: "Log Explorer" },
+          { label: "Trace", badge: "Beta" },
+          { label: "Logpush" },
+        ],
+      },
+      {
+        label: "Analytics",
+        icon: ChartPieIcon,
+        children: [
+          { label: "Dashboards", badge: "New" },
+          { label: "Account analytics" },
+          { label: "Web analytics" },
+        ],
+      },
+    ],
+  },
+  {
+    group: "Build",
+    items: [
+      {
+        label: "Compute",
+        icon: CodeIcon,
+        children: [
+          { label: "Workers & Pages" },
+          { label: "Observability" },
+          { label: "Workers for Platforms" },
+          { label: "Containers" },
+          { label: "Durable Objects" },
+          { label: "Queues" },
+          { label: "Workflows" },
+          { label: "Browser Run" },
+          { label: "VPC", badge: "Beta" },
+        ],
+      },
+      {
+        label: "Storage & Databases",
+        icon: DatabaseIcon,
+        children: [
+          { label: "R2 Object Storage" },
+          { label: "KV" },
+          { label: "D1 SQL Database" },
+          { label: "Hyperdrive" },
+        ],
+      },
+    ],
+  },
+  {
+    group: "Secure",
+    items: [
+      {
+        label: "Access",
+        icon: LockIcon,
+        children: [{ label: "Applications" }, { label: "Service Auth" }],
+      },
+      { label: "WAF", icon: ShieldCheckIcon },
+    ],
+  },
+];
+
+/**
+ * Renders a nav subtree. Branches are collapsible and auto-open when they are
+ * on the selected path; leaves select and close the nav.
+ */
+function NavSubtree({
+  nodes,
+  path,
+  selected,
+  onSelect,
+}: {
+  nodes: NavNode[];
+  path: string[];
+  selected: string[];
+  onSelect: (path: string[]) => void;
+}) {
+  return (
+    <Sidebar.MenuSub>
+      {nodes.map((node) => {
+        const nodePath = [...path, node.label];
+        const onSelectedPath = nodePath.every((p, i) => selected[i] === p);
+
+        if (!node.children) {
+          return (
+            <Sidebar.MenuSubItem key={node.label}>
+              <Sidebar.MenuSubButton
+                active={onSelectedPath && selected.length === nodePath.length}
+                onClick={() => onSelect(nodePath)}
+              >
+                {node.label}
+                {node.badge && <NavBadge>{node.badge}</NavBadge>}
+              </Sidebar.MenuSubButton>
+            </Sidebar.MenuSubItem>
+          );
+        }
+
+        return (
+          <Sidebar.MenuSubItem key={node.label}>
+            <Sidebar.Collapsible defaultOpen={onSelectedPath}>
+              <Sidebar.CollapsibleTrigger
+                render={
+                  <Sidebar.MenuSubButton>
+                    {node.label}
+                    <Sidebar.MenuChevron />
+                  </Sidebar.MenuSubButton>
+                }
+              />
+              <Sidebar.CollapsibleContent>
+                <NavSubtree
+                  nodes={node.children}
+                  path={nodePath}
+                  selected={selected}
+                  onSelect={onSelect}
+                />
+              </Sidebar.CollapsibleContent>
+            </Sidebar.Collapsible>
+          </Sidebar.MenuSubItem>
+        );
+      })}
+    </Sidebar.MenuSub>
+  );
+}
+
+/** Closes the mobile nav after a leaf is chosen, mirroring real navigation. */
+function NavTree({
+  selected,
+  onSelect,
+}: {
+  selected: string[];
+  onSelect: (path: string[]) => void;
+}) {
+  const { setOpenMobile } = useSidebar();
+  const select = (path: string[]) => {
+    onSelect(path);
+    setOpenMobile(false);
+  };
+
+  return (
+    <>
+      {NAV_TREE.map(({ group, items }) => (
+        <Sidebar.Group key={group ?? "root"}>
+          {group && <Sidebar.GroupLabel>{group}</Sidebar.GroupLabel>}
+          <Sidebar.Menu>
+            {items.map((node) => {
+              const nodePath = [node.label];
+              const onSelectedPath = selected[0] === node.label;
+
+              if (!node.children) {
+                return (
+                  <Sidebar.MenuButton
+                    key={node.label}
+                    icon={node.icon}
+                    active={onSelectedPath && selected.length === 1}
+                    onClick={() => select(nodePath)}
+                  >
+                    {node.label}
+                  </Sidebar.MenuButton>
+                );
+              }
+
+              return (
+                <Sidebar.MenuItem key={node.label}>
+                  <Sidebar.Collapsible defaultOpen={onSelectedPath}>
+                    <Sidebar.CollapsibleTrigger
+                      render={
+                        <Sidebar.MenuButton icon={node.icon}>
+                          {node.label}
+                          <Sidebar.MenuChevron />
+                        </Sidebar.MenuButton>
+                      }
+                    />
+                    <Sidebar.CollapsibleContent>
+                      <NavSubtree
+                        nodes={node.children}
+                        path={nodePath}
+                        selected={selected}
+                        onSelect={select}
+                      />
+                    </Sidebar.CollapsibleContent>
+                  </Sidebar.Collapsible>
+                </Sidebar.MenuItem>
+              );
+            })}
+          </Sidebar.Menu>
+        </Sidebar.Group>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Full-screen mobile nav. The sheet covers the viewport instead of leaving a
+ * sliver of the page behind, so nav items get comfortable touch targets. The
+ * current route is carried by breadcrumbs derived from the nav tree itself.
+ */
+export function SidebarFullScreenMobileDemo() {
+  // Deep default selection, so the trail starts in a realistic overflow state.
+  const [selected, setSelected] = useState(["Analytics", "Account analytics"]);
+  // Narrower than the demo box, so overflow collapsing is visible without
+  // needing to resize the browser.
+  const [width, setWidth] = useState(390);
+
+  // Trail derived from the selection: ancestors collapse, leaf is current.
+  const ancestors = selected.slice(0, -1);
+  const current = selected[selected.length - 1];
+  // No overflow machinery: render the trail plainly and let the leaf truncate
+  // when it runs out of room. Simpler, and the route stays readable because it
+  // is the only thing allowed to shrink.
+  // No account crumb — the avatar to the left already carries it, and at phone
+  // widths every crumb spent on context is width taken from the actual route.
+  const trail = ancestors;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Width control — stands in for resizing a real phone viewport. */}
+      <label className="flex items-center gap-3 text-sm text-kumo-subtle">
+        <span className="shrink-0">Viewport</span>
+        <input
+          type="range"
+          min={280}
+          max={720}
+          value={width}
+          onChange={(e) => setWidth(Number(e.target.value))}
+          className="flex-1 cursor-pointer"
+        />
+        <span className="w-14 shrink-0 text-right tabular-nums">{width}px</span>
+      </label>
+
+      <div
+        className="relative h-[540px] overflow-hidden rounded-lg border border-kumo-line bg-kumo-base"
+        style={{ width }}
+      >
+        <Sidebar.Provider contained mobileBreakpoint={9999} className="h-full">
+          <Sidebar fullScreenOnMobile>
+            {/* Single row: avatar, then the trail takes the rest of the width.
+                Mirrors the product header — account mark, then breadcrumbs. */}
+            <Sidebar.Header className="gap-2 px-3.5">
+              <CompactAccountSwitcher />
+              <div className="min-w-0 flex-1">
+                <Breadcrumbs size="sm">
+                  {trail.map((label) => (
+                    <Fragment key={label}>
+                      <Breadcrumbs.Link href="#">{label}</Breadcrumbs.Link>
+                      <Breadcrumbs.Separator />
+                    </Fragment>
+                  ))}
+                  <Breadcrumbs.Current>{current}</Breadcrumbs.Current>
+                </Breadcrumbs>
+              </div>
+            </Sidebar.Header>
+            <Sidebar.Content>
+              <div className="pt-1 pb-2">
+                <QuickSearch />
+              </div>
+              <NavTree selected={selected} onSelect={setSelected} />
+            </Sidebar.Content>
+          </Sidebar>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <header className="flex h-12 shrink-0 items-center gap-2 border-b border-kumo-line px-3">
+              <Sidebar.Trigger />
+              <div className="min-w-0 flex-1">
+                <Breadcrumbs size="sm">
+                  {trail.map((label) => (
+                    <Fragment key={label}>
+                      <Breadcrumbs.Link href="#">{label}</Breadcrumbs.Link>
+                      <Breadcrumbs.Separator />
+                    </Fragment>
+                  ))}
+                  <Breadcrumbs.Current>{current}</Breadcrumbs.Current>
+                </Breadcrumbs>
+              </div>
+            </header>
+            <DemoMain>
+              <p className="text-kumo-default">{current}</p>
+              <p className="text-sm text-kumo-subtle">
+                Drill into the nav — the trail is derived from the tree, so it
+                always matches where you are.
+              </p>
+            </DemoMain>
+          </div>
+        </Sidebar.Provider>
+      </div>
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -344,10 +344,14 @@ const { state, isPeeking } = useSidebar();
         <p>
           Pass <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">fullScreenOnMobile</code> to have the drawer cover the whole viewport instead of leaving a sliver of the page visible.
           Nav items get comfortable touch targets, and the backdrop is suppressed since nothing shows behind the sheet.
+          Add <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Sidebar.Close</code> inside the header so the sheet can be dismissed from within the nav.
           Pair it with breadcrumbs in the page header so the current route stays visible once the nav is closed.
         </p>
         <ComponentExample code={`<Sidebar.Provider mobileBreakpoint={9999}>
   <Sidebar fullScreenOnMobile>
+    <Sidebar.Header>
+      <Sidebar.Close />
+    </Sidebar.Header>
     <Sidebar.Content>...</Sidebar.Content>
   </Sidebar>
 

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -16,6 +16,7 @@ import {
   SidebarAutoScrollDemo,
   SidebarSlidingViewsDemo,
   SidebarMobileDemo,
+  SidebarFullScreenMobileDemo,
 } from "../../components/demos/SidebarDemo";
 ---
 
@@ -335,6 +336,31 @@ const { state, isPeeking } = useSidebar();
   </Sidebar>
 </Sidebar.Provider>`}>
           <SidebarMobileDemo client:load />
+        </ComponentExample>
+      </div>
+
+      <div>
+        <Heading level={3}>Full-screen mobile</Heading>
+        <p>
+          Pass <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">fullScreenOnMobile</code> to have the drawer cover the whole viewport instead of leaving a sliver of the page visible.
+          Nav items get comfortable touch targets, and the backdrop is suppressed since nothing shows behind the sheet.
+          Pair it with breadcrumbs in the page header so the current route stays visible once the nav is closed.
+        </p>
+        <ComponentExample code={`<Sidebar.Provider mobileBreakpoint={9999}>
+  <Sidebar fullScreenOnMobile>
+    <Sidebar.Content>...</Sidebar.Content>
+  </Sidebar>
+
+  <header>
+    <Sidebar.Trigger />
+    <Breadcrumbs size="sm">
+      <Breadcrumbs.Link href="/">Company</Breadcrumbs.Link>
+      <Breadcrumbs.Separator />
+      <Breadcrumbs.Current>Analytics</Breadcrumbs.Current>
+    </Breadcrumbs>
+  </header>
+</Sidebar.Provider>`}>
+          <SidebarFullScreenMobileDemo client:load />
         </ComponentExample>
       </div>
 

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -75,10 +75,13 @@ const Link = ({
       data-kumo-component="Breadcrumbs"
       data-kumo-part="link"
       to={href}
-      className="flex max-w-full min-w-0 items-center gap-1 text-kumo-subtle no-underline"
+      // Ancestors do not shrink. Letting every crumb truncate proportionally
+      // turns the whole trail into unreadable stubs ("Com… › Anal… › Acco…");
+      // the current page is the only crumb allowed to give up width.
+      className="flex shrink-0 items-center gap-1 whitespace-nowrap text-kumo-subtle no-underline"
     >
       {!!icon && <span className="flex shrink-0 items-center">{icon}</span>}
-      <span className="truncate">{children}</span>
+      <span>{children}</span>
     </LinkComponent>
   );
 };

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -14,11 +14,12 @@ import React, {
 } from "react";
 import { ScrollArea as ScrollAreaBase } from "@base-ui/react/scroll-area";
 
-import { CaretRightIcon } from "@phosphor-icons/react";
+import { CaretRightIcon, XIcon } from "@phosphor-icons/react";
 import { cn } from "../../utils/cn";
 import { useLinkComponent } from "../../utils/link-provider";
 import { SkeletonLine } from "../loader/skeleton-line";
 import { Tooltip, TooltipProvider } from "../tooltip";
+import { Button } from "../button";
 
 // ============================================================================
 // Variants (required by Kumo convention)
@@ -431,7 +432,16 @@ export interface SidebarRootProps extends ComponentPropsWithoutRef<"aside"> {
  * ```
  */
 const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
-  ({ className, contentClassName, children, fullScreenOnMobile = false, ...props }, ref) => {
+  (
+    {
+      className,
+      contentClassName,
+      children,
+      fullScreenOnMobile = false,
+      ...props
+    },
+    ref,
+  ) => {
     const {
       state,
       open,
@@ -578,7 +588,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
               "motion-reduce:transition-none",
               openMobile && !fullScreenOnMobile
                 ? "opacity-80"
-                : "opacity-0 pointer-events-none",
+                : "pointer-events-none opacity-0",
             )}
             onClick={() => {
               shouldRestoreFocusRef.current = true;
@@ -603,7 +613,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             data-sidebar="sidebar"
             data-mobile="true"
             className={cn(
-              "group/sidebar z-50 flex inset-y-0 flex-col overflow-hidden",
+              "group/sidebar inset-y-0 z-50 flex flex-col overflow-hidden",
               contained ? "absolute" : "fixed",
               fullScreenOnMobile ? "w-full" : "w-(--sidebar-width)",
               "bg-(--sidebar-bg) text-kumo-default",
@@ -1639,6 +1649,56 @@ const SidebarTrigger = forwardRef<
 SidebarTrigger.displayName = "Sidebar.Trigger";
 
 // ============================================================================
+// Sidebar Close
+// ============================================================================
+
+/**
+ * Close button for the mobile sidebar sheet. Most useful inside
+ * `Sidebar.Header` when `fullScreenOnMobile` is true, where the backdrop is
+ * hidden and there is no adjacent page content to click.
+ *
+ * On desktop this is a no-op (the sidebar is not a sheet), so it can be
+ * rendered unconditionally without conditional checks.
+ *
+ * @example
+ * ```tsx
+ * <Sidebar.Header>
+ *   <span className="flex-1">Navigation</span>
+ *   <Sidebar.Close />
+ * </Sidebar.Header>
+ * ```
+ */
+const SidebarClose = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<"button">
+>(({ className, onClick, ...props }, ref) => {
+  const { setOpenMobile } = useSidebar();
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      shape="square"
+      size="sm"
+      data-sidebar="close"
+      data-kumo-component="Sidebar"
+      data-kumo-part="close"
+      aria-label="Close navigation"
+      className={cn("shrink-0", className)}
+      onClick={(e) => {
+        onClick?.(e);
+        setOpenMobile(false);
+      }}
+      {...props}
+    >
+      <XIcon size={18} />
+    </Button>
+  );
+});
+
+SidebarClose.displayName = "Sidebar.Close";
+
+// ============================================================================
 // Sidebar Rail
 // ============================================================================
 
@@ -2285,11 +2345,12 @@ SidebarSlidingView.displayName = "Sidebar.SlidingView";
  * Sidebar — responsive navigation panel with expand/collapse support.
  *
  * Compound component: `Sidebar` (root `<aside>`), `.Provider`, `.Header`,
- * `.Content`, `.Footer`, `.Group`, `.GroupLabel`,
+ * `.Content`, `.Footer`, `.Loading`, `.Group`, `.GroupLabel`,
  * `.Menu`, `.MenuItem`, `.MenuButton`, `.MenuBadge`,
  * `.MenuSub`, `.MenuSubItem`, `.MenuSubButton`, `.Separator`,
- * `.Trigger`, `.Rail`, `.MenuChevron`,
- * `.Collapsible`, `.CollapsibleTrigger`, `.CollapsibleContent`.
+ * `.Trigger`, `.Close`, `.Rail`, `.ResizeHandle`, `.MenuChevron`,
+ * `.Collapsible`, `.CollapsibleTrigger`, `.CollapsibleContent`,
+ * `.SlidingViews`, `.SlidingView`.
  *
  * @example
  * ```tsx
@@ -2328,6 +2389,7 @@ export const Sidebar = Object.assign(SidebarRoot, {
   MenuSubButton: SidebarMenuSubButton,
   Separator: SidebarSeparator,
   Trigger: SidebarTrigger,
+  Close: SidebarClose,
   Rail: SidebarRail,
   ResizeHandle: SidebarResizeHandle,
   MenuChevron: SidebarMenuChevron,
@@ -2356,6 +2418,7 @@ export {
   SidebarMenuSubButton,
   SidebarSeparator,
   SidebarTrigger,
+  SidebarClose,
   SidebarRail,
   SidebarResizeHandle,
   SidebarMenuChevron,

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -406,6 +406,13 @@ export interface SidebarRootProps extends ComponentPropsWithoutRef<"aside"> {
   contentClassName?: string;
   /** Sidebar content — Header, Content, Footer, etc. */
   children: ReactNode;
+  /**
+   * On mobile, expand the sidebar sheet to the full viewport width instead of
+   * `--sidebar-width`. The backdrop is suppressed since nothing shows behind it.
+   * Pair with breadcrumbs in the page header so the current route stays visible.
+   * @default false
+   */
+  fullScreenOnMobile?: boolean;
 }
 
 /**
@@ -424,7 +431,7 @@ export interface SidebarRootProps extends ComponentPropsWithoutRef<"aside"> {
  * ```
  */
 const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
-  ({ className, contentClassName, children, ...props }, ref) => {
+  ({ className, contentClassName, children, fullScreenOnMobile = false, ...props }, ref) => {
     const {
       state,
       open,
@@ -569,7 +576,9 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
                 : "fixed inset-0 z-40 bg-kumo-recessed",
               "transition-opacity duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
               "motion-reduce:transition-none",
-              openMobile ? "opacity-80" : "pointer-events-none opacity-0",
+              openMobile && !fullScreenOnMobile
+                ? "opacity-80"
+                : "opacity-0 pointer-events-none",
             )}
             onClick={() => {
               shouldRestoreFocusRef.current = true;
@@ -594,10 +603,12 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
             data-sidebar="sidebar"
             data-mobile="true"
             className={cn(
-              contained
-                ? "group/sidebar absolute inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden"
-                : "group/sidebar fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden",
-              "border-r border-kumo-line bg-(--sidebar-bg) text-kumo-default",
+              "group/sidebar z-50 flex inset-y-0 flex-col overflow-hidden",
+              contained ? "absolute" : "fixed",
+              fullScreenOnMobile ? "w-full" : "w-(--sidebar-width)",
+              "bg-(--sidebar-bg) text-kumo-default",
+              // No border when full-screen — there is no adjacent content to divide.
+              !fullScreenOnMobile && "border-r border-kumo-line",
               "transition-transform duration-(--sidebar-animation-duration) ease-(--sidebar-easing)",
               "motion-reduce:transition-none",
               side === "left" && "left-0",


### PR DESCRIPTION
## Summary

On mobile the sidebar sheet leaves a sliver of the page visible. That sliver exists to show which page you're on — but the header breadcrumbs already carry that, and the leftover width squeezes nav items into small touch targets.

`fullScreenOnMobile` expands the sheet to the full viewport instead:

```tsx
<Sidebar.Provider mobileBreakpoint={9999}>
  <Sidebar fullScreenOnMobile>
    <Sidebar.Content>...</Sidebar.Content>
  </Sidebar>
</Sidebar.Provider>
```

- Sheet goes `w-full` instead of `w-(--sidebar-width)`
- Backdrop suppressed — nothing shows behind a full-width sheet
- Right border dropped — no adjacent content to divide
- Existing slide-in, focus management, `inert`/`aria-hidden`, and Escape-to-close are untouched
- Defaults to `false`, so existing consumers are unaffected

## Also included

`Breadcrumbs.Link` had `min-w-0` + `truncate`, so flexbox distributed shrinkage across *every* crumb — a narrow trail rendered as `Com… › Anal… › Acco…`. Ancestors are now `shrink-0`; only `Breadcrumbs.Current` gives up width. This matters here because the full-screen nav leans on breadcrumbs to carry the route.

`Sidebar.Close` — a ghost button that dismisses the mobile sheet, intended for `Sidebar.Header` in full-screen mobile layouts where the backdrop is hidden.

## Demo

New "Full-screen mobile" example on the sidebar docs page, with a viewport slider (280–720px). Nav mirrors the real product IA (Observe / Build / Secure), with quick search and an avatar account switcher. The trail is derived from the nav tree, so it can't drift out of sync with the sidebar.

## Not addressed

- **Account selector zoom/jank on focus** — reported alongside this feedback. I couldn't reproduce it from the code: the viewport meta is correct and the trigger is a `<button>`, not an input. Still open.
- **Swipe-to-dismiss** — the sheet can currently only be closed via the trigger or the new `Sidebar.Close`. Worth a follow-up.
- Responsive breadcrumb overflow is intentionally out of scope; see #389.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: full-screen mobile behavior and visual details need human review on the preview deploy
- Tests
- [ ] Tests included/updated
- [x] Automated tests not possible - manual testing has been completed as follows: verified rendering and close interactions in the docs full-screen mobile demo at multiple viewport widths
- [ ] Additional testing not necessary because: