### PR TITLE
build: bump prettier to 3.9.5 and reformat

### DIFF
--- a/.agents/skills/index-knowledge/SKILL.md
+++ b/.agents/skills/index-knowledge/SKILL.md
@@ -29,7 +29,7 @@ Default: Update mode (modify existing + create new where warranted)
 
 <critical>
 **TodoWrite ALL phases. Mark in_progress → completed in real-time.**
-  
+
 ```
 TodoWrite([
   { id: "discovery", content: "Fire explore agents + LSP codemap + read existing", status: "pending", priority: "high" },
@@ -38,6 +38,7 @@ TodoWrite([
   { id: "review", content: "Deduplicate, validate, trim", status: "pending", priority: "medium" }
 ])
 ```
+
 </critical>
 
 ---

--- a/.changeset/bump-prettier.md
+++ b/.changeset/bump-prettier.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Bump Prettier 3.6.2 → 3.9.5 and reformat (Prettier changed e.g. interface heritage-clause wrapping). No functional changes.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "oxlint": "catalog:",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
-    "prettier": "3.6.2",
+    "prettier": "3.9.5",
     "prettier-plugin-tailwindcss": "0.7.1",
     "tsx": "catalog:",
     "typescript": "catalog:"

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ColorDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ColorDemo.tsx
@@ -154,12 +154,7 @@ const LINE_STYLE_BY_SERIES: Record<string, "solid" | "dashed" | "dotted"> = {
 };
 
 type SemanticColorName =
