### PR TITLE
fix: split Base UI into fine-grained chunks

### DIFF
--- a/.changeset/split-base-ui-chunk.md
+++ b/.changeset/split-base-ui-chunk.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Split Base UI across fine-grained chunks instead of one `vendor-base-ui` chunk
+
+Components now pull in only the Base UI modules they actually use, improving
+consumer tree-shaking: a single-Button app bundle drops from ~173 KB to
+~129 KB minified (~57 KB to ~44 KB gzipped) compared to 2.8.0.

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -281,7 +281,6 @@ export default defineConfig({
               name: "vendor-floating-ui",
               test: /node_modules\/.*@floating-ui/,
             },
-            { name: "vendor-base-ui", test: /node_modules\/.*@base-ui/ },
             {
               name: "vendor-utils",
               test: /node_modules\/.*(?:tabbable|reselect)/,


### PR DESCRIPTION
This restores proper tree-shaking. Before, pulling in a simple `Button` always added the *whole* base ui chunk, adding unnecessary JavaScript for smaller needs.

Potential downsides:

* More files than before (but better tree-shaking)
* Slightly worse minification (doesn't matter as the consumers minify as well)
* Module init order (the only "real" downside, but can be easily tested)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: tested locally 🤷🏻‍♂️
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: built the thing, compared the size.
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
