### PR TITLE
fix(button): use borders for button and input colors

### DIFF
--- a/.changeset/warm-buttons-border.md
+++ b/.changeset/warm-buttons-border.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Render Button, Input, and InputArea colors with borders and clip backgrounds to the border padding box.

--- a/packages/kumo-docs-astro/src/pages/tests/button.astro
+++ b/packages/kumo-docs-astro/src/pages/tests/button.astro
@@ -1,0 +1,31 @@
+---
+import { Button, Input, Select } from "@cloudflare/kumo";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Button test">
+  <main class="mx-auto max-w-3xl p-6 md:p-12 grid gap-8">
+    <div class="flex items-center gap-2">
+      <Input aria-label="Name" placeholder="Enter a name" />
+      <Select
+        aria-label="Action"
+        className="w-40"
+        items={{ create: "Create", update: "Update" }}
+        placeholder="Choose an action"
+        client:load
+      />
+      <Button variant="primary">Submit</Button>
+    </div>
+    <div class="flex items-center gap-2">
+      <Input aria-label="Name" placeholder="Enter a name" />
+      <Select
+        aria-label="Action"
+        className="w-40"
+        items={{ create: "Create", update: "Update" }}
+        placeholder="Choose an action"
+        client:load
+      />
+      <Button>Submit</Button>
+    </div>
+  </main>
+</BaseLayout>

