### PR TITLE
ci: respect no-changeset-required label

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -2,6 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - "*.md"
       - ".changeset/**"
@@ -23,6 +24,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/install-dependencies
       - run: vp exec tsx ci/scripts/validate-kumo-changeset.ts
+        env:
+          NO_CHANGESET_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'no-changeset-required') }}
 
   build:
     timeout-minutes: 5

--- a/ci/scripts/validate-kumo-changeset.ts
+++ b/ci/scripts/validate-kumo-changeset.ts
@@ -42,6 +42,13 @@ function main() {
     return;
   }
 
+  if (process.env.NO_CHANGESET_REQUIRED === "true") {
+    console.log(
+      "Detected no-changeset-required label; skipping changeset validation.",
+    );
+    return;
+  }
+
   // Skip validation on Changesets release PRs. The `changesets/action` bot
   // opens these PRs from a `changeset-release/<target>` branch and, by
   // design, their diff modifies `packages/kumo/` (version bump + CHANGELOG)


### PR DESCRIPTION
This PR ensures that  the `no-changeset-required` label (if set) is passed into the changeset validator and sets the validator accordingly.

It also reruns the workflow on label additions/removals.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: we will see in CI
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: we will see in CI

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
