### PR TITLE
feat(kumo): wrap LinkButton in a Tooltip when title is set

### DIFF
--- a/.changeset/linkbutton-title-tooltip.md
+++ b/.changeset/linkbutton-title-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+`LinkButton` now wraps in a Kumo `Tooltip` when a `title` is provided, matching `Button`'s behavior. Previously an enabled `LinkButton` only set a native `title` attribute; it now surfaces the same styled tooltip on hover and focus.

--- a/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
@@ -149,6 +149,19 @@ export function ButtonLinkAsButtonDemo() {
   );
 }
 
+/** Demonstrates a title tooltip on an enabled LinkButton. */
+export function ButtonLinkTooltipDemo() {
+  return (
+    <LinkButton
+      href="/components/link"
+      variant="secondary"
+      title="Opens the Link component docs"
+    >
+      Read Link docs
+    </LinkButton>
+  );
+}
+
 /** Demonstrates the disabled LinkButton, including a title tooltip explaining why. */
 export function ButtonDisabledLinkDemo() {
   return (

--- a/packages/kumo-docs-astro/src/pages/components/button.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/button.mdx
@@ -24,6 +24,7 @@ import {
   ButtonDisabledDemo,
   ButtonTitleDemo,
   ButtonLinkAsButtonDemo,
+  ButtonLinkTooltipDemo,
   ButtonDisabledLinkDemo,
 } from "~/components/demos/ButtonDemo";
 
@@ -232,6 +233,20 @@ export default function Example() {
   vrTitle="Link as Button"
 >
   <ButtonLinkAsButtonDemo client:visible />
+</ComponentExample>
+
+### Link with Tooltip
+
+<p>
+  Pass `title` to a `LinkButton` to wrap it in a tooltip, just like `Button`.
+  This surfaces extra context on hover and focus.
+</p>
+<ComponentExample
+  demo="ButtonLinkTooltipDemo"
+  vrSection="link-tooltip"
+  vrTitle="Link with Tooltip"
+>
+  <ButtonLinkTooltipDemo client:visible />
 </ComponentExample>
 
 ### Disabled Link

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -202,6 +202,18 @@ describe("LinkButton", () => {
     expect(ref.current).toBe(screen.getByRole("link"));
   });
 
+  it("title prop wraps the anchor in a Tooltip and removes the native title attribute", () => {
+    render(
+      <LinkButton href="/home" title="Go to the home page">
+        Home
+      </LinkButton>,
+    );
+    const link = screen.getByRole("link", { name: "Home" });
+    // title is intercepted by the Kumo Tooltip wrapper, not set as a native attribute
+    expect(link.getAttribute("title")).toBeNull();
+    expect(link.hasAttribute("data-base-ui-tooltip-trigger")).toBe(true);
+  });
+
   describe("disabled", () => {
     it("renders a disabled <button> instead of an <a>", () => {
       render(

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -459,7 +459,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
       );
     }
 
-    return (
+    const link = (
       <LinkComponent
         ref={ref}
         data-kumo-component="LinkButton"
@@ -470,7 +470,6 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
         )}
         href={href}
         style={emphasisStyle ? { ...emphasisStyle, ...style } : style}
-        title={title}
         to={typeof href === "string" ? href : undefined}
         {...externalProps}
         {...props}
@@ -478,6 +477,12 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
         {renderButtonContent(variant, renderIconNode(IconComponent), children)}
       </LinkComponent>
     );
+
+    if (title) {
+      return <Tooltip content={title} render={link} />;
+    }
+
+    return link;
   },
 );
 


### PR DESCRIPTION
## Summary

Makes `LinkButton` wrap in a Kumo `Tooltip` when a `title` is provided, matching `Button`'s behavior. Previously an enabled `LinkButton` only set a native `title` attribute (browser default tooltip); it now surfaces the same styled Kumo tooltip on hover and focus.

The disabled `LinkButton` already got the Kumo tooltip because it delegates to `Button` — this closes the gap for the enabled anchor.

## Implementation

The enabled branch now builds the anchor as a variable and wraps it when `title` is set, mirroring `Button`'s `if (title)` path:

```tsx
const link = (
  <LinkComponent … >{…}</LinkComponent>
);

if (title) {
  return <Tooltip content={title} render={link} />;
}

return link;
```

The native `title={title}` passthrough on the anchor was removed so we don't get a double (native + Kumo) tooltip. `title` is already destructured out of the spread props, so nothing leaks onto the DOM.

## Tests

1 new test in `button.test.tsx`: an enabled `LinkButton` with `title` becomes a Base UI tooltip trigger (`data-base-ui-tooltip-trigger`) and does not set a native `title` attribute. All 24 `button.test.tsx` tests pass.

## Docs

- New `ButtonLinkTooltipDemo` in `ButtonDemo.tsx`
- New "Link with Tooltip" section on `/components/button`

## Verification

- `pnpm --filter @cloudflare/kumo typecheck` → 0 errors
- `pnpm lint` → 0 errors (pre-existing chart warnings only, unrelated)
- `pnpm --filter @cloudflare/kumo test:run button` → 24/24 pass
- Manual browser check on `/components/button`: hovering the enabled `LinkButton` renders the Kumo tooltip ("Opens the Link component docs"); the anchor has `data-base-ui-tooltip-trigger` and no native `title`

## Changeset

`minor` bump for `@cloudflare/kumo` (additive behavior, no breaking change).

---

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: feature work on a personal fork — bonk reviews can run after merge to main
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:
