### PR TITLE
feat(chart): add loading skeleton and legend loading state

### DIFF
--- a/.changeset/chart-legend-loading.md
+++ b/.changeset/chart-legend-loading.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Improve chart loading states with a static, reduced-motion-aware `TimeseriesChart` skeleton (line and bar variants matching `type`) and a new `loading` prop for `ChartLegend.SmallItem` and `ChartLegend.LargeItem`.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -5,6 +5,7 @@ import {
   ChartLegend,
   LayerCard,
   Select,
+  Switch,
 } from "@cloudflare/kumo";
 import * as echarts from "echarts/core";
 import type { EChartsOption } from "echarts";
@@ -451,6 +452,12 @@ export function LegendDefaultDemo() {
           inactive
         />
       </div>
+
+      <h3 className="text-sm font-medium mt-12">Loading state</h3>
+
+      <div className="flex flex-wrap gap-4 divide-x divide-kumo-hairline">
+        <ChartLegend.LargeItem loading />
+      </div>
     </div>
   );
 }
@@ -507,6 +514,12 @@ export function LegendCompactDemo() {
           inactive
         />
       </div>
+
+      <h3 className="text-sm font-medium mt-12">Loading state</h3>
+
+      <div className="flex flex-wrap gap-4">
+        <ChartLegend.SmallItem loading />
+      </div>
     </div>
   );
 }
