### PR TITLE
build: add cached codegen task chain via vp run

### DIFF
--- a/.github/actions/vite-task-cache/action.yml
+++ b/.github/actions/vite-task-cache/action.yml
@@ -7,8 +7,8 @@ runs:
     - uses: actions/cache@v6
       with:
         path: node_modules/.vite/task-cache
-        # A unique key makes each successful job save its updated cache. The
-        # broad prefix restores the newest cache available to the current ref.
+        # The per-run key never pre-exists, so every successful job saves.
+        # The prefix restore falls back to the newest prior cache.
         key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           vite-task-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/actions/vite-task-cache/action.yml
+++ b/.github/actions/vite-task-cache/action.yml
@@ -1,0 +1,14 @@
+name: "Vite Task cache"
+description: "Restore and save the Vite Task cache."
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/cache@v6
+      with:
+        path: node_modules/.vite/task-cache
+        # A unique key makes each successful job save its updated cache. The
+        # broad prefix restores the newest cache available to the current ref.
+        key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          vite-task-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -66,8 +66,9 @@ jobs:
         with:
           filter: "@cloudflare/kumo..."
 
+      - uses: ./.github/actions/vite-task-cache
       - name: Build @cloudflare/kumo
-        run: vp run --filter @cloudflare/kumo build
+        run: vp run build:kumo
 
       - name: Publish preview package
         run: vp dlx pkg-pr-new publish --pnpm --compact --no-template ./packages/kumo
@@ -90,11 +91,10 @@ jobs:
         with:
           filter: "@cloudflare/kumo-docs-astro..."
 
-      - name: Build @cloudflare/kumo
-        run: vp run --filter @cloudflare/kumo build
-
+      - uses: ./.github/actions/vite-task-cache
+      # build:docs builds kumo first (task dependency).
       - name: Build docs
-        run: vp run --filter @cloudflare/kumo-docs-astro build
+        run: vp run build:docs
 
       - name: Test docs
         run: vp run --filter @cloudflare/kumo-docs-astro test

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/install-dependencies
-      - run: vp run --filter @cloudflare/kumo build
+      - uses: ./.github/actions/vite-task-cache
+      - run: vp run build:kumo
       - uses: actions/upload-artifact@v4
         with:
           name: kumo-dist
@@ -71,8 +72,9 @@ jobs:
         with:
           name: kumo-ai
           path: packages/kumo/ai
+      - uses: ./.github/actions/vite-task-cache
       # kumo-figma imports generated JSON data; type-aware lint needs it
-      - run: vp run --filter @cloudflare/kumo-figma build:data
+      - run: vp run gen:figma-data
       - run: vp run --filter @cloudflare/kumo lint:oxlint
       - run: vp lint packages/*/src
 

--- a/.github/workflows/warm-task-cache.yml
+++ b/.github/workflows/warm-task-cache.yml
@@ -1,0 +1,25 @@
+# Keeps the Vite Task cache warm on main so pull requests can restore a
+# populated base-branch cache.
+name: Warm Task Cache
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/install-dependencies
+      - uses: ./.github/actions/vite-task-cache
+      - run: vp run gen:figma-data
+      # Warms the whole chain: demos, registry, kumo build, docs build.
+      - run: vp run build:docs

--- a/.github/workflows/warm-task-cache.yml
+++ b/.github/workflows/warm-task-cache.yml
@@ -1,5 +1,5 @@
-# Keeps the Vite Task cache warm on main so pull requests can restore a
-# populated base-branch cache.
+# PRs can only restore caches created on their base branch, so warm main's
+# cache after every push.
 name: Warm Task Cache
 
 on:
@@ -21,5 +21,5 @@ jobs:
       - uses: ./.github/actions/install-dependencies
       - uses: ./.github/actions/vite-task-cache
       - run: vp run gen:figma-data
-      # Warms the whole chain: demos, registry, kumo build, docs build.
+      # Pulls in the rest of the chain via task dependencies.
       - run: vp run build:docs

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,49 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix",
   },
+  run: {
+    // We use pnpm until
+    // https://github.com/voidzero-dev/vite-plus/issues/2238 is fixed.
+    tasks: {
+      "gen:demos": {
+        command: "pnpm --filter @cloudflare/kumo-docs-astro codegen:demos",
+      },
+      "gen:registry": {
+        command: "tsx packages/kumo/scripts/component-registry/index.ts",
+        dependsOn: ["gen:demos"],
+        // The registry's own incremental cache is memoization, not an input.
+        input: [{ auto: true }, "!packages/kumo/.cache/**"],
+      },
+      "build:kumo": {
+        command: "pnpm --filter @cloudflare/kumo build",
+        // Pre-warms the registry memo so the in-build codegen pass is incremental.
+        dependsOn: ["gen:registry"],
+        // The build regenerates these itself; outputs, not inputs.
+        input: [
+          { auto: true },
+          "!packages/kumo/ai/**",
+          "!packages/kumo/dist/**",
+          "!packages/kumo/.cache/**",
+          "!packages/kumo-docs-astro/dist/**",
+        ],
+      },
+      "gen:figma-data": {
+        command: "pnpm --filter @cloudflare/kumo-figma build:data",
+      },
+      "build:docs": {
+        command: "pnpm --filter @cloudflare/kumo-docs-astro build",
+        // The docs site consumes the built kumo package.
+        dependsOn: ["build:kumo"],
+        // The build regenerates these itself; outputs, not inputs.
+        input: [
+          { auto: true },
+          "!packages/kumo-docs-astro/.astro/**",
+          "!packages/kumo-docs-astro/public/skill.md",
+          "!packages/kumo-docs-astro/dist/**",
+        ],
+      },
+    },
+  },
   fmt: {
     // Match the repo's previous Prettier print width.
     printWidth: 80,


### PR DESCRIPTION
This PR adds caching graph for:
* demo extraction
* registry generation
* Kumo builds
* Figma data generation
* and docs builds

The cache will be used in PRs and preview so unchanged parts can be simply replayed. The base-branch cache is also warmed after pushes to main.

---

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because:
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because the affected CI workflows execute the configured task graph directly.