### PR TITLE
ci: install toolchain via the official `setup-vp` action

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,5 +1,5 @@
 name: "Install Dependencies"
-description: "Install pnpm, Node.js, and project dependencies"
+description: "Install Vite+ (vp), Node.js, and project dependencies"
 
 inputs:
   filter:
@@ -9,17 +9,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
+    - name: Setup Vite+
+      uses: voidzero-dev/setup-vp@v1
       with:
-        version: 10.22.0
-
-    - name: Install Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 24
-        cache: "pnpm"
+        # Same pin as local dev (vp env); replaces the hardcoded node-version.
+        node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"
+        cache: true
+        run-install: false
 
     - name: Cache node_modules
       uses: actions/cache@v4
@@ -33,7 +30,7 @@ runs:
       shell: bash
       run: |
         if [ -n "${{ inputs.filter }}" ]; then
-          pnpm install --frozen-lockfile --filter "${{ inputs.filter }}"
+          vp install --frozen-lockfile --filter "${{ inputs.filter }}"
         else
-          pnpm install --frozen-lockfile
+          vp install --frozen-lockfile
         fi

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Vite+
-      uses: voidzero-dev/setup-vp@v1
+      uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
       with:
         # Same pin as local dev (vp env); replaces the hardcoded node-version.
         node-version-file: .node-version

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -3,7 +3,7 @@ description: "Install Vite+ (vp), Node.js, and project dependencies"
 
 inputs:
   filter:
-    description: "pnpm --filter value to scope install (e.g. '@cloudflare/kumo'). Omit for all packages."
+    description: "--filter value to scope install (e.g. '@cloudflare/kumo'). Omit for all packages."
     required: false
 
 runs:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -225,7 +225,7 @@ jobs:
           BEFORE_URL: "https://kumo-ui.com"
           AFTER_URL: ${{ needs.deploy.outputs.preview_url }}
           SCREENSHOT_API_KEY: ${{ secrets.SCREENSHOT_API_KEY }}
-        run: pnpm tsx ci/visual-regression/run-visual-regression.ts
+        run: vp exec tsx ci/visual-regression/run-visual-regression.ts
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -67,10 +67,10 @@ jobs:
           filter: "@cloudflare/kumo..."
 
       - name: Build @cloudflare/kumo
-        run: pnpm --filter @cloudflare/kumo build
+        run: vp run --filter @cloudflare/kumo build
 
       - name: Publish preview package
-        run: pnpm dlx pkg-pr-new publish --pnpm --compact --no-template ./packages/kumo
+        run: vp dlx pkg-pr-new publish --pnpm --compact --no-template ./packages/kumo
 
   # Stage 1: Build docs (runs for ALL PRs including forks).
   # Produces an artifact consumed by either docs-deploy (internal) or
@@ -91,13 +91,13 @@ jobs:
           filter: "@cloudflare/kumo-docs-astro..."
 
       - name: Build @cloudflare/kumo
-        run: pnpm --filter @cloudflare/kumo build
+        run: vp run --filter @cloudflare/kumo build
 
       - name: Build docs
-        run: pnpm --filter @cloudflare/kumo-docs-astro build
+        run: vp run --filter @cloudflare/kumo-docs-astro build
 
       - name: Test docs
-        run: pnpm --filter @cloudflare/kumo-docs-astro test
+        run: vp run --filter @cloudflare/kumo-docs-astro test
 
       - name: Upload docs artifact
         uses: actions/upload-artifact@v4
@@ -267,7 +267,7 @@ jobs:
           BEFORE_URL: "https://kumo-ui.com"
           AFTER_URL: ${{ needs.docs-deploy.outputs.preview_url }}
           SCREENSHOT_API_KEY: ${{ secrets.SCREENSHOT_API_KEY }}
-        run: pnpm tsx ci/visual-regression/run-visual-regression.ts
+        run: vp exec tsx ci/visual-regression/run-visual-regression.ts
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -73,7 +73,7 @@ jobs:
           path: packages/kumo/ai
       # kumo-figma imports generated JSON data; type-aware lint needs it
       - run: vp run --filter @cloudflare/kumo-figma build:data
-      - run: vp run lint
+      - run: pnpm lint
 
   typecheck:
     needs: build

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/install-dependencies
-      - run: pnpm tsx ci/scripts/validate-kumo-changeset.ts
+      - run: vp exec tsx ci/scripts/validate-kumo-changeset.ts
 
   build:
     timeout-minutes: 5
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/install-dependencies
-      - run: pnpm --filter @cloudflare/kumo build
+      - run: vp run --filter @cloudflare/kumo build
       - uses: actions/upload-artifact@v4
         with:
           name: kumo-dist
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/install-dependencies
-      - run: pnpm format:check
+      - run: vp run format:check
 
   lint:
     needs: build
