### PR TITLE
build: ship unminified dist without sourcemaps

### DIFF
--- a/.changeset/unminified-dist.md
+++ b/.changeset/unminified-dist.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Ship unminified `dist` output without sourcemaps or declaration maps
+
+Consumers' bundlers minify (and tree-shake) the library code anyway, so
+pre-minifying only obscured the shipped modules, and the declaration maps
+pointed at source files that aren't published. The package shrinks from
+~13.9 MB to ~6.5 MB unpacked, and the code in `node_modules` is now
+readable. No API or behavior changes; final application bundle sizes are
+effectively unchanged.

--- a/packages/kumo/tests/imports/export-path-validation.test.ts
+++ b/packages/kumo/tests/imports/export-path-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vite-plus/test";
-import { existsSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { readFileSync } from "fs";
@@ -221,60 +221,24 @@ describe.skipIf(!isBuilt)("Export Path Validation (Post-Build)", () => {
       expect(hasChunkFiles).toBe(true);
     });
 
-    it("should have source maps for primitives", () => {
-      const primitivesDir = join(__dirname, "../../dist/primitives");
-      const primitiveExports = Object.keys(packageJson.exports).filter((key) =>
-        key.startsWith("./primitives/"),
-      );
-
-      const missingMaps: string[] = [];
-      for (const exportKey of primitiveExports) {
-        const primitiveName = exportKey.replace("./primitives/", "");
-        const mapPath = join(primitivesDir, `${primitiveName}.js.map`);
-
-        if (existsSync(mapPath)) {
-          continue;
+    it("should not ship source maps or declaration maps", () => {
+      // The dist is intentionally unminified with no maps: consumers' bundlers
+      // minify anyway, and declaration maps would point at unpublished ../src.
+      const distDir = join(__dirname, "../../dist");
+      const mapFiles: string[] = [];
+      const walk = (dir: string) => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const fullPath = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(fullPath);
+          } else if (entry.name.endsWith(".map")) {
+            mapFiles.push(fullPath);
+          }
         }
+      };
+      walk(distDir);
 
-        // Rolldown emits primitive entries as facade chunks (pure re-exports
-        // from ../chunks/*) without their own source map; the chunks that
-        // contain the actual code carry the maps. Only flag entries that hold
-        // real code but lack a map.
-        const jsPath = join(primitivesDir, `${primitiveName}.js`);
-        const content = existsSync(jsPath) ? readFileSync(jsPath, "utf-8") : "";
-        // Minified single-line facade: "use client";import{...}from"...";export{...};
-        const isMinifiedFacade =
-          /^("use client";)?(import\s*\{[^}]*\}\s*from\s*"[^"]+";)+export\s*\{[^}]*\};?\s*$/.test(
-            content.trim(),
-          );
-        const isFacade =
-          isMinifiedFacade ||
-          content
-            .split("\n")
-            .every(
-              (line) =>
-                line.trim() === "" ||
-                line.trim() === '"use client";' ||
-                line.startsWith("import ") ||
-                line.startsWith("export ") ||
-                /^[\w$]+ as [\w$$]+,?$/.test(line.trim()) ||
-                line.trim() === "};",
-            );
-        if (!isFacade) {
-          missingMaps.push(`${primitiveName}.js.map`);
-        }
-      }
-
-      // Source maps are nice-to-have, just warn if missing
-      if (missingMaps.length > 0) {
-        console.warn(
-          `\n⚠️  ${missingMaps.length} primitive source maps missing`,
-        );
-      }
-
-      // We expect source maps (directly or via the underlying chunks) in
-      // production builds
-      expect(missingMaps.length).toBeLessThan(primitiveExports.length / 2);
+      expect(mapFiles).toEqual([]);
     });
 
     it("primitive JS files should import from bundled chunks", async () => {

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -191,8 +191,6 @@ export default defineConfig({
       format: "esm",
       platform: "browser",
       outDir: "dist",
-      sourcemap: true,
-      minify: true,
       dts: false,
       // The dts pass emits declarations this pass can't see — pair them by
       // co-location; asset entries aren't chunks, so re-attach them here.
@@ -305,7 +303,9 @@ export default defineConfig({
       clean: false,
       // Keep bare imports external so consumers resolve real packages' types.
       deps: { neverBundle: /^[^./]/ },
-      dts: { emitDtsOnly: true },
+      // tsconfig's declarationMap is for the workspace; published maps point at
+      // ../src, which isn't shipped.
+      dts: { emitDtsOnly: true, sourcemap: false },
       sourcemap: false,
       // rolldown-plugin-dts transforms without maps; maps are irrelevant for d.ts.
       inputOptions: { checks: { sourcemapBroken: false } },


### PR DESCRIPTION
This will improve debugging experience and greatly reduce package install size. Developers now have readable code in their node modules.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

