### PR TITLE
docs: pad homepage date picker

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -498,7 +498,7 @@ export function HomeGrid() {
       name: "DatePicker",
       id: "date-picker",
       Component: (
-        <div className="-m-4 scale-85">
+        <div className="scale-85 bg-kumo-base p-4">
           <DatePicker mode="single" />
         </div>
       ),


### PR DESCRIPTION
## Summary
- Replace the HomeGrid DatePicker negative margin with semantic base background and padding.

<img width="388" height="388" alt="Screenshot 2026-07-23 at 10 51 42 AM" src="https://github.com/user-attachments/assets/b97bea07-0991-48e6-865e-fb055d846de6" />


## Testing
- `pnpm --filter @cloudflare/kumo-docs-astro exec oxlint src/components/demos/HomeGrid.tsx`
- `pnpm exec prettier --check packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx`
- `pnpm --filter @cloudflare/kumo-docs-astro lint` currently fails on existing unrelated docs lint issues outside HomeGrid.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: tiny docs styling-only change
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: local visual-only change reviewed in code
- [x] Additional testing not necessary because: docs-only padding tweak covered by targeted lint and formatting checks