@@ -72,8 +72,8 @@ jobs:
           name: kumo-ai
           path: packages/kumo/ai
       # kumo-figma imports generated JSON data; type-aware lint needs it
-      - run: pnpm --filter @cloudflare/kumo-figma build:data
-      - run: pnpm lint
+      - run: vp run --filter @cloudflare/kumo-figma build:data
+      - run: vp run lint
 
   typecheck:
     needs: build
@@ -92,7 +92,7 @@ jobs:
         with:
           name: kumo-ai
           path: packages/kumo/ai
-      - run: pnpm typecheck
+      - run: vp run typecheck
 
   test:
     needs: build
@@ -111,7 +111,7 @@ jobs:
         with:
           name: kumo-ai
           path: packages/kumo/ai
-      - run: pnpm --filter @cloudflare/kumo test
+      - run: vp run --filter @cloudflare/kumo test
 
   test-react-compatibility:
     needs: build
@@ -134,12 +134,12 @@ jobs:
       - uses: ./.github/actions/install-dependencies
       - name: Install React ${{ matrix.react-version }} test dependencies
         run: |
-          pnpm pkg set \
+          npm pkg set \
             "pnpm.overrides.react=${{ matrix.react-version }}" \
             "pnpm.overrides.react-dom=${{ matrix.react-version }}" \
             "pnpm.overrides.@types/react=${{ matrix.types-react-version }}" \
             "pnpm.overrides.@types/react-dom=${{ matrix.types-react-dom-version }}"
-          pnpm install --no-frozen-lockfile --ignore-scripts --filter "@cloudflare/kumo..."
+          vp install --no-frozen-lockfile --ignore-scripts --filter "@cloudflare/kumo..."
       - uses: actions/download-artifact@v4
         with:
           name: kumo-dist
@@ -150,7 +150,8 @@ jobs:
           path: packages/kumo/ai
       - name: Verify React test versions
         run: |
-          pnpm --filter @cloudflare/kumo exec node -e "if (require('react/package.json').version !== '${{ matrix.react-version }}') process.exit(1)"
-          pnpm --filter @cloudflare/kumo exec node -e "if (require('react-dom/package.json').version !== '${{ matrix.react-version }}') process.exit(1)"
-      - run: pnpm --filter @cloudflare/kumo typecheck
-      - run: pnpm --filter @cloudflare/kumo test
+          cd packages/kumo
+          node -e "if (require('react/package.json').version !== '${{ matrix.react-version }}') process.exit(1)"
+          node -e "if (require('react-dom/package.json').version !== '${{ matrix.react-version }}') process.exit(1)"
+      - run: vp run --filter @cloudflare/kumo typecheck
+      - run: vp run --filter @cloudflare/kumo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,20 +29,20 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Build @cloudflare/kumo
-        run: pnpm --filter @cloudflare/kumo build
+        run: vp run --filter @cloudflare/kumo build
 
       # changesets/action either:
       # 1. Creates/updates a "Version Packages" PR (when changesets exist)
-      # 2. Publishes to npm via `pnpm run release` (when Version Packages PR merges)
-      # Note: `pnpm run release` runs `pnpm build:all && changeset publish`,
+      # 2. Publishes to npm via `vp run release` (when Version Packages PR merges)
+      # Note: `vp run release` runs `pnpm build:all && changeset publish`,
       # which rebuilds kumo (redundant but harmless). If this becomes slow,
       # consider a publish-only script.
       - name: Create Version PR or Publish to npm
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
-          version: pnpm run version
-          publish: pnpm run release
+          version: vp run version
+          publish: vp run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
@@ -51,4 +51,4 @@ jobs:
       # (GITHUB_TOKEN PRs don't trigger workflows, so we do it here)
       - name: Publish package preview
         if: ${{ steps.changesets.outputs.pullRequestNumber }}
-        run: pnpm dlx pkg-pr-new publish --pnpm --compact --no-template ./packages/kumo
+        run: vp dlx pkg-pr-new publish --pnpm --compact --no-template ./packages/kumo

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           format: "json"
 
-      - run: pnpm tsx tools/deployments/validate-pr-description.ts
+      - run: vp exec tsx tools/deployments/validate-pr-description.ts
         if: steps.changes.outputs.everything_but_markdown == 'true'
         env:
           TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Uses the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action for GH to use vp to the fullest, and always select the correct node version + pkg manager. Also mimics global CLI usage for potential contributors.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: The action should run successfully 😛
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
