### PR TITLE
fix(chart): mute timeseries chart chrome

### DIFF
--- a/.changeset/muted-timeseries-axis-labels.md
+++ b/.changeset/muted-timeseries-axis-labels.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Use muted chart text colors for timeseries axis labels and titles.

--- a/.changeset/muted-timeseries-axis-labels.md
+++ b/.changeset/muted-timeseries-axis-labels.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Use muted chart colors for timeseries axes and brush selections.
+Use muted chart text colors for timeseries axis labels and titles.

--- a/.changeset/muted-timeseries-axis-labels.md
+++ b/.changeset/muted-timeseries-axis-labels.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Use muted chart text colors for timeseries axis labels and titles.
+Use muted chart colors for timeseries axes and brush selections.

--- a/.changeset/muted-timeseries-axis-labels.md
+++ b/.changeset/muted-timeseries-axis-labels.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Use muted chart text colors for timeseries axis labels and titles.
+Use muted chart colors for timeseries axes and horizontal gridlines.

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -435,8 +435,8 @@ export const TimeseriesChart = forwardRef<
         },
         brushStyle: {
           borderWidth: 1,
-          color: colorWithOpacity(axisTextColor, 0.2),
-          borderColor: colorWithOpacity(axisTextColor, 0.6),
+          color: "rgba(120,140,180,0.3)",
+          borderColor: "rgba(120,140,180,0.8)",
         },
       },
       tooltip: {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -309,6 +309,7 @@ export const TimeseriesChart = forwardRef<
   const incompleteAfter = incomplete?.after;
 
   const markerColor = ChartPalette.text("primary", isDarkMode);
+  const axisTextColor = ChartPalette.text("primary", isDarkMode);
   const markerLabelBackgroundColor = isDarkMode
     ? "rgba(0, 0, 0, 0.5)"
     : "rgba(255, 255, 255, 0.5)";
@@ -450,26 +451,30 @@ export const TimeseriesChart = forwardRef<
         name: xAxisName,
         nameLocation: "middle" as const,
         nameGap: 30,
+        nameTextStyle: { color: axisTextColor },
         type: "time" as const,
         splitLine: {
           show: false,
         },
         axisLine: { show: false },
         splitNumber: xAxisTickCount ?? DEFAULT_X_AXIS_TICK_COUNT,
-        ...(xAxisTickFormat && {
-          axisLabel: {
+        axisLabel: {
+          color: axisTextColor,
+          ...(xAxisTickFormat && {
             formatter: (value: number) => xAxisTickFormat(value),
-          },
-        }),
+          }),
+        },
       },
       yAxis: {
         name: yAxisName,
         nameLocation: "middle" as const,
         nameGap: 40,
+        nameTextStyle: { color: axisTextColor },
         type: "value" as const,
         axisTick: { show: true },
         axisLabel: {
           margin: 15,
+          color: axisTextColor,
           ...(yAxisTickFormat && {
             formatter: (value: number) => yAxisTickFormat(value),
           }),
@@ -513,6 +518,7 @@ export const TimeseriesChart = forwardRef<
     thresholds,
     markerColor,
     markerLabelBackgroundColor,
+    axisTextColor,
   ]);
 
   const events = useMemo<Partial<ChartEvents>>(() => {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -435,8 +435,8 @@ export const TimeseriesChart = forwardRef<
         },
         brushStyle: {
           borderWidth: 1,
-          color: "rgba(120,140,180,0.3)",
-          borderColor: "rgba(120,140,180,0.8)",
+          color: colorWithOpacity(axisTextColor, 0.2),
+          borderColor: colorWithOpacity(axisTextColor, 0.6),
         },
       },
       tooltip: {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -310,6 +310,7 @@ export const TimeseriesChart = forwardRef<
 
   const markerColor = ChartPalette.text("primary", isDarkMode);
   const axisTextColor = ChartPalette.text("primary", isDarkMode);
+  const gridLineColor = colorWithOpacity(axisTextColor, 0.2);
   const markerLabelBackgroundColor = isDarkMode
     ? "rgba(0, 0, 0, 0.5)"
     : "rgba(255, 255, 255, 0.5)";
@@ -481,7 +482,11 @@ export const TimeseriesChart = forwardRef<
         },
         splitLine: {
           show: true,
-          lineStyle: { type: "dashed" as const, width: 1 },
+          lineStyle: {
+            type: "dashed" as const,
+            width: 1,
+            color: gridLineColor,
+          },
         },
         splitNumber: yAxisTickCount,
         ...(thresholdExtent && {
@@ -519,6 +524,7 @@ export const TimeseriesChart = forwardRef<
     markerColor,
     markerLabelBackgroundColor,
     axisTextColor,
+    gridLineColor,
   ]);
 
   const events = useMemo<Partial<ChartEvents>>(() => {


### PR DESCRIPTION
## Summary
- use the theme-aware muted chart text color for timeseries axis ticks and titles
- soften horizontal gridlines using the same chart palette color at reduced opacity
- add a patch changeset for `@cloudflare/kumo`

## Testing
- `pnpm --filter @cloudflare/kumo exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: no automated review integration is available in this environment
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [x] Additional testing not necessary because: this is a visual styling change using existing chart palette utilities; typecheck and lint pass