--- a/packages/kumo/src/components/autocomplete/autocomplete.test.tsx
+++ b/packages/kumo/src/components/autocomplete/autocomplete.test.tsx
@@ -90,7 +90,7 @@ describe("Autocomplete", () => {
       renderAutocomplete({ error: "Country is required" });
 
       const input = screen.getByRole("combobox");
-      expect(input.className).toContain("ring-kumo-danger");
+      expect(input.className).toContain("border-kumo-danger");
     });
 
     it("renders error message string with label", () => {

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, expect, it } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import { Plus } from "@phosphor-icons/react";
-import { Button, RefreshButton, LinkButton, buttonVariants } from "./button";
+import { Button, RefreshButton, LinkButton } from "./button";
 
 describe("Button", () => {
   describe("children wrapper", () => {
@@ -143,21 +143,6 @@ describe("Button", () => {
     expect(trigger?.tagName).toBe("SPAN");
     expect(trigger?.hasAttribute("data-base-ui-tooltip-trigger")).toBe(true);
     expect(trigger?.hasAttribute("disabled")).toBe(false);
-  });
-
-  it("keeps emphasized variant rings color-matched when pressed or focused", () => {
-    for (const variant of ["primary", "destructive"] as const) {
-      const className = buttonVariants({ variant });
-
-      expect(className).toContain("ring-(--kumo-button-emphasis-ring)");
-      expect(className).toContain("focus:ring-(--kumo-button-emphasis-ring)");
-      expect(className).toContain(
-        "focus-visible:ring-(--kumo-button-emphasis-ring)",
-      );
-      expect(className).toContain("active:ring-(--kumo-button-emphasis-ring)");
-      expect(className).not.toContain("focus:ring-kumo-focus/50");
-      expect(className).not.toContain("focus-visible:ring-kumo-brand");
-    }
   });
 });
 

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -49,12 +49,12 @@ export const KUMO_BUTTON_VARIANTS = {
   variant: {
     primary: {
       classes:
-        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) focus:ring-(--kumo-button-emphasis-ring) focus-visible:ring-(--kumo-button-emphasis-ring) active:ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
+        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white border border-(--kumo-button-emphasis-border) focus:border-(--kumo-button-emphasis-border) focus-visible:border-(--kumo-button-emphasis-border) active:border-(--kumo-button-emphasis-border) disabled:opacity-50",
       description: "High-emphasis button for primary actions",
     },
     secondary: {
       classes:
-        "bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-base",
+        "bg-kumo-base !text-kumo-default border not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 border-kumo-line data-[state=open]:bg-kumo-base",
       description: "Default button style for most actions",
     },
     ghost: {
@@ -63,18 +63,18 @@ export const KUMO_BUTTON_VARIANTS = {
     },
     destructive: {
       classes:
-        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) focus:ring-(--kumo-button-emphasis-ring) focus-visible:ring-(--kumo-button-emphasis-ring) active:ring-(--kumo-button-emphasis-ring) disabled:opacity-50",
+        "relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white border border-(--kumo-button-emphasis-border) focus:border-(--kumo-button-emphasis-border) focus-visible:border-(--kumo-button-emphasis-border) active:border-(--kumo-button-emphasis-border) disabled:opacity-50",
       description: "Danger button for destructive actions like delete",
     },
     "secondary-destructive": {
       classes:
-        "bg-kumo-base !text-kumo-danger ring not-disabled:hover:!text-kumo-danger not-disabled:hover:ring-kumo-danger/30 disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-line data-[state=open]:bg-kumo-base",
+        "bg-kumo-base !text-kumo-danger border not-disabled:hover:!text-kumo-danger not-disabled:hover:border-kumo-danger/30 disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 border-kumo-line data-[state=open]:bg-kumo-base",
       description:
         "Secondary button with destructive text for less prominent dangerous actions",
     },
     outline: {
       classes:
-        "bg-transparent text-kumo-default ring ring-kumo-line transition-colors not-disabled:hover:text-kumo-strong not-disabled:hover:ring-kumo-focus/25",
+        "bg-transparent text-kumo-default border border-kumo-line transition-colors not-disabled:hover:text-kumo-strong not-disabled:hover:border-kumo-focus/25",
       description: "Bordered button with transparent background",
     },
   },
@@ -132,8 +132,8 @@ export function buttonVariants({
   return cn(
     // Base styles
     "group flex w-max shrink-0 items-center font-medium select-none",
-    "border-0 shadow-xs",
-    "focus:ring-kumo-focus/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
+    "border-0 bg-clip-padding",
+    "focus:border-kumo-focus/50 focus:outline-none focus-visible:border-2 focus-visible:border-kumo-brand",
     "cursor-pointer",
     // Disabled state
     "disabled:cursor-not-allowed disabled:text-kumo-subtle",
@@ -180,7 +180,7 @@ const getEmphasisStyle = (variant: KumoButtonVariant) => {
   if (!token) return undefined;
 
   return {
-    "--kumo-button-emphasis-ring": `color-mix(in oklch, ${token}, black 10%)`,
+    "--kumo-button-emphasis-border": `color-mix(in oklch, ${token}, black 10%)`,
     "--kumo-button-emphasis-bg": `color-mix(in oklch, ${token}, white 30%)`,
     "--kumo-button-emphasis-gradient-start": `color-mix(in oklch, ${token}, white 15%)`,
     "--kumo-button-emphasis-gradient-end": token,
@@ -235,7 +235,7 @@ const renderButtonContent = (
     <>
       <span
         aria-hidden="true"
-        className="absolute inset-0 rounded-[inherit] bg-linear-to-b from-(--kumo-button-emphasis-gradient-start) to-(--kumo-button-emphasis-gradient-end) shadow-[inset_0_1px_0_0_var(--kumo-button-emphasis-bg)] group-hover:from-(--kumo-button-emphasis-bg)"
+        className="absolute inset-0 rounded-t-[inherit] bg-linear-to-b from-(--kumo-button-emphasis-gradient-start) to-(--kumo-button-emphasis-gradient-end) shadow-[inset_0_1px_0_0_var(--kumo-button-emphasis-bg)] group-hover:from-(--kumo-button-emphasis-bg)"
       />
       <span className="relative flex items-center gap-1.5">
         {iconNode}

--- a/packages/kumo/src/components/combobox/combobox.test.tsx
+++ b/packages/kumo/src/components/combobox/combobox.test.tsx
@@ -90,7 +90,7 @@ describe("Combobox", () => {
       renderComboboxWithInput({ error: "Selection required" });
 
       const input = screen.getByRole("combobox");
-      expect(input.className).toContain("ring-kumo-danger");
+      expect(input.className).toContain("border-kumo-danger");
     });
 
     it("applies error border to TriggerValue when error prop is truthy", () => {
@@ -114,7 +114,7 @@ describe("Combobox", () => {
       );
 
       const trigger = screen.getByRole("combobox");
-      expect(trigger.className).toContain("ring-kumo-danger");
+      expect(trigger.className).toContain("border-kumo-danger");
     });
 
     it("renders error message string with label", () => {

--- a/packages/kumo/src/components/input/input.test.tsx
+++ b/packages/kumo/src/components/input/input.test.tsx
@@ -80,14 +80,18 @@ describe("Input", () => {
   // Variant styles
   it("renders with default variant 'default'", () => {
     render(<Input aria-label="Test" />);
-    expect(screen.getByRole("textbox").className).toContain(
-      "focus:ring-kumo-focus/50",
-    );
+    const className = screen.getByRole("textbox").className;
+
+    expect(className).toContain("bg-clip-padding");
+    expect(className).toContain("focus:border-kumo-focus/50");
+    expect(className).not.toContain("ring-");
   });
 
   it("renders with variant 'error'", () => {
     render(<Input aria-label="Test" variant="error" />);
-    expect(screen.getByRole("textbox").className).toContain("ring-kumo-danger");
+    expect(screen.getByRole("textbox").className).toContain(
+      "border-kumo-danger",
+    );
   });
 
   // Field wrapping
@@ -145,7 +149,9 @@ describe("Input", () => {
 
   it("applies error variant styling without label", () => {
     render(<Input aria-label="Email" error="Bad value" />);
-    expect(screen.getByRole("textbox").className).toContain("ring-kumo-danger");
+    expect(screen.getByRole("textbox").className).toContain(
+      "border-kumo-danger",
+    );
   });
 
   it("renders description without label", () => {
@@ -199,7 +205,7 @@ describe("Input", () => {
 
   it("applies variant classes from KUMO_INPUT_VARIANTS", () => {
     const classes = inputVariants({ variant: "error" });
-    expect(classes).toContain("ring-kumo-danger");
+    expect(classes).toContain("border-kumo-danger");
   });
 
   it("applies parentFocusIndicator class when true", () => {
@@ -209,7 +215,7 @@ describe("Input", () => {
 
   it("applies focusIndicator class when true", () => {
     const classes = inputVariants({ focusIndicator: true });
-    expect(classes).toContain("focus:ring-kumo-focus/50");
+    expect(classes).toContain("focus:border-kumo-focus/50");
   });
 
   // Variants export

--- a/packages/kumo/src/components/input/input.tsx
+++ b/packages/kumo/src/components/input/input.tsx
@@ -34,11 +34,12 @@ export const KUMO_INPUT_VARIANTS = {
   },
   variant: {
     default: {
-      classes: "focus:ring-kumo-focus/50 focus:ring-[1.5px]",
+      classes: "focus:border-kumo-focus/50 focus:border-[1.5px]",
       description: "Default input appearance",
     },
     error: {
-      classes: "!ring-kumo-danger focus:ring-kumo-danger/50 focus:ring-[1.5px]",
+      classes:
+        "!border-kumo-danger focus:border-kumo-danger/50 focus:border-[1.5px]",
       description: "Error state for validation failures",
     },
   },
@@ -66,11 +67,11 @@ export const KUMO_INPUT_STYLING = {
     background: "color-secondary",
     text: "text-color-surface",
     placeholder: "text-color-muted",
-    ring: "color-border",
+    border: "color-border",
   },
   stateTokens: {
-    focus: { ring: "color-active" },
-    error: { ring: "color-error" },
+    focus: { border: "color-active" },
+    error: { border: "color-error" },
     disabled: { opacity: 0.5, text: "text-color-muted" },
   },
 } as const;
@@ -111,7 +112,7 @@ export function inputVariants({
 }: KumoInputVariantsProps = {}) {
   return cn(
     // Base styles
-    "border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none focus:outline-none",
+    "border border-kumo-line bg-kumo-control bg-clip-padding text-kumo-default outline-none focus:outline-none",
     // Disabled state and placeholder styles (using vanilla CSS class for Chrome compatibility)
     "kumo-input-placeholder disabled:text-kumo-disabled",
     // Apply size styles from KUMO_INPUT_VARIANTS
@@ -129,12 +130,12 @@ export function inputVariants({
     // Focus state handling
     parentFocusIndicator &&
       (variant === "error"
-        ? "focus-within:ring-[1.5px] focus-within:ring-kumo-danger/50"
-        : "focus-within:ring-[1.5px] focus-within:ring-kumo-focus/50"),
+        ? "focus-within:border-[1.5px] focus-within:border-kumo-danger/50"
+        : "focus-within:border-[1.5px] focus-within:border-kumo-focus/50"),
     focusIndicator &&
       (variant === "error"
-        ? "focus:ring-[1.5px] focus:ring-kumo-danger/50"
-        : "focus:ring-[1.5px] focus:ring-kumo-focus/50"),
+        ? "focus:border-[1.5px] focus:border-kumo-danger/50"
+        : "focus:border-[1.5px] focus:border-kumo-focus/50"),
   );
 }
 

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.test.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.test.tsx
@@ -41,8 +41,8 @@ describe("SensitiveInput", () => {
     const { container } = render(
       <SensitiveInput aria-label="API Key" error="Invalid key" />,
     );
-    // Error styling (ring-kumo-danger) is on the container div wrapping the password input
+    // Error border styling is on the container div wrapping the password input
     const inputEl = container.querySelector("input");
-    expect(inputEl?.parentElement?.className).toContain("ring-kumo-danger");
+    expect(inputEl?.parentElement?.className).toContain("border-kumo-danger");
   });
 });


### PR DESCRIPTION
## Summary

- replace ring-based edge colors with borders for Button, Input, and InputArea
- clip control backgrounds to the padding box so borders remain visible
- preserve focus, active, hover, and error-state colors
- add a `/tests/button` fixture with Input, Select, primary Button, and secondary Button combinations

Jira: [DESENG-1114](https://jira.cfdata.org/browse/DESENG-1114)

## Validation

- `pnpm --filter @cloudflare/kumo test`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- targeted docs lint and Astro color-token checks

## Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: no automated review was run before opening this PR

## Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable
