### PR TITLE
fix(button): use title as accessible label fallback

### DIFF
--- a/.changeset/bright-buttons-speak.md
+++ b/.changeset/bright-buttons-speak.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Use a string or numeric Button title as the fallback accessible label when the button has no text children.

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -113,6 +113,32 @@ describe("Button", () => {
     expect(button.getAttribute("title")).toBeNull();
   });
 
+  it("uses title as the accessible name when there are no children", () => {
+    render(<Button shape="square" icon={Plus} title="Remove" />);
+
+    const button = screen.getByRole("button", { name: "Remove" });
+    expect(button.getAttribute("aria-label")).toBe("Remove");
+    expect(button.getAttribute("title")).toBeNull();
+  });
+
+  it("does not override explicit accessible names with title", () => {
+    render(
+      <>
+        <Button aria-label="Delete" shape="square" icon={Plus} title="Remove" />
+        <span id="archive-label">Archive</span>
+        <Button
+          aria-labelledby="archive-label"
+          shape="square"
+          icon={Plus}
+          title="Move"
+        />
+      </>,
+    );
+
+    expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Archive" })).toBeTruthy();
+  });
+
   it("uses an enabled tooltip trigger around a disabled button", () => {
     render(
       <Button title="Saving is unavailable" disabled>

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -303,14 +303,17 @@ type IconOnlyButtonAccessibleNameProps =
 
 type IconOnlyButtonProps = ButtonBaseProps &
   IconOnlyButtonAccessibleNameProps & {
-  shape: "square" | "circle";
-  size?: KumoButtonSize;
-  variant?: KumoButtonVariant;
-};
+    shape: "square" | "circle";
+    size?: KumoButtonSize;
+    variant?: KumoButtonVariant;
+  };
 
 export type ButtonProps = ButtonWithTextProps | IconOnlyButtonProps;
 
-export type RefreshButtonProps = Omit<IconOnlyButtonProps, "children" | "icon" | "shape">;
+export type RefreshButtonProps = Omit<
+  IconOnlyButtonProps,
+  "children" | "icon" | "shape"
+>;
 
 /**
  * LinkButton component props — renders an anchor styled as a button.

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -245,11 +245,17 @@ const renderButtonContent = (
   );
 };
 
+const getTitleLabel = (title: React.ReactNode) => {
+  if (typeof title === "string") return title;
+  if (typeof title === "number") return String(title);
+  return undefined;
+};
+
 /**
  * Button component props.
  *
  * Uses a discriminated union on `shape` so that icon-only buttons
- * (`shape="square"` or `shape="circle"`) require an `aria-label`.
+ * (`shape="square"` or `shape="circle"`) require an accessible name.
  *
  * @example
  * ```tsx
@@ -277,15 +283,34 @@ type ButtonWithTextProps = ButtonBaseProps & {
   variant?: KumoButtonVariant;
 };
 
-type IconOnlyButtonProps = ButtonBaseProps & {
+type IconOnlyButtonAccessibleNameProps =
+  | {
+      /** Required for icon-only buttons to provide an accessible label for screen readers. */
+      "aria-label": string;
+      "aria-labelledby"?: string;
+    }
+  | {
+      "aria-label"?: string;
+      /** References an element that provides the accessible label for screen readers. */
+      "aria-labelledby": string;
+    }
+  | {
+      /** Used as tooltip content and as a fallback accessible label when no children are provided. */
+      title: string | number;
+      "aria-label"?: string;
+      "aria-labelledby"?: string;
+    };
+
+type IconOnlyButtonProps = ButtonBaseProps &
+  IconOnlyButtonAccessibleNameProps & {
   shape: "square" | "circle";
   size?: KumoButtonSize;
   variant?: KumoButtonVariant;
-  /** Required for icon-only buttons to provide accessible label for screen readers */
-  "aria-label": string;
 };
 
 export type ButtonProps = ButtonWithTextProps | IconOnlyButtonProps;
+
+export type RefreshButtonProps = Omit<IconOnlyButtonProps, "children" | "icon" | "shape">;
 
 /**
  * LinkButton component props — renders an anchor styled as a button.
@@ -339,6 +364,14 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const { type, ...restProps } = props;
     const emphasisStyle = getEmphasisStyle(variant);
+    const titleLabel = getTitleLabel(title);
+    const buttonProps = {
+      ...restProps,
+      ...(!React.Children.count(children) &&
+        !restProps["aria-label"] &&
+        !restProps["aria-labelledby"] &&
+        titleLabel && { "aria-label": titleLabel }),
+    };
     const iconNode = loading ? (
       <Loader size={size === "lg" ? 16 : 14} />
     ) : (
@@ -357,7 +390,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={loading || disabled}
         style={emphasisStyle ? { ...emphasisStyle, ...style } : style}
         type={type ?? "button"}
-        {...restProps}
+        {...buttonProps}
       >
         {renderButtonContent(variant, iconNode, children)}
       </button>
@@ -393,7 +426,7 @@ export const RefreshButton = ({
   "aria-label": ariaLabel = "Refresh",
   loading,
   ...props
-}: ButtonProps) => (
+}: RefreshButtonProps) => (
   <Button shape="square" aria-label={ariaLabel} {...props}>
     <ArrowsClockwise
       className={cn({

--- a/packages/kumo/src/components/clipboard-text/clipboard-text.test.tsx
+++ b/packages/kumo/src/components/clipboard-text/clipboard-text.test.tsx
@@ -13,7 +13,6 @@ describe("ClipboardText", () => {
   let writeText: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    vi.useFakeTimers();
     writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -27,6 +26,13 @@ describe("ClipboardText", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
+
+  const clickCopyButton = async (
+    button = screen.getByRole("button", { name: "Copy to clipboard" }),
+  ) => {
+    fireEvent.click(button);
+    await act(() => Promise.resolve());
+  };
 
   it("should be defined", () => {
     expect(ClipboardText).toBeDefined();
@@ -43,23 +49,18 @@ describe("ClipboardText", () => {
   it("copies text and announces copied state without tooltip", async () => {
     render(<ClipboardText text="token-value" />);
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Copy to clipboard" }),
-      );
-    });
+    await clickCopyButton();
 
     expect(writeText).toHaveBeenCalledWith("token-value");
     expect(screen.getByText("Copied")).toBeTruthy();
   });
 
   it("keeps the check state while spam-clicking and resets after the last click settles", async () => {
+    vi.useFakeTimers();
     render(<ClipboardText text="token-value" />);
     const button = screen.getByRole("button", { name: "Copy to clipboard" });
 
-    await act(async () => {
-      fireEvent.click(button);
-    });
+    await clickCopyButton(button);
     expect(screen.getByText("Copied")).toBeTruthy();
 
     // Advance partway through the feedback window, then click again
@@ -68,9 +69,7 @@ describe("ClipboardText", () => {
     });
     expect(screen.getByText("Copied")).toBeTruthy();
 
-    await act(async () => {
-      fireEvent.click(button);
-    });
+    await clickCopyButton(button);
     expect(screen.getByText("Copied")).toBeTruthy();
 
     // Previous timeout must have been cleared — still copied after 1000ms
@@ -91,16 +90,13 @@ describe("ClipboardText", () => {
       <ClipboardText text="visible-text" textToCopy="hidden-secret-value" />,
     );
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Copy to clipboard" }),
-      );
-    });
+    await clickCopyButton();
 
     expect(writeText).toHaveBeenCalledWith("hidden-secret-value");
   });
 
   it("shows a single anchored copied toast and bumps it on re-click", async () => {
+    vi.useFakeTimers();
     const { container } = render(
       <ClipboardText
         text="npx kumo add button"
@@ -110,9 +106,7 @@ describe("ClipboardText", () => {
     const button = screen.getByRole("button", { name: "Copy to clipboard" });
     const liveRegion = container.querySelector('[aria-live="polite"]');
 
-    await act(async () => {
-      fireEvent.click(button);
-    });
+    await clickCopyButton(button);
 
     // Live region + toast description both surface "Copied!"
     expect(screen.getAllByText("Copied!").length).toBeGreaterThanOrEqual(1);
@@ -122,9 +116,7 @@ describe("ClipboardText", () => {
       vi.advanceTimersByTime(1000);
     });
 
-    await act(async () => {
-      fireEvent.click(button);
-    });
+    await clickCopyButton(button);
 
     const secondToast = document.querySelector(".animate-clipboard-toast-bump");
     expect(secondToast).toBeTruthy();
@@ -133,9 +125,7 @@ describe("ClipboardText", () => {
     ).toHaveLength(1);
     expect(liveRegion?.textContent).toBe("Copied!");
 
-    await act(async () => {
-      fireEvent.click(button);
-    });
+    await clickCopyButton(button);
 
     const thirdToast = document.querySelector(".animate-clipboard-toast-bump");
     expect(thirdToast).toBeTruthy();
@@ -159,11 +149,7 @@ describe("ClipboardText", () => {
     const onCopy = vi.fn();
     render(<ClipboardText text="token-value" onCopy={onCopy} />);
 
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole("button", { name: "Copy to clipboard" }),
-      );
-    });
+    await clickCopyButton();
 
     expect(onCopy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Fixes #672.

- Uses a string or numeric `Button` `title` as a fallback `aria-label` when the button has no text children and no explicit accessible name.
- Preserves explicit `aria-label` and `aria-labelledby` values.
- Adds coverage for icon-only title fallback behavior.
- Adds a patch changeset for `@cloudflare/kumo`.
- Stabilizes recently added `ClipboardText` tests by scoping fake timers only to timer-specific cases.

## Tests

- `pnpm --filter @cloudflare/kumo test src/components/button/button.test.tsx`
- `pnpm --filter @cloudflare/kumo test src/components/clipboard-text/clipboard-text.test.tsx`
- `pnpm --filter @cloudflare/kumo test tests/imports/deep-imports.test.ts`
- `pnpm --filter @cloudflare/kumo test tests/imports/node-esm-import.test.ts`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm vp fmt --check`

Note: one local full-suite run timed out in import smoke tests under load, but those failed tests passed in isolation and the prior full-suite run passed.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: targeted accessibility fix and test stabilization validated by focused tests
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: <description>
- [ ] Additional testing not necessary because: <your reason here>