### PR TITLE
docs: clarify that the global vp CLI is optional for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ Cross-package dependency: registry codegen requires docs demo metadata. Run `cod
 
 Lint/format/test config lives in `vite.config.ts` (root and per-package) — there
 are no `.oxlintrc.json` / `.prettierrc` files. `vp check` runs format + lint.
+The [global Vite+ CLI](https://viteplus.dev/) is optional but recommended for contributors: the binary ships with the local `vite-plus` dependency (`pnpm vp …`), and hooks resolve it from `node_modules/.bin`.
 
 ## SECURITY
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,14 @@ git checkout -b <new-branch-name>
 git push origin <new-branch-name>
 ```
 
+### Global Vite+ CLI (optional)
+
+Everything in this repo works through `pnpm` scripts. The `vp` binary ships with the local `vite-plus` dependency, and git hooks resolve it from `node_modules/.bin` automatically.
+
+[Installing the global CLI](https://viteplus.dev/) is **optional but recommended**. It adds bare `vp <command>` usage such as `vp install` and managed Node.js versions (`vp env`) if enabled.
+
+Without it, use `pnpm vp <command>` for direct commands, and `.nvmrc` / `.node-version` with your own version manager for Node.
+
 ### Install dependencies
 
 This repository is setup as a [mono-repo](https://pnpm.io/workspaces) of workspaces. The workspaces are stored in the [`packages`](https://github.com/cloudflare/kumo/tree/main/packages) directory.
@@ -169,7 +177,7 @@ The code is formatted by [Oxfmt](https://oxc.rs/docs/guide/usage/formatter.html)
   pnpm run format
   ```
 
-- You can also run `vp check` to format, lint, and validate in one pass (`vp check --fix` applies fixes).
+- You can also run `pnpm vp check` to format, lint, and validate in one pass (`--fix` applies fixes). If you have the [global Vite+ CLI](#global-vite-cli-optional) installed, plain `vp check` does the same.
 
 ### Testing
 


### PR DESCRIPTION
Docs update to tell about Vite+, the global (optional) CLI and fixing one `vp check` that wouldn't run if you don't have `vp` installed (`pnpm exec vp check`)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
