### PR TITLE
feat(clipboardText): spam-safe copy feedback and toast bump animation

### DIFF
--- a/.changeset/clipboard-text-copy-feedback.md
+++ b/.changeset/clipboard-text-copy-feedback.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+ClipboardText: keep the check icon until the last copy click settles, and bump the anchored "Copied" toast (without stacking) when the button is pressed again while it's open.

--- a/packages/kumo/src/components/clipboard-text/clipboard-text.test.tsx
+++ b/packages/kumo/src/components/clipboard-text/clipboard-text.test.tsx
@@ -1,0 +1,150 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { ClipboardText } from "./clipboard-text";
+
+describe("ClipboardText", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(ClipboardText).toBeDefined();
+  });
+
+  it("renders the text and a copy button", () => {
+    render(<ClipboardText text="sk_live_abc123" />);
+    expect(screen.getByText("sk_live_abc123")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Copy to clipboard" }),
+    ).toBeTruthy();
+  });
+
+  it("copies text and announces copied state without tooltip", async () => {
+    render(<ClipboardText text="token-value" />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" }),
+      );
+    });
+
+    expect(writeText).toHaveBeenCalledWith("token-value");
+    expect(screen.getByText("Copied")).toBeTruthy();
+  });
+
+  it("keeps the check state while spam-clicking and resets after the last click settles", async () => {
+    render(<ClipboardText text="token-value" />);
+    const button = screen.getByRole("button", { name: "Copy to clipboard" });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(screen.getByText("Copied")).toBeTruthy();
+
+    // Advance partway through the feedback window, then click again
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText("Copied")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(screen.getByText("Copied")).toBeTruthy();
+
+    // Previous timeout must have been cleared — still copied after 1000ms
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText("Copied")).toBeTruthy();
+
+    // Full window after the *last* click clears the feedback
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.queryByText("Copied")).toBeNull();
+  });
+
+  it("copies textToCopy when provided instead of text", async () => {
+    render(
+      <ClipboardText text="visible-text" textToCopy="hidden-secret-value" />,
+    );
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" }),
+      );
+    });
+
+    expect(writeText).toHaveBeenCalledWith("hidden-secret-value");
+  });
+
+  it("shows a single anchored copied toast and bumps it on re-click", async () => {
+    render(
+      <ClipboardText
+        text="npx kumo add button"
+        tooltip={{ text: "Copy", copiedText: "Copied!", side: "top" }}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Copy to clipboard" });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Live region + toast description both surface "Copied!"
+    expect(screen.getAllByText("Copied!").length).toBeGreaterThanOrEqual(1);
+    expect(document.querySelector(".animate-clipboard-toast-bump")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(
+      document.querySelector(".animate-clipboard-toast-bump"),
+    ).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Still bumps on subsequent spam clicks while open
+    expect(
+      document.querySelector(".animate-clipboard-toast-bump"),
+    ).toBeTruthy();
+  });
+
+  it("calls onCopy after a successful copy", async () => {
+    const onCopy = vi.fn();
+    render(<ClipboardText text="token-value" onCopy={onCopy} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" }),
+      );
+    });
+
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kumo/src/components/clipboard-text/clipboard-text.test.tsx
+++ b/packages/kumo/src/components/clipboard-text/clipboard-text.test.tsx
@@ -101,13 +101,14 @@ describe("ClipboardText", () => {
   });
 
   it("shows a single anchored copied toast and bumps it on re-click", async () => {
-    render(
+    const { container } = render(
       <ClipboardText
         text="npx kumo add button"
         tooltip={{ text: "Copy", copiedText: "Copied!", side: "top" }}
       />,
     );
     const button = screen.getByRole("button", { name: "Copy to clipboard" });
+    const liveRegion = container.querySelector('[aria-live="polite"]');
 
     await act(async () => {
       fireEvent.click(button);
@@ -118,21 +119,40 @@ describe("ClipboardText", () => {
     expect(document.querySelector(".animate-clipboard-toast-bump")).toBeNull();
 
     await act(async () => {
-      fireEvent.click(button);
+      vi.advanceTimersByTime(1000);
     });
-
-    expect(
-      document.querySelector(".animate-clipboard-toast-bump"),
-    ).toBeTruthy();
 
     await act(async () => {
       fireEvent.click(button);
     });
 
-    // Still bumps on subsequent spam clicks while open
+    const secondToast = document.querySelector(".animate-clipboard-toast-bump");
+    expect(secondToast).toBeTruthy();
     expect(
-      document.querySelector(".animate-clipboard-toast-bump"),
-    ).toBeTruthy();
+      document.querySelectorAll(".animate-clipboard-toast-bump"),
+    ).toHaveLength(1);
+    expect(liveRegion?.textContent).toBe("Copied!");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    const thirdToast = document.querySelector(".animate-clipboard-toast-bump");
+    expect(thirdToast).toBeTruthy();
+    expect(thirdToast).not.toBe(secondToast);
+    expect(
+      document.querySelectorAll(".animate-clipboard-toast-bump"),
+    ).toHaveLength(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(liveRegion?.textContent).toBe("Copied!");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(liveRegion?.textContent).toBe("");
   });
 
   it("calls onCopy after a successful copy", async () => {

--- a/packages/kumo/src/components/clipboard-text/clipboard-text.tsx
+++ b/packages/kumo/src/components/clipboard-text/clipboard-text.tsx
@@ -1,5 +1,12 @@
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
-import { forwardRef, useCallback, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import { Toast } from "@base-ui/react/toast";
 import { Tooltip } from "@base-ui/react/tooltip";
 import { Button } from "../button";
@@ -7,8 +14,10 @@ import { inputVariants } from "../input";
 import { cn } from "../../utils/cn";
 import { resolveVariant } from "../../utils/resolve-variant";
 
-// Create a toast manager for anchored "Copied" toasts
+// External manager — same-id re-adds update + reset timeout in Base UI's store
 const clipboardToastManager = Toast.createToastManager();
+
+const COPIED_FEEDBACK_MS = 1500;
 
 /** ClipboardText size variant definitions mapping sizes to their Tailwind classes. */
 export const KUMO_CLIPBOARD_TEXT_VARIANTS = {
@@ -120,6 +129,11 @@ export interface ClipboardTextProps extends KumoClipboardTextVariantsProps {
   };
 }
 
+type ClipboardToastData = {
+  /** Monotonic key so the bump animation restarts on every spam click */
+  bumpKey?: number;
+};
+
 /**
  * Anchored toasts viewport - renders "Copied" toasts anchored to buttons
  */
@@ -127,19 +141,26 @@ function AnchoredToasts() {
   const { toasts } = Toast.useToastManager();
   return (
     <Toast.Viewport className="pointer-events-none fixed inset-0 isolate">
-      {toasts.map((toast) => (
-        <Toast.Positioner key={toast.id} toast={toast} className="absolute">
-          <Toast.Root
-            toast={toast}
-            className={cn(
-              "flex origin-[var(--transform-origin)] flex-col rounded-md bg-kumo-base px-3 py-1.5 font-sans text-xs text-kumo-default",
-              "shadow-lg shadow-kumo-tip-shadow outline outline-kumo-fill",
-            )}
-          >
-            <Toast.Description />
-          </Toast.Root>
-        </Toast.Positioner>
-      ))}
+      {toasts.map((toast) => {
+        const data = toast.data as ClipboardToastData | undefined;
+        const bumpKey = data?.bumpKey ?? 0;
+        return (
+          <Toast.Positioner key={toast.id} toast={toast} className="absolute">
+            {/* key forces a fresh animation instance on every bump */}
+            <Toast.Root
+              key={bumpKey}
+              toast={toast}
+              className={cn(
+                "flex origin-[var(--transform-origin)] flex-col rounded-md bg-kumo-base px-3 py-1.5 font-sans text-xs text-kumo-default",
+                "shadow-lg shadow-kumo-tip-shadow outline outline-kumo-fill",
+                bumpKey > 0 && "animate-clipboard-toast-bump",
+              )}
+            >
+              <Toast.Description />
+            </Toast.Root>
+          </Toast.Positioner>
+        );
+      })}
     </Toast.Viewport>
   );
 }
@@ -181,6 +202,10 @@ export const ClipboardText = forwardRef<HTMLDivElement, ClipboardTextProps>(
   ) => {
     const [copied, setCopied] = useState(false);
     const buttonRef = useRef<HTMLButtonElement | null>(null);
+    const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const toastOpenRef = useRef(false);
+    const bumpKeyRef = useRef(0);
+    const toastId = useId();
     const sizeConfig = resolveVariant(
       KUMO_CLIPBOARD_TEXT_VARIANTS.size,
       size,
@@ -193,6 +218,24 @@ export const ClipboardText = forwardRef<HTMLDivElement, ClipboardTextProps>(
       copiedText = "Copied",
       side: tooltipSide = "top",
     } = tooltip ?? {};
+
+    useEffect(() => {
+      return () => {
+        if (resetTimeoutRef.current !== null) {
+          clearTimeout(resetTimeoutRef.current);
+        }
+      };
+    }, []);
+
+    const scheduleCopiedReset = useCallback(() => {
+      if (resetTimeoutRef.current !== null) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+      resetTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+        resetTimeoutRef.current = null;
+      }, COPIED_FEEDBACK_MS);
+    }, []);
 
     const copyToClipboard = useCallback(async () => {
       try {
@@ -230,28 +273,57 @@ export const ClipboardText = forwardRef<HTMLDivElement, ClipboardTextProps>(
 
         // Show anchored toast if tooltip mode is enabled
         if (tooltip) {
-          clipboardToastManager.add({
-            description: copiedText,
-            positionerProps: {
-              anchor: buttonRef.current,
-              side: tooltipSide,
-              sideOffset: 8,
-            },
-            timeout: 1500,
-            onClose() {
-              setCopied(false);
-            },
-          });
+          const alreadyOpen = toastOpenRef.current;
+
+          if (alreadyOpen) {
+            // Same toast visible — bump + refresh dismiss timer on every click
+            bumpKeyRef.current += 1;
+            clipboardToastManager.update(toastId, {
+              description: copiedText,
+              timeout: COPIED_FEEDBACK_MS,
+              data: {
+                bumpKey: bumpKeyRef.current,
+              } satisfies ClipboardToastData,
+            });
+          } else {
+            bumpKeyRef.current = 0;
+            clipboardToastManager.add({
+              id: toastId,
+              description: copiedText,
+              positionerProps: {
+                anchor: buttonRef.current,
+                side: tooltipSide,
+                sideOffset: 8,
+              },
+              timeout: COPIED_FEEDBACK_MS,
+              data: { bumpKey: 0 } satisfies ClipboardToastData,
+              onClose() {
+                toastOpenRef.current = false;
+                bumpKeyRef.current = 0;
+                setCopied(false);
+              },
+            });
+            toastOpenRef.current = true;
+          }
         } else {
-          // Reset copied state after delay when no tooltip
-          setTimeout(() => setCopied(false), 1500);
+          // Keep check icon visible; only reset after the last click settles
+          scheduleCopiedReset();
         }
 
         onCopy?.();
       } catch (error) {
         console.warn("Clipboard copy failed", error);
       }
-    }, [text, onCopy, tooltip, copiedText, tooltipSide]);
+    }, [
+      text,
+      textToCopy,
+      onCopy,
+      tooltip,
+      copiedText,
+      tooltipSide,
+      toastId,
+      scheduleCopiedReset,
+    ]);
 
     const copyButton = (
       <Button

--- a/packages/kumo/src/components/clipboard-text/clipboard-text.tsx
+++ b/packages/kumo/src/components/clipboard-text/clipboard-text.tsx
@@ -1,12 +1,5 @@
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import { Toast } from "@base-ui/react/toast";
 import { Tooltip } from "@base-ui/react/tooltip";
 import { Button } from "../button";
@@ -129,11 +122,6 @@ export interface ClipboardTextProps extends KumoClipboardTextVariantsProps {
   };
 }
 
-type ClipboardToastData = {
-  /** Monotonic key so the bump animation restarts on every spam click */
-  bumpKey?: number;
-};
-
 /**
  * Anchored toasts viewport - renders "Copied" toasts anchored to buttons
  */
@@ -142,18 +130,17 @@ function AnchoredToasts() {
   return (
     <Toast.Viewport className="pointer-events-none fixed inset-0 isolate">
       {toasts.map((toast) => {
-        const data = toast.data as ClipboardToastData | undefined;
-        const bumpKey = data?.bumpKey ?? 0;
+        const updateKey = toast.updateKey ?? 0;
         return (
           <Toast.Positioner key={toast.id} toast={toast} className="absolute">
             {/* key forces a fresh animation instance on every bump */}
             <Toast.Root
-              key={bumpKey}
+              key={updateKey}
               toast={toast}
               className={cn(
                 "flex origin-[var(--transform-origin)] flex-col rounded-md bg-kumo-base px-3 py-1.5 font-sans text-xs text-kumo-default",
                 "shadow-lg shadow-kumo-tip-shadow outline outline-kumo-fill",
-                bumpKey > 0 && "animate-clipboard-toast-bump",
+                updateKey > 0 && "animate-clipboard-toast-bump",
               )}
             >
               <Toast.Description />
@@ -203,9 +190,7 @@ export const ClipboardText = forwardRef<HTMLDivElement, ClipboardTextProps>(
     const [copied, setCopied] = useState(false);
     const buttonRef = useRef<HTMLButtonElement | null>(null);
     const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const toastOpenRef = useRef(false);
-    const bumpKeyRef = useRef(0);
-    const toastId = useId();
+    const toastIdRef = useRef<string | null>(null);
     const sizeConfig = resolveVariant(
       KUMO_CLIPBOARD_TEXT_VARIANTS.size,
       size,
@@ -273,38 +258,20 @@ export const ClipboardText = forwardRef<HTMLDivElement, ClipboardTextProps>(
 
         // Show anchored toast if tooltip mode is enabled
         if (tooltip) {
-          const alreadyOpen = toastOpenRef.current;
-
-          if (alreadyOpen) {
-            // Same toast visible — bump + refresh dismiss timer on every click
-            bumpKeyRef.current += 1;
-            clipboardToastManager.update(toastId, {
-              description: copiedText,
-              timeout: COPIED_FEEDBACK_MS,
-              data: {
-                bumpKey: bumpKeyRef.current,
-              } satisfies ClipboardToastData,
-            });
-          } else {
-            bumpKeyRef.current = 0;
-            clipboardToastManager.add({
-              id: toastId,
-              description: copiedText,
-              positionerProps: {
-                anchor: buttonRef.current,
-                side: tooltipSide,
-                sideOffset: 8,
-              },
-              timeout: COPIED_FEEDBACK_MS,
-              data: { bumpKey: 0 } satisfies ClipboardToastData,
-              onClose() {
-                toastOpenRef.current = false;
-                bumpKeyRef.current = 0;
-                setCopied(false);
-              },
-            });
-            toastOpenRef.current = true;
-          }
+          toastIdRef.current = clipboardToastManager.add({
+            id: toastIdRef.current ?? undefined,
+            description: copiedText,
+            positionerProps: {
+              anchor: buttonRef.current,
+              side: tooltipSide,
+              sideOffset: 8,
+            },
+            timeout: COPIED_FEEDBACK_MS,
+            onClose() {
+              toastIdRef.current = null;
+              setCopied(false);
+            },
+          });
         } else {
           // Keep check icon visible; only reset after the last click settles
           scheduleCopiedReset();
@@ -321,7 +288,6 @@ export const ClipboardText = forwardRef<HTMLDivElement, ClipboardTextProps>(
       tooltip,
       copiedText,
       tooltipSide,
-      toastId,
       scheduleCopiedReset,
     ]);
 

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -173,6 +173,26 @@
   transform-origin: center;
 }
 
+/* Subtle bump for small anchored clipboard "Copied" toasts */
+@keyframes clipboard-toast-bump {
+  0% {
+    transform: scale(1);
+  }
+
+  35% {
+    transform: scale(1.04);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+.animate-clipboard-toast-bump {
+  animation: clipboard-toast-bump 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform-origin: center;
+}
+
 @layer base {
   .skeleton-line {
     position: relative;

--- a/packages/kumo/src/styles/kumo-binding.css
+++ b/packages/kumo/src/styles/kumo-binding.css
@@ -193,6 +193,12 @@
   transform-origin: center;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-clipboard-toast-bump {
+    animation: none;
+  }
+}
+
 @layer base {
   .skeleton-line {
     position: relative;


### PR DESCRIPTION
### Summary of changes

Improves `ClipboardText` copy feedback when the button is pressed repeatedly:

- The check icon stays 1.5s after the **last** click instead of after the first, fixing 
a "glitching" of the copy/check icons fighting for placement (essentially timeout is cleared and restarted on each press, so it no longer flickers back to the copy icon while spamming)

| Before | After |
|--------|--------|
|<img width="464" height="288" alt="spambefore" src="https://github.com/user-attachments/assets/ef3e0995-2a2e-4e59-b9a4-09b5edc32442" /> | <img width="464" height="288" alt="spamafter" src="https://github.com/user-attachments/assets/0baab3bf-da3f-49f5-ae15-5fc5ce4278cb" /> |

- Only one "Copied" toast for the ClipboardText with tooltip, instead of a stack of toasts. Also includes a subtle "bump" animation to the one tooltip when copying again, instead of adding another one.

| Before | After |
|--------|--------|
| <img width="688" height="290" alt="tooltipspambefore" src="https://github.com/user-attachments/assets/3a293c06-5745-4b7f-ad1e-fbd335eeda60" /> | <img width="688" height="290" alt="tooltipspamafter" src="https://github.com/user-attachments/assets/40aeee89-910b-48d2-b550-aa498d011818" /> |

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
