### PR TITLE
fix: remove obsolete tailwind classes

### DIFF
--- a/.changeset/remove-inert-classes.md
+++ b/.changeset/remove-inert-classes.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Remove inert Tailwind classes surfaced by class sorting: `ring` alongside `ring-2` (overridden — later stylesheet rule wins) and bare `outline` in three places (no such utility in Tailwind v4; `outline-1` already applies the default solid style). No visual changes.

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -761,7 +761,7 @@ export const TimeseriesChart = forwardRef<
           >
             <TooltipPrimitive.Popup
               data-mode={isDarkMode ? "dark" : "light"}
-              className="max-w-xs min-w-[150px] rounded-lg bg-kumo-base p-2 shadow-lg shadow-kumo-tip-shadow outline outline-1 outline-kumo-fill"
+              className="max-w-xs min-w-[150px] rounded-lg bg-kumo-base p-2 shadow-lg shadow-kumo-tip-shadow outline-1 outline-kumo-fill"
             >
               <TooltipContent
                 state={tooltipState}

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -356,7 +356,7 @@ function _RadioItem<T = string>(
           value={value}
           disabled={disabled}
           className={cn(
-            "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring ring-2 focus:ring-kumo-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
+            "relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring-2 focus:ring-kumo-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
             variant === "error" ? "ring-kumo-danger" : "ring-kumo-line",
             !disabled &&
               variant !== "error" &&

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -326,7 +326,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
       inputVariants({ size, variant, parentFocusIndicator: true }),
       "group/container relative flex w-full items-center",
       // Show browser-native focus outline on container when child input is focused
-      "focus-within:outline focus-within:outline-2 focus-within:outline-kumo-focus",
+      "focus-within:outline-2 focus-within:outline-kumo-focus",
       isMaskedWithValue && !disabled && "cursor-pointer",
       disabled && "cursor-not-allowed",
       className,

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -54,7 +54,7 @@ export function tooltipVariants({
   return cn(
     // Base styles
     "flex origin-[var(--transform-origin)] flex-col rounded-md bg-kumo-base px-2.5 py-1.5 text-sm text-kumo-default",
-    "shadow-lg shadow-kumo-tip-shadow outline outline-1 outline-kumo-fill",
+    "shadow-lg shadow-kumo-tip-shadow outline-1 outline-kumo-fill",
     "transition-[transform,scale,opacity] duration-150",
     "data-[starting-style]:scale-90 data-[starting-style]:opacity-0",
     "data-[ending-style]:scale-90 data-[ending-style]:opacity-0",


### PR DESCRIPTION
This PR removes obsolete Tailwind classes that #660 made visible:

* `ring` next to `ring-2` (overridden as the *later stylesheet rule* wins
* 3x bare `outline` ×3 (utility removed in Tailwind v4)

Removing these should not change any visuals

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: checked output
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
