### PR TITLE
fix(docs): make markdown table export robust to block content and whitespace

### DIFF
--- a/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
+++ b/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
@@ -49,9 +49,7 @@ describe("htmlToMarkdown table robustness", () => {
     const withParagraphs =
       "<main><table><thead><tr><th>Token</th><th>Use</th></tr></thead><tbody><tr><td><code>bg-kumo-elevated</code></td><td><p>Slightly elevated surface</p></td></tr></tbody></table></main>";
     const md = htmlToMarkdown(withParagraphs);
-    expect(md).toContain(
-      "| `bg-kumo-elevated` | Slightly elevated surface |",
-    );
+    expect(md).toContain("| `bg-kumo-elevated` | Slightly elevated surface |");
   });
 
   it("produces identical valid tables from compact and formatted markup", () => {

--- a/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
+++ b/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
@@ -45,7 +45,6 @@ describe("htmlToMarkdown table robustness", () => {
     expect(htmlToMarkdown(html)).toContain("| `sm` `base` | x |");
   });
 
-
   it("renders block elements inside cells inline (MDX paragraph-wrapping)", () => {
     const withParagraphs =
       "<main><table><thead><tr><th>Token</th><th>Use</th></tr></thead><tbody><tr><td><code>bg-kumo-elevated</code></td><td><p>Slightly elevated surface</p></td></tr></tbody></table></main>";

--- a/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
+++ b/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
@@ -50,7 +50,7 @@ describe("htmlToMarkdown table robustness", () => {
       "<main><table><thead><tr><th>Token</th><th>Use</th></tr></thead><tbody><tr><td><code>bg-kumo-elevated</code></td><td><p>Slightly elevated surface</p></td></tr></tbody></table></main>";
     const md = htmlToMarkdown(withParagraphs);
     expect(md).toContain(
-      "| \`bg-kumo-elevated\` | Slightly elevated surface |",
+      "| `bg-kumo-elevated` | Slightly elevated surface |",
     );
   });
 

--- a/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
+++ b/packages/kumo-docs-astro/src/lib/html-to-markdown.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+import { htmlToMarkdown, normalizeTableWhitespace } from "./html-to-markdown";
+
+const compact =
+  "<main><table><thead><tr><th>Token</th><th>Use</th></tr></thead><tbody><tr><td><code>bg-kumo-elevated</code></td><td>Slightly elevated surface</td></tr></tbody></table></main>";
+
+const formatted = `<main>
+  <table>
+    <thead>
+      <tr>
+        <th>Token</th>
+        <th>Use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>bg-kumo-elevated</code>
+        </td>
+        <td>
+          Slightly elevated surface
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</main>`;
+
+describe("normalizeTableWhitespace", () => {
+  it("collapses formatted table markup to the compact form", () => {
+    expect(normalizeTableWhitespace(formatted).trim()).toContain(
+      "<table><thead><tr><th>Token</th>",
+    );
+  });
+
+  it("leaves non-table content untouched", () => {
+    const html = "<p>keep\n  these\n  lines</p>";
+    expect(normalizeTableWhitespace(html)).toBe(html);
+  });
+});
+
+describe("htmlToMarkdown table robustness", () => {
+  it("preserves significant spaces between inline elements in cells", () => {
+    const html =
+      "<main><table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr>\n  <td>\n    <code>sm</code> <code>base</code>\n  </td>\n  <td>x</td>\n</tr></tbody></table></main>";
+    expect(htmlToMarkdown(html)).toContain("| `sm` `base` | x |");
+  });
+
+
+  it("renders block elements inside cells inline (MDX paragraph-wrapping)", () => {
+    const withParagraphs =
+      "<main><table><thead><tr><th>Token</th><th>Use</th></tr></thead><tbody><tr><td><code>bg-kumo-elevated</code></td><td><p>Slightly elevated surface</p></td></tr></tbody></table></main>";
+    const md = htmlToMarkdown(withParagraphs);
+    expect(md).toContain(
+      "| \`bg-kumo-elevated\` | Slightly elevated surface |",
+    );
+  });
+
+  it("produces identical valid tables from compact and formatted markup", () => {
+    const a = htmlToMarkdown(compact);
+    const b = htmlToMarkdown(formatted);
+    expect(b).toBe(a);
+    expect(b).toContain("| `bg-kumo-elevated` | Slightly elevated surface |");
+  });
+});

--- a/packages/kumo-docs-astro/src/lib/html-to-markdown.ts
+++ b/packages/kumo-docs-astro/src/lib/html-to-markdown.ts
@@ -47,6 +47,20 @@ export function createTurndownService(): TurndownService {
   return turndown;
 }
 
+/** GFM table rows are single-line; multi-line or block cell markup would break the export. */
+export function normalizeTableWhitespace(html: string): string {
+  return html.replace(/<table[\s\S]*?<\/table>/gi, (table) =>
+    table
+      // Block elements in cells would break single-line GFM rows.
+      .replace(/<\/?(?:p|div)[^>]*>/g, " ")
+      .replace(/\s+/g, " ")
+      // Spacing between inline elements is content; only structural/edge whitespace is insignificant.
+      .replace(/\s*(<\/?(?:table|thead|tbody|tr)\b[^>]*>)\s*/g, "$1")
+      .replace(/(<(?:td|th)\b[^>]*>)\s+/g, "$1")
+      .replace(/\s+(<\/(?:td|th)>)/g, "$1"),
+  );
+}
+
 /**
  * Extract page metadata and content from a full HTML page string
  * and convert to a well-structured Markdown document.
@@ -104,7 +118,9 @@ export function htmlToMarkdown(html: string): string {
   // Extract and convert <main> content
   const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
   const content = mainMatch ? mainMatch[1] : html;
-  const mainMarkdown = turndown.turndown(content).trim();
+  const mainMarkdown = turndown
+    .turndown(normalizeTableWhitespace(content))
+    .trim();
 
   if (mainMarkdown) {
     parts.push(mainMarkdown);

--- a/skills/kumo-design/SKILL.md
+++ b/skills/kumo-design/SKILL.md
@@ -42,7 +42,9 @@ Never capitalize or uppercase headings. Product names must be title-cased.
 ```
 
 ```tsx
-<Text as="h2" DANGEROUS_className="uppercase">Recent requests</Text>
+<Text as="h2" DANGEROUS_className="uppercase">
+  Recent requests
+</Text>
 ```
 
 ### `font-tracking` Never change the font's tracking
@@ -134,7 +136,9 @@ Color changes on hover must be immediate. Transitions on fast interactions make 
 **Avoid**
 
 ```tsx
-<button className="transition-colors duration-300 hover:bg-kumo-tint">...</button>
+<button className="transition-colors duration-300 hover:bg-kumo-tint">
+  ...
+</button>
 ```
 
 ### `shadow-borders` Never use borders with drop shadows
@@ -181,7 +185,9 @@ Inline icons must be optically the same size as and be center-aligned with text.
 
 ```tsx
 <div className="flex items-start gap-2">
-  <span className="h-lh flex items-center"><Icon /></span>
+  <span className="h-lh flex items-center">
+    <Icon />
+  </span>
   <Text>Text that may wrap onto multiple lines</Text>
 </div>
 ```
@@ -190,7 +196,9 @@ Inline icons must be optically the same size as and be center-aligned with text.
 
 ```tsx
 <div className="flex items-start gap-2">
-  <span className="flex items-center"><Icon /></span>
+  <span className="flex items-center">
+    <Icon />
+  </span>
   <Text>Text that may wrap onto multiple lines</Text>
 </div>
 ```
@@ -210,8 +218,8 @@ Monospaced text should have a slightly smaller font size (~0.9em) when mixed wit
 
 ```tsx
 <Text size="lg">
-  Edit <span className="font-mono text-[0.9em]">wrangler.toml</span>{" "}
-  to continue.
+  Edit <span className="font-mono text-[0.9em]">wrangler.toml</span> to
+  continue.
 </Text>
 ```
 
@@ -295,11 +303,13 @@ Conditionally rendering dialogs disables their open/close animation. Use the `op
 **Avoid**
 
 ```tsx
-{open && (
-  <Dialog.Root open>
-    <Dialog>
-      <Dialog.Title>Edit Worker</Dialog.Title>
-    </Dialog>
-  </Dialog.Root>
-)}
+{
+  open && (
+    <Dialog.Root open>
+      <Dialog>
+        <Dialog.Title>Edit Worker</Dialog.Title>
+      </Dialog>
+    </Dialog.Root>
+  );
+}
 ```

--- a/skills/kumo-design/SKILL.md
+++ b/skills/kumo-design/SKILL.md
@@ -42,9 +42,7 @@ Never capitalize or uppercase headings. Product names must be title-cased.
 ```
 
 ```tsx
-<Text as="h2" DANGEROUS_className="uppercase">
-  Recent requests
-</Text>
+<Text as="h2" DANGEROUS_className="uppercase">Recent requests</Text>
 ```
 
 ### `font-tracking` Never change the font's tracking
@@ -136,9 +134,7 @@ Color changes on hover must be immediate. Transitions on fast interactions make 
 **Avoid**
 
 ```tsx
-<button className="transition-colors duration-300 hover:bg-kumo-tint">
-  ...
-</button>
+<button className="transition-colors duration-300 hover:bg-kumo-tint">...</button>
 ```
 
 ### `shadow-borders` Never use borders with drop shadows
@@ -185,9 +181,7 @@ Inline icons must be optically the same size as and be center-aligned with text.
 
 ```tsx
 <div className="flex items-start gap-2">
-  <span className="h-lh flex items-center">
-    <Icon />
-  </span>
+  <span className="h-lh flex items-center"><Icon /></span>
   <Text>Text that may wrap onto multiple lines</Text>
 </div>
 ```
@@ -196,9 +190,7 @@ Inline icons must be optically the same size as and be center-aligned with text.
 
 ```tsx
 <div className="flex items-start gap-2">
-  <span className="flex items-center">
-    <Icon />
-  </span>
+  <span className="flex items-center"><Icon /></span>
   <Text>Text that may wrap onto multiple lines</Text>
 </div>
 ```
@@ -218,8 +210,8 @@ Monospaced text should have a slightly smaller font size (~0.9em) when mixed wit
 
 ```tsx
 <Text size="lg">
-  Edit <span className="font-mono text-[0.9em]">wrangler.toml</span> to
-  continue.
+  Edit <span className="font-mono text-[0.9em]">wrangler.toml</span>{" "}
+  to continue.
 </Text>
 ```
 
@@ -303,13 +295,11 @@ Conditionally rendering dialogs disables their open/close animation. Use the `op
 **Avoid**
 
 ```tsx
-{
-  open && (
-    <Dialog.Root open>
-      <Dialog>
-        <Dialog.Title>Edit Worker</Dialog.Title>
-      </Dialog>
-    </Dialog.Root>
-  );
-}
+{open && (
+  <Dialog.Root open>
+    <Dialog>
+      <Dialog.Title>Edit Worker</Dialog.Title>
+    </Dialog>
+  </Dialog.Root>
+)}
 ```


### PR DESCRIPTION
Right now, the HTML to MD exporter (for llms.txt, per-page .md docs) breaks tables whenever a cell contains block elements or multi-line markup 

This PR fixes it by adding a `normalizeTableWhitespace` function that strips whitespace only where HTML defines it as insignificant

---

- Reviews
- [x] bonk has reviewed the change
- [ ] automated review not possible because: <your reason here>
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [ ] Additional testing not necessary because: <your reason here>