@@ -547,8 +560,7 @@ export function BarChartDemo() {
 }
 
 /**
- * Timeseries chart in loading state, showing the animated sine-wave skeleton.
- * Loads for 5 seconds then reveals the real chart. A button restarts the cycle.
+ * Line timeseries chart in loading state, showing the calm area-shaped skeleton.
  */
 export function LoadingChartDemo() {
   const isDarkMode = useIsDarkMode();
@@ -561,6 +573,83 @@ export function LoadingChartDemo() {
         yAxisName="Count"
         data={[]}
         loading
+      />
+    </div>
+  );
+}
+
+/**
+ * Bar timeseries chart in loading state, showing the bar-shaped skeleton that
+ * matches the chart's `type="bar"` output.
+ */
+export function LoadingBarChartDemo() {
+  const isDarkMode = useIsDarkMode();
+  return (
+    <div className="flex flex-col flex-1 w-full">
+      <TimeseriesChart
+        echarts={echarts}
+        isDarkMode={isDarkMode}
+        type="bar"
+        xAxisName="Time (UTC)"
+        yAxisName="Count"
+        data={[]}
+        loading
+      />
+    </div>
+  );
+}
+
+/**
+ * Timeseries chart with a Switch to toggle between the loading skeleton and the
+ * real chart, plus a small legend. Useful for comparing the two states directly.
+ */
+export function LoadingToggleChartDemo() {
+  const isDarkMode = useIsDarkMode();
+  const [loading, setLoading] = useState(true);
+
+  const data = useMemo(
+    () => [
+      {
+        name: "Requests",
+        data: buildSeriesData(0, 50, 60_000, 1),
+        color: ChartPalette.semantic("Neutral", isDarkMode),
+      },
+      {
+        name: "Errors",
+        data: buildSeriesData(1, 50, 60_000, 0.3),
+        color: ChartPalette.semantic("Attention", isDarkMode),
+      },
+    ],
+    [isDarkMode],
+  );
+
+  return (
+    <div className="flex flex-col flex-1 w-full gap-3">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-wrap gap-4">
+          {data.map((series) => (
+            <ChartLegend.SmallItem
+              loading={loading}
+              key={series.name}
+              name={series.name}
+              color={series.color}
+              value={Math.round(series.data.at(-1)?.[1] ?? 0).toLocaleString()}
+            />
+          ))}
+        </div>
+        <Switch
+          label="Loading"
+          checked={loading}
+          onCheckedChange={setLoading}
+        />
+      </div>
+      <TimeseriesChart
+        echarts={echarts}
+        isDarkMode={isDarkMode}
+        xAxisName="Time (UTC)"
+        yAxisName="Count"
+        data={loading ? [] : data}
+        loading={loading}
       />
     </div>
   );

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -18,6 +18,7 @@ import {
   LegendHighlightDemo,
   LegendOnClickDemo,
   LoadingChartDemo,
+  LoadingBarChartDemo,
   TimeRangeSelectionChartDemo,
   TooltipFollowCursorDemo,
   TooltipBoundaryDemo,
@@ -211,12 +212,19 @@ import {
 ## Loading State
 
 <p>
-  Set <code>loading</code> to <code>true</code> to display an animated sine-wave
-  skeleton while data is being fetched. The chart canvas is hidden until loading
-  completes; swap back to <code>loading={`{false}`}</code> to reveal the chart.
+  Set <code>loading</code> to <code>true</code> to show a skeleton that matches
+  the chart's <code>type</code> while data loads.
 </p>
+
+### Line
 
   <ComponentExample demo="LoadingChartDemo">
     <LoadingChartDemo client:only="react" />
+  </ComponentExample>
+
+### Bar
+
+  <ComponentExample demo="LoadingBarChartDemo">
+    <LoadingBarChartDemo client:only="react" />
   </ComponentExample>
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/tests/timeseries.astro
+++ b/packages/kumo-docs-astro/src/pages/tests/timeseries.astro
@@ -1,0 +1,64 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import {
+  BarChartDemo,
+  BasicLineChartDemo,
+  LoadingBarChartDemo,
+  LoadingChartDemo,
+  LoadingToggleChartDemo,
+} from "../../components/demos/Chart/ChartDemo";
+---
+
+<BaseLayout title="Timeseries Chart Test">
+  <main class="mx-auto mb-64 max-w-3xl space-y-12 p-6 md:p-12">
+    <header>
+      <h1 class="text-2xl font-semibold text-kumo-strong">
+        Timeseries chart test
+      </h1>
+      <p class="mt-2 text-kumo-subtle">
+        Test fixtures for the primary timeseries chart states. Press <kbd
+          class="rounded bg-kumo-tint px-1.5 py-0.5 text-xs">D</kbd
+        > to toggle dark mode.
+      </p>
+    </header>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold text-kumo-default">Basic line</h2>
+      <div class="rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <BasicLineChartDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold text-kumo-default">Stacked bar</h2>
+      <div class="rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <BarChartDemo client:visible />
+      </div>
+    </section>
+
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold text-kumo-default">Loading (line)</h2>
+      <div class="rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <LoadingChartDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold text-kumo-default">Loading (bar)</h2>
+      <div class="rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <LoadingBarChartDemo client:visible />
+      </div>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-xl font-semibold text-kumo-default">
+        Loading toggle
+      </h2>
+      <div class="rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <LoadingToggleChartDemo client:visible />
+      </div>
+    </section>
+
+  </main>
+</BaseLayout>

--- a/packages/kumo/src/components/chart/Legend.tsx
+++ b/packages/kumo/src/components/chart/Legend.tsx
@@ -146,7 +146,7 @@ function SmallItem({
     return (
       <div
         aria-hidden="true"
-        className={cn("inline-flex items-center gap-2", className)}
+        className={cn("inline-flex items-center gap-2 h-4", className)}
       >
         <span className="size-2 rounded-full inline-block bg-kumo-fill" />
         <SkeletonLine className="w-[5ch] h-3" />
@@ -161,7 +161,7 @@ function SmallItem({
       role="button"
       tabIndex={onClick ? 0 : -1}
       className={cn(
-        "inline-flex items-center gap-2",
+        "inline-flex items-center gap-2 h-4",
         { "cursor-pointer": !!onClick },
         className,
       )}

--- a/packages/kumo/src/components/chart/Legend.tsx
+++ b/packages/kumo/src/components/chart/Legend.tsx
@@ -4,6 +4,7 @@ import type {
   PointerEventHandler,
 } from "react";
 import { cn } from "../../utils";
+import { SkeletonLine } from "../loader";
 
 const onInteractiveKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
   if (event.key !== "Enter" && event.key !== " ") return;
@@ -11,8 +12,8 @@ const onInteractiveKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
   event.currentTarget.click();
 };
 
-/** Shared props for both legend item variants */
-interface LegendItemProps {
+/** Content props shared by both legend item variants when data is present */
+interface LegendItemContentProps {
   /** Series name shown as a label */
   name: string;
   /** Hex color string for the series indicator dot */
@@ -29,9 +30,22 @@ interface LegendItemProps {
   onPointerLeave?: PointerEventHandler<HTMLDivElement>;
   /** Fired when the legend item is clicked — useful for toggling series visibility */
   onClick?: MouseEventHandler<HTMLDivElement>;
-  /** Optional className to customize legend item presentation */
-  className?: string;
 }
+
+/**
+ * Legend item props. When `loading` is `true`, the item renders skeleton
+ * placeholders (you typically have no data yet); otherwise pass `name`,
+ * `color`, and `value`.
+ */
+type LegendItemProps = {
+  className?: string;
+} & (
+  | ({
+      /** When `true`, renders animated skeleton placeholders instead of content */
+      loading: true;
+    } & Partial<LegendItemContentProps>)
+  | ({ loading?: boolean } & LegendItemContentProps)
+);
 
 /**
  * Large legend item — stacked layout with a colored dot + series name on top
@@ -44,11 +58,27 @@ function LargeItem({
   name,
   unit,
   inactive,
+  loading,
   onPointerEnter,
   onPointerLeave,
   onClick,
   className,
 }: LegendItemProps) {
+  if (loading) {
+    return (
+      <div
+        aria-hidden="true"
+        className={cn("inline-flex flex-col gap-2 min-w-42 py-2", className)}
+      >
+        <div className="flex items-center gap-2">
+          <span className="size-2 rounded-full inline-block bg-kumo-fill" />
+          <SkeletonLine className="w-[8ch] h-3" />
+        </div>
+        <SkeletonLine className="w-[5ch] h-5" />
+      </div>
+    );
+  }
+
   return (
     <div
       // oxlint-disable-next-line prefer-tag-over-role
@@ -106,11 +136,25 @@ function SmallItem({
   value,
   name,
   inactive,
+  loading,
   onPointerEnter,
   onPointerLeave,
   onClick,
   className,
 }: LegendItemProps) {
+  if (loading) {
+    return (
+      <div
+        aria-hidden="true"
+        className={cn("inline-flex items-center gap-2", className)}
+      >
+        <span className="size-2 rounded-full inline-block bg-kumo-fill" />
+        <SkeletonLine className="w-[5ch] h-3" />
+        <SkeletonLine className="w-[3ch] h-3" />
+      </div>
+    );
+  }
+
   return (
     <div
       // oxlint-disable-next-line prefer-tag-over-role
@@ -150,6 +194,9 @@ function SmallItem({
  * ```tsx
  * <ChartLegend.SmallItem name="Requests" color="#086FFF" value="1,234" />
  * <ChartLegend.LargeItem name="Latency" color="#CF7EE9" value="42" unit="ms" inactive />
+ *
+ * // While data is loading, render skeleton placeholders:
+ * <ChartLegend.SmallItem loading />
  * ```
  */
 export const ChartLegend = {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -163,8 +164,8 @@ export interface TimeseriesChartProps {
    */
   gradient?: boolean;
   /**
-   * When `true`, hides the chart and displays an animated sine-wave skeleton
-   * that oscillates back and forth to indicate that data is being fetched.
+   * When `true`, hides the chart and displays a skeleton matching the chart
+   * type with a subtle shimmer.
    */
   loading?: boolean;
   /**
@@ -323,7 +324,8 @@ export const TimeseriesChart = forwardRef<
         ? ({ type: "bar", stack: "total" } as const)
         : ({ type: "line", showSymbol: false } as const);
 
-    const thresholdAnnotations = buildTimeseriesThresholdAnnotations(thresholds);
+    const thresholdAnnotations =
+      buildTimeseriesThresholdAnnotations(thresholds);
     const thresholdExtent = getThresholdValueExtent(thresholds);
 
     const markerClusters = clusterTimeseriesMarkers(
@@ -698,11 +700,17 @@ export const TimeseriesChart = forwardRef<
             ref={containerRef}
             className="relative w-full"
             style={{ height }}
+            aria-busy={loading || undefined}
           />
         }
       >
-        {loading && <ChartWaveLoader height={height} isDarkMode={isDarkMode} />}
-        {!loading && (
+        {loading ? (
+          <ChartSkeletonLoader
+            height={height}
+            isDarkMode={isDarkMode}
+            type={type}
+          />
+        ) : (
           <Chart
             echarts={echarts}
             ref={mergedRef}
@@ -866,56 +874,145 @@ function isSameTooltipRows(a: TooltipRow[], b: TooltipRow[]): boolean {
   });
 }
 
+/** Line/area or bar chart skeleton with a reduced-motion-aware shimmer. */
+const CHART_LOADER_WIDTH = 400;
+const CHART_LOADER_SAMPLES = 80;
+const CHART_LOADER_BARS = 24;
+const CHART_LOADER_BAR_GAP_RATIO = 0.35;
+
 /**
- * Animated sine-wave skeleton shown while `TimeseriesChart` is in `loading` state.
- * Renders multiple staggered wave paths that sweep continuously left-to-right,
- * mimicking the motion of live time-series data being drawn.
+ * Sum of harmonics used to shape both the area line and the bar heights, so the
+ * two skeleton variants share the same calm, organic silhouette.
+ * Returns a value roughly in the range `[-1, 1]`.
  */
-function ChartWaveLoader({
+function chartLoaderWave(theta: number): number {
+  return (
+    0.45 * Math.sin(3 * theta) +
+    0.3 * Math.sin(5 * theta + 0.9) +
+    0.25 * Math.sin(7 * theta + 2.1)
+  );
+}
+
+function ChartSkeletonLoader({
   height,
   isDarkMode,
+  type = "line",
 }: {
   height: number;
   isDarkMode?: boolean;
+  type?: "line" | "bar";
 }) {
+  const id = `kumo-chart-loader-${useId().replace(/[^a-zA-Z0-9_-]/g, "")}`;
+  const fillId = `${id}-fill`;
+  const shineId = `${id}-shine`;
+  const clipId = `${id}-clip`;
+  const color = ChartPalette.semantic("Skeleton", isDarkMode);
+
+  const strokeOpacity = isDarkMode ? 0.36 : 0.6;
+  const fillOpacity = isDarkMode ? 0.07 : 0.1;
+  const shineOpacity = isDarkMode ? 0.16 : 0.24;
+
+  const barFillOpacity = isDarkMode ? 0.12 : 0.16;
+
+  // Bars: harmonic-driven heights so the silhouette matches the line variant.
+  const slot = CHART_LOADER_WIDTH / CHART_LOADER_BARS;
+  const barW = slot * (1 - CHART_LOADER_BAR_GAP_RATIO);
+  const minBarH = height * 0.15;
+  const maxBarH = height * 0.85;
+  const bars = Array.from({ length: CHART_LOADER_BARS }, (_, i) => {
+    const theta = ((i + 0.5) / CHART_LOADER_BARS) * 2 * Math.PI;
+    const norm = (chartLoaderWave(theta) + 1) / 2;
+    const barH = minBarH + norm * (maxBarH - minBarH);
+    const x = i * slot + (slot - barW) / 2;
+    return { x, y: height - barH, w: barW, h: barH };
+  });
+
+  // Area: sampled wave line with a filled area beneath it.
   const mid = height / 2;
-  const amp = Math.min(height * 0.12, 28);
-  const period = 400;
-  const steps = 120;
+  const amp = Math.min(height * 0.18, 40);
+  const lineD = Array.from({ length: CHART_LOADER_SAMPLES + 1 }, (_, i) => {
+    const x = (i / CHART_LOADER_SAMPLES) * CHART_LOADER_WIDTH;
+    const theta = (x / CHART_LOADER_WIDTH) * 2 * Math.PI;
+    const y = mid - chartLoaderWave(theta) * amp;
+    return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+  }).join(" ");
+  const areaD = `${lineD} L${CHART_LOADER_WIDTH},${height} L0,${height} Z`;
 
-  const points: string[] = [];
-  for (let i = 0; i <= steps; i++) {
-    const x = -period + (i / steps) * period * 3;
-    const y = mid + Math.sin((i / steps) * 2 * Math.PI * 3) * amp;
-    points.push(`${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`);
-  }
-  const d = points.join(" ");
-
-  const strokeColor = isDarkMode ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.2)";
+  const isBar = type === "bar";
 
   return (
     <div
-      aria-hidden="true"
+      role="status"
+      aria-label="Loading chart"
       className="absolute inset-0 overflow-hidden"
       style={{ height }}
     >
       <svg
+        aria-hidden="true"
         width="100%"
         height={height}
-        viewBox={`0 0 ${period} ${height}`}
+        viewBox={`0 0 ${CHART_LOADER_WIDTH} ${height}`}
         preserveAspectRatio="none"
-        className="w-full animate-pulse"
+        className="block w-full"
       >
-        <path
-          d={d}
-          fill="none"
-          stroke={strokeColor}
-          strokeWidth="2"
-          style={{
-            animation: `kumo-chart-wave 2.4s linear infinite`,
-            transformOrigin: "0 0",
-          }}
-        />
+        <defs>
+          <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={fillOpacity} />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+          <linearGradient id={shineId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor={color} stopOpacity="0" />
+            <stop offset="50%" stopColor={color} stopOpacity={shineOpacity} />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+          <clipPath id={clipId}>
+            {isBar ? (
+              bars.map((b, i) => (
+                <rect key={i} x={b.x} y={b.y} width={b.w} height={b.h} />
+              ))
+            ) : (
+              <path d={areaD} />
+            )}
+          </clipPath>
+        </defs>
+
+        {isBar ? (
+          bars.map((b, i) => (
+            <rect
+              key={i}
+              x={b.x}
+              y={b.y}
+              width={b.w}
+              height={b.h}
+              fill={color}
+              fillOpacity={barFillOpacity}
+              stroke="none"
+            />
+          ))
+        ) : (
+          <>
+            <path d={areaD} fill={`url(#${fillId})`} stroke="none" />
+            <path
+              d={lineD}
+              fill="none"
+              stroke={color}
+              strokeOpacity={strokeOpacity}
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+            />
+          </>
+        )}
+
+        <g clipPath={`url(#${clipId})`}>
+          <rect
+            className="kumo-chart-shimmer"
+            x="0"
+            y="0"
+            width={CHART_LOADER_WIDTH}
+            height={height}
+            fill={`url(#${shineId})`}
+          />
+        </g>
       </svg>
     </div>
   );

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -141,15 +141,16 @@
   }
 }
 
-/* Chart wave-loader animation: slides the SVG path left by one full period,
-   creating a seamless looping sine wave. Used by TimeseriesChart loading state. */
-@keyframes kumo-chart-wave {
-  from {
-    transform: translateX(0);
-  }
+/* Chart loading skeleton: the wave stays static while the shimmer moves. */
+.kumo-chart-shimmer {
+  animation: shimmer 1.8s ease-in-out infinite;
+  transform-box: fill-box;
+}
 
-  to {
-    transform: translateX(-400px);
+@media (prefers-reduced-motion: reduce) {
+  .kumo-chart-shimmer {
+    animation: none;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
Replace the animated sine-wave loader with a static, reduced-motion-aware TimeseriesChart skeleton with line and bar variants matching `type`, and add a `loading` prop for ChartLegend.SmallItem and ChartLegend.LargeItem.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: verified in the docs preview link
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
