### PR TITLE
fix(command-palette): improve match highlight contrast

### DIFF
--- a/.changeset/tidy-command-palette-highlights.md
+++ b/.changeset/tidy-command-palette-highlights.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix command palette match highlight contrast in dark mode.

--- a/packages/kumo/src/components/command-palette/command-palette.test.tsx
+++ b/packages/kumo/src/components/command-palette/command-palette.test.tsx
@@ -257,6 +257,21 @@ describe("CommandPalette", () => {
     });
   });
 
+  describe("Highlighted Text", () => {
+    it("uses a themed background for matching text", () => {
+      render(
+        <CommandPalette.HighlightedText
+          text="Autocomplete"
+          highlights={[[0, 3]]}
+        />,
+      );
+
+      const highlight = screen.getByText("Auto");
+      expect(highlight.tagName).toBe("MARK");
+      expect(highlight.className).toContain("bg-kumo-warning/50");
+    });
+  });
+
   describe("Keyboard Navigation", () => {
     it("navigates items with arrow keys", async () => {
       const user = userEvent.setup();

--- a/packages/kumo/src/components/command-palette/command-palette.tsx
+++ b/packages/kumo/src/components/command-palette/command-palette.tsx
@@ -452,7 +452,7 @@ function HighlightedText({
     parts.push(
       <mark
         key={`highlight-${i}`}
-        className="rounded-sm fill-kumo-warning/15 text-kumo-default"
+        className="rounded-sm bg-kumo-warning/50 text-kumo-default"
       >
         {text.slice(start, end + 1)}
       </mark>,


### PR DESCRIPTION
## Summary

- restore the command palette match background used before the accidental regression in #628
- use the theme-aware warning background at 50% opacity in light and dark modes
- add a regression test for highlighted text styling

## Tests

- `pnpm --filter @cloudflare/kumo exec vitest run --project=unit src/components/command-palette/command-palette.test.tsx`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a one-line semantic utility correction with a focused regression test
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable