### PR TITLE
fix(chart): constrain timeseries tooltip to chart

### DIFF
--- a/.changeset/calm-timeseries-context-menu.md
+++ b/.changeset/calm-timeseries-context-menu.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Prevent TimeseriesChart tooltips from following the cursor outside the chart after a browser context menu interaction.

--- a/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
@@ -1,4 +1,10 @@
-import { render, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TimeseriesChart } from "./TimeseriesChart";
 
@@ -16,6 +22,47 @@ const createMockEcharts = (mockChart = createMockChart()) => ({
 });
 
 describe("TimeseriesChart", () => {
+  it("closes the tooltip when leaving the chart after a context menu interaction", async () => {
+    const mockChart = createMockChart();
+    const mockEcharts = createMockEcharts(mockChart);
+
+    render(
+      <TimeseriesChart
+        echarts={mockEcharts as any}
+        data={[
+          {
+            name: "Requests",
+            color: "#4290F0",
+            data: [[1, 10]],
+          },
+        ]}
+      />,
+    );
+
+    const updateAxisPointer = mockChart.on.mock.calls.find(
+      (call) => call[0] === "updateaxispointer",
+    )?.[1];
+    expect(updateAxisPointer).toBeTypeOf("function");
+
+    await act(() => updateAxisPointer({ axesInfo: [{ value: 1 }] }));
+    expect(await screen.findByText("Requests")).not.toBeNull();
+
+    const trigger = document.querySelector("[data-base-ui-tooltip-trigger]");
+    expect(trigger).toBeInstanceOf(HTMLElement);
+    fireEvent.contextMenu(trigger as HTMLElement);
+    expect(screen.queryByText("Requests")).not.toBeNull();
+
+    await act(() => updateAxisPointer({ axesInfo: [{ value: 1 }] }));
+    expect(await screen.findByText("Requests")).not.toBeNull();
+
+    vi.spyOn(trigger as HTMLElement, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(0, 0, 100, 100),
+    );
+    fireEvent.mouseMove(window, { clientX: 101, clientY: 50 });
+
+    expect(screen.queryByText("Requests")).toBeNull();
+  });
+
   it("reactivates brush-to-zoom after a notMerge option update", async () => {
     const mockChart = createMockChart();
     const mockEcharts = createMockEcharts(mockChart);

--- a/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { TimeseriesChart } from "./TimeseriesChart";
 
@@ -22,6 +23,35 @@ const createMockEcharts = (mockChart = createMockChart()) => ({
 });
 
 describe("TimeseriesChart", () => {
+  it("server-renders without browser globals", () => {
+    const mockEcharts = createMockEcharts();
+    const originalWindow = globalThis.window;
+    const originalDocument = globalThis.document;
+
+    vi.stubGlobal("window", undefined);
+    vi.stubGlobal("document", undefined);
+
+    try {
+      expect(() =>
+        renderToString(
+          <TimeseriesChart
+            echarts={mockEcharts as any}
+            data={[
+              {
+                name: "Requests",
+                color: "#4290F0",
+                data: [[1, 10]],
+              },
+            ]}
+          />,
+        ),
+      ).not.toThrow();
+    } finally {
+      vi.stubGlobal("window", originalWindow);
+      vi.stubGlobal("document", originalDocument);
+    }
+  });
+
   it("closes the tooltip when leaving the chart after a context menu interaction", async () => {
     const mockChart = createMockChart();
     const mockEcharts = createMockEcharts(mockChart);

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -290,6 +290,39 @@ export const TimeseriesChart = forwardRef<
 
   const [tooltipState, setTooltipState] = useState<TooltipState | null>(null);
 
+  const closeTooltip = useCallback(() => {
+    activeMarkerKeyRef.current = null;
+    markerHoverRef.current = false;
+    setTooltipState(null);
+  }, []);
+  const tooltipOpen = tooltipState !== null;
+
+  // Fallback close: after a native context menu (right-click "Save image as…")
+  // the browser can drop the mouse events ECharts needs to fire `globalout`,
+  // leaving the tooltip stuck open. Closing on any mousemove outside the chart
+  // recovers from that.
+  useEffect(() => {
+    if (!tooltipOpen) return;
+
+    const closeWhenOutsideChart = (event: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const rect = container.getBoundingClientRect();
+      if (
+        event.clientX < rect.left ||
+        event.clientX > rect.right ||
+        event.clientY < rect.top ||
+        event.clientY > rect.bottom
+      ) {
+        closeTooltip();
+      }
+    };
+
+    window.addEventListener("mousemove", closeWhenOutsideChart);
+    return () => window.removeEventListener("mousemove", closeWhenOutsideChart);
+  }, [tooltipOpen, closeTooltip]);
+
   // Track cursor position for single-mode y lookup (convertFromPixel needs relative coords)
   const mousePosRef = useRef({ x: 0, y: 0 });
   useEffect(() => {
@@ -619,15 +652,9 @@ export const TimeseriesChart = forwardRef<
       },
       mouseout: (params) => {
         if (!getTimeseriesMarkerFromEvent(params)) return;
-        activeMarkerKeyRef.current = null;
-        markerHoverRef.current = false;
-        setTooltipState(null);
+        closeTooltip();
       },
-      globalout: () => {
-        activeMarkerKeyRef.current = null;
-        markerHoverRef.current = false;
-        setTooltipState(null);
-      },
+      globalout: closeTooltip,
       // Keep the tooltip in sync with legend selection. Each action fires a
       // different event — `legendToggleSelect` → `legendselectchanged`,
       // `legendSelect` → `legendselected`, `legendUnSelect` → `legendunselected`
@@ -650,7 +677,7 @@ export const TimeseriesChart = forwardRef<
         },
       }),
     };
-  }, [onTimeRangeChange, markerColor]);
+  }, [onTimeRangeChange, markerColor, closeTooltip]);
 
   // Activate the lineX brush cursor when a time-range callback is provided,
   // and reactivate it after options are replaced. ECharts clears the active
@@ -687,7 +714,6 @@ export const TimeseriesChart = forwardRef<
   }, [chartRef, hasTimeRangeCallback, loading, brushResetKey]);
 
   const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat;
-  const tooltipOpen = tooltipState !== null;
 
   return (
     <TooltipPrimitive.Root

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -303,6 +303,7 @@ export const TimeseriesChart = forwardRef<
   // recovers from that.
   useEffect(() => {
     if (!tooltipOpen) return;
+    if (typeof window === "undefined") return;
 
     const closeWhenOutsideChart = (event: MouseEvent) => {
       const container = containerRef.current;


### PR DESCRIPTION
Fixes the TimeseriesChart tooltip following the cursor outside the chart after a native context-menu interaction.

Adds chart-boundary detection while the tooltip is open, providing a fallback when ECharts does not emit `globalout`. Includes regression coverage for the affected interaction.

**Reviews**
- [x] bonk has reviewed the change
- [ ] automated review not possible because:

**Tests**
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