-  | "Attention"
-  | "Warning"
-  | "Success"
-  | "Neutral"
-  | "Disabled"
-  | "Skeleton";
+  "Attention" | "Warning" | "Success" | "Neutral" | "Disabled" | "Skeleton";
 
 const semanticColorNames: SemanticColorName[] = [
   "Attention",

--- a/packages/kumo-figma/src/generators/shared.ts
+++ b/packages/kumo-figma/src/generators/shared.ts
@@ -485,8 +485,7 @@ export type AutoLayoutConfig = {
   counterAxisAlignItems?: "MIN" | "CENTER" | "MAX";
   /** Padding (all sides equal, or {top, right, bottom, left}) */
   padding?:
-    | number
-    | { top: number; right: number; bottom: number; left: number };
+    number | { top: number; right: number; bottom: number; left: number };
   /** Gap between child elements */
   itemSpacing?: number;
   /** Primary axis sizing behavior */

--- a/packages/kumo-figma/src/parsers/tailwind-to-figma.ts
+++ b/packages/kumo-figma/src/parsers/tailwind-to-figma.ts
@@ -194,11 +194,7 @@ export function parseTailwindClasses(classes: string): ParsedStyles {
     );
     if (stateMatch) {
       const state = stateMatch[1] as
-        | "hover"
-        | "focus"
-        | "active"
-        | "disabled"
-        | "pressed";
+        "hover" | "focus" | "active" | "disabled" | "pressed";
       const stateClass = stateMatch[2];
 
       // Parse the state class recursively

--- a/packages/kumo-screenshot-worker/worker-configuration.d.ts
+++ b/packages/kumo-screenshot-worker/worker-configuration.d.ts
@@ -18,8 +18,9 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
     : string;
 };
 declare namespace NodeJS {
-  interface ProcessEnv
-    extends StringifyValues<Pick<Cloudflare.Env, "API_KEY">> {}
+  interface ProcessEnv extends StringifyValues<
+    Pick<Cloudflare.Env, "API_KEY">
+  > {}
 }
 
 // Begin runtime types
@@ -110,7 +111,7 @@ declare abstract class WorkerGlobalScope extends EventTarget<WorkerGlobalScopeEv
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/console)
  */
 interface Console {
-  "assert"(condition?: boolean, ...data: any[]): void;
+  assert(condition?: boolean, ...data: any[]): void;
   /**
    * The **`console.clear()`** static method clears the console if possible.
    *
@@ -243,13 +244,7 @@ declare namespace WebAssembly {
     constructor(message?: string);
   }
   type ValueType =
-    | "anyfunc"
-    | "externref"
-    | "f32"
-    | "f64"
-    | "i32"
-    | "i64"
-    | "v128";
+    "anyfunc" | "externref" | "f32" | "f64" | "i32" | "i64" | "v128";
   interface GlobalDescriptor {
     value: ValueType;
     mutable?: boolean;
@@ -624,15 +619,7 @@ interface DurableObjectNamespaceNewUniqueIdOptions {
   jurisdiction?: DurableObjectJurisdiction;
 }
 type DurableObjectLocationHint =
-  | "wnam"
-  | "enam"
-  | "sam"
-  | "weur"
-  | "eeur"
-  | "apac"
-  | "oc"
-  | "afr"
-  | "me";
+  "wnam" | "enam" | "sam" | "weur" | "eeur" | "apac" | "oc" | "afr" | "me";
 type DurableObjectRoutingMode = "primary-only";
 interface DurableObjectNamespaceGetDurableObjectOptions {
   locationHint?: DurableObjectLocationHint;
@@ -905,8 +892,7 @@ interface EventListenerObject<EventType extends Event = Event> {
   handleEvent(event: EventType): void;
 }
 type EventListenerOrEventListenerObject<EventType extends Event = Event> =
-  | EventListener<EventType>
-  | EventListenerObject<EventType>;
+  EventListener<EventType> | EventListenerObject<EventType>;
 /**
  * The **`EventTarget`** interface is implemented by objects that can receive events and may have listeners for them.
  *
@@ -1858,9 +1844,7 @@ declare abstract class FetchEvent extends ExtendableEvent {
   passThroughOnException(): void;
 }
 type HeadersInit =
-  | Headers
-  | Iterable<Iterable<string>>
-  | Record<string, string>;
+  Headers | Iterable<Iterable<string>> | Record<string, string>;
 /**
  * The **`Headers`** interface of the Fetch API allows you to perform various actions on HTTP request and response headers.
  *
@@ -2021,8 +2005,7 @@ interface ResponseInit {
   encodeBody?: "automatic" | "manual";
 }
 type RequestInfo<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>> =
-  | Request<CfHostMetadata, Cf>
-  | string;
+  Request<CfHostMetadata, Cf> | string;
 /**
  * The **`Request`** interface of the Fetch API represents a resource request.
  *
@@ -2040,8 +2023,10 @@ declare var Request: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request)
  */
-interface Request<CfHostMetadata = unknown, Cf = CfProperties<CfHostMetadata>>
-  extends Body {
+interface Request<
+  CfHostMetadata = unknown,
+  Cf = CfProperties<CfHostMetadata>,
+> extends Body {
   /**
    * The **`clone()`** method of the Request interface creates a copy of the current `Request` object.
    *
@@ -2361,12 +2346,7 @@ declare abstract class R2Bucket {
   put(
     key: string,
     value:
-      | ReadableStream
-      | ArrayBuffer
-      | ArrayBufferView
-      | string
-      | null
-      | Blob,
+      ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
     options?: R2PutOptions & {
       onlyIf: R2Conditional | Headers;
     },
@@ -2374,12 +2354,7 @@ declare abstract class R2Bucket {
   put(
     key: string,
     value:
-      | ReadableStream
-      | ArrayBuffer
-      | ArrayBufferView
-      | string
-      | null
-      | Blob,
+      ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
     options?: R2PutOptions,
   ): Promise<R2Object>;
   createMultipartUpload(
@@ -3069,9 +3044,7 @@ interface TextDecoderStreamTextDecoderStreamInit {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy)
  */
-declare class ByteLengthQueuingStrategy
-  implements QueuingStrategy<ArrayBufferView>
-{
+declare class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferView> {
   constructor(init: QueuingStrategyInit);
   /**
    * The read-only **`ByteLengthQueuingStrategy.highWaterMark`** property returns the total number of bytes that can be contained in the internal queue before backpressure is applied.
@@ -4028,11 +4001,7 @@ declare abstract class BaseAiTextEmbeddings {
 }
 type RoleScopedChatInput = {
   role:
-    | "user"
-    | "assistant"
-    | "system"
-    | "tool"
-    | (string & NonNullable<unknown>);
+    "user" | "assistant" | "system" | "tool" | (string & NonNullable<unknown>);
   content: string;
   name?: string;
 };
@@ -4344,8 +4313,7 @@ type ResponseFunctionCallArgumentsDoneEvent = {
   type: "response.function_call_arguments.done";
 };
 type ResponseFunctionCallOutputItem =
-  | ResponseInputTextContent
-  | ResponseInputImageContent;
+  ResponseInputTextContent | ResponseInputImageContent;
 type ResponseFunctionCallOutputItemList = Array<ResponseFunctionCallOutputItem>;
 type ResponseFunctionToolCall = {
   arguments: string;
@@ -4366,8 +4334,7 @@ type ResponseFunctionToolCallOutputItem = {
   status?: "in_progress" | "completed" | "incomplete";
 };
 type ResponseIncludable =
-  | "message.input_image.image_url"
-  | "message.output_text.logprobs";
+  "message.input_image.image_url" | "message.output_text.logprobs";
 type ResponseIncompleteEvent = {
   response: Response;
   sequence_number: number;
@@ -4433,9 +4400,7 @@ type ResponseItem =
   | ResponseFunctionToolCallItem
   | ResponseFunctionToolCallOutputItem;
 type ResponseOutputItem =
-  | ResponseOutputMessage
-  | ResponseFunctionToolCall
-  | ResponseReasoningItem;
+  ResponseOutputMessage | ResponseFunctionToolCall | ResponseReasoningItem;
 type ResponseOutputItemAddedEvent = {
   item: ResponseOutputItem;
   output_index: number;
@@ -6029,8 +5994,7 @@ declare abstract class Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct {
   postProcessedOutputs: Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Output;
 }
 type Ai_Cf_Qwen_Qwq_32B_Input =
-  | Ai_Cf_Qwen_Qwq_32B_Prompt
-  | Ai_Cf_Qwen_Qwq_32B_Messages;
+  Ai_Cf_Qwen_Qwq_32B_Prompt | Ai_Cf_Qwen_Qwq_32B_Messages;
 interface Ai_Cf_Qwen_Qwq_32B_Prompt {
   /**
    * The input text prompt for the model to generate a response.
@@ -6577,8 +6541,7 @@ declare abstract class Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct {
   postProcessedOutputs: Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Output;
 }
 type Ai_Cf_Google_Gemma_3_12B_It_Input =
-  | Ai_Cf_Google_Gemma_3_12B_It_Prompt
-  | Ai_Cf_Google_Gemma_3_12B_It_Messages;
+  Ai_Cf_Google_Gemma_3_12B_It_Prompt | Ai_Cf_Google_Gemma_3_12B_It_Messages;
 interface Ai_Cf_Google_Gemma_3_12B_It_Prompt {
   /**
    * The input text prompt for the model to generate a response.
@@ -9085,11 +9048,7 @@ interface Ai_Cf_Deepgram_Flux_Output {
    * The type of event being reported.
    */
   event?:
-    | "Update"
-    | "StartOfTurn"
-    | "EagerEndOfTurn"
-    | "TurnResumed"
-    | "EndOfTurn";
+    "Update" | "StartOfTurn" | "EagerEndOfTurn" | "TurnResumed" | "EndOfTurn";
   /**
    * The index of the current turn
    */
@@ -9500,8 +9459,7 @@ type AIGatewayProviders =
   | "adobe-firefly";
 type AIGatewayHeaders = {
   "cf-aig-metadata":
-    | Record<string, number | string | boolean | null | bigint>
-    | string;
+    Record<string, number | string | boolean | null | bigint> | string;
   "cf-aig-custom-cost":
     | {
         per_token_in?: number;
@@ -10098,8 +10056,7 @@ interface IncomingRequestCfPropertiesBotManagement {
    */
   clientTrustScore: number;
 }
-interface IncomingRequestCfPropertiesBotManagementEnterprise
-  extends IncomingRequestCfPropertiesBotManagement {
+interface IncomingRequestCfPropertiesBotManagementEnterprise extends IncomingRequestCfPropertiesBotManagement {
   /**
    * Results of Cloudflare's Bot Management analysis
    */
@@ -10640,8 +10597,7 @@ declare type Iso3166Alpha2Code =
 /** The 2-letter continent codes Cloudflare uses */
 declare type ContinentCode = "AF" | "AN" | "AS" | "EU" | "NA" | "OC" | "SA";
 type CfProperties<HostMetadata = unknown> =
-  | IncomingRequestCfProperties<HostMetadata>
-  | RequestInitCfProperties;
+  IncomingRequestCfProperties<HostMetadata> | RequestInitCfProperties;
 interface D1Meta {
   duration: number;
   size_after: number;
@@ -11305,9 +11261,7 @@ declare namespace Rpc {
     [__WORKFLOW_ENTRYPOINT_BRAND]: never;
   }
   export type EntrypointBranded =
-    | WorkerEntrypointBranded
-    | DurableObjectBranded
-    | WorkflowEntrypointBranded;
+    WorkerEntrypointBranded | DurableObjectBranded | WorkflowEntrypointBranded;
   // Types that can be used through `Stub`s
   export type Stubable = RpcTargetBranded | ((...args: any[]) => any);
   // Types that can be passed over RPC
@@ -11517,16 +11471,9 @@ declare namespace CloudflareWorkersModule {
     webSocketError?(ws: WebSocket, error: unknown): void | Promise<void>;
   }
   export type WorkflowDurationLabel =
-    | "second"
-    | "minute"
-    | "hour"
-    | "day"
-    | "week"
-    | "month"
-    | "year";
+    "second" | "minute" | "hour" | "day" | "week" | "month" | "year";
   export type WorkflowSleepDuration =
-    | `${number} ${WorkflowDurationLabel}${"s" | ""}`
-    | number;
+    `${number} ${WorkflowDurationLabel}${"s" | ""}` | number;
   export type WorkflowDelayDuration = WorkflowSleepDuration;
   export type WorkflowTimeoutDuration = WorkflowSleepDuration;
   export type WorkflowRetentionDuration = WorkflowSleepDuration;
@@ -11572,7 +11519,8 @@ declare namespace CloudflareWorkersModule {
   export abstract class WorkflowEntrypoint<
     Env = unknown,
     T extends Rpc.Serializable<T> | unknown = unknown,
-  > implements Rpc.WorkflowEntrypointBranded
+  >
+    implements Rpc.WorkflowEntrypointBranded
   {
     [Rpc.__WORKFLOW_ENTRYPOINT_BRAND]: never;
     protected ctx: ExecutionContext;
@@ -11893,8 +11841,7 @@ type VectorizeVectorMetadataValue = string | number | boolean | string[];
  * Additional information to associate with a vector.
  */
 type VectorizeVectorMetadata =
-  | VectorizeVectorMetadataValue
-  | Record<string, VectorizeVectorMetadataValue>;
+  VectorizeVectorMetadataValue | Record<string, VectorizeVectorMetadataValue>;
 type VectorFloatArray = Float32Array | Float64Array;
 interface VectorizeError {
   code?: number;
@@ -11906,12 +11853,7 @@ interface VectorizeError {
  * This list is expected to grow as support for more operations are released.
  */
 type VectorizeVectorMetadataFilterOp =
-  | "$eq"
-  | "$ne"
-  | "$lt"
-  | "$lte"
-  | "$gt"
-  | "$gte";
+  "$eq" | "$ne" | "$lt" | "$lte" | "$gt" | "$gte";
 type VectorizeVectorMetadataFilterCollectionOp = "$in" | "$nin";
 /**
  * Filter criteria for vector metadata used to limit the retrieved query result set.
@@ -12234,16 +12176,9 @@ declare abstract class Workflow<PARAMS = unknown> {
   ): Promise<WorkflowInstance[]>;
 }
 type WorkflowDurationLabel =
-  | "second"
-  | "minute"
-  | "hour"
-  | "day"
-  | "week"
-  | "month"
-  | "year";
+  "second" | "minute" | "hour" | "day" | "week" | "month" | "year";
 type WorkflowSleepDuration =
-  | `${number} ${WorkflowDurationLabel}${"s" | ""}`
-  | number;
+  `${number} ${WorkflowDurationLabel}${"s" | ""}` | number;
 type WorkflowRetentionDuration = WorkflowSleepDuration;
 interface WorkflowInstanceCreateOptions<PARAMS = unknown> {
   /**

--- a/packages/kumo/src/components/banner/banner.tsx
+++ b/packages/kumo/src/components/banner/banner.tsx
@@ -154,8 +154,10 @@ export enum BannerVariant {
  * <Banner variant="error" title="Save failed" description="We couldn't save your changes." />
  * ```
  */
-export interface BannerProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "title"> {
+export interface BannerProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children" | "title"
+> {
   /** Icon element rendered before the banner content (e.g. from `@phosphor-icons/react`). */
   icon?: ReactNode;
   /** Primary heading text for the banner. Use for i18n string injection. */

--- a/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/kumo/src/components/breadcrumbs/breadcrumbs.tsx
@@ -195,8 +195,7 @@ function Clipboard({ text }: { text: string }) {
  * ```
  */
 export interface BreadcrumbsProps
-  extends PropsWithChildren,
-    KumoBreadcrumbsVariantsProps {
+  extends PropsWithChildren, KumoBreadcrumbsVariantsProps {
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
 }

--- a/packages/kumo/src/components/chart/Color.ts
+++ b/packages/kumo/src/components/chart/Color.ts
@@ -49,12 +49,7 @@ enum ChartSemanticDarkColors {
 }
 
 export type ChartSemanticColorName =
-  | "Attention"
-  | "Warning"
-  | "Success"
-  | "Neutral"
-  | "Disabled"
-  | "Skeleton";
+  "Attention" | "Warning" | "Success" | "Neutral" | "Disabled" | "Skeleton";
 
 /**
  * Sequential color palettes for light mode with the colour in position #2 of the array as the base.

--- a/packages/kumo/src/components/cloudflare-logo/cloudflare-logo.tsx
+++ b/packages/kumo/src/components/cloudflare-logo/cloudflare-logo.tsx
@@ -89,8 +89,7 @@ export type CloudflareLogoVariant =
 export type CloudflareLogoColor =
   keyof typeof KUMO_CLOUDFLARE_LOGO_VARIANTS.color;
 
-export interface CloudflareLogoProps
-  extends React.SVGAttributes<SVGSVGElement> {
+export interface CloudflareLogoProps extends React.SVGAttributes<SVGSVGElement> {
   /**
    * Logo variant
    * - `glyph`: Cloud icon only
@@ -214,8 +213,7 @@ CloudflareLogo.displayName = "CloudflareLogo";
 // PoweredByCloudflare Component
 // =============================================================================
 
-export interface PoweredByCloudflareProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface PoweredByCloudflareProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /**
    * Color scheme for the logo and text
    * @default "color"

--- a/packages/kumo/src/components/command-palette/types.ts
+++ b/packages/kumo/src/components/command-palette/types.ts
@@ -167,11 +167,10 @@ export interface CommandPaletteResultItemProps<T = unknown> {
  * Extends standard HTML input attributes so you can pass props like
  * `autoComplete`, `autoCorrect`, `autoCapitalize`, `spellCheck`, `data-*`, etc.
  */
-export interface CommandPaletteInputProps
-  extends Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    "children" | "defaultValue" | "defaultChecked" | "color"
-  > {
+export interface CommandPaletteInputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "children" | "defaultValue" | "defaultChecked" | "color"
+> {
   /** Optional leading content (e.g., back button) */
   leading?: ReactNode;
   /** Optional trailing content (e.g., Esc button) */

--- a/packages/kumo/src/components/dialog/dialog.tsx
+++ b/packages/kumo/src/components/dialog/dialog.tsx
@@ -322,8 +322,7 @@ type BaseAlertDialogTriggerProps = ComponentPropsWithoutRef<
 >;
 
 export type DialogTriggerProps =
-  | BaseDialogTriggerProps
-  | BaseAlertDialogTriggerProps;
+  BaseDialogTriggerProps | BaseAlertDialogTriggerProps;
 
 function DialogTrigger({ children, ...props }: DialogTriggerProps) {
   const role = useDialogRole();

--- a/packages/kumo/src/components/input-group/context.ts
+++ b/packages/kumo/src/components/input-group/context.ts
@@ -120,7 +120,8 @@ export const INPUT_GROUP_HAS_CLASSES: Record<KumoInputSize, string> = {
  * (see `detectFocusMode`), so it is not part of the public or internal API.
  */
 export interface InputGroupRootPropsInternal
-  extends HTMLAttributes<HTMLElement>,
+  extends
+    HTMLAttributes<HTMLElement>,
     Partial<
       Pick<
         FieldProps,

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -465,8 +465,7 @@ export interface PaginationCompoundProps extends PaginationBaseProps {
  * ```
  */
 export interface PaginationLegacyProps
-  extends PaginationBaseProps,
-    KumoPaginationVariantsProps {
+  extends PaginationBaseProps, KumoPaginationVariantsProps {
   children?: never;
   /** @deprecated Use Pagination.Info with children prop instead */
   text?: (props: {

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -37,11 +37,10 @@ type Mode = "masked" | "revealed" | "empty";
  * <SensitiveInput label="Secret" value={secret} onValueChange={setSecret} />
  * ```
  */
-export interface SensitiveInputProps
-  extends Omit<
-    ComponentPropsWithoutRef<"input">,
-    "size" | "type" | "value" | "defaultValue"
-  > {
+export interface SensitiveInputProps extends Omit<
+  ComponentPropsWithoutRef<"input">,
+  "size" | "type" | "value" | "defaultValue"
+> {
   /** Controlled value */
   value?: string;
   /** Uncontrolled default value */

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1041,11 +1041,10 @@ SidebarMenuItem.displayName = "Sidebar.MenuItem";
 
 export type SidebarMenuButtonSize = "base" | "sm";
 
-export interface SidebarMenuButtonProps
-  extends Omit<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    "className" | "children"
-  > {
+export interface SidebarMenuButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "className" | "children"
+> {
   icon?: React.ComponentType<{ className?: string }> | React.ReactNode;
   active?: boolean;
   /**
@@ -1347,8 +1346,7 @@ SidebarMenuSubItem.displayName = "Sidebar.MenuSubItem";
 // Sidebar MenuSubButton
 // ============================================================================
 
-export interface SidebarMenuSubButtonProps
-  extends ComponentPropsWithoutRef<"button"> {
+export interface SidebarMenuSubButtonProps extends ComponentPropsWithoutRef<"button"> {
   /** Marks this sub-item as currently active/selected. @default false */
   active?: boolean;
   /** Navigation URL. When set, renders as a link via LinkProvider. */
@@ -1765,8 +1763,7 @@ const SidebarCollapseContext = createContext<SidebarCollapseContextValue>({
   toggle: () => {},
 });
 
-export interface SidebarCollapsibleProps
-  extends ComponentPropsWithoutRef<"div"> {
+export interface SidebarCollapsibleProps extends ComponentPropsWithoutRef<"div"> {
   /** Initial open state (uncontrolled). @default false */
   defaultOpen?: boolean;
   /** Controlled open state. */
@@ -2051,8 +2048,7 @@ SidebarMenuChevron.displayName = "Sidebar.MenuChevron";
 
 const SlidingViewActiveContext = createContext<string>("");
 
-export interface SidebarSlidingViewsProps
-  extends ComponentPropsWithoutRef<"div"> {
+export interface SidebarSlidingViewsProps extends ComponentPropsWithoutRef<"div"> {
   /** Key of the currently active view. Must match a child `SlidingView` value. */
   activeKey: string;
   /**
@@ -2138,8 +2134,7 @@ const SidebarSlidingViews = forwardRef<
 
 SidebarSlidingViews.displayName = "Sidebar.SlidingViews";
 
-export interface SidebarSlidingViewProps
-  extends ComponentPropsWithoutRef<"div"> {
+export interface SidebarSlidingViewProps extends ComponentPropsWithoutRef<"div"> {
   /** Unique key matching this view. Must correspond to `activeKey` on `SlidingViews`. */
   value: string;
 }

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -69,8 +69,7 @@ const TableOfContentsList = forwardRef<
     {...props}
   />
 ));
-export interface TableOfContentsItemProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface TableOfContentsItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Whether this item represents the currently active section. */
   active?: boolean;
   /**
@@ -126,8 +125,10 @@ const TableOfContentsItem = forwardRef<
   );
 });
 
-export interface TableOfContentsGroupProps
-  extends Omit<React.HTMLAttributes<HTMLLIElement>, "title"> {
+export interface TableOfContentsGroupProps extends Omit<
+  React.HTMLAttributes<HTMLLIElement>,
+  "title"
+> {
   /** Label displayed above the group's items. */
   label: string;
   /** URL the group label links to. When provided, the label renders as a clickable link with item styling. */

--- a/packages/kumo/src/components/toast/toast.tsx
+++ b/packages/kumo/src/components/toast/toast.tsx
@@ -213,8 +213,7 @@ function wrapManagerMethods<
     add: (options: KumoToastManagerAddOptions<any>) => {
       if (options.id) {
         const toasts = (manager as any).toasts as
-          | Array<ToastObject<any>>
-          | undefined;
+          Array<ToastObject<any>> | undefined;
 
         if (toasts) {
           const existingToast = toasts.find((toast) => toast.id === options.id);

--- a/packages/kumo/src/utils/portal-provider.tsx
+++ b/packages/kumo/src/utils/portal-provider.tsx
@@ -10,10 +10,7 @@ import {
  * Supports HTMLElement, ShadowRoot, or a ref to either.
  */
 export type PortalContainer =
-  | HTMLElement
-  | ShadowRoot
-  | null
-  | RefObject<HTMLElement | ShadowRoot | null>;
+  HTMLElement | ShadowRoot | null | RefObject<HTMLElement | ShadowRoot | null>;
 
 const PortalContainerContext = createContext<PortalContainer>(null);
 

--- a/packages/kumo/src/utils/resolve-variant.ts
+++ b/packages/kumo/src/utils/resolve-variant.ts
@@ -29,8 +29,7 @@ export function resolveVariant<T extends Record<string, unknown>>(
   fallback: keyof T & string,
 ): T[keyof T] {
   const config = (variants as Record<string, unknown>)[key] as
-    | T[keyof T]
-    | undefined;
+    T[keyof T] | undefined;
 
   if (config !== undefined) return config;
 

--- a/packages/kumo/tests/imports/primitives.test.ts
+++ b/packages/kumo/tests/imports/primitives.test.ts
@@ -125,9 +125,8 @@ describe("Primitives Export", () => {
 
     it("should keep OTPFieldPreview as a compatibility alias", async () => {
       const barrelPrimitives = await import("../../src/primitives/index.ts");
-      const otpFieldPrimitives = await import(
-        "../../src/primitives/otp-field.ts"
-      );
+      const otpFieldPrimitives =
+        await import("../../src/primitives/otp-field.ts");
 
       expect(barrelPrimitives.OTPFieldPreview).toBe(barrelPrimitives.OTPField);
       expect(otpFieldPrimitives.OTPFieldPreview).toBe(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       prettier:
-        specifier: 3.6.2
-        version: 3.6.2
+        specifier: 3.9.5
+        version: 3.9.5
       prettier-plugin-tailwindcss:
         specifier: 0.7.1
-        version: 0.7.1(prettier@3.6.2)
+        version: 0.7.1(prettier@3.9.5)
       tsx:
         specifier: 'catalog:'
         version: 4.20.6
@@ -788,15 +788,15 @@ packages:
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
-    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz}
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
 
   '@cloudflare/puppeteer@1.0.6':
-    resolution: {integrity: sha512-e/0s9Ac2IhyBrgnyTDrYEippqrXqKtllP8qezyunOb6icOJ2FzbfQwhWRIVwV3AgZtutQTF5Kb/gFAGXCuGRqQ==, tarball: https://registry.npmjs.org/@cloudflare/puppeteer/-/puppeteer-1.0.6.tgz}
+    resolution: {integrity: sha512-e/0s9Ac2IhyBrgnyTDrYEippqrXqKtllP8qezyunOb6icOJ2FzbfQwhWRIVwV3AgZtutQTF5Kb/gFAGXCuGRqQ==}
     engines: {node: '>=18'}
 
   '@cloudflare/unenv-preset@2.16.1':
-    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz}
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: '>1.20260305.0 <2.0.0-0'
@@ -805,31 +805,31 @@ packages:
         optional: true
 
   '@cloudflare/workerd-darwin-64@1.20260430.1':
-    resolution: {integrity: sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260430.1.tgz}
+    resolution: {integrity: sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260430.1':
-    resolution: {integrity: sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260430.1.tgz}
+    resolution: {integrity: sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20260430.1':
-    resolution: {integrity: sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260430.1.tgz}
+    resolution: {integrity: sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260430.1':
-    resolution: {integrity: sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260430.1.tgz}
+    resolution: {integrity: sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20260430.1':
-    resolution: {integrity: sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz}
+    resolution: {integrity: sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5486,11 +5486,6 @@ packages:
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
-    engines: {node: '>=14'}
     hasBin: true
 
   prettier@3.9.5:
@@ -12182,13 +12177,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.7.1(prettier@3.6.2):
+  prettier-plugin-tailwindcss@0.7.1(prettier@3.9.5):
     dependencies:
-      prettier: 3.6.2
+      prettier: 3.9.5
 
   prettier@2.8.8: {}
-
-  prettier@3.6.2: {}
 
   prettier@3.9.5: {}
 

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -46,14 +46,12 @@ export function validateDescription(
   // Validate bonk review
   // Flexible: allows optional leading whitespace/indentation
   // Uses [ \t]* (space/tab only) after colon to require justification on same line
-  if (
-    !(
-      /^\s*-\s*\[x\]\s*bonk has reviewed the change/im.test(body) ||
-      /^\s*-\s*\[x\]\s*automated review not possible because:[ \t]*\S/im.test(
-        body,
-      )
+  if (!(
+    /^\s*-\s*\[x\]\s*bonk has reviewed the change/im.test(body) ||
+    /^\s*-\s*\[x\]\s*automated review not possible because:[ \t]*\S/im.test(
+      body,
     )
-  ) {
+  )) {
     errors.push(
       "Your PR must have bonk review, or provide justification for why automated review is not possible. " +
         "If providing a justification, it must be on the same line as the checkbox (e.g., '- [x] automated review not possible because: reason here').",
@@ -63,17 +61,15 @@ export function validateDescription(
   // Validate tests
   // Flexible: allows optional leading whitespace/indentation
   // Uses [ \t]* (space/tab only) after colon to require justification on same line
-  if (
-    !(
-      /^\s*-\s*\[x\]\s*Tests included\/updated/im.test(body) ||
-      /^\s*-\s*\[x\]\s*Automated tests not possible - manual testing has been completed as follows:[ \t]*\S/im.test(
-        body,
-      ) ||
-      /^\s*-\s*\[x\]\s*Additional testing not necessary because:[ \t]*\S/im.test(
-        body,
-      )
+  if (!(
+    /^\s*-\s*\[x\]\s*Tests included\/updated/im.test(body) ||
+    /^\s*-\s*\[x\]\s*Automated tests not possible - manual testing has been completed as follows:[ \t]*\S/im.test(
+      body,
+    ) ||
+    /^\s*-\s*\[x\]\s*Additional testing not necessary because:[ \t]*\S/im.test(
+      body,
     )
-  ) {
+  )) {
     errors.push(
       "Your PR must include tests, or provide justification for why no tests are required. " +
         "If providing a justification, it must be on the same line as the checkbox.",


### PR DESCRIPTION
This bumps prettier to latest and applies formatting again. Follow-up on #652 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: just running prettier

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
