### PR TITLE
feat(checkbox,radio): add bordered group appearance

### DIFF
--- a/.changeset/bordered-choice-groups.md
+++ b/.changeset/bordered-choice-groups.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add bordered appearances and horizontal orientation support to radio and checkbox groups.

--- a/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import { Badge, Checkbox } from '@cloudflare/kumo';
-import { ChatCircleTextIcon, EnvelopeIcon } from '@phosphor-icons/react';
+import { useState } from "react";
+import { Badge, Checkbox } from "@cloudflare/kumo";
+import { ChatCircleTextIcon, EnvelopeIcon } from "@phosphor-icons/react";
 
 export function CheckboxBasicDemo() {
   const [checked, setChecked] = useState(false);
@@ -63,7 +63,7 @@ export function CheckboxErrorDemo() {
 }
 
 export function CheckboxGroupDemo() {
-  const [preferences, setPreferences] = useState<string[]>(['email']);
+  const [preferences, setPreferences] = useState<string[]>(["email"]);
 
   return (
     <Checkbox.Group
@@ -80,16 +80,16 @@ export function CheckboxGroupDemo() {
 }
 
 export function CheckboxBorderedGroupDemo() {
-  const [notifications, setNotifications] = useState<string[]>(['email']);
+  const [notifications, setNotifications] = useState<string[]>(["email"]);
   const [alertCategories, setAlertCategories] = useState<string[]>([
-    'security',
-    'performance'
+    "security",
+    "performance",
   ]);
   const [exportContents, setExportContents] = useState<string[]>([
-    'configuration',
-    'analytics'
+    "configuration",
+    "analytics",
   ]);
-  const [permissions, setPermissions] = useState<string[]>(['read', 'edit']);
+  const [permissions, setPermissions] = useState<string[]>(["read", "edit"]);
 
   return (
     <div className="flex flex-col gap-8">
@@ -187,7 +187,7 @@ export function CheckboxBorderedGroupDemo() {
 
 /** Shows Checkbox.Legend with sr-only to visually hide the legend while keeping it accessible, useful when a parent Field already provides a visible label */
 export function CheckboxLegendSrOnlyDemo() {
-  const [preferences, setPreferences] = useState<string[]>(['email']);
+  const [preferences, setPreferences] = useState<string[]>(["email"]);
   return (
     <Checkbox.Group value={preferences} onValueChange={setPreferences}>
       <Checkbox.Legend className="sr-only">
@@ -202,7 +202,7 @@ export function CheckboxLegendSrOnlyDemo() {
 
 /** Shows Checkbox.Legend with custom styling for full control over legend presentation */
 export function CheckboxLegendCustomDemo() {
-  const [preferences, setPreferences] = useState<string[]>(['email']);
+  const [preferences, setPreferences] = useState<string[]>(["email"]);
   return (
     <Checkbox.Group value={preferences} onValueChange={setPreferences}>
       <Checkbox.Legend className="text-sm font-normal text-kumo-subtle">

--- a/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { Checkbox } from "@cloudflare/kumo";
+import { useState } from 'react';
+import { Badge, Checkbox } from '@cloudflare/kumo';
+import { ChatCircleTextIcon, EnvelopeIcon } from '@phosphor-icons/react';
 
 export function CheckboxBasicDemo() {
   const [checked, setChecked] = useState(false);
@@ -62,7 +63,7 @@ export function CheckboxErrorDemo() {
 }
 
 export function CheckboxGroupDemo() {
-  const [preferences, setPreferences] = useState<string[]>(["email"]);
+  const [preferences, setPreferences] = useState<string[]>(['email']);
 
   return (
     <Checkbox.Group
@@ -78,9 +79,115 @@ export function CheckboxGroupDemo() {
   );
 }
 
+export function CheckboxBorderedGroupDemo() {
+  const [notifications, setNotifications] = useState<string[]>(['email']);
+  const [alertCategories, setAlertCategories] = useState<string[]>([
+    'security',
+    'performance'
+  ]);
+  const [exportContents, setExportContents] = useState<string[]>([
+    'configuration',
+    'analytics'
+  ]);
+  const [permissions, setPermissions] = useState<string[]>(['read', 'edit']);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <Checkbox.Group
+        legend="Notifications"
+        appearance="bordered"
+        orientation="horizontal"
+        value={notifications}
+        onValueChange={setNotifications}
+      >
+        <Checkbox.Item
+          value="email"
+          label={
+            <span className="flex items-center gap-2">
+              <EnvelopeIcon
+                size={18}
+                className="text-kumo-subtle"
+                aria-hidden
+              />
+              Email
+            </span>
+          }
+        />
+        <Checkbox.Item
+          value="sms"
+          label={
+            <span className="flex items-center gap-2">
+              <ChatCircleTextIcon
+                size={18}
+                className="text-kumo-subtle"
+                aria-hidden
+              />
+              SMS
+            </span>
+          }
+        />
+      </Checkbox.Group>
+      <Checkbox.Group
+        legend="Alert categories (control first)"
+        appearance="bordered"
+        controlFirst
+        value={alertCategories}
+        onValueChange={setAlertCategories}
+      >
+        <Checkbox.Item value="security" label="Security" />
+        <Checkbox.Item value="performance" label="Performance" />
+        <Checkbox.Item
+          value="reliability"
+          label={
+            <span className="flex flex-wrap items-center gap-2">
+              Reliability
+              <Badge variant="neutral">Beta</Badge>
+            </span>
+          }
+        />
+        <Checkbox.Item value="billing" label="Billing (unavailable)" disabled />
+      </Checkbox.Group>
+      <Checkbox.Group
+        legend="Export contents"
+        description="Long labels should wrap without moving or shrinking the controls."
+        appearance="bordered"
+        orientation="horizontal"
+        value={exportContents}
+        onValueChange={setExportContents}
+      >
+        <Checkbox.Item
+          value="configuration"
+          label="Account and zone configuration settings"
+        />
+        <Checkbox.Item
+          value="analytics"
+          label="Historical analytics and event data"
+        />
+        <Checkbox.Item
+          value="members"
+          label="Member profiles, roles, and access policies"
+        />
+      </Checkbox.Group>
+      <Checkbox.Group
+        legend="Team permissions"
+        appearance="bordered"
+        controlFirst
+        value={permissions}
+        onValueChange={setPermissions}
+      >
+        <Checkbox.Item value="read" label="View resources" />
+        <Checkbox.Item value="edit" label="Create and edit resources" />
+        <Checkbox.Item value="deploy" label="Deploy to production" />
+        <Checkbox.Item value="members" label="Manage team members" />
+        <Checkbox.Item value="billing" label="Manage billing" disabled />
+      </Checkbox.Group>
+    </div>
+  );
+}
+
 /** Shows Checkbox.Legend with sr-only to visually hide the legend while keeping it accessible, useful when a parent Field already provides a visible label */
 export function CheckboxLegendSrOnlyDemo() {
-  const [preferences, setPreferences] = useState<string[]>(["email"]);
+  const [preferences, setPreferences] = useState<string[]>(['email']);
   return (
     <Checkbox.Group value={preferences} onValueChange={setPreferences}>
       <Checkbox.Legend className="sr-only">
@@ -95,7 +202,7 @@ export function CheckboxLegendSrOnlyDemo() {
 
 /** Shows Checkbox.Legend with custom styling for full control over legend presentation */
 export function CheckboxLegendCustomDemo() {
-  const [preferences, setPreferences] = useState<string[]>(["email"]);
+  const [preferences, setPreferences] = useState<string[]>(['email']);
   return (
     <Checkbox.Group value={preferences} onValueChange={setPreferences}>
       <Checkbox.Legend className="text-sm font-normal text-kumo-subtle">

--- a/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/RadioDemo.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 import { Badge, Radio } from "@cloudflare/kumo";
+import {
+  GitBranchIcon,
+  GlobeIcon,
+  ShieldCheckIcon,
+} from "@phosphor-icons/react";
 
 /** Shows a basic controlled radio group */
 export function RadioBasicDemo() {
@@ -43,6 +48,103 @@ export function RadioHorizontalDemo() {
       <Radio.Item label="Medium" value="md" />
       <Radio.Item label="Large" value="lg" />
     </Radio.Group>
+  );
+}
+
+/** Shows bordered radio groups in horizontal and vertical layouts */
+export function RadioBorderedDemo() {
+  const [scope, setScope] = useState("all");
+  const [environment, setEnvironment] = useState("production");
+  const [routingMode, setRoutingMode] = useState("smart");
+  const [securityLevel, setSecurityLevel] = useState("balanced");
+
+  return (
+    <div className="flex flex-col gap-8">
+      <Radio.Group
+        legend="Scope"
+        appearance="bordered"
+        orientation="horizontal"
+        value={scope}
+        onValueChange={setScope}
+      >
+        <Radio.Item
+          label={
+            <span className="flex items-center gap-2">
+              <GlobeIcon size={18} className="text-kumo-subtle" />
+              All traffic
+            </span>
+          }
+          value="all"
+        />
+        <Radio.Item
+          label={
+            <span className="flex items-center gap-2">
+              <GitBranchIcon size={18} className="text-kumo-subtle" />
+              Previews only
+            </span>
+          }
+          value="previews"
+        />
+      </Radio.Group>
+      <Radio.Group
+        legend="Environment (control first)"
+        appearance="bordered"
+        controlPosition="start"
+        value={environment}
+        onValueChange={setEnvironment}
+      >
+        <Radio.Item label="Production" value="production" />
+        <Radio.Item label="Staging" value="staging" />
+        <Radio.Item label="Development" value="development" />
+        <Radio.Item
+          label="Local preview (unavailable)"
+          value="local"
+          disabled
+        />
+      </Radio.Group>
+      <Radio.Group
+        legend="Request routing"
+        description="Long labels should wrap without moving or shrinking the controls."
+        appearance="bordered"
+        orientation="horizontal"
+        value={routingMode}
+        onValueChange={setRoutingMode}
+      >
+        <Radio.Item
+          label="Route to the nearest healthy origin"
+          value="nearest"
+        />
+        <Radio.Item
+          label="Automatically balance latency and availability"
+          value="smart"
+        />
+        <Radio.Item
+          label="Always use the designated primary origin"
+          value="primary"
+        />
+      </Radio.Group>
+      <Radio.Group
+        legend="Security level"
+        appearance="bordered"
+        controlPosition="start"
+        value={securityLevel}
+        onValueChange={setSecurityLevel}
+      >
+        <Radio.Item label="Essential" value="essential" />
+        <Radio.Item
+          label={
+            <span className="flex items-center gap-2">
+              <ShieldCheckIcon size={18} className="text-kumo-subtle" />
+              Balanced (recommended)
+              <Badge variant="primary">Default</Badge>
+            </span>
+          }
+          value="balanced"
+        />
+        <Radio.Item label="Strict" value="strict" />
+        <Radio.Item label="Maximum" value="maximum" />
+      </Radio.Group>
+    </div>
   );
 }
 

--- a/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
@@ -304,6 +304,61 @@ export function SidebarLoadingDemo() {
   );
 }
 
+function SidebarLoadingSkeleton() {
+  return (
+    <>
+      <Sidebar.Header>
+        <div className="flex items-center gap-2 px-3 group-data-[state=collapsed]/sidebar:px-2">
+          <div className="size-4 shrink-0 rounded-sm bg-kumo-interact" />
+          <div className="h-3 w-24 rounded-full bg-kumo-interact group-data-[state=collapsed]/sidebar:hidden" />
+        </div>
+      </Sidebar.Header>
+      <Sidebar.Content>
+        {["72%", "58%"].map((labelWidth, groupIndex) => (
+          <Sidebar.Group key={labelWidth}>
+            <div className="mb-2 h-2.5 rounded-full bg-kumo-interact group-data-[state=collapsed]/sidebar:hidden" style={{ width: labelWidth }} />
+            <div className="space-y-1.5">
+              {["68%", "82%", "55%"].map((width, rowIndex) => (
+                <div key={width} className="flex h-8 items-center gap-3 px-2">
+                  <div className="size-4 shrink-0 rounded bg-kumo-interact" />
+                  <div
+                    className="h-2.5 rounded-full bg-kumo-interact group-data-[state=collapsed]/sidebar:hidden"
+                    style={{ width: groupIndex === 1 && rowIndex === 2 ? "74%" : width }}
+                  />
+                </div>
+              ))}
+            </div>
+          </Sidebar.Group>
+        ))}
+      </Sidebar.Content>
+      <Sidebar.Footer>
+        <Sidebar.Trigger />
+      </Sidebar.Footer>
+    </>
+  );
+}
+
+/** Concept loading state that mirrors sidebar groups in expanded and collapsed modes. */
+export function SidebarLoadingDemo() {
+  return (
+    <DemoContainer>
+      <Sidebar.Provider contained defaultOpen className="min-h-0! h-full">
+        <Sidebar
+          aria-label="Loading navigation"
+          aria-busy="true"
+          className="animate-pulse motion-reduce:animate-none"
+        >
+          <SidebarLoadingSkeleton />
+        </Sidebar>
+        <DemoMain>
+          <ToggleButton />
+          <p>Toggle to preview both loading states</p>
+        </DemoMain>
+      </Sidebar.Provider>
+    </DemoContainer>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // 3. Resizable — drag handle with auto-collapse
 // ---------------------------------------------------------------------------

--- a/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SidebarDemo.tsx
@@ -304,61 +304,6 @@ export function SidebarLoadingDemo() {
   );
 }
 
-function SidebarLoadingSkeleton() {
-  return (
-    <>
-      <Sidebar.Header>
-        <div className="flex items-center gap-2 px-3 group-data-[state=collapsed]/sidebar:px-2">
-          <div className="size-4 shrink-0 rounded-sm bg-kumo-interact" />
-          <div className="h-3 w-24 rounded-full bg-kumo-interact group-data-[state=collapsed]/sidebar:hidden" />
-        </div>
-      </Sidebar.Header>
-      <Sidebar.Content>
-        {["72%", "58%"].map((labelWidth, groupIndex) => (
-          <Sidebar.Group key={labelWidth}>
-            <div className="mb-2 h-2.5 rounded-full bg-kumo-interact group-data-[state=collapsed]/sidebar:hidden" style={{ width: labelWidth }} />
-            <div className="space-y-1.5">
-              {["68%", "82%", "55%"].map((width, rowIndex) => (
-                <div key={width} className="flex h-8 items-center gap-3 px-2">
-                  <div className="size-4 shrink-0 rounded bg-kumo-interact" />
-                  <div
-                    className="h-2.5 rounded-full bg-kumo-interact group-data-[state=collapsed]/sidebar:hidden"
-                    style={{ width: groupIndex === 1 && rowIndex === 2 ? "74%" : width }}
-                  />
-                </div>
-              ))}
-            </div>
-          </Sidebar.Group>
-        ))}
-      </Sidebar.Content>
-      <Sidebar.Footer>
-        <Sidebar.Trigger />
-      </Sidebar.Footer>
-    </>
-  );
-}
-
-/** Concept loading state that mirrors sidebar groups in expanded and collapsed modes. */
-export function SidebarLoadingDemo() {
-  return (
-    <DemoContainer>
-      <Sidebar.Provider contained defaultOpen className="min-h-0! h-full">
-        <Sidebar
-          aria-label="Loading navigation"
-          aria-busy="true"
-          className="animate-pulse motion-reduce:animate-none"
-        >
-          <SidebarLoadingSkeleton />
-        </Sidebar>
-        <DemoMain>
-          <ToggleButton />
-          <p>Toggle to preview both loading states</p>
-        </DemoMain>
-      </Sidebar.Provider>
-    </DemoContainer>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // 3. Resizable — drag handle with auto-collapse
 // ---------------------------------------------------------------------------

--- a/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/checkbox.mdx
@@ -19,6 +19,7 @@ import {
   CheckboxDisabledDemo,
   CheckboxErrorDemo,
   CheckboxGroupDemo,
+  CheckboxBorderedGroupDemo,
   CheckboxGroupErrorDemo,
   CheckboxLegendSrOnlyDemo,
   CheckboxLegendCustomDemo,
@@ -126,6 +127,19 @@ export default function Example() {
 </p>
 <ComponentExample demo="CheckboxGroupDemo">
   <CheckboxGroupDemo client:visible />
+</ComponentExample>
+
+### Bordered Checkbox Group
+
+<p>
+  Use `appearance="bordered"` to place checkbox options in one contiguous
+  surface with shared dividers. Set `orientation="horizontal"` for a
+  side-by-side layout; groups are vertical by default. Bordered groups place
+  controls at the end unless `controlFirst` is set. The examples below also
+  cover long wrapping text, disabled options, and larger option sets.
+</p>
+<ComponentExample demo="CheckboxBorderedGroupDemo">
+  <CheckboxBorderedGroupDemo client:visible />
 </ComponentExample>
 
 ### Checkbox Group with Error

--- a/packages/kumo-docs-astro/src/pages/components/radio.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/radio.mdx
@@ -13,6 +13,7 @@ import {
   RadioBasicDemo,
   RadioDefaultDemo,
   RadioHorizontalDemo,
+  RadioBorderedDemo,
   RadioDescriptionDemo,
   RadioErrorDemo,
   RadioDisabledDemo,
@@ -99,6 +100,19 @@ export default function Example() {
 </p>
 <ComponentExample demo="RadioHorizontalDemo">
   <RadioHorizontalDemo client:visible />
+</ComponentExample>
+
+### Bordered Group
+
+<p>
+  Use `appearance="bordered"` to place options in one contiguous surface with
+  shared dividers. It supports both vertical and horizontal orientations and
+  places controls at the end by default. Set `controlPosition="start"` to place
+  controls before their labels. The examples below also cover rich labels, long
+  wrapping text, disabled options, and larger option sets.
+</p>
+<ComponentExample demo="RadioBorderedDemo">
+  <RadioBorderedDemo client:visible />
 </ComponentExample>
 
 ### With Description

--- a/packages/kumo/src/components/checkbox/checkbox.test.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { Checkbox } from './checkbox';
+
+describe('Checkbox.Group', () => {
+  it.each([
+    ['vertical', 'border-t'],
+    ['horizontal', 'border-l']
+  ] as const)(
+    'renders a bordered %s group with shared dividers',
+    (orientation, dividerClass) => {
+      const { container } = render(
+        <Checkbox.Group
+          legend="Notifications"
+          appearance="bordered"
+          orientation={orientation}
+          defaultValue={['email']}
+        >
+          <Checkbox.Item label="Email" value="email" />
+          <Checkbox.Item label="SMS" value="sms" />
+        </Checkbox.Group>
+      );
+
+      const group = container.querySelector('[data-kumo-part="group-items"]');
+      const item = container.querySelector('[data-kumo-part="item-label"]');
+
+      expect(group?.className).toContain('rounded-lg');
+      expect(group?.className).toContain(dividerClass);
+      expect(item?.className).toContain('flex-1');
+      expect(item?.className).toContain('flex-row-reverse');
+      expect(item?.className).toContain('bg-kumo-elevated');
+      expect(
+        item?.querySelector('[data-kumo-part="item-content"]')?.className
+      ).toContain('leading-5');
+    }
+  );
+
+  it('preserves control-first layout when explicitly requested', () => {
+    const { container } = render(
+      <Checkbox.Group appearance="bordered" controlFirst>
+        <Checkbox.Item label="Email" value="email" />
+      </Checkbox.Group>
+    );
+
+    expect(
+      container.querySelector('[data-kumo-part="item-label"]')?.className
+    ).not.toContain('flex-row-reverse');
+  });
+
+  it('renders rich label content', () => {
+    const { getByText } = render(
+      <Checkbox.Group appearance="bordered">
+        <Checkbox.Item
+          label={
+            <span>
+              Security <strong>Recommended</strong>
+            </span>
+          }
+          value="security"
+        />
+      </Checkbox.Group>
+    );
+
+    expect(getByText('Recommended').tagName).toBe('STRONG');
+  });
+
+  it('dims only content for disabled bordered items', () => {
+    const { container } = render(
+      <Checkbox.Group appearance="bordered">
+        <Checkbox.Item label="Unavailable" value="unavailable" disabled />
+      </Checkbox.Group>
+    );
+
+    const itemClassName = container.querySelector(
+      '[data-kumo-part="item-label"]'
+    )?.className;
+
+    expect(itemClassName).toContain('[&>*]:opacity-50');
+    expect(itemClassName?.split(' ')).not.toContain('opacity-50');
+  });
+});

--- a/packages/kumo/src/components/checkbox/checkbox.test.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.test.tsx
@@ -1,53 +1,53 @@
-import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
-import { Checkbox } from './checkbox';
+import { describe, expect, it } from "vite-plus/test";
+import { render } from "@testing-library/react";
+import { Checkbox } from "./checkbox";
 
-describe('Checkbox.Group', () => {
+describe("Checkbox.Group", () => {
   it.each([
-    ['vertical', 'border-t'],
-    ['horizontal', 'border-l']
+    ["vertical", "border-t"],
+    ["horizontal", "border-l"],
   ] as const)(
-    'renders a bordered %s group with shared dividers',
+    "renders a bordered %s group with shared dividers",
     (orientation, dividerClass) => {
       const { container } = render(
         <Checkbox.Group
           legend="Notifications"
           appearance="bordered"
           orientation={orientation}
-          defaultValue={['email']}
+          defaultValue={["email"]}
         >
           <Checkbox.Item label="Email" value="email" />
           <Checkbox.Item label="SMS" value="sms" />
-        </Checkbox.Group>
+        </Checkbox.Group>,
       );
 
       const group = container.querySelector('[data-kumo-part="group-items"]');
       const item = container.querySelector('[data-kumo-part="item-label"]');
 
-      expect(group?.className).toContain('rounded-lg');
+      expect(group?.className).toContain("rounded-lg");
       expect(group?.className).toContain(dividerClass);
-      expect(item?.className).toContain('flex-1');
-      expect(item?.className).toContain('flex-row-reverse');
-      expect(item?.className).toContain('bg-kumo-elevated');
+      expect(item?.className).toContain("flex-1");
+      expect(item?.className).toContain("flex-row-reverse");
+      expect(item?.className).toContain("bg-kumo-elevated");
       expect(
-        item?.querySelector('[data-kumo-part="item-content"]')?.className
-      ).toContain('leading-5');
-    }
+        item?.querySelector('[data-kumo-part="item-content"]')?.className,
+      ).toContain("leading-5");
+    },
   );
 
-  it('preserves control-first layout when explicitly requested', () => {
+  it("preserves control-first layout when explicitly requested", () => {
     const { container } = render(
       <Checkbox.Group appearance="bordered" controlFirst>
         <Checkbox.Item label="Email" value="email" />
-      </Checkbox.Group>
+      </Checkbox.Group>,
     );
 
     expect(
-      container.querySelector('[data-kumo-part="item-label"]')?.className
-    ).not.toContain('flex-row-reverse');
+      container.querySelector('[data-kumo-part="item-label"]')?.className,
+    ).not.toContain("flex-row-reverse");
   });
 
-  it('renders rich label content', () => {
+  it("renders rich label content", () => {
     const { getByText } = render(
       <Checkbox.Group appearance="bordered">
         <Checkbox.Item
@@ -58,24 +58,24 @@ describe('Checkbox.Group', () => {
           }
           value="security"
         />
-      </Checkbox.Group>
+      </Checkbox.Group>,
     );
 
-    expect(getByText('Recommended').tagName).toBe('STRONG');
+    expect(getByText("Recommended").tagName).toBe("STRONG");
   });
 
-  it('dims only content for disabled bordered items', () => {
+  it("dims only content for disabled bordered items", () => {
     const { container } = render(
       <Checkbox.Group appearance="bordered">
         <Checkbox.Item label="Unavailable" value="unavailable" disabled />
-      </Checkbox.Group>
+      </Checkbox.Group>,
     );
 
     const itemClassName = container.querySelector(
-      '[data-kumo-part="item-label"]'
+      '[data-kumo-part="item-label"]',
     )?.className;
 
-    expect(itemClassName).toContain('[&>*]:opacity-50');
-    expect(itemClassName?.split(' ')).not.toContain('opacity-50');
+    expect(itemClassName).toContain("[&>*]:opacity-50");
+    expect(itemClassName?.split(" ")).not.toContain("opacity-50");
   });
 });

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -1,16 +1,16 @@
-import { forwardRef, createContext, useContext, type ReactNode } from 'react';
-import { CheckIcon, MinusIcon } from '@phosphor-icons/react';
-import { cn } from '../../utils/cn';
-import { resolveVariant } from '../../utils/resolve-variant';
-import { Label } from '../label';
-import { Fieldset } from '@base-ui/react/fieldset';
-import { Field as FieldBase } from '@base-ui/react/field';
-import { CheckboxGroup as BaseCheckboxGroup } from '@base-ui/react/checkbox-group';
-import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox';
+import { forwardRef, createContext, useContext, type ReactNode } from "react";
+import { CheckIcon, MinusIcon } from "@phosphor-icons/react";
+import { cn } from "../../utils/cn";
+import { resolveVariant } from "../../utils/resolve-variant";
+import { Label } from "../label";
+import { Fieldset } from "@base-ui/react/fieldset";
+import { Field as FieldBase } from "@base-ui/react/field";
+import { CheckboxGroup as BaseCheckboxGroup } from "@base-ui/react/checkbox-group";
+import { Checkbox as BaseCheckbox } from "@base-ui/react/checkbox";
 
 /** Event details passed to onCheckedChange callback. Re-exported from Base UI. */
 export type CheckboxChangeEventDetails = Parameters<
-  NonNullable<BaseCheckbox.Root.Props['onCheckedChange']>
+  NonNullable<BaseCheckbox.Root.Props["onCheckedChange"]>
 >[1];
 
 /** Checkbox variant definitions mapping variant names to their Tailwind classes. */
@@ -18,18 +18,18 @@ export const KUMO_CHECKBOX_VARIANTS = {
   variant: {
     default: {
       classes:
-        '[&:focus-within>span]:ring-kumo-focus [&:hover>span]:ring-kumo-hairline',
-      description: 'Default checkbox appearance'
+        "[&:focus-within>span]:ring-kumo-focus [&:hover>span]:ring-kumo-hairline",
+      description: "Default checkbox appearance",
     },
     error: {
-      classes: '[&>span]:ring-kumo-danger',
-      description: 'Error state for validation failures'
-    }
-  }
+      classes: "[&>span]:ring-kumo-danger",
+      description: "Error state for validation failures",
+    },
+  },
 } as const;
 
 export const KUMO_CHECKBOX_DEFAULT_VARIANTS = {
-  variant: 'default'
+  variant: "default",
 } as const;
 
 // Derived types from KUMO_CHECKBOX_VARIANTS
@@ -46,14 +46,14 @@ export interface KumoCheckboxVariantsProps {
 }
 
 export function checkboxVariants({
-  variant = KUMO_CHECKBOX_DEFAULT_VARIANTS.variant
+  variant = KUMO_CHECKBOX_DEFAULT_VARIANTS.variant,
 }: KumoCheckboxVariantsProps = {}) {
   return cn(
     resolveVariant(
       KUMO_CHECKBOX_VARIANTS.variant,
       variant,
-      KUMO_CHECKBOX_DEFAULT_VARIANTS.variant
-    ).classes
+      KUMO_CHECKBOX_DEFAULT_VARIANTS.variant,
+    ).classes,
   );
 }
 
@@ -61,10 +61,10 @@ export function checkboxVariants({
 export type CheckboxVariant = KumoCheckboxVariant;
 
 /** Visual treatment for items within a checkbox group. */
-export type CheckboxGroupAppearance = 'default' | 'bordered';
+export type CheckboxGroupAppearance = "default" | "bordered";
 
 /** Layout direction for items within a checkbox group. */
-export type CheckboxGroupOrientation = 'vertical' | 'horizontal';
+export type CheckboxGroupOrientation = "vertical" | "horizontal";
 
 // Context for passing group layout options to Items.
 const CheckboxGroupContext = createContext<{
@@ -72,7 +72,7 @@ const CheckboxGroupContext = createContext<{
   appearance: CheckboxGroupAppearance;
 }>({
   controlFirst: true,
-  appearance: 'default'
+  appearance: "default",
 });
 
 /**
@@ -135,7 +135,7 @@ export type CheckboxProps = {
   /** Whether the checkbox is disabled */
   disabled?: boolean;
   /** Callback when the checked state changes */
-  onCheckedChange?: BaseCheckbox.Root.Props['onCheckedChange'];
+  onCheckedChange?: BaseCheckbox.Root.Props["onCheckedChange"];
   /** Name for form submission */
   name?: string;
   /** Whether the field is required */
@@ -143,9 +143,9 @@ export type CheckboxProps = {
   /** Additional class name */
   className?: string;
   /** Accessible label when no visible label is provided */
-  'aria-label'?: string;
+  "aria-label"?: string;
   /** ID of element that labels this checkbox */
-  'aria-labelledby'?: string;
+  "aria-labelledby"?: string;
 };
 
 /**
@@ -232,7 +232,7 @@ export type CheckboxItemProps = {
   indeterminate?: boolean;
   disabled?: boolean;
   /** Callback when the checked state changes */
-  onCheckedChange?: BaseCheckbox.Root.Props['onCheckedChange'];
+  onCheckedChange?: BaseCheckbox.Root.Props["onCheckedChange"];
   name?: string;
 };
 
@@ -244,7 +244,7 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       checked,
       indeterminate,
       disabled,
-      variant = 'default',
+      variant = "default",
       label,
       labelTooltip,
       controlFirst = true,
@@ -253,21 +253,21 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       name,
       ...props
     },
-    ref
+    ref,
   ) => {
     // A11y enforcement: warn in dev if no accessible name provided
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== "production") {
       const hasLabel = Boolean(label);
-      const hasAriaLabel = Boolean(props['aria-label']);
-      const hasAriaLabelledBy = Boolean(props['aria-labelledby']);
+      const hasAriaLabel = Boolean(props["aria-label"]);
+      const hasAriaLabelledBy = Boolean(props["aria-labelledby"]);
 
       if (!hasLabel && !hasAriaLabel && !hasAriaLabelledBy) {
         console.warn(
-          '[Kumo Checkbox]: Checkbox must have an accessible name. Provide either:\n' +
+          "[Kumo Checkbox]: Checkbox must have an accessible name. Provide either:\n" +
             "  - label prop: <Checkbox label='Accept terms' />\n" +
             "  - aria-label: <Checkbox aria-label='Select item' />\n" +
-            '  - aria-labelledby for custom label association\n' +
-            '  Note: When used inside Checkbox.Group, label is optional'
+            "  - aria-labelledby for custom label association\n" +
+            "  Note: When used inside Checkbox.Group, label is optional",
         );
       }
     }
@@ -282,14 +282,14 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
         disabled={disabled}
         onCheckedChange={onCheckedChange}
         className={cn(
-          'relative flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2',
-          label && 'mt-0.5',
-          variant === 'error' ? 'ring-kumo-danger' : 'ring-kumo-hairline',
+          "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2 focus:outline-none",
+          label && "mt-0.5",
+          variant === "error" ? "ring-kumo-danger" : "ring-kumo-hairline",
           !disabled &&
-            'hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand',
-          'data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast',
-          disabled && 'cursor-not-allowed opacity-50',
-          className
+            "hover:ring-kumo-hairline focus:ring-2 focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand",
+          "data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast",
+          disabled && "cursor-not-allowed opacity-50",
+          className,
         )}
         {...props}
       >
@@ -320,9 +320,9 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       <FieldBase.Root className="inline-flex">
         <FieldBase.Label
           className={cn(
-            '!m-0 !min-h-0 !text-base inline-flex items-start gap-2',
-            controlFirst ? 'flex-row' : 'flex-row-reverse justify-end',
-            disabled ? 'cursor-not-allowed' : 'cursor-pointer'
+            "!m-0 inline-flex !min-h-0 items-start gap-2 !text-base",
+            controlFirst ? "flex-row" : "flex-row-reverse justify-end",
+            disabled ? "cursor-not-allowed" : "cursor-pointer",
           )}
         >
           {checkboxControl}
@@ -336,10 +336,10 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
         </FieldBase.Label>
       </FieldBase.Root>
     );
-  }
+  },
 );
 
-CheckboxBase.displayName = 'Checkbox';
+CheckboxBase.displayName = "Checkbox";
 
 // Checkbox.Item for use within Checkbox.Group
 const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
@@ -349,35 +349,35 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
       checked,
       indeterminate,
       disabled,
-      variant = 'default',
+      variant = "default",
       label,
       value,
       onCheckedChange,
-      name
+      name,
     },
-    ref
+    ref,
   ) => {
     const { controlFirst, appearance } = useContext(CheckboxGroupContext);
-    const isBordered = appearance === 'bordered';
+    const isBordered = appearance === "bordered";
 
     return (
       <label
         data-kumo-component="Checkbox"
         data-kumo-part="item-label"
         className={cn(
-          'm-0 relative inline-flex items-start gap-2',
+          "relative m-0 inline-flex items-start gap-2",
           isBordered &&
-            'w-full flex-1 p-3 transition-colors has-[[data-checked]]:bg-kumo-elevated',
+            "w-full flex-1 p-3 transition-colors has-[[data-checked]]:bg-kumo-elevated",
           // Control first (default): checkbox before label
           // Label first: label before checkbox using flex-row-reverse
-          !controlFirst && 'flex-row-reverse justify-end',
+          !controlFirst && "flex-row-reverse justify-end",
           disabled
             ? cn(
-                'cursor-not-allowed',
-                isBordered ? '[&>*]:opacity-50' : 'opacity-50'
+                "cursor-not-allowed",
+                isBordered ? "[&>*]:opacity-50" : "opacity-50",
               )
-            : cn('cursor-pointer', isBordered && 'hover:bg-kumo-elevated'),
-          className
+            : cn("cursor-pointer", isBordered && "hover:bg-kumo-elevated"),
+          className,
         )}
       >
         <BaseCheckbox.Root
@@ -391,11 +391,11 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
           disabled={disabled}
           onCheckedChange={onCheckedChange}
           className={cn(
-            'peer relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2',
-            variant === 'error' ? 'ring-kumo-danger' : 'ring-kumo-hairline',
+            "peer relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2",
+            variant === "error" ? "ring-kumo-danger" : "ring-kumo-hairline",
             !disabled &&
-              'group-hover:ring-kumo-hairline hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand',
-            'data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast'
+              "group-hover:ring-kumo-hairline hover:ring-kumo-hairline focus:ring-2 focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand",
+            "data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast",
           )}
         >
           <BaseCheckbox.Indicator
@@ -415,31 +415,31 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
         <span
           data-kumo-part="item-content"
           className={cn(
-            'text-base text-kumo-default',
-            isBordered && 'flex-1 text-pretty leading-5'
+            "text-base text-kumo-default",
+            isBordered && "flex-1 leading-5 text-pretty",
           )}
         >
           {label}
         </span>
       </label>
     );
-  }
+  },
 );
 
-CheckboxItem.displayName = 'Checkbox.Item';
+CheckboxItem.displayName = "Checkbox.Item";
 
 // Checkbox.Legend — composable legend sub-component for Checkbox.Group
 function CheckboxLegend({ children, className }: CheckboxLegendProps) {
   return (
     <Fieldset.Legend
-      className={cn('text-base font-medium text-kumo-default', className)}
+      className={cn("text-base font-medium text-kumo-default", className)}
     >
       {children}
     </Fieldset.Legend>
   );
 }
 
-CheckboxLegend.displayName = 'Checkbox.Legend';
+CheckboxLegend.displayName = "Checkbox.Legend";
 
 // Checkbox.Group with built-in Fieldset and CheckboxGroup
 function CheckboxGroup({
@@ -452,12 +452,12 @@ function CheckboxGroup({
   onValueChange,
   allValues,
   disabled,
-  orientation = 'vertical',
-  appearance = 'default',
+  orientation = "vertical",
+  appearance = "default",
   controlFirst,
-  className
+  className,
 }: CheckboxGroupProps) {
-  const effectiveControlFirst = controlFirst ?? appearance === 'default';
+  const effectiveControlFirst = controlFirst ?? appearance === "default";
 
   return (
     <CheckboxGroupContext.Provider
@@ -470,7 +470,7 @@ function CheckboxGroup({
         allValues={allValues}
         disabled={disabled}
       >
-        <Fieldset.Root className={cn('flex flex-col gap-4', className)}>
+        <Fieldset.Root className={cn("flex flex-col gap-4", className)}>
           {legend && (
             <Fieldset.Legend className="text-base font-medium text-kumo-default">
               {legend}
@@ -480,16 +480,16 @@ function CheckboxGroup({
             data-kumo-component="Checkbox"
             data-kumo-part="group-items"
             className={cn(
-              appearance === 'bordered'
+              appearance === "bordered"
                 ? cn(
-                    'overflow-hidden rounded-lg border border-kumo-hairline bg-kumo-base',
-                    orientation === 'vertical'
-                      ? 'flex flex-col [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-t [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line'
-                      : 'flex flex-row [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-l [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line'
+                    "overflow-hidden rounded-lg border border-kumo-hairline bg-kumo-base",
+                    orientation === "vertical"
+                      ? "flex flex-col [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-t [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line"
+                      : "flex flex-row [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-l [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line",
                   )
-                : orientation === 'vertical'
-                  ? 'flex flex-col gap-2'
-                  : 'flex flex-row flex-wrap gap-2'
+                : orientation === "vertical"
+                  ? "flex flex-col gap-2"
+                  : "flex flex-row flex-wrap gap-2",
             )}
           >
             {children}
@@ -508,7 +508,7 @@ function CheckboxGroup({
 export const Checkbox = Object.assign(CheckboxBase, {
   Item: CheckboxItem,
   Group: CheckboxGroup,
-  Legend: CheckboxLegend
+  Legend: CheckboxLegend,
 });
 
-Checkbox.displayName = 'Checkbox';
+Checkbox.displayName = "Checkbox";

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -1,16 +1,16 @@
-import { forwardRef, createContext, useContext, type ReactNode } from "react";
-import { CheckIcon, MinusIcon } from "@phosphor-icons/react";
-import { cn } from "../../utils/cn";
-import { resolveVariant } from "../../utils/resolve-variant";
-import { Label } from "../label";
-import { Fieldset } from "@base-ui/react/fieldset";
-import { Field as FieldBase } from "@base-ui/react/field";
-import { CheckboxGroup as BaseCheckboxGroup } from "@base-ui/react/checkbox-group";
-import { Checkbox as BaseCheckbox } from "@base-ui/react/checkbox";
+import { forwardRef, createContext, useContext, type ReactNode } from 'react';
+import { CheckIcon, MinusIcon } from '@phosphor-icons/react';
+import { cn } from '../../utils/cn';
+import { resolveVariant } from '../../utils/resolve-variant';
+import { Label } from '../label';
+import { Fieldset } from '@base-ui/react/fieldset';
+import { Field as FieldBase } from '@base-ui/react/field';
+import { CheckboxGroup as BaseCheckboxGroup } from '@base-ui/react/checkbox-group';
+import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox';
 
 /** Event details passed to onCheckedChange callback. Re-exported from Base UI. */
 export type CheckboxChangeEventDetails = Parameters<
-  NonNullable<BaseCheckbox.Root.Props["onCheckedChange"]>
+  NonNullable<BaseCheckbox.Root.Props['onCheckedChange']>
 >[1];
 
 /** Checkbox variant definitions mapping variant names to their Tailwind classes. */
@@ -18,18 +18,18 @@ export const KUMO_CHECKBOX_VARIANTS = {
   variant: {
     default: {
       classes:
-        "[&:focus-within>span]:ring-kumo-focus [&:hover>span]:ring-kumo-hairline",
-      description: "Default checkbox appearance",
+        '[&:focus-within>span]:ring-kumo-focus [&:hover>span]:ring-kumo-hairline',
+      description: 'Default checkbox appearance'
     },
     error: {
-      classes: "[&>span]:ring-kumo-danger",
-      description: "Error state for validation failures",
-    },
-  },
+      classes: '[&>span]:ring-kumo-danger',
+      description: 'Error state for validation failures'
+    }
+  }
 } as const;
 
 export const KUMO_CHECKBOX_DEFAULT_VARIANTS = {
-  variant: "default",
+  variant: 'default'
 } as const;
 
 // Derived types from KUMO_CHECKBOX_VARIANTS
@@ -46,23 +46,33 @@ export interface KumoCheckboxVariantsProps {
 }
 
 export function checkboxVariants({
-  variant = KUMO_CHECKBOX_DEFAULT_VARIANTS.variant,
+  variant = KUMO_CHECKBOX_DEFAULT_VARIANTS.variant
 }: KumoCheckboxVariantsProps = {}) {
   return cn(
     resolveVariant(
       KUMO_CHECKBOX_VARIANTS.variant,
       variant,
-      KUMO_CHECKBOX_DEFAULT_VARIANTS.variant,
-    ).classes,
+      KUMO_CHECKBOX_DEFAULT_VARIANTS.variant
+    ).classes
   );
 }
 
 // Legacy type alias for backwards compatibility
 export type CheckboxVariant = KumoCheckboxVariant;
 
-// Context for passing controlFirst from Group to Items
-const CheckboxGroupContext = createContext<{ controlFirst: boolean }>({
+/** Visual treatment for items within a checkbox group. */
+export type CheckboxGroupAppearance = 'default' | 'bordered';
+
+/** Layout direction for items within a checkbox group. */
+export type CheckboxGroupOrientation = 'vertical' | 'horizontal';
+
+// Context for passing group layout options to Items.
+const CheckboxGroupContext = createContext<{
+  controlFirst: boolean;
+  appearance: CheckboxGroupAppearance;
+}>({
   controlFirst: true,
+  appearance: 'default'
 });
 
 /**
@@ -125,7 +135,7 @@ export type CheckboxProps = {
   /** Whether the checkbox is disabled */
   disabled?: boolean;
   /** Callback when the checked state changes */
-  onCheckedChange?: BaseCheckbox.Root.Props["onCheckedChange"];
+  onCheckedChange?: BaseCheckbox.Root.Props['onCheckedChange'];
   /** Name for form submission */
   name?: string;
   /** Whether the field is required */
@@ -133,9 +143,9 @@ export type CheckboxProps = {
   /** Additional class name */
   className?: string;
   /** Accessible label when no visible label is provided */
-  "aria-label"?: string;
+  'aria-label'?: string;
   /** ID of element that labels this checkbox */
-  "aria-labelledby"?: string;
+  'aria-labelledby'?: string;
 };
 
 /**
@@ -196,7 +206,11 @@ export interface CheckboxGroupProps {
   allValues?: string[];
   /** Whether all checkboxes in the group are disabled */
   disabled?: boolean;
-  /** When true (default), checkbox appears before label. When false, label appears before checkbox. */
+  /** Layout direction of the checkbox items. */
+  orientation?: CheckboxGroupOrientation;
+  /** Visual treatment applied to the group. */
+  appearance?: CheckboxGroupAppearance;
+  /** When true, checkbox appears before label. When false, label appears before checkbox. Defaults to true for default appearance and false for bordered appearance. */
   controlFirst?: boolean;
   /** Additional CSS classes */
   className?: string;
@@ -208,8 +222,8 @@ export interface CheckboxGroupProps {
 export type CheckboxItemProps = {
   /** Visual variant: "default" or "error" for validation failures */
   variant?: CheckboxVariant;
-  /** Label text displayed next to checkbox */
-  label: string;
+  /** Label content displayed next to checkbox */
+  label: ReactNode;
   /** Value of the checkbox (required when used in Checkbox.Group) */
   value?: string;
   /** Additional CSS classes for the label wrapper */
@@ -218,7 +232,7 @@ export type CheckboxItemProps = {
   indeterminate?: boolean;
   disabled?: boolean;
   /** Callback when the checked state changes */
-  onCheckedChange?: BaseCheckbox.Root.Props["onCheckedChange"];
+  onCheckedChange?: BaseCheckbox.Root.Props['onCheckedChange'];
   name?: string;
 };
 
@@ -230,7 +244,7 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       checked,
       indeterminate,
       disabled,
-      variant = "default",
+      variant = 'default',
       label,
       labelTooltip,
       controlFirst = true,
@@ -239,21 +253,21 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       name,
       ...props
     },
-    ref,
+    ref
   ) => {
     // A11y enforcement: warn in dev if no accessible name provided
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV !== 'production') {
       const hasLabel = Boolean(label);
-      const hasAriaLabel = Boolean(props["aria-label"]);
-      const hasAriaLabelledBy = Boolean(props["aria-labelledby"]);
+      const hasAriaLabel = Boolean(props['aria-label']);
+      const hasAriaLabelledBy = Boolean(props['aria-labelledby']);
 
       if (!hasLabel && !hasAriaLabel && !hasAriaLabelledBy) {
         console.warn(
-          "[Kumo Checkbox]: Checkbox must have an accessible name. Provide either:\n" +
+          '[Kumo Checkbox]: Checkbox must have an accessible name. Provide either:\n' +
             "  - label prop: <Checkbox label='Accept terms' />\n" +
             "  - aria-label: <Checkbox aria-label='Select item' />\n" +
-            "  - aria-labelledby for custom label association\n" +
-            "  Note: When used inside Checkbox.Group, label is optional",
+            '  - aria-labelledby for custom label association\n' +
+            '  Note: When used inside Checkbox.Group, label is optional'
         );
       }
     }
@@ -268,14 +282,14 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
         disabled={disabled}
         onCheckedChange={onCheckedChange}
         className={cn(
-          "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2 focus:outline-none",
-          label && "mt-0.5",
-          variant === "error" ? "ring-kumo-danger" : "ring-kumo-hairline",
+          'relative flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2',
+          label && 'mt-0.5',
+          variant === 'error' ? 'ring-kumo-danger' : 'ring-kumo-hairline',
           !disabled &&
-            "hover:ring-kumo-hairline focus:ring-2 focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand",
-          "data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast",
-          disabled && "cursor-not-allowed opacity-50",
-          className,
+            'hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand',
+          'data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast',
+          disabled && 'cursor-not-allowed opacity-50',
+          className
         )}
         {...props}
       >
@@ -306,9 +320,9 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       <FieldBase.Root className="inline-flex">
         <FieldBase.Label
           className={cn(
-            "!m-0 inline-flex !min-h-0 items-start gap-2 !text-base",
-            controlFirst ? "flex-row" : "flex-row-reverse justify-end",
-            disabled ? "cursor-not-allowed" : "cursor-pointer",
+            '!m-0 !min-h-0 !text-base inline-flex items-start gap-2',
+            controlFirst ? 'flex-row' : 'flex-row-reverse justify-end',
+            disabled ? 'cursor-not-allowed' : 'cursor-pointer'
           )}
         >
           {checkboxControl}
@@ -322,10 +336,10 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
         </FieldBase.Label>
       </FieldBase.Root>
     );
-  },
+  }
 );
 
-CheckboxBase.displayName = "Checkbox";
+CheckboxBase.displayName = 'Checkbox';
 
 // Checkbox.Item for use within Checkbox.Group
 const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
@@ -335,27 +349,35 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
       checked,
       indeterminate,
       disabled,
-      variant = "default",
+      variant = 'default',
       label,
       value,
       onCheckedChange,
-      name,
+      name
     },
-    ref,
+    ref
   ) => {
-    const { controlFirst } = useContext(CheckboxGroupContext);
+    const { controlFirst, appearance } = useContext(CheckboxGroupContext);
+    const isBordered = appearance === 'bordered';
 
     return (
       <label
         data-kumo-component="Checkbox"
         data-kumo-part="item-label"
         className={cn(
-          "relative m-0 inline-flex items-start gap-2",
+          'm-0 relative inline-flex items-start gap-2',
+          isBordered &&
+            'w-full flex-1 p-3 transition-colors has-[[data-checked]]:bg-kumo-elevated',
           // Control first (default): checkbox before label
           // Label first: label before checkbox using flex-row-reverse
-          !controlFirst && "flex-row-reverse justify-end",
-          disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
-          className,
+          !controlFirst && 'flex-row-reverse justify-end',
+          disabled
+            ? cn(
+                'cursor-not-allowed',
+                isBordered ? '[&>*]:opacity-50' : 'opacity-50'
+              )
+            : cn('cursor-pointer', isBordered && 'hover:bg-kumo-elevated'),
+          className
         )}
       >
         <BaseCheckbox.Root
@@ -369,11 +391,11 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
           disabled={disabled}
           onCheckedChange={onCheckedChange}
           className={cn(
-            "peer relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2",
-            variant === "error" ? "ring-kumo-danger" : "ring-kumo-hairline",
+            'peer relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border-0 bg-kumo-base ring after:absolute after:-inset-x-3 after:-inset-y-2',
+            variant === 'error' ? 'ring-kumo-danger' : 'ring-kumo-hairline',
             !disabled &&
-              "group-hover:ring-kumo-hairline hover:ring-kumo-hairline focus:ring-2 focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand",
-            "data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast",
+              'group-hover:ring-kumo-hairline hover:ring-kumo-hairline focus:ring-kumo-focus focus:ring-2 focus-visible:ring-2 focus-visible:ring-kumo-brand',
+            'data-[checked]:bg-kumo-contrast data-[checked]:ring-kumo-contrast data-[indeterminate]:bg-kumo-contrast data-[indeterminate]:ring-kumo-contrast'
           )}
         >
           <BaseCheckbox.Indicator
@@ -390,26 +412,34 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
             )}
           />
         </BaseCheckbox.Root>
-        <span className="text-base text-kumo-default">{label}</span>
+        <span
+          data-kumo-part="item-content"
+          className={cn(
+            'text-base text-kumo-default',
+            isBordered && 'flex-1 text-pretty leading-5'
+          )}
+        >
+          {label}
+        </span>
       </label>
     );
-  },
+  }
 );
 
-CheckboxItem.displayName = "Checkbox.Item";
+CheckboxItem.displayName = 'Checkbox.Item';
 
 // Checkbox.Legend — composable legend sub-component for Checkbox.Group
 function CheckboxLegend({ children, className }: CheckboxLegendProps) {
   return (
     <Fieldset.Legend
-      className={cn("text-base font-medium text-kumo-default", className)}
+      className={cn('text-base font-medium text-kumo-default', className)}
     >
       {children}
     </Fieldset.Legend>
   );
 }
 
-CheckboxLegend.displayName = "Checkbox.Legend";
+CheckboxLegend.displayName = 'Checkbox.Legend';
 
 // Checkbox.Group with built-in Fieldset and CheckboxGroup
 function CheckboxGroup({
@@ -422,11 +452,17 @@ function CheckboxGroup({
   onValueChange,
   allValues,
   disabled,
-  controlFirst = true,
-  className,
+  orientation = 'vertical',
+  appearance = 'default',
+  controlFirst,
+  className
 }: CheckboxGroupProps) {
+  const effectiveControlFirst = controlFirst ?? appearance === 'default';
+
   return (
-    <CheckboxGroupContext.Provider value={{ controlFirst }}>
+    <CheckboxGroupContext.Provider
+      value={{ controlFirst: effectiveControlFirst, appearance }}
+    >
       <BaseCheckboxGroup
         defaultValue={defaultValue}
         value={value}
@@ -434,13 +470,30 @@ function CheckboxGroup({
         allValues={allValues}
         disabled={disabled}
       >
-        <Fieldset.Root className={cn("flex flex-col gap-4", className)}>
+        <Fieldset.Root className={cn('flex flex-col gap-4', className)}>
           {legend && (
             <Fieldset.Legend className="text-base font-medium text-kumo-default">
               {legend}
             </Fieldset.Legend>
           )}
-          <div className="flex flex-col gap-2">{children}</div>
+          <div
+            data-kumo-component="Checkbox"
+            data-kumo-part="group-items"
+            className={cn(
+              appearance === 'bordered'
+                ? cn(
+                    'overflow-hidden rounded-lg border border-kumo-hairline bg-kumo-base',
+                    orientation === 'vertical'
+                      ? 'flex flex-col [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-t [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line'
+                      : 'flex flex-row [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-l [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line'
+                  )
+                : orientation === 'vertical'
+                  ? 'flex flex-col gap-2'
+                  : 'flex flex-row flex-wrap gap-2'
+            )}
+          >
+            {children}
+          </div>
           {error && <p className="text-sm text-kumo-danger">{error}</p>}
           {description && (
             <p className="text-sm text-kumo-subtle">{description}</p>
@@ -455,7 +508,7 @@ function CheckboxGroup({
 export const Checkbox = Object.assign(CheckboxBase, {
   Item: CheckboxItem,
   Group: CheckboxGroup,
-  Legend: CheckboxLegend,
+  Legend: CheckboxLegend
 });
 
-Checkbox.displayName = "Checkbox";
+Checkbox.displayName = 'Checkbox';

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -366,8 +366,7 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
         data-kumo-part="item-label"
         className={cn(
           "relative m-0 inline-flex items-start gap-2",
-          isBordered &&
-            "w-full flex-1 p-3 transition-colors has-[[data-checked]]:bg-kumo-elevated",
+          isBordered && "w-full flex-1 p-3 transition-colors",
           // Control first (default): checkbox before label
           // Label first: label before checkbox using flex-row-reverse
           !controlFirst && "flex-row-reverse justify-end",

--- a/packages/kumo/src/components/checkbox/index.ts
+++ b/packages/kumo/src/components/checkbox/index.ts
@@ -6,6 +6,8 @@ export {
   type CheckboxProps,
   type CheckboxLegendProps,
   type CheckboxGroupProps,
+  type CheckboxGroupAppearance,
+  type CheckboxGroupOrientation,
   type CheckboxItemProps,
   type KumoCheckboxVariant,
   type CheckboxVariant,

--- a/packages/kumo/src/components/radio/radio.test.tsx
+++ b/packages/kumo/src/components/radio/radio.test.tsx
@@ -101,6 +101,66 @@ describe("Radio", () => {
   it("exports KUMO_RADIO_VARIANTS with appearance axis", () => {
     expect(KUMO_RADIO_VARIANTS.appearance.default).toBeDefined();
     expect(KUMO_RADIO_VARIANTS.appearance.card).toBeDefined();
+    expect(KUMO_RADIO_VARIANTS.appearance.bordered).toBeDefined();
     expect(KUMO_RADIO_DEFAULT_VARIANTS.appearance).toBe("default");
+  });
+
+  it.each([
+    ["vertical", "border-t"],
+    ["horizontal", "border-l"],
+  ] as const)(
+    "renders a bordered %s group with shared dividers",
+    (orientation, dividerClass) => {
+      const { container } = render(
+        <Radio.Group
+          legend="Scope"
+          appearance="bordered"
+          orientation={orientation}
+          defaultValue="all"
+        >
+          <Radio.Item label="All traffic" value="all" />
+          <Radio.Item label="Previews only" value="previews" />
+        </Radio.Group>,
+      );
+
+      const group = container.querySelector('[data-kumo-part="group-items"]');
+      const item = container.querySelector('[data-kumo-part="item-label"]');
+
+      expect(group?.className).toContain("rounded-lg");
+      expect(group?.className).toContain(dividerClass);
+      expect(item?.className).toContain("flex-1");
+      expect(item?.className).toContain("flex-row-reverse");
+      expect(item?.className).toContain("bg-kumo-elevated");
+      expect(
+        item?.querySelector('[data-kumo-part="item-content"]')?.className,
+      ).toContain("leading-5");
+    },
+  );
+
+  it("supports controlPosition='start' on bordered appearance", () => {
+    const { container } = render(
+      <Radio.Group appearance="bordered" controlPosition="start">
+        <Radio.Item label="All traffic" value="all" />
+      </Radio.Group>,
+    );
+
+    expect(
+      container.querySelector('[data-kumo-part="item-label"]')?.className,
+    ).not.toContain("flex-row-reverse");
+  });
+
+  it("dims only content for disabled bordered items", () => {
+    const { container } = render(
+      <Radio.Group appearance="bordered">
+        <Radio.Item label="Unavailable" value="unavailable" disabled />
+      </Radio.Group>,
+    );
+
+    const itemClassName = container.querySelector(
+      '[data-kumo-part="item-label"]',
+    )?.className;
+
+    expect(itemClassName).toContain("[&>*]:opacity-50");
+    expect(itemClassName?.split(" ")).not.toContain("opacity-50");
   });
 });

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -45,6 +45,11 @@ export const KUMO_RADIO_VARIANTS = {
       description:
         "Choice card appearance with border, padding, and highlighted selection state",
     },
+    bordered: {
+      classes:
+        "p-3 transition-colors hover:bg-kumo-elevated has-[[data-checked]]:bg-kumo-elevated",
+      description: "Option within a bordered group with shared dividers",
+    },
   },
 } as const;
 
@@ -69,6 +74,7 @@ export interface KumoRadioVariantsProps {
    * Visual appearance.
    * - `"default"` — Standard inline radio item
    * - `"card"` — Choice card with border, padding, and highlighted selection state
+   * - `"bordered"` — Option within a bordered group with shared dividers
    * @default "default"
    */
   appearance?: KumoRadioAppearance;
@@ -100,7 +106,7 @@ export type RadioControlPosition = "start" | "end";
 
 // Context for passing controlPosition and appearance from Group to Items.
 // `controlPosition` may be undefined so each item can fall back to an
-// appearance-appropriate default (start for default, end for card).
+// appearance-appropriate default (start for default, end for card/bordered).
 const RadioGroupContext = createContext<{
   controlPosition: RadioControlPosition | undefined;
   appearance: KumoRadioAppearance;
@@ -220,6 +226,7 @@ export interface RadioGroupProps<Value = string> {
    * Visual appearance applied to all Radio.Item children.
    * - `"default"` — Standard inline radio items
    * - `"card"` — Choice card with border, padding, and highlighted selection state
+   * - `"bordered"` — Contiguous bordered group with dividers between items
    *
    * Individual items can override this with their own `appearance` prop.
    * @default "default"
@@ -243,7 +250,7 @@ export interface RadioGroupProps<Value = string> {
   ) => void;
   /** Whether all radios in the group are disabled */
   disabled?: boolean;
-  /** Position of radio control relative to label: "start" puts radio before label, "end" puts label before radio. Defaults to "start" for default appearance and "end" for card appearance. */
+  /** Position of radio control relative to label: "start" puts radio before label, "end" puts label before radio. Defaults to "start" for default appearance and "end" for card or bordered appearance. */
   controlPosition?: RadioControlPosition;
   /** Form submission name for the radio group */
   name?: string;
@@ -279,6 +286,7 @@ export type RadioItemProps<Value = string> = {
    * Visual appearance of the radio item.
    * - `"default"` — Standard inline radio item
    * - `"card"` — Choice card with border, padding, and highlighted selection state
+   * - `"bordered"` — Option within a contiguous bordered group
    *
    * When set on an individual item, overrides the group-level `appearance`.
    * @default "default"
@@ -313,12 +321,13 @@ function _RadioItem<T = string>(
     useContext(RadioGroupContext);
   const appearance = appearanceProp ?? groupAppearance;
   const isCard = appearance === "card";
+  const isBordered = appearance === "bordered";
 
   // Fall back to an appearance-appropriate default when controlPosition is
-  // not provided: card defaults to "end" (radio on the right), default
-  // appearance defaults to "start" (radio on the left).
+  // not provided: card and bordered default to "end" (radio on the right),
+  // while default appearance puts the radio on the left.
   const effectiveControlPosition: RadioControlPosition =
-    controlPosition ?? (isCard ? "end" : "start");
+    controlPosition ?? (isCard || isBordered ? "end" : "start");
 
   if (isCard) {
     const controlAtStart = effectiveControlPosition === "start";
@@ -389,7 +398,12 @@ function _RadioItem<T = string>(
         // "start" (default): radio before label
         // "end": label before radio using flex-row-reverse
         effectiveControlPosition === "end" && "flex-row-reverse justify-end",
-        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        disabled
+          ? cn(
+              "cursor-not-allowed",
+              isBordered ? "[&>*]:opacity-50" : "opacity-50",
+            )
+          : cn("cursor-pointer", isBordered && "hover:bg-kumo-elevated"),
         className,
       )}
     >
@@ -490,12 +504,24 @@ function RadioGroup<Value = string>({
             </Fieldset.Legend>
           )}
           <div
+            data-kumo-component="Radio"
+            data-kumo-part="group-items"
             className={cn(
-              orientation === "vertical"
-                ? cn("flex flex-col", appearance === "card" ? "gap-3" : "gap-2")
-                : appearance === "card"
-                  ? "grid grid-cols-2 gap-3"
-                  : "flex flex-row flex-wrap gap-2",
+              appearance === "bordered"
+                ? cn(
+                    "overflow-hidden rounded-lg border border-kumo-hairline bg-kumo-base",
+                    orientation === "vertical"
+                      ? "flex flex-col [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-t [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line"
+                      : "flex flex-row [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-l [&>[data-kumo-part=item-label]+[data-kumo-part=item-label]]:border-kumo-line",
+                  )
+                : orientation === "vertical"
+                  ? cn(
+                      "flex flex-col",
+                      appearance === "card" ? "gap-3" : "gap-2",
+                    )
+                  : appearance === "card"
+                    ? "grid grid-cols-2 gap-3"
+                    : "flex flex-row flex-wrap gap-2",
             )}
           >
             {children}

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -46,8 +46,7 @@ export const KUMO_RADIO_VARIANTS = {
         "Choice card appearance with border, padding, and highlighted selection state",
     },
     bordered: {
-      classes:
-        "p-3 transition-colors hover:bg-kumo-elevated has-[[data-checked]]:bg-kumo-elevated",
+      classes: "p-3 transition-colors hover:bg-kumo-elevated",
       description: "Option within a bordered group with shared dividers",
     },
   },
@@ -393,8 +392,7 @@ function _RadioItem<T = string>(
       data-kumo-part="item-label"
       className={cn(
         "group relative m-0 inline-flex items-start gap-2",
-        isBordered &&
-          "w-full flex-1 p-3 transition-colors has-[[data-checked]]:bg-kumo-elevated",
+        isBordered && "w-full flex-1 p-3 transition-colors",
         // "start" (default): radio before label
         // "end": label before radio using flex-row-reverse
         effectiveControlPosition === "end" && "flex-row-reverse justify-end",

--- a/packages/kumo/src/components/radio/radio.tsx
+++ b/packages/kumo/src/components/radio/radio.tsx
@@ -384,6 +384,8 @@ function _RadioItem<T = string>(
       data-kumo-part="item-label"
       className={cn(
         "group relative m-0 inline-flex items-start gap-2",
+        isBordered &&
+          "w-full flex-1 p-3 transition-colors has-[[data-checked]]:bg-kumo-elevated",
         // "start" (default): radio before label
         // "end": label before radio using flex-row-reverse
         effectiveControlPosition === "end" && "flex-row-reverse justify-end",
@@ -416,7 +418,15 @@ function _RadioItem<T = string>(
           <span className="h-2 w-2 rounded-full bg-kumo-base" />
         </BaseRadio.Indicator>
       </BaseRadio.Root>
-      <span className="text-base text-kumo-default">{label}</span>
+      <span
+        data-kumo-part="item-content"
+        className={cn(
+          "text-base text-kumo-default",
+          isBordered && "flex-1 leading-5 text-pretty",
+        )}
+      >
+        {label}
+      </span>
     </label>
   );
 }


### PR DESCRIPTION
Adds a new "bordered" appearance for Checkbox.Group and Radio.Group, plus horizontal orientation support for Checkbox.Group.

<img width="722" height="374" alt="Screenshot 2026-07-24 at 5 26 57 PM" src="https://github.com/user-attachments/assets/a5743326-c78e-4fe1-aedd-6e3ac3078da1" />

<img width="709" height="367" alt="Screenshot 2026-07-24 at 5 23 25 PM" src="https://github.com/user-attachments/assets/fcb7ee08-d678-424d-b182-1c7836d4ff1e" />

## Changes
- Checkbox.Group: new `appearance="bordered"` and `orientation` props
- Radio.Group: new `appearance="bordered"` option
- Bordered items use shared outer border + dividers between options
- Selection is indicated by the control only (no selected background fill)
- Added demos, docs examples, and tests

## Checklist
- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: significant visual/design changes require human review
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:
