### PR TITLE
feat: update font scale

### DIFF
--- a/.changeset/banner-action-sm-size.md
+++ b/.changeset/banner-action-sm-size.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/kumo": patch
+---
+
+`Banner`: stop rendering `Banner.Action` children at the deprecated
+`size="xs"` in compact (`size="sm"`) banners. Both `base` and compact
+banners now render actions at `Button`'s `sm` size (26px), which is the
+smallest size in the current Button scale. This silences the
+`[Kumo Button]: size="xs" is deprecated` warning that was emitted whenever
+a compact banner rendered a `Banner.Action`.
+
+`BannerActionSize` narrows from `"xs" | "sm"` to `"sm"`. Consumers didn't
+set this prop directly — `Banner.Action` receives its size via context
+from the parent `Banner` — so this is a type-level cleanup with no
+behavioral change beyond removing the internal `xs` usage.

--- a/.changeset/banner-typography-weight-first.md
+++ b/.changeset/banner-typography-weight-first.md
@@ -1,0 +1,37 @@
+---
+"@cloudflare/kumo": minor
+---
+
+`Banner`: align title and description with the weight-first typography scale.
+Both now inherit the banner container's text size (`text-base` in
+`size="base"`, `text-sm` in `size="sm"`), and the title is distinguished
+from the description by `font-medium` alone — matching how
+`<Text variant="heading">` relates to `<Text variant="body">`.
+
+Previously the description carried an internal `text-sm` override that made
+it render one step below the container's `text-base` title. That override
+is gone; a banner now reads as one hierarchy level, with weight as the
+signal.
+
+**Rendered pixel changes (as part of the wider font-scale refresh):**
+
+- `size="base"`: title `text-base` renders at 13px (was 14px on the old
+  scale). Description was `text-sm` → 13px on both scales; on the new
+  scale it now inherits `text-base` at 13px. Net: title shrinks 14 → 13px,
+  description stays at 13px, and the two now sit at identical size
+  distinguished only by weight.
+- `size="sm"`: title and description both render at `text-sm` = 12px (were
+  both 13px on the old scale). Description already inherited from the
+  container, so the class change is purely a token rename with the same
+  net pixel shift the whole scale is undergoing.
+
+The `text-sm` class is no longer applied directly to the description
+element in either size; it lives on the banner container. If you were
+relying on that class being present on the description node specifically
+(e.g. for selector-based styling), update to select the banner container
+instead.
+
+**Visual regression note:** consumers with Chromatic or screenshot tests on
+`Banner` will see diffs — the title shrinks on `size="base"`, and the
+whole component picks up the refreshed scale on both sizes. This is
+intentional; approve the new baseline.

--- a/.changeset/button-sizes-refresh.md
+++ b/.changeset/button-sizes-refresh.md
@@ -1,0 +1,33 @@
+---
+"@cloudflare/kumo": minor
+---
+
+`Button`: refresh size scale to align with the refreshed typography.
+
+**Height changes:**
+
+| Size | Before | After |
+| ---- | ------ | ----- |
+| `sm` | 26px   | 26px (unchanged) |
+| `base` | 36px | 32px |
+| `lg` | 40px   | 36px |
+
+**Font size:** `sm` buttons render at `text-sm` (12px) — one step below body
+— so a small button reads as secondary next to `base` (13px) copy. `base`
+and `lg` both render at `text-base` (13px); `lg` signals prominence via
+height and padding, not larger type, so a button-plus-input row keeps its
+type on one line without vertical bounce.
+
+**Optical centering (`sm`):** `sm` now applies `leading-none` to fix vertical
+centering. At 12px the default `text-sm` line-height (~17px) combined with
+the 26px button height left ~8.6px of slack that sans-serif ascender-heavy
+metrics pushed off-center. Collapsing the line-box to glyph height lets flex
+centering land the text exactly on the button's optical midline. Other sizes
+keep their default `text-base` line-heights.
+
+**Deprecated:** `size="xs"`. Use `size="sm"` instead. The `xs` variant still
+renders and looks the same as before, but emits a `console.warn` in
+development and will be removed in a future major version.
+
+Icon-only (`shape="square"` / `shape="circle"`) buttons shrink in step with
+their text siblings — `base` is 32×32, `lg` is 36×36.

--- a/.changeset/collapsible-trigger-text-base.md
+++ b/.changeset/collapsible-trigger-text-base.md
@@ -1,0 +1,17 @@
+---
+"@cloudflare/kumo": patch
+---
+
+`Collapsible.DefaultTrigger`: align tokens with the refreshed typography
+scale.
+
+- Label class swaps `text-sm` → `text-base`. Rendered pixel size is
+  unchanged (old `text-sm` = 13px, new `text-base` = 13px); only the class
+  name changes so the trigger reads consistently with the refreshed body
+  scale.
+- Caret icon shrinks from 16×16 (`h-4 w-4`) to 14×14 (`h-3.5 w-3.5`) so it
+  sits visually flush with the 13px label rather than looming larger than
+  it. This is the actual visible change.
+
+Only affects `Collapsible.DefaultTrigger`. Bare `Collapsible.Trigger` still
+inherits its label size from its consumer as before.

--- a/.changeset/font-scale-multiplier.md
+++ b/.changeset/font-scale-multiplier.md
@@ -1,0 +1,51 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Expose `--font-scale` as a hookable multiplier on every font-size token.
+
+**Why:** we want to give products a way to let users bump up type size
+without breaking layout. Neither browser zoom nor rem-based font scaling
+solves this today:
+
+- **Browser zoom** scales everything — including the viewport and pixel
+  values in CSS — so raising font size also enlarges paddings, gaps,
+  container widths, and cursor targets. The layout you designed at 100%
+  is not the layout the user sees at 125%.
+- **Native browser font-size preferences** would work if the library
+  reserved `rem` strictly for font-size. It doesn't — and neither does
+  Tailwind's default theme, which uses `rem` for paddings, margins, and
+  gaps as well. So changing the browser's base font-size would rescale
+  spacing along with type, producing the same "zoomed layout" effect.
+
+`--font-scale` sidesteps both by living inside font-size tokens only.
+Every font-size token is now emitted as `calc(<px> * var(--font-scale, 1))`.
+Consumers override the variable at any scope; spacing tokens are
+untouched, so the layout grid stays put while type scales inside it.
+
+**Mechanics:**
+
+- Default multiplier (`1`) lives in the `var()` fallback, so no `:root`
+  rule is emitted — consumers can override `--font-scale` at any scope
+  without fighting `:root` specificity.
+- Line-heights stay as raw ratios and multiply against the already-scaled
+  font-size at use time, so they grow naturally.
+- No named presets ship with the library. Density modes are an
+  application-level UX concern; consumers who want a "compact" or
+  "comfortable" mode declare their own selectors (e.g.
+  `[data-density="compact"] { --font-scale: 0.875; }`) in their own
+  stylesheet.
+- Recommended multipliers are terminating decimals so every scaled size
+  is also a terminating decimal — `0.875` (7/8) and `1.125` (9/8) work
+  cleanly; `12/13` and `14/13` produce infinite decimals like `13.9997px`
+  that read as floating-point noise in DevTools.
+
+**Future work (not in this PR):** for `--font-scale` to fully deliver
+"scale type without scaling layout", the library needs to move to
+`rem`-for-font-size + `px`-for-spacing as a hard convention. Tailwind
+default utilities still emit `rem` for spacing, so a follow-up will
+either swap the spacing scale to `px` or ship a Tailwind preset that
+does. Icon sizing is already `em`-relative (see the `icons-em-relative-sizing`
+changeset) so icons come along for the ride automatically.
+
+No visual regression at the default multiplier.

--- a/.changeset/form-controls-size-refresh.md
+++ b/.changeset/form-controls-size-refresh.md
@@ -1,0 +1,37 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Align form control sizes with the refreshed Button scale. Affects `Input`,
+`InputArea`, `Select`, `Combobox`, `Autocomplete`, and `InputGroup`.
+
+**Height changes:**
+
+| Size   | Before | After            |
+| ------ | ------ | ---------------- |
+| `sm`   | 26px   | 26px (unchanged) |
+| `base` | 36px   | 32px             |
+| `lg`   | 40px   | 36px             |
+
+**Font size:** `sm` form controls now use `text-sm` (12px) instead of
+`text-xs` (11px), matching Button's `sm`. `base` and `lg` remain at
+`text-base` (13px) — form inputs stay at body-text legibility across
+their larger sizes rather than scaling their type up with height. Button
+follows the same policy at `lg` (also `text-base`, 13px), so a
+button-plus-input row keeps its type on one line; `lg` here signals a
+larger touch target and prominence, not larger type.
+
+**Deprecated:** `size="xs"` on all form controls. Use `size="sm"` instead.
+The `xs` variant still renders and looks the same as before, but emits a
+`console.warn` in development and will be removed in a future major
+version.
+
+**Trigger icons** (`Select` caret, `Combobox` caret + clear X) no longer
+carry per-size hardcoded pixel values. They now inherit their size from
+the containing control's text size — see the `icons-em-relative-sizing`
+changeset for the pattern. Net effect: at `base` size a caret renders
+around 13px (matching the label) instead of the previous 16px, which
+read heavy against 13px labels.
+
+Select's Figma styling metadata is updated accordingly
+(`height: 36 → 32`, `fontSize: 16 → 13`).

--- a/.changeset/icons-em-relative-sizing.md
+++ b/.changeset/icons-em-relative-sizing.md
@@ -1,0 +1,57 @@
+---
+"@cloudflare/kumo": minor
+---
+
+**Icons now scale with the surrounding text.** Hardcoded pixel sizes on
+icons across ~20 components were replaced with em-relative sizes (or
+dropped entirely so icons inherit Phosphor's `1em` default). Following
+Apple's SF Symbols pattern — a UI icon is a glyph in the text's context,
+and should shrink and grow with the text it sits alongside.
+
+**Rationale:**
+
+Under the old scale we used hardcoded pixel sizes (`size={12}`, `h-4 w-4`)
+per component + per size variant, which meant every time the type scale
+shifted, dozens of icon sizes across the library had to be re-audited by
+hand. Worse, hardcoded sizes broke `--font-scale` (see the
+`font-scale-multiplier` changeset): scaling body text up without touching
+icons produced surfaces where icons floated at fixed pixel sizes while
+their labels grew around them.
+
+Em-based sizing solves both problems:
+
+- Icons inside a `text-sm` (12px) label render at 12px automatically; the
+  same icon inside a `text-base` (13px) label renders at 13px.
+- When `--font-scale` shifts the whole type scale, icons come along for
+  the ride without any per-component intervention.
+- Component-internal decisions collapse from "what pixel size at what
+  variant" to "what ratio to the surrounding text" — expressed in one
+  place, valid at every scale.
+
+**Sizing conventions established:**
+
+| Ratio                   | Use for                                                      |
+| ----------------------- | ------------------------------------------------------------ |
+| **Bare (`1em`)**        | Caret / chevron icons in form controls, buttons, pagination  |
+| **`0.85em`**            | Inline glyphs inside chips, badges, checkboxes (X, check)    |
+| **`1.15em`**            | Leading icons in dropdown items, menu items                  |
+| **`1.25em`**            | Sidebar menu icons, larger inline actions                    |
+| **`var(--text-lg)`**    | One-offs where the icon size must survive nested type scopes |
+
+**Affected components** (icon sizing internals only — no API changes):
+
+`Autocomplete`, `Button` (`RefreshButton`, loader glyph),
+`Checkbox` (indicator glyph), `Collapsible` (caret), `Combobox` (caret,
+clear X, chip X), `CommandPalette` (leading icons, back-arrow),
+`DatePicker` (nav carets, globe), `DateRangePicker` (nav carets),
+`Dropdown` (leading icons, submenu caret, check indicator, external-link
+glyph), `Empty` (illustration icon), `InputGroup.Addon`,
+`InputGroup.Button`, `Menubar` (leading icons via `IconContext`),
+`Pagination` (nav carets), `Select` (caret), `SensitiveInput` (eye
+toggle), `Sidebar` (menu-button icons, submenu chevron), `Toast` (close
+X, variant icon).
+
+**Visual regression:** icons on nearly every component will shift by 1–3px
+per size variant to align with the refreshed type scale. This is
+intentional — the previous hardcoded values were tuned for the 14px body
+baseline and read heavy against 13px labels.

--- a/.changeset/label-tooltip-button-sm.md
+++ b/.changeset/label-tooltip-button-sm.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/kumo": patch
+---
+
+`Label`: bump the inline "More information" help button from `size="xs"` to
+`size="sm"` (20px → 26px). Follows the Button `xs` deprecation — the label
+tooltip trigger is internal, so this is a size increase rather than a
+deprecation. The 26px button sits comfortably next to `text-base` (13px)
+label copy without dominating it.

--- a/.changeset/line-height-ratios-tighten.md
+++ b/.changeset/line-height-ratios-tighten.md
@@ -1,0 +1,22 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Tighten line-height ratios on the refreshed typography scale so dense UI
+surfaces (sidebar rows, table of contents, form controls) don't gain
+excess leading versus the previous scale:
+
+- `--text-sm--line-height`: `1.45` → `1.35` (12px × 1.35 = 16.2px)
+- `--text-base--line-height`: `1.5` → `1.4` (13px × 1.4 = 18.2px)
+- `--text-lg--line-height`: `1.5` → `1.45` (15px × 1.45 ≈ 21.75px)
+
+Rationale: the old scale used tight ratios (`1/0.85 ≈ 1.176` for sm,
+`1/0.75 ≈ 1.333` for xs) that produced roughly constant absolute leading
+across the small end of the scale. The refreshed scale switched to
+conventional per-size ratios, which loosened `text-sm` and `text-base`
+by ~2–4px per line at the same rendered font-size. Components that
+swapped from `text-sm` → `text-base` (Sidebar, TableOfContents) were
+particularly affected. The new ratios split the difference — still
+airier than the old tight scale, but closer to the previous dense feel.
+
+`xs`, `xl`, and `2xl` ratios are unchanged.

--- a/.changeset/table-header-weight.md
+++ b/.changeset/table-header-weight.md
@@ -1,0 +1,16 @@
+---
+"@cloudflare/kumo": patch
+---
+
+`Table`: align header styling with the refreshed typography scale.
+
+- Column header (`<th>`) weight bumped down from `font-semibold` to
+  `font-medium`. 13px semibold was louder than any Text heading variant;
+  medium matches the `Text variant="heading"` role, which is what a column
+  header structurally is.
+- Compact table header size bumped up from `text-xs` (11px) to `text-sm`
+  (12px). 11px is the escape-hatch tier reserved for chart labels and dense
+  metadata; a compact table header is still a header and reads more
+  comfortably at 12px.
+
+Body cell typography is unchanged (`text-base`, 13px).

--- a/.changeset/text-role-based-variants.md
+++ b/.changeset/text-role-based-variants.md
@@ -1,0 +1,42 @@
+---
+"@cloudflare/kumo": minor
+---
+
+`Text` component: introduce role-based heading variants and deprecate raw
+size steps on body variants.
+
+**New variants** (all require the `as` prop for document-outline safety):
+
+- `variant="display"` — hero / prominent moments (24px semibold)
+- `variant="page-title"` — the single title of a page or dialog (19px medium)
+- `variant="section-title"` — card / panel / section heading (15px medium)
+- `variant="heading"` — inline / row / list-item heading (13px medium)
+
+**Deprecated (still functional, emits a dev warning):**
+
+- `variant="heading1"` → use `variant="display"`
+- `variant="heading2"` → use `variant="page-title"`
+- `variant="heading3"` → use `variant="section-title"`
+- `size="xs"` (11px) and `size="lg"` (15px) on body variants → use `size="sm"`
+  (12px) or `size="base"` (13px), or reach for a heading variant for
+  hierarchy. Both still render and look the same as before but emit a
+  `console.warn` in development and will be removed in a future major
+  version.
+
+For monospace variants, `size="lg"` remains accepted for backwards
+compatibility but no longer changes the rendered size (mono always renders
+at 12px, one step below body, for optical parity).
+
+**`bold` prop (kept, refined):**
+
+The `bold` prop is retained but its type is now narrowed to copy variants
+only (`body`, `secondary`, `success`, `error`), where it bumps weight to
+`font-medium` (500). Passing it on heading or monospace variants is a type
+error — headings already carry their role's weight, and mono deliberately
+stays regular.
+
+The role-based names make it obvious which variant to reach for based on
+what the text **is**, not what size you want. Weight-first hierarchy —
+differentiating by weight rather than raw size steps on body text — is the
+recommended pattern going forward. Use `bold` for inline emphasis; use
+`variant="heading"` for structural hierarchy inside a document outline.

--- a/.changeset/toast-typography-role-based.md
+++ b/.changeset/toast-typography-role-based.md
@@ -1,0 +1,13 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Toast: align title and description with the role-based typography scale.
+
+- Title: `text-[0.975rem]` (15.6px) → `text-lg` (15px medium) — matches `Text variant="section-title"` role.
+- Description: `text-[0.925rem]` (14.8px) → `text-lg` (15px regular) — body-lg, muted color.
+- Weight-first hierarchy: title and description share the 15px `lg` size; the medium weight on the title carries the differentiation (consistent with Linear's approach).
+- `leading-5` retained on both for a compact toast footprint (vs. the default `lg--line-height` of 1.5).
+- Figma metadata (`KUMO_TOAST_STYLING`) updated: title fontSize 16 → 15.
+
+No API changes.

--- a/.changeset/token-refresh-class-swaps.md
+++ b/.changeset/token-refresh-class-swaps.md
@@ -3,12 +3,17 @@
 ---
 
 Align internal typography class tokens with the refreshed scale for `Badge`,
-`Sidebar`, and `TableOfContents`. **Rendered pixel size is unchanged** in
+`Sidebar`, and `TableOfContents`. **Rendered font-size is unchanged** in
 every case — old `text-sm` / `text-xs` and new `text-base` / `text-sm`
 resolve to the same pixel values on their respective scales. Only the
 class names change so component internals read consistently with the
 refreshed scale (body = `text-base`, caption = `text-sm`, escape hatch =
 `text-xs`).
+
+Note: rendered *line-height* shifts slightly because the refreshed scale
+uses different ratios (see the accompanying line-height tuning changeset).
+Sidebar rows in particular gain ~1px of leading vs. the old scale even
+though the font-size is identical.
 
 **Affected surfaces:**
 

--- a/.changeset/token-refresh-class-swaps.md
+++ b/.changeset/token-refresh-class-swaps.md
@@ -1,0 +1,30 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Align internal typography class tokens with the refreshed scale for `Badge`,
+`Sidebar`, and `TableOfContents`. **Rendered pixel size is unchanged** in
+every case — old `text-sm` / `text-xs` and new `text-base` / `text-sm`
+resolve to the same pixel values on their respective scales. Only the
+class names change so component internals read consistently with the
+refreshed scale (body = `text-base`, caption = `text-sm`, escape hatch =
+`text-xs`).
+
+**Affected surfaces:**
+
+- `Badge` (`KUMO_BADGE_BASE_STYLES`): `text-xs` → `text-sm` (12px both
+  scales)
+- `Sidebar.GroupLabel`, `Sidebar.MenuButton` (`base` and `sm`), and
+  `Sidebar.MenuSubButton`: `text-sm` → `text-base` (13px both scales)
+- `TableOfContents` items and group-labels: `text-sm` → `text-base` (13px
+  both scales). `TableOfContents.Title` (uppercase eyebrow) remains
+  `text-xs`.
+
+Consumers extending these components via `className` or selecting on the
+old class names (e.g. `[class*="text-sm"]` on sidebar rows, custom styling
+that extends `KUMO_BADGE_BASE_STYLES`) will need to update their
+references. The bump is `minor` (not `patch`) because sidebar internals in
+particular ship stringly-typed class contracts that consumers occasionally
+lean on.
+
+No visible change to rendered typography on any of these components.

--- a/.changeset/toolbar-deprecate-xs.md
+++ b/.changeset/toolbar-deprecate-xs.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/kumo": patch
+---
+
+`Toolbar`: deprecate `size="xs"`. Use `size="sm"` instead. Toolbar forwards
+its `size` to child `Button` and `Input` components, both of which already
+deprecated `xs`. To avoid three duplicate warnings for the same underlying
+issue, Toolbar now:
+
+1. Emits a single `[Kumo Toolbar]: size="xs" is deprecated` warning at the
+   Toolbar level in development, and
+2. Silently remaps `xs → sm` internally on the forwarded context so child
+   `Button`, `Input`, and `InputGroup` render at their `sm` (26px) size and
+   do **not** emit their own deprecation warnings.
+
+The container itself still applies the deprecated size's text class for
+backwards visual compatibility. The `xs` size will be removed in a future
+major version.

--- a/packages/kumo-docs-astro/src/components/FontScaleToggle.tsx
+++ b/packages/kumo-docs-astro/src/components/FontScaleToggle.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from "react";
+import { Button, cn } from "@cloudflare/kumo";
+
+/**
+ * The three available font-scale steps, in the *cycle order* the user
+ * traverses on repeated clicks.
+ *
+ *   default → large → small → default
+ */
+const CYCLE = ["default", "large", "small"] as const;
+type Step = (typeof CYCLE)[number];
+
+const STORAGE_KEY = "font-scale";
+
+/** Human-readable label per step, used for aria + title. */
+const LABELS: Record<Step, string> = {
+  small: "Small",
+  default: "Default",
+  large: "Large",
+};
+
+function applyStep(step: Step) {
+  const root = document.documentElement;
+  if (step === "default") {
+    root.removeAttribute("data-font-scale");
+  } else {
+    root.setAttribute("data-font-scale", step);
+  }
+}
+
+function readInitialStep(): Step {
+  if (typeof window === "undefined") return "default";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && (CYCLE as readonly string[]).includes(stored)) {
+    return stored as Step;
+  }
+  return "default";
+}
+
+/**
+ * "aA" toggle — cycles the docs site through five font-scale presets.
+ *
+ * The lowercase `a` renders at the *previous* step's size, the uppercase `A`
+ * at the *current* step's size, so the button itself illustrates where you
+ * are on the scale. On click, the icon briefly pulses in the direction the
+ * scale moved (up or down) as visual feedback.
+ */
+export function FontScaleToggle() {
+  const [step, setStep] = useState<Step>("default");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const initial = readInitialStep();
+    setStep(initial);
+    applyStep(initial);
+  }, []);
+
+  const cycle = () => {
+    const idx = CYCLE.indexOf(step);
+    const next = CYCLE[(idx + 1) % CYCLE.length];
+    setStep(next);
+    applyStep(next);
+    localStorage.setItem(STORAGE_KEY, next);
+  };
+
+  const nextStep = CYCLE[(CYCLE.indexOf(step) + 1) % CYCLE.length];
+
+  // Show the icon in its default state during SSR + before hydration to
+  // avoid a layout shift.
+  if (!mounted) {
+    return (
+      <Button variant="ghost" shape="square" aria-label="Adjust font size">
+        <FontScaleIcon step="default" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      shape="square"
+      aria-label={`Font size: ${LABELS[step]}. Click for ${LABELS[nextStep]}.`}
+      title={`Font size: ${LABELS[step]}`}
+      onClick={cycle}
+    >
+      <FontScaleIcon step={step} />
+    </Button>
+  );
+}
+
+/**
+ * "aaA" glyph icon — three letters at fixed pixel sizes (11 / 13 / 15) that
+ * illustrate the scale. The active step's glyph is rendered in
+ * `kumo-default`; the two inactive glyphs are in `kumo-subtle`, so the icon
+ * itself doubles as a state indicator.
+ *
+ * All three sizes are hardcoded in px so the icon does NOT scale with the
+ * `--font-scale` multiplier it controls.
+ *
+ *   small   → left small `a` active
+ *   default → middle medium `a` active
+ *   large   → uppercase `A` active
+ */
+function FontScaleIcon({ step }: { step: Step }) {
+  const glyphClass = "font-medium transition-colors duration-150";
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-baseline gap-px leading-none"
+    >
+      <span
+        className={cn(
+          glyphClass,
+          "text-[11px]",
+          step === "small" ? "text-kumo-default" : "text-kumo-subtle",
+        )}
+      >
+        a
+      </span>
+      <span
+        className={cn(
+          glyphClass,
+          "text-[13px]",
+          step === "default" ? "text-kumo-default" : "text-kumo-subtle",
+        )}
+      >
+        a
+      </span>
+      <span
+        className={cn(
+          glyphClass,
+          "text-[15px]",
+          step === "large" ? "text-kumo-default" : "text-kumo-subtle",
+        )}
+      >
+        A
+      </span>
+    </span>
+  );
+}

--- a/packages/kumo-docs-astro/src/components/Header.astro
+++ b/packages/kumo-docs-astro/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import { ThemeToggle } from "./ThemeToggle";
+import { FontScaleToggle } from "./FontScaleToggle";
 
 declare const __KUMO_VERSION__: string;
 
@@ -26,7 +27,12 @@ const kumoVersion =
     </a>
   </div>
 
-  <div class="flex w-12 shrink-0 items-center justify-center">
-    <ThemeToggle client:only="react" />
+  <div class="flex shrink-0 items-stretch">
+    <div class="flex w-12 shrink-0 items-center justify-center border-r border-kumo-hairline">
+      <FontScaleToggle client:only="react" />
+    </div>
+    <div class="flex w-12 shrink-0 items-center justify-center">
+      <ThemeToggle client:only="react" />
+    </div>
   </div>
 </header>

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -8,6 +8,7 @@ import {
 import { KumoMenuIcon } from "./KumoMenuIcon";
 import { SearchDialog } from "./SearchDialog";
 import { ThemeToggle } from "./ThemeToggle";
+import { FontScaleToggle } from "./FontScaleToggle";
 
 interface NavItem {
   label: string;
@@ -213,9 +214,9 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
     <>
       <button
         onClick={() => setSearchOpen(true)}
-        className="mb-3 flex w-full items-center gap-2 rounded-lg bg-kumo-control px-3 py-2 text-sm text-kumo-subtle ring-1 ring-kumo-line transition-all hover:ring-kumo-hairline focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
+        className="mb-3 flex h-8 w-full items-center gap-2 rounded-lg bg-kumo-control pr-3 pl-2 text-base text-kumo-subtle ring-1 ring-kumo-line transition-all hover:ring-kumo-hairline focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
       >
-        <MagnifyingGlassIcon size={16} className="shrink-0" />
+        <MagnifyingGlassIcon size={14} className="shrink-0" />
         <span>Search...</span>
       </button>
 
@@ -242,7 +243,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
         {/* Components Section */}
         <button
           type="button"
-          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-sm font-medium text-kumo-default transition-colors hover:bg-kumo-tint focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
+          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-base font-medium text-kumo-default transition-colors hover:bg-kumo-tint focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
           onClick={() => setComponentsOpen(!componentsOpen)}
         >
           <span>Components</span>
@@ -282,7 +283,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
       <div className="mb-4">
         <button
           type="button"
-          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-sm font-medium text-kumo-default transition-colors hover:bg-kumo-tint focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
+          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-base font-medium text-kumo-default transition-colors hover:bg-kumo-tint focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
           onClick={() => setChartsOpen(!chartsOpen)}
         >
           <span>Charts</span>
@@ -322,7 +323,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
         {/* Blocks Section */}
         <button
           type="button"
-          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-sm font-medium text-kumo-default transition-colors hover:bg-kumo-tint focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
+          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-2 text-base font-medium text-kumo-default transition-colors hover:bg-kumo-tint focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
           onClick={() => setBlocksOpen(!blocksOpen)}
         >
           <span>Blocks</span>
@@ -378,7 +379,10 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
           <KumoMenuIcon />
         </Button>
         <h1 className="text-base font-medium">Kumo</h1>
-        <ThemeToggle />
+        <div className="flex items-center gap-1">
+          <FontScaleToggle />
+          <ThemeToggle />
+        </div>
       </div>
 
       {/* Mobile slide-out drawer */}
@@ -403,7 +407,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
         <div
           ref={mobileScrollRef}
           data-sidebar-scroll="mobile"
-          className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-sm text-kumo-subtle"
+          className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-base leading-tight text-kumo-subtle"
           style={{ scrollBehavior: "auto" }}
         >
           {navContent}
@@ -453,7 +457,7 @@ export function SidebarNav({ currentPath }: SidebarNavProps) {
         <div
           ref={desktopScrollRef}
           data-sidebar-scroll="desktop"
-          className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-sm text-kumo-subtle"
+          className="min-h-0 grow overflow-y-auto overscroll-contain px-3 py-4 text-base leading-tight text-kumo-subtle"
         >
           {navContent}
         </div>

--- a/packages/kumo-docs-astro/src/components/demos/AutocompleteDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/AutocompleteDemo.tsx
@@ -210,22 +210,10 @@ export function AutocompleteGroupedDemo() {
   );
 }
 
-/** Demonstrates the four size variants: xs, sm, base, and lg. */
+/** Demonstrates the three size variants: sm, base, and lg. */
 export function AutocompleteSizesDemo() {
   return (
     <div className="flex flex-wrap items-center gap-4">
-      <Autocomplete items={fruits.slice(0, 10)}>
-        <Autocomplete.InputGroup size="xs" placeholder="xs" />
-        <Autocomplete.Content>
-          <Autocomplete.List>
-            {(item: string) => (
-              <Autocomplete.Item key={item} value={item}>
-                {item}
-              </Autocomplete.Item>
-            )}
-          </Autocomplete.List>
-        </Autocomplete.Content>
-      </Autocomplete>
       <Autocomplete items={fruits.slice(0, 10)}>
         <Autocomplete.InputGroup size="sm" placeholder="sm" />
         <Autocomplete.Content>

--- a/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/BreadcrumbsDemo.tsx
@@ -16,7 +16,7 @@ export function BreadcrumbsDemo() {
 export function BreadcrumbsWithIconsDemo() {
   return (
     <Breadcrumbs>
-      <Breadcrumbs.Link href="#" icon={<House size={16} />}>
+      <Breadcrumbs.Link href="#" icon={<House size={15} />}>
         Home
       </Breadcrumbs.Link>
       <Breadcrumbs.Separator />
@@ -30,7 +30,7 @@ export function BreadcrumbsWithIconsDemo() {
 export function BreadcrumbsLoadingDemo() {
   return (
     <Breadcrumbs>
-      <Breadcrumbs.Link href="#" icon={<House size={16} />}>
+      <Breadcrumbs.Link href="#" icon={<House size={15} />}>
         Home
       </Breadcrumbs.Link>
       <Breadcrumbs.Separator />
@@ -44,7 +44,7 @@ export function BreadcrumbsLoadingDemo() {
 export function BreadcrumbsRootDemo() {
   return (
     <Breadcrumbs>
-      <Breadcrumbs.Current icon={<House size={16} />}>
+      <Breadcrumbs.Current icon={<House size={15} />}>
         Worker Analytics
       </Breadcrumbs.Current>
     </Breadcrumbs>

--- a/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ButtonDemo.tsx
@@ -42,9 +42,6 @@ export function ButtonSecondaryDestructiveDemo() {
 export function ButtonSizesDemo() {
   return (
     <div className="flex flex-wrap items-center gap-3">
-      <Button size="xs" variant="secondary">
-        Extra Small
-      </Button>
       <Button size="sm" variant="secondary">
         Small
       </Button>

--- a/packages/kumo-docs-astro/src/components/demos/DialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/DialogDemo.tsx
@@ -15,7 +15,7 @@ export function DialogBasicDemo() {
       <Dialog.Trigger render={(p) => <Button {...p}>Click me</Button>} />
       <Dialog className="p-8">
         <div className="mb-4 flex items-start justify-between gap-4">
-          <Dialog.Title className="text-2xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Modal Title
           </Dialog.Title>
           <Dialog.Close
@@ -31,7 +31,7 @@ export function DialogBasicDemo() {
             )}
           />
         </div>
-        <Dialog.Description className="text-kumo-subtle">
+        <Dialog.Description className="text-lg text-kumo-subtle">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </Dialog.Description>
@@ -46,7 +46,7 @@ export function DialogWithActionsDemo() {
       <Dialog.Trigger render={(p) => <Button {...p}>Delete</Button>} />
       <Dialog className="p-8">
         <div className="mb-4 flex items-start justify-between gap-4">
-          <Dialog.Title className="text-2xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Modal Title
           </Dialog.Title>
           <Dialog.Close
@@ -62,7 +62,7 @@ export function DialogWithActionsDemo() {
             )}
           />
         </div>
-        <Dialog.Description className="text-kumo-subtle">
+        <Dialog.Description className="text-lg text-kumo-subtle">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </Dialog.Description>
@@ -99,7 +99,7 @@ export function DialogMaxWidthDemo() {
       />
       <Dialog className="max-w-lg p-8">
         <div className="mb-4 flex items-start justify-between gap-4">
-          <Dialog.Title className="text-2xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Max width override
           </Dialog.Title>
           <Dialog.Close
@@ -115,7 +115,7 @@ export function DialogMaxWidthDemo() {
             )}
           />
         </div>
-        <Dialog.Description className="text-kumo-subtle">
+        <Dialog.Description className="text-lg text-kumo-subtle">
           This dialog uses <code>className="max-w-lg"</code> and should stay
           capped around 512px on desktop.
         </Dialog.Description>
@@ -142,11 +142,11 @@ export function DialogConfirmationDemo() {
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-kumo-danger/20">
             <Warning size={20} className="text-kumo-danger" />
           </div>
-          <Dialog.Title className="text-xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Delete Project?
           </Dialog.Title>
         </div>
-        <Dialog.Description className="text-kumo-subtle">
+        <Dialog.Description className="text-lg text-kumo-subtle">
           This action cannot be undone. This will permanently delete the project
           and all associated data.
         </Dialog.Description>
@@ -190,11 +190,11 @@ export function DialogAlertDemo() {
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-kumo-danger/20">
             <Warning size={20} className="text-kumo-danger" weight="fill" />
           </div>
-          <Dialog.Title className="text-xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Delete Account?
           </Dialog.Title>
         </div>
-        <Dialog.Description className="text-kumo-subtle">
+        <Dialog.Description className="text-lg text-kumo-subtle">
           This action cannot be undone. All your data will be permanently
           removed from our servers. Are you sure you want to proceed?
         </Dialog.Description>
@@ -232,7 +232,7 @@ export function DialogWithSelectDemo() {
       <Dialog.Trigger render={(p) => <Button {...p}>Open Form</Button>} />
       <Dialog className="p-8">
         <div className="mb-4 flex items-start justify-between gap-4">
-          <Dialog.Title className="text-2xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Create Resource
           </Dialog.Title>
           <Dialog.Close
@@ -248,7 +248,7 @@ export function DialogWithSelectDemo() {
             )}
           />
         </div>
-        <Dialog.Description className="mb-4 text-kumo-subtle">
+        <Dialog.Description className="mb-4 text-lg text-kumo-subtle">
           Select a region for your new resource.
         </Dialog.Description>
         <Select
@@ -287,7 +287,7 @@ export function DialogWithComboboxDemo() {
       <Dialog.Trigger render={(p) => <Button {...p}>Open Form</Button>} />
       <Dialog className="p-8">
         <div className="mb-4 flex items-start justify-between gap-4">
-          <Dialog.Title className="text-2xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Create Resource
           </Dialog.Title>
           <Dialog.Close
@@ -303,7 +303,7 @@ export function DialogWithComboboxDemo() {
             )}
           />
         </div>
-        <Dialog.Description className="mb-4 text-kumo-subtle">
+        <Dialog.Description className="mb-4 text-lg text-kumo-subtle">
           Search and select a region for your new resource.
         </Dialog.Description>
         <Combobox value={value} onValueChange={setValue} items={regions}>
@@ -343,7 +343,7 @@ export function DialogWithDropdownDemo() {
       <Dialog.Trigger render={(p) => <Button {...p}>Open Form</Button>} />
       <Dialog className="p-8">
         <div className="mb-4 flex items-start justify-between gap-4">
-          <Dialog.Title className="text-2xl font-semibold">
+          <Dialog.Title className="text-lg font-medium">
             Resource Actions
           </Dialog.Title>
           <Dialog.Close
@@ -359,7 +359,7 @@ export function DialogWithDropdownDemo() {
             )}
           />
         </div>
-        <Dialog.Description className="mb-4 text-kumo-subtle">
+        <Dialog.Description className="mb-4 text-lg text-kumo-subtle">
           Choose an action for the selected resource.
         </Dialog.Description>
         <DropdownMenu>
@@ -415,7 +415,7 @@ export function DialogSizesDemo() {
           />
           <Dialog size={size} className="p-8">
             <div className="mb-4 flex items-start justify-between gap-4">
-              <Dialog.Title className="text-2xl font-semibold">
+              <Dialog.Title className="text-lg font-medium">
                 {label} Dialog
               </Dialog.Title>
               <Dialog.Close
@@ -431,7 +431,7 @@ export function DialogSizesDemo() {
                 )}
               />
             </div>
-            <Dialog.Description className="text-kumo-subtle">
+            <Dialog.Description className="text-lg text-kumo-subtle">
               This <code>size="{size}"</code> dialog should stay at {width} wide
               regardless of the content below.
             </Dialog.Description>

--- a/packages/kumo-docs-astro/src/components/demos/GridDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/GridDemo.tsx
@@ -5,7 +5,7 @@ export function GridDemo() {
     <Grid variant="2up" gap="base">
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text bold>Item 1</Text>
+          <Text DANGEROUS_className="font-medium">Item 1</Text>
           <div className="mt-1">
             <Text variant="secondary">First grid item</Text>
           </div>
@@ -13,7 +13,7 @@ export function GridDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text bold>Item 2</Text>
+          <Text DANGEROUS_className="font-medium">Item 2</Text>
           <div className="mt-1">
             <Text variant="secondary">Second grid item</Text>
           </div>
@@ -100,7 +100,7 @@ export function GridAsymmetricDemo() {
         <Grid variant="2-1" gap="sm">
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text bold>Main Content</Text>
+              <Text DANGEROUS_className="font-medium">Main Content</Text>
               <div className="mt-1">
                 <Text variant="secondary">Two-thirds width</Text>
               </div>
@@ -108,7 +108,7 @@ export function GridAsymmetricDemo() {
           </GridItem>
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text bold>Sidebar</Text>
+              <Text DANGEROUS_className="font-medium">Sidebar</Text>
               <div className="mt-1">
                 <Text variant="secondary">One-third width</Text>
               </div>
@@ -122,7 +122,7 @@ export function GridAsymmetricDemo() {
         <Grid variant="1-2" gap="sm">
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text bold>Sidebar</Text>
+              <Text DANGEROUS_className="font-medium">Sidebar</Text>
               <div className="mt-1">
                 <Text variant="secondary">One-third width</Text>
               </div>
@@ -130,7 +130,7 @@ export function GridAsymmetricDemo() {
           </GridItem>
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text bold>Main Content</Text>
+              <Text DANGEROUS_className="font-medium">Main Content</Text>
               <div className="mt-1">
                 <Text variant="secondary">Two-thirds width</Text>
               </div>
@@ -219,7 +219,7 @@ export function GridMobileDividerDemo() {
     <Grid variant="4up" gap="base" mobileDivider>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text bold>Item 1</Text>
+          <Text DANGEROUS_className="font-medium">Item 1</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>
@@ -227,7 +227,7 @@ export function GridMobileDividerDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text bold>Item 2</Text>
+          <Text DANGEROUS_className="font-medium">Item 2</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>
@@ -235,7 +235,7 @@ export function GridMobileDividerDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text bold>Item 3</Text>
+          <Text DANGEROUS_className="font-medium">Item 3</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>
@@ -243,7 +243,7 @@ export function GridMobileDividerDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text bold>Item 4</Text>
+          <Text DANGEROUS_className="font-medium">Item 4</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>

--- a/packages/kumo-docs-astro/src/components/demos/GridDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/GridDemo.tsx
@@ -5,7 +5,7 @@ export function GridDemo() {
     <Grid variant="2up" gap="base">
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text DANGEROUS_className="font-medium">Item 1</Text>
+          <Text bold>Item 1</Text>
           <div className="mt-1">
             <Text variant="secondary">First grid item</Text>
           </div>
@@ -13,7 +13,7 @@ export function GridDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text DANGEROUS_className="font-medium">Item 2</Text>
+          <Text bold>Item 2</Text>
           <div className="mt-1">
             <Text variant="secondary">Second grid item</Text>
           </div>
@@ -100,7 +100,7 @@ export function GridAsymmetricDemo() {
         <Grid variant="2-1" gap="sm">
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text DANGEROUS_className="font-medium">Main Content</Text>
+              <Text bold>Main Content</Text>
               <div className="mt-1">
                 <Text variant="secondary">Two-thirds width</Text>
               </div>
@@ -108,7 +108,7 @@ export function GridAsymmetricDemo() {
           </GridItem>
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text DANGEROUS_className="font-medium">Sidebar</Text>
+              <Text bold>Sidebar</Text>
               <div className="mt-1">
                 <Text variant="secondary">One-third width</Text>
               </div>
@@ -122,7 +122,7 @@ export function GridAsymmetricDemo() {
         <Grid variant="1-2" gap="sm">
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text DANGEROUS_className="font-medium">Sidebar</Text>
+              <Text bold>Sidebar</Text>
               <div className="mt-1">
                 <Text variant="secondary">One-third width</Text>
               </div>
@@ -130,7 +130,7 @@ export function GridAsymmetricDemo() {
           </GridItem>
           <GridItem>
             <Surface className="rounded-lg p-4">
-              <Text DANGEROUS_className="font-medium">Main Content</Text>
+              <Text bold>Main Content</Text>
               <div className="mt-1">
                 <Text variant="secondary">Two-thirds width</Text>
               </div>
@@ -219,7 +219,7 @@ export function GridMobileDividerDemo() {
     <Grid variant="4up" gap="base" mobileDivider>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text DANGEROUS_className="font-medium">Item 1</Text>
+          <Text bold>Item 1</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>
@@ -227,7 +227,7 @@ export function GridMobileDividerDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text DANGEROUS_className="font-medium">Item 2</Text>
+          <Text bold>Item 2</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>
@@ -235,7 +235,7 @@ export function GridMobileDividerDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text DANGEROUS_className="font-medium">Item 3</Text>
+          <Text bold>Item 3</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>
@@ -243,7 +243,7 @@ export function GridMobileDividerDemo() {
       </GridItem>
       <GridItem>
         <Surface className="rounded-lg p-4">
-          <Text DANGEROUS_className="font-medium">Item 4</Text>
+          <Text bold>Item 4</Text>
           <div className="mt-1">
             <Text variant="secondary">Has divider on mobile</Text>
           </div>

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -542,7 +542,7 @@ export function HomeGrid() {
       name: "Link",
       id: "link",
       Component: (
-        <div className="flex flex-col gap-2 text-sm">
+        <div className="flex flex-col gap-2">
           <Link href="#">Default link</Link>
           <Link href="#" variant="current">
             Current color link
@@ -671,11 +671,14 @@ export function HomeGrid() {
       id: "text",
       Component: (
         <div className="flex flex-col gap-1">
-          <Text size="lg" bold>
-            Large Bold Text
+          <Text variant="section-title" as="span">
+            Section title
           </Text>
-          <Text size="base">Regular text content</Text>
-          <Text size="sm" color="subtle">
+          <Text variant="heading" as="span">
+            Heading
+          </Text>
+          <Text>Regular text content</Text>
+          <Text variant="secondary" size="sm">
             Small subtle text
           </Text>
         </div>
@@ -704,7 +707,7 @@ export function HomeGrid() {
                 {c.name}
               </span>
             )}
-            <div className="flex w-full items-center justify-center p-8 leading-normal tracking-normal">
+            <div className="flex w-full items-center justify-center p-8 text-base leading-normal tracking-normal">
               {c.Component ?? (
                 <p className="text-base font-medium text-kumo-subtle">TBD</p>
               )}

--- a/packages/kumo-docs-astro/src/components/demos/InputAreaDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/InputAreaDemo.tsx
@@ -48,11 +48,6 @@ export function InputAreaErrorObjectDemo() {
 export function InputAreaSizesDemo() {
   return (
     <div className="flex flex-col gap-4">
-      <InputArea
-        size="xs"
-        label="Extra Small"
-        placeholder="Extra small textarea"
-      />
       <InputArea size="sm" label="Small" placeholder="Small textarea" />
       <InputArea label="Base" placeholder="Base textarea (default)" />
       <InputArea size="lg" label="Large" placeholder="Large textarea" />

--- a/packages/kumo-docs-astro/src/components/demos/InputDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/InputDemo.tsx
@@ -50,7 +50,6 @@ export function InputErrorObjectDemo() {
 export function InputSizesDemo() {
   return (
     <div className="flex flex-col gap-4">
-      <Input size="xs" label="Extra Small" placeholder="Extra small input" />
       <Input size="sm" label="Small" placeholder="Small input" />
       <Input label="Base" placeholder="Base input (default)" />
       <Input size="lg" label="Large" placeholder="Large input" />

--- a/packages/kumo-docs-astro/src/components/demos/InputGroupDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/InputGroupDemo.tsx
@@ -226,21 +226,6 @@ export function InputGroupSuffixDemo() {
 export function InputGroupSizesDemo() {
   return (
     <div className="flex w-full max-w-3xs flex-col gap-4">
-      <InputGroup size="xs" label="Extra Small">
-        <InputGroup.Addon>
-          <MagnifyingGlassIcon />
-        </InputGroup.Addon>
-        <InputGroup.Input placeholder="Extra small input" />
-        <InputGroup.Addon align="end">
-          <InputGroup.Button
-            className="text-kumo-subtle"
-            icon={QuestionIcon}
-            shape="square"
-            aria-label="Help"
-          />
-        </InputGroup.Addon>
-      </InputGroup>
-
       <InputGroup size="sm" label="Small">
         <InputGroup.Addon>
           <MagnifyingGlassIcon />

--- a/packages/kumo-docs-astro/src/components/demos/LayerCardDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerCardDemo.tsx
@@ -26,9 +26,7 @@ export function LayerCardBasicDemo() {
     <LayerCard className="w-[250px]">
       <LayerCard.Secondary>Getting Started</LayerCard.Secondary>
       <LayerCard.Primary>
-        <p className="text-sm text-kumo-subtle">
-          Quick start guide for new users
-        </p>
+        <p className="text-kumo-subtle">Quick start guide for new users</p>
       </LayerCard.Primary>
     </LayerCard>
   );
@@ -37,9 +35,7 @@ export function LayerCardBasicDemo() {
 export function LayerCardSurfaceDemo() {
   return (
     <LayerCard className="w-[250px] p-4">
-      <p className="text-sm text-kumo-subtle">
-        Quick start guide for new users
-      </p>
+      <p className="text-kumo-subtle">Quick start guide for new users</p>
     </LayerCard>
   );
 }
@@ -52,9 +48,7 @@ export function LayerCardTestIdDemo() {
         Getting Started
       </LayerCard.Secondary>
       <LayerCard.Primary data-testid="card-body">
-        <p className="text-sm text-kumo-subtle">
-          Quick start guide for new users
-        </p>
+        <p className="text-kumo-subtle">Quick start guide for new users</p>
       </LayerCard.Primary>
     </LayerCard>
   );
@@ -66,13 +60,13 @@ export function LayerCardMultipleDemo() {
       <LayerCard className="w-[200px]">
         <LayerCard.Secondary>Components</LayerCard.Secondary>
         <LayerCard.Primary>
-          <p className="text-sm">Browse all components</p>
+          <p>Browse all components</p>
         </LayerCard.Primary>
       </LayerCard>
       <LayerCard className="w-[200px]">
         <LayerCard.Secondary>Examples</LayerCard.Secondary>
         <LayerCard.Primary>
-          <p className="text-sm">View code examples</p>
+          <p>View code examples</p>
         </LayerCard.Primary>
       </LayerCard>
     </div>

--- a/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PopoverDemo.tsx
@@ -200,7 +200,7 @@ export function PopoverVirtualAnchorDemo() {
                 <td className="px-4 py-2 text-kumo-subtle">{row.status}</td>
                 <td className="px-4 py-2">
                   <Button
-                    size="xs"
+                    size="sm"
                     variant="ghost"
                     shape="square"
                     icon={DotsThree}

--- a/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
@@ -16,20 +16,10 @@ export function SelectBasicDemo() {
   );
 }
 
-/** Select trigger sizes (xs/sm/base/lg) matching Input and Combobox. */
+/** Select trigger sizes (sm/base/lg) matching Input and Combobox. */
 export function SelectSizesDemo() {
   return (
     <div className="grid gap-4">
-      <div className="flex items-center gap-3">
-        <span className="w-10 text-sm text-kumo-subtle">xs</span>
-        <Select
-          aria-label="Select size xs"
-          size="xs"
-          className="w-[200px]"
-          placeholder="Choose..."
-          items={{ a: "Option A", b: "Option B" }}
-        />
-      </div>
       <div className="flex items-center gap-3">
         <span className="w-10 text-sm text-kumo-subtle">sm</span>
         <Select

--- a/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
@@ -4,68 +4,56 @@ export function TextVariantsDemo() {
   return (
     <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading1" as="h1">
-          Heading 1
-        </Text>
-        <Text variant="mono-secondary">text-3xl (30px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading2" as="h2">
-          Heading 2
+        <Text variant="display" as="h1">
+          Display
         </Text>
         <Text variant="mono-secondary">text-2xl (24px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading3" as="h3">
-          Heading 3
+        <Text variant="page-title" as="h2">
+          Page title
         </Text>
-        <Text variant="mono-secondary">text-lg (16px)</Text>
+        <Text variant="mono-secondary">text-xl (19px)</Text>
+      </div>
+      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <Text variant="section-title" as="h3">
+          Section title
+        </Text>
+        <Text variant="mono-secondary">text-lg (15px)</Text>
+      </div>
+      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <Text variant="heading" as="h4">
+          Heading
+        </Text>
+        <Text variant="mono-secondary">text-base (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text>Body</Text>
-        <Text variant="mono-secondary">text-base (14px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text bold>Body bold</Text>
-        <Text variant="mono-secondary">text-base (14px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text size="lg">Body lg</Text>
-        <Text variant="mono-secondary">text-lg (16px)</Text>
+        <Text variant="mono-secondary">text-base (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text size="sm">Body sm</Text>
-        <Text variant="mono-secondary">text-sm (13px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text size="xs">Body xs</Text>
-        <Text variant="mono-secondary">text-xs (12px)</Text>
+        <Text variant="mono-secondary">text-sm (12px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text variant="secondary">Body secondary</Text>
-        <Text variant="mono-secondary">text-base (14px)</Text>
+        <Text variant="mono-secondary">text-base (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text variant="mono">Monospace</Text>
-        <Text variant="mono-secondary">text-sm (13px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="mono" size="lg">
-          Monospace lg
-        </Text>
-        <Text variant="mono-secondary">text-base (14px)</Text>
+        <Text variant="mono-secondary">text-sm (12px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text variant="mono-secondary">Monospace secondary</Text>
-        <Text variant="mono-secondary">text-sm (13px)</Text>
+        <Text variant="mono-secondary">text-sm (12px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text variant="success">Success</Text>
-        <Text variant="mono-secondary">text-base (14px)</Text>
+        <Text variant="mono-secondary">text-base (13px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text variant="error">Error</Text>
-        <Text variant="mono-secondary">text-base (14px)</Text>
+        <Text variant="mono-secondary">text-base (13px)</Text>
       </div>
     </div>
   );

--- a/packages/kumo-docs-astro/src/components/demos/ToolbarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ToolbarDemo.tsx
@@ -27,7 +27,7 @@ export function ToolbarDemo() {
 export function ToolbarSizesDemo() {
   return (
     <div className="grid gap-3">
-      {(["xs", "sm", "base", "lg"] as const).map((size) => (
+      {(["sm", "base", "lg"] as const).map((size) => (
         <div key={size} className="flex items-center gap-3">
           <span className="w-10 text-sm text-kumo-subtle">{size}</span>
           <Toolbar size={size} className="w-fit">

--- a/packages/kumo-docs-astro/src/components/docs/ComponentPreview.astro
+++ b/packages/kumo-docs-astro/src/components/docs/ComponentPreview.astro
@@ -5,7 +5,7 @@ const { class: className, ...rest } = Astro.props;
 
 <div
   class:list={[
-    "flex min-h-[120px] items-center justify-center rounded-t-lg border border-kumo-hairline bg-kumo-canvas p-6",
+    "flex min-h-[120px] items-center justify-center rounded-t-lg border border-kumo-hairline bg-kumo-canvas p-6 text-base",
     className,
   ]}
   {...rest}

--- a/packages/kumo-docs-astro/src/components/docs/StickyDocHeader.tsx
+++ b/packages/kumo-docs-astro/src/components/docs/StickyDocHeader.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { cn } from "@cloudflare/kumo";
 import { GithubLogoIcon } from "@phosphor-icons/react";
 import { ThemeToggle } from "../ThemeToggle";
+import { FontScaleToggle } from "../FontScaleToggle";
 import { BaseUIIcon } from "./icons/BaseUIIcon";
 
 interface StickyDocHeaderProps {
@@ -159,8 +160,13 @@ export function StickyDocHeader({
             @cloudflare/kumo
           </a>
         </div>
-        <div className="hidden w-12 shrink-0 items-center justify-center lg:flex">
-          <ThemeToggle />
+        <div className="hidden shrink-0 items-stretch lg:flex">
+          <div className="flex w-12 shrink-0 items-center justify-center border-r border-kumo-hairline">
+            <FontScaleToggle />
+          </div>
+          <div className="flex w-12 shrink-0 items-center justify-center">
+            <ThemeToggle />
+          </div>
         </div>
       </header>
     </>

--- a/packages/kumo-docs-astro/src/components/skill/CollapseSizeExample.tsx
+++ b/packages/kumo-docs-astro/src/components/skill/CollapseSizeExample.tsx
@@ -32,7 +32,7 @@ export function CollapseSizeExample({
             preserveContentSize ? "w-64" : "w-full min-w-0",
           )}
         >
-          <Text as="h3" variant="heading3">
+          <Text as="h3" variant="heading">
             Web Analytics
           </Text>
           <Text variant="secondary">

--- a/packages/kumo-docs-astro/src/components/skill/design-tips.tsx
+++ b/packages/kumo-docs-astro/src/components/skill/design-tips.tsx
@@ -34,16 +34,17 @@ export function CodeExample({ code }: CodeExampleProps) {
 export const designTips = [
   {
     id: "content-text-size",
-    title: "Use 14px for content text",
+    title: "Use 13px for content text",
     description:
-      "All content text—body, buttons, data, other interactables—must be 14px in size. 16px and above are restricted to headings and subheadings.",
+      "Body copy, buttons, inputs, table cells, and other interactables all render at 13px (`text-base`) — the default `Text` size. Reserve 15px+ (`section-title`, `page-title`, `display`) for role-based headings. Never bump body up with `size=\"lg\"` to signal importance; use `variant=\"heading\"` (13px medium) or a stronger heading variant instead. `size=\"xs\"` (11px) and `size=\"lg\"` (15px) on body variants are deprecated.",
     examples: [
       {
         variant: "good",
-        exampleCode: `<Text>Content text</Text>`,
+        exampleCode: `<Text as="h3" variant="heading">API tokens</Text>
+<Text>Production token expires in 30 days.</Text>`,
         jsx: (
           <LayerCard className="grid w-full gap-1 p-5">
-            <Text as="h3" variant="heading3">
+            <Text as="h3" variant="heading">
               API tokens
             </Text>
             <Text>Production token expires in 30 days.</Text>
@@ -52,10 +53,11 @@ export const designTips = [
       },
       {
         variant: "bad",
-        exampleCode: `<Text size="lg">Content text</Text>`,
+        exampleCode: `<Text as="h3" variant="heading">API tokens</Text>
+<Text size="lg">Production token expires in 30 days.</Text>`,
         jsx: (
           <LayerCard className="grid w-full gap-1 p-5">
-            <Text as="h3" variant="heading3">
+            <Text as="h3" variant="heading">
               API tokens
             </Text>
             <Text size="lg">Production token expires in 30 days.</Text>
@@ -126,20 +128,20 @@ export const designTips = [
     id: "font-weight",
     title: "Never use `font-bold`",
     description:
-      "Use `font-semibold` for headings and `font-medium` for bold inline text.",
+      "Weight-first hierarchy is the recommended pattern: reach for `variant=\"heading\"` (13px medium), `variant=\"section-title\"` (15px medium), or `variant=\"page-title\"` (19px medium) instead of bumping size. For inline emphasis on body copy, pass `bold` on `Text` (bumps to `font-medium`) or wrap in `<strong>`. Never use `font-bold`; use `font-semibold` for the rare heading that genuinely needs it.",
     examples: [
       {
         variant: "good",
-        exampleCode: `<Text as="h3" variant="heading3">Account settings</Text>
-<Text as="strong" bold>required</Text>`,
+        exampleCode: `<Text as="h3" variant="heading">Account settings</Text>
+<Text as="strong" DANGEROUS_className="font-medium">required</Text>`,
         jsx: (
           <div className="grid gap-1">
-            <Text as="h3" variant="heading3">
+            <Text as="h3" variant="heading">
               Account settings
             </Text>
             <Text>
               This action is{" "}
-              <Text as="strong" bold>
+              <Text as="strong" DANGEROUS_className="font-medium">
                 required
               </Text>
               .
@@ -187,7 +189,7 @@ export const designTips = [
           <LayerCard className="w-full p-5">
             <div className="grid gap-6">
               <div className="grid gap-1.5">
-                <Text as="h3" variant="heading3">
+                <Text as="h3" variant="heading">
                   Web Analytics
                 </Text>
                 <Text variant="secondary" DANGEROUS_className="text-pretty">
@@ -209,7 +211,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full p-5">
             <div className="grid gap-4">
-              <Text as="h3" variant="heading3">
+              <Text as="h3" variant="heading">
                 Web Analytics
               </Text>
               <Text variant="secondary" DANGEROUS_className="text-pretty">
@@ -233,7 +235,7 @@ export const designTips = [
         exampleCode: `<LayerCard className="px-5 py-4">...</LayerCard>`,
         jsx: (
           <LayerCard className="px-5 py-4">
-            <Text bold>Production</Text>
+            <Text DANGEROUS_className="font-medium">Production</Text>
           </LayerCard>
         ),
       },
@@ -242,7 +244,7 @@ export const designTips = [
         exampleCode: `<LayerCard className="p-5">...</LayerCard>`,
         jsx: (
           <LayerCard className="p-5">
-            <Text bold>Production</Text>
+            <Text DANGEROUS_className="font-medium">Production</Text>
           </LayerCard>
         ),
       },
@@ -292,7 +294,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full shadow-md ring ring-kumo-line">
             <LayerCard.Primary className="grid gap-1 p-5">
-              <Text as="h3" variant="heading3">
+              <Text as="h3" variant="heading">
                 Workers API
               </Text>
               <Text variant="secondary">Last deployed 4 minutes ago</Text>
@@ -306,7 +308,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full border border-kumo-line shadow-md ring-0">
             <LayerCard.Primary className="grid gap-1 p-5 ring-0">
-              <Text as="h3" variant="heading3">
+              <Text as="h3" variant="heading">
                 Workers API
               </Text>
               <Text variant="secondary">Last deployed 4 minutes ago</Text>
@@ -410,7 +412,7 @@ export const designTips = [
       {
         variant: "good",
         jsx: (
-          <Text size="lg">
+          <Text>
             Edit <span className="font-mono text-[0.9em]">wrangler.toml</span>{" "}
             to continue.
           </Text>
@@ -419,7 +421,7 @@ export const designTips = [
       {
         variant: "bad",
         jsx: (
-          <Text size="lg">
+          <Text>
             Edit <span className="font-mono">wrangler.toml</span> to continue.
           </Text>
         ),
@@ -436,7 +438,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="h-56 w-full overflow-auto">
             <div className="sticky top-0 z-10 flex items-center justify-between border-b border-kumo-line bg-kumo-base px-3 py-2">
-              <Text bold>API tokens</Text>
+              <Text DANGEROUS_className="font-medium">API tokens</Text>
               <Button size="sm">Create</Button>
             </div>
             <div className="grid gap-4 p-3">
@@ -460,7 +462,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="h-56 w-full overflow-auto">
             <div className="sticky top-0 z-10 flex items-center justify-between bg-kumo-base px-3 py-2">
-              <Text bold>API tokens</Text>
+              <Text DANGEROUS_className="font-medium">API tokens</Text>
               <Button size="sm">Create</Button>
             </div>
             <div className="grid gap-4 p-3">
@@ -515,19 +517,19 @@ export const designTips = [
         jsx: (
           <div className="grid w-full">
             <div className="flex h-10 items-center">
-              <Text as="h3" bold>
+              <Text as="h3" DANGEROUS_className="font-medium">
                 Recent Requests
               </Text>
             </div>
             <LayerCard>
               <LayerCard.Secondary className="grid h-12 grid-cols-3 items-center gap-4 px-3 py-0">
-                <Text bold size="sm">
+                <Text size="sm" DANGEROUS_className="font-medium">
                   Time
                 </Text>
-                <Text bold size="sm">
+                <Text size="sm" DANGEROUS_className="font-medium">
                   Status
                 </Text>
-                <Text bold size="sm">
+                <Text size="sm" DANGEROUS_className="font-medium">
                   Query
                 </Text>
               </LayerCard.Secondary>
@@ -551,15 +553,15 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full">
             <div className="flex h-10 items-center px-3">
-              <Text as="h3" bold>
+              <Text as="h3" DANGEROUS_className="font-medium">
                 Recent Requests
               </Text>
             </div>
             <LayerCard>
               <LayerCard.Secondary className="grid h-12 grid-cols-3 gap-4 px-3 py-0">
-                <Text bold>Time</Text>
-                <Text bold>Status</Text>
-                <Text bold>Query</Text>
+                <Text DANGEROUS_className="font-medium">Time</Text>
+                <Text DANGEROUS_className="font-medium">Status</Text>
+                <Text DANGEROUS_className="font-medium">Query</Text>
               </LayerCard.Secondary>
               <LayerCard.Primary className="grid h-10 grid-cols-3 items-center gap-4 px-3 py-0">
                 <Text>00:50 UTC</Text>

--- a/packages/kumo-docs-astro/src/components/skill/design-tips.tsx
+++ b/packages/kumo-docs-astro/src/components/skill/design-tips.tsx
@@ -133,7 +133,7 @@ export const designTips = [
       {
         variant: "good",
         exampleCode: `<Text as="h3" variant="heading">Account settings</Text>
-<Text as="strong" DANGEROUS_className="font-medium">required</Text>`,
+<Text as="strong" bold>required</Text>`,
         jsx: (
           <div className="grid gap-1">
             <Text as="h3" variant="heading">
@@ -141,7 +141,7 @@ export const designTips = [
             </Text>
             <Text>
               This action is{" "}
-              <Text as="strong" DANGEROUS_className="font-medium">
+              <Text as="strong" bold>
                 required
               </Text>
               .
@@ -235,7 +235,7 @@ export const designTips = [
         exampleCode: `<LayerCard className="px-5 py-4">...</LayerCard>`,
         jsx: (
           <LayerCard className="px-5 py-4">
-            <Text DANGEROUS_className="font-medium">Production</Text>
+            <Text bold>Production</Text>
           </LayerCard>
         ),
       },
@@ -244,7 +244,7 @@ export const designTips = [
         exampleCode: `<LayerCard className="p-5">...</LayerCard>`,
         jsx: (
           <LayerCard className="p-5">
-            <Text DANGEROUS_className="font-medium">Production</Text>
+            <Text bold>Production</Text>
           </LayerCard>
         ),
       },
@@ -438,7 +438,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="h-56 w-full overflow-auto">
             <div className="sticky top-0 z-10 flex items-center justify-between border-b border-kumo-line bg-kumo-base px-3 py-2">
-              <Text DANGEROUS_className="font-medium">API tokens</Text>
+              <Text bold>API tokens</Text>
               <Button size="sm">Create</Button>
             </div>
             <div className="grid gap-4 p-3">
@@ -462,7 +462,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="h-56 w-full overflow-auto">
             <div className="sticky top-0 z-10 flex items-center justify-between bg-kumo-base px-3 py-2">
-              <Text DANGEROUS_className="font-medium">API tokens</Text>
+              <Text bold>API tokens</Text>
               <Button size="sm">Create</Button>
             </div>
             <div className="grid gap-4 p-3">
@@ -517,19 +517,19 @@ export const designTips = [
         jsx: (
           <div className="grid w-full">
             <div className="flex h-10 items-center">
-              <Text as="h3" DANGEROUS_className="font-medium">
+              <Text as="h3" variant="heading">
                 Recent Requests
               </Text>
             </div>
             <LayerCard>
               <LayerCard.Secondary className="grid h-12 grid-cols-3 items-center gap-4 px-3 py-0">
-                <Text size="sm" DANGEROUS_className="font-medium">
+                <Text size="sm" bold>
                   Time
                 </Text>
-                <Text size="sm" DANGEROUS_className="font-medium">
+                <Text size="sm" bold>
                   Status
                 </Text>
-                <Text size="sm" DANGEROUS_className="font-medium">
+                <Text size="sm" bold>
                   Query
                 </Text>
               </LayerCard.Secondary>
@@ -553,15 +553,15 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full">
             <div className="flex h-10 items-center px-3">
-              <Text as="h3" DANGEROUS_className="font-medium">
+              <Text as="h3" variant="heading">
                 Recent Requests
               </Text>
             </div>
             <LayerCard>
               <LayerCard.Secondary className="grid h-12 grid-cols-3 gap-4 px-3 py-0">
-                <Text DANGEROUS_className="font-medium">Time</Text>
-                <Text DANGEROUS_className="font-medium">Status</Text>
-                <Text DANGEROUS_className="font-medium">Query</Text>
+                <Text bold>Time</Text>
+                <Text bold>Status</Text>
+                <Text bold>Query</Text>
               </LayerCard.Secondary>
               <LayerCard.Primary className="grid h-10 grid-cols-3 items-center gap-4 px-3 py-0">
                 <Text>00:50 UTC</Text>

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -75,6 +75,8 @@ const buildDate =
       // must be re-applied after each view-transition swap because the <html>
       // attributes are replaced during navigation.
       (function () {
+        var FONT_SCALES = ["small", "default", "large"];
+
         function setTheme(theme) {
           localStorage.setItem("theme", theme);
           document.documentElement.setAttribute("data-mode", theme);
@@ -92,16 +94,28 @@ const buildDate =
           }
         }
 
+        function applyStoredFontScale() {
+          const stored = localStorage.getItem("font-scale");
+          if (stored && FONT_SCALES.indexOf(stored) !== -1 && stored !== "default") {
+            document.documentElement.setAttribute("data-font-scale", stored);
+          } else {
+            document.documentElement.removeAttribute("data-font-scale");
+          }
+        }
+
         // Apply on this (initial or freshly-swapped) document immediately.
         applyStoredTheme();
+        applyStoredFontScale();
 
         // Register global listeners exactly once across soft navigations.
         if (!window.__kumoThemeInit) {
           window.__kumoThemeInit = true;
 
-          // Reapply theme before each swap paints, so there's no light flash.
+          // Reapply theme + font-scale before each swap paints, so there's no flash.
           document.addEventListener("astro:before-swap", applyStoredTheme);
           document.addEventListener("astro:after-swap", applyStoredTheme);
+          document.addEventListener("astro:before-swap", applyStoredFontScale);
+          document.addEventListener("astro:after-swap", applyStoredFontScale);
 
           document.addEventListener("keydown", function (event) {
             if (event.defaultPrevented || event.repeat) return;

--- a/packages/kumo-docs-astro/src/pages/changelog/[...page].astro
+++ b/packages/kumo-docs-astro/src/pages/changelog/[...page].astro
@@ -161,7 +161,7 @@ const GITHUB_RELEASE_URL = "https://github.com/cloudflare/kumo/releases/tag/%40c
             >
               <LinkSimple className="size-4 text-kumo-subtle" />
             </span>
-            <Text as="span" variant="heading2">{v.version}</Text>
+            <Text as="span" variant="page-title">{v.version}</Text>
           </a>
           <Badge variant={badgeConfig[v.bump].variant}>{badgeConfig[v.bump].label}</Badge>
           <a
@@ -180,7 +180,7 @@ const GITHUB_RELEASE_URL = "https://github.com/cloudflare/kumo/releases/tag/%40c
           {v.sections.map((section: ParsedSection) => (
             <div>
               <div class="mb-2.5 [&>h3]:m-0">
-                <Text as="h3" bold>{sectionLabels[section.type]}</Text>
+                <Text as="h3" DANGEROUS_className="font-medium">{sectionLabels[section.type]}</Text>
               </div>
               <ul class="list-none p-0 mt-0 mb-0 [&>li]:ps-0 md:[&>li]:ml-4">
                 {section.entries.map((entry: ParsedEntry) => (

--- a/packages/kumo-docs-astro/src/pages/changelog/[...page].astro
+++ b/packages/kumo-docs-astro/src/pages/changelog/[...page].astro
@@ -180,7 +180,7 @@ const GITHUB_RELEASE_URL = "https://github.com/cloudflare/kumo/releases/tag/%40c
           {v.sections.map((section: ParsedSection) => (
             <div>
               <div class="mb-2.5 [&>h3]:m-0">
-                <Text as="h3" DANGEROUS_className="font-medium">{sectionLabels[section.type]}</Text>
+                <Text as="h3" variant="heading">{sectionLabels[section.type]}</Text>
               </div>
               <ul class="list-none p-0 mt-0 mb-0 [&>li]:ps-0 md:[&>li]:ml-4">
                 {section.entries.map((entry: ParsedEntry) => (

--- a/packages/kumo-docs-astro/src/pages/components-vs-blocks.mdx
+++ b/packages/kumo-docs-astro/src/pages/components-vs-blocks.mdx
@@ -89,10 +89,10 @@ Consider a `ProductCard`. It's a specific arrangement of components for a specif
 <Surface className="rounded-lg p-4">
   <img src={imgSrc} alt={imgAlt} className="rounded-md" />
   <div className="mt-3">
-    <Text size="lg" weight="semibold">
+    <Text variant="section-title" as="h3">
       {title}
     </Text>
-    <Text className="text-kumo-subtle">{description}</Text>
+    <Text variant="secondary">{description}</Text>
     <StarRating rating={rating} />
   </div>
   <div className="mt-4">

--- a/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/autocomplete.mdx
@@ -124,8 +124,9 @@ import {
 ## Sizes
 
 <p>
-  The `size` prop on `Autocomplete.InputGroup` supports four variants matching the
-  Input component: `xs`, `sm`, `base` (default), and `lg`.
+  The `size` prop on `Autocomplete.InputGroup` supports three variants matching
+  the Input component: `sm`, `base` (default), and `lg`. (`xs` is deprecated —
+  use `sm`.)
 </p>
 <ComponentExample demo="AutocompleteSizesDemo">
   <AutocompleteSizesDemo client:load />

--- a/packages/kumo-docs-astro/src/pages/components/combobox.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/combobox.mdx
@@ -95,8 +95,8 @@ export default function Example() {
 ### Sizes
 
 <p>
-  The Combobox supports four size variants that match the Input component: `xs`,
-  `sm`, `base` (default), and `lg`.
+  The Combobox supports three size variants that match the Input component:
+  `sm`, `base` (default), and `lg`. (`xs` is deprecated — use `sm`.)
 </p>
 <ComponentExample demo="ComboboxSizesDemo">
   <ComboboxSizesDemo client:load />

--- a/packages/kumo-docs-astro/src/pages/components/input-area.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input-area.mdx
@@ -132,7 +132,7 @@ export default function Example() {
 
 ### Sizes
 
-<p>Four sizes available: `xs`, `sm`, `base` (default), `lg`.</p>
+<p>Three sizes available: `sm`, `base` (default), `lg`. (`xs` is deprecated — use `sm`.)</p>
 <ComponentExample demo="InputAreaSizesDemo">
   <InputAreaSizesDemo client:visible />
 </ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/components/input.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/input.mdx
@@ -136,7 +136,7 @@ export default function Example() {
 
 ### Input Sizes
 
-<p>Four sizes available: `xs`, `sm`, `base` (default), `lg`.</p>
+<p>Three sizes available: `sm`, `base` (default), `lg`. (`xs` is deprecated — use `sm`.)</p>
 <ComponentExample demo="InputSizesDemo">
   <InputSizesDemo client:visible />
 </ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -45,9 +45,9 @@ import {
 
   <ComponentSection>
     <Heading level={2}>Installation</Heading>
-    <Heading level={3} class="mb-2 text-lg">Barrel</Heading>
+    <Heading level={3} class="mb-2">Barrel</Heading>
     <CodeBlock code={`import { Sidebar } from "@cloudflare/kumo";`} lang="tsx" />
-    <h3 class="mt-4 mb-2 text-lg font-semibold">Granular</h3>
+    <Heading level={3} class="mt-4 mb-2">Granular</Heading>
     <CodeBlock code={`import { Sidebar } from "@cloudflare/kumo/components/sidebar";`} lang="tsx" />
   </ComponentSection>
 
@@ -376,7 +376,7 @@ const { state, isPeeking } = useSidebar();
 
     <div class="space-y-8">
       <div>
-        <h3 class="mb-3 text-lg font-semibold font-mono">Sidebar</h3>
+        <Heading level={3} class="mb-3 font-mono">Sidebar</Heading>
         <p>
           The main sidebar container. Renders as <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;aside&gt;</code> on desktop and a navigation drawer on mobile.
         </p>
@@ -384,7 +384,7 @@ const { state, isPeeking } = useSidebar();
       </div>
 
       <div>
-        <h3 class="mb-3 text-lg font-semibold font-mono">Sidebar.Provider</h3>
+        <Heading level={3} class="mb-3 font-mono">Sidebar.Provider</Heading>
         <p>
           Context provider managing expand/collapse state and mobile detection.
         </p>
@@ -392,14 +392,14 @@ const { state, isPeeking } = useSidebar();
       </div>
 
       <div>
-        <h3 class="mb-3 text-lg font-semibold font-mono">Sidebar.Content</h3>
+        <Heading level={3} class="mb-3 font-mono">Sidebar.Content</Heading>
         <p>
           Scrollable middle section (<code class="rounded bg-kumo-control px-1 py-0.5 text-xs">flex-1 overflow-y-auto</code>). Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Header</code> / <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Footer</code> to pin content above or below this scroll area.
         </p>
       </div>
 
       <div>
-        <h3 class="mb-3 text-lg font-semibold font-mono">Sidebar.MenuButton</h3>
+        <Heading level={3} class="mb-3 font-mono">Sidebar.MenuButton</Heading>
         <p>
           Primary interactive element. Supports icons, active state, links, and auto-tooltip when collapsed.
           Auto-wraps in <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;li&gt;</code> &mdash; no <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">MenuItem</code> wrapper needed unless wrapping a <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Collapsible</code>.
@@ -408,7 +408,7 @@ const { state, isPeeking } = useSidebar();
       </div>
 
       <div>
-        <h3 class="mb-3 text-lg font-semibold font-mono">Sidebar.MenuSubButton</h3>
+        <Heading level={3} class="mb-3 font-mono">Sidebar.MenuSubButton</Heading>
         <p>
           Button inside a sub-menu for nested navigation.
           Auto-wraps in <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;li&gt;</code> &mdash; no <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">MenuSubItem</code> wrapper needed.

--- a/packages/kumo-docs-astro/src/pages/components/text.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/text.mdx
@@ -57,7 +57,25 @@ export default function Example() {
 ```
 
 <section class="mt-8 space-y-4">
-  <Text variant="heading3" as="h3">Semantic HTML</Text>
+  <Text variant="section-title" as="h3">Heading variants</Text>
+  <Text>
+    Heading variants are role-based. Reach for the one that describes what the
+    text **is**, not how big you want it:
+  </Text>
+
+  - `variant="display"` — hero / prominent moments (24px semibold)
+  - `variant="page-title"` — the single title of a page or dialog (19px medium)
+  - `variant="section-title"` — card / panel / section heading (15px medium)
+  - `variant="heading"` — inline / row / list-item heading (13px medium)
+
+  <Text>
+    `heading` is the small, most-used one — reach for it before adding extra
+    weight or size to body text.
+  </Text>
+</section>
+
+<section class="mt-8 space-y-4">
+  <Text variant="section-title" as="h3">Semantic HTML</Text>
   <Text>
     The `variant` prop controls visual styling only—it does not determine the HTML element rendered.
     Heading variants **require** the `as` prop to avoid silently excluding real section headings from
@@ -67,17 +85,19 @@ export default function Example() {
 
 ```tsx
 // Heading variants REQUIRE `as` — TypeScript will flag usages missing it
-<Text variant="heading1">Page Title</Text> // Doesn't compile
+<Text variant="display">Welcome</Text> // Doesn't compile
 
 // Real section headings (contribute to the document outline)
-<Text variant="heading1" as="h1">Page Title</Text>
-<Text variant="heading2" as="h2">Section Title</Text>
+<Text variant="display" as="h1">Welcome</Text>
+<Text variant="page-title" as="h1">Account settings</Text>
+<Text variant="section-title" as="h2">General</Text>
+<Text variant="heading" as="h3">API tokens</Text>
 
 // Decorative heading-styled text that is NOT a section heading
-<Text variant="heading1" as="span">Big bold card label</Text>
+<Text variant="display" as="span">Big card label</Text>
 
 // Visually one size, semantically another
-<Text variant="heading1" as="h3">Visually large, but semantically h3</Text>
+<Text variant="display" as="h3">Visually large, but semantically h3</Text>
 ```
 
   <Text>
@@ -88,40 +108,59 @@ export default function Example() {
 </section>
 
 <section class="mt-8 space-y-4">
-  <Text variant="heading3" as="h3">Restrictions</Text>
+  <Text variant="section-title" as="h3">Restrictions</Text>
   <Text>
-    The `bold` and `size` props are intentionally restricted to the `base`, `secondary`, `success`, and `error` text variants.
+    The `size` prop is intentionally restricted to the `body`, `secondary`, `success`, and `error` variants.
   </Text>
 
 ```tsx
-<Text size="sm" bold>Body</Text>
-<Text variant="secondary" bold>Body secondary</Text>
-<Text variant="success" size="lg">Success</Text>
+<Text size="sm">Body</Text>
+<Text variant="secondary" size="sm">Body secondary</Text>
+<Text variant="success">Success</Text>
 <Text variant="error">Error</Text>
 ```
 
 <Text>
-  Monospace variants (`mono` and `mono-secondary`) can only set `size` to `lg`
-  and cannot use the `bold` prop:
+  Monospace variants (`mono` and `mono-secondary`) always render at 12px and
+  do not accept a `size` prop.
 </Text>
 
 ```tsx
 <Text variant="mono">Monospace</Text>
-<Text variant="mono" size="lg">Monospace</Text>
-<Text variant="mono" bold>Monospace</Text> // Doesn't compile
 ```
 
 <Text>
-  Headings (i.e. `heading1`, `heading2` and `heading3` variants) cannot use
-  these props at all:
+  Heading variants (`display`, `page-title`, `section-title`, `heading`) don't
+  accept `size` — the size is part of the role.
+</Text>
+
+<Text>
+  The `bold` prop follows the same shape: it applies only to copy variants
+  (`body`, `secondary`, `success`, `error`), where it bumps weight to
+  `font-medium` (500) for inline emphasis. Heading variants already carry
+  their role's weight, and monospace stays regular by design — both type
+  `bold` as `never` so consumers get a compile error rather than a silent
+  no-op. For structural hierarchy inside a document outline reach for
+  `variant="heading"` instead of `bold`.
 </Text>
 
 ```tsx
-<Text variant="heading1" bold>
-  Heading 1
-</Text> // Doesn't compile
+<Text bold>Important detail</Text>
+<Text variant="secondary" bold>Muted but bumped</Text>
 ```
 
+</section>
+
+<section class="mt-8 space-y-4">
+  <Text variant="section-title" as="h3">Deprecated variants</Text>
+  <Text>
+    The numeric heading names still work but emit a warning in development.
+    Migrate call sites to the role-based names:
+  </Text>
+
+  - `heading1` → `display`
+  - `heading2` → `page-title`
+  - `heading3` → `section-title`
 </section>
 
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/styles/global.css
+++ b/packages/kumo-docs-astro/src/styles/global.css
@@ -12,6 +12,23 @@
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
+/* ==========================================================================
+   Font-scale presets (docs-only)
+   --------------------------------------------------------------------------
+   Kumo exposes `--font-scale` as a hookable multiplier on every font-size
+   token via `calc(<rem> * var(--font-scale, 1))`. The library ships NO
+   presets — density modes are an application-level UX concern. These
+   selectors are docs-only and drive the FontScaleToggle in the header.
+   ========================================================================== */
+@layer base {
+  [data-font-scale="small"] {
+    --font-scale: 0.875;
+  }
+  [data-font-scale="large"] {
+    --font-scale: 1.125;
+  }
+}
+
 * {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;

--- a/packages/kumo-figma/src/build-theme-data.ts
+++ b/packages/kumo-figma/src/build-theme-data.ts
@@ -114,18 +114,29 @@ function remToPx(remValue: string): number {
 function parseKumoFontSizes(css: string): Record<string, number> {
   const sizes: Record<string, number> = {};
 
+  // Match `calc(<Npx> * var(--font-scale, ...))` — extract the unscaled
+  // px value. Font-size tokens are emitted wrapped in this multiplier so
+  // consumers can shift the whole scale via `--font-scale`; Figma
+  // operates at 1× so we take the base value.
+  const calcMatches = css.matchAll(
+    /--text-(\w+):\s*calc\(\s*(\d+)px\s*\*\s*var\(--font-scale[^)]*\)\s*\)/g,
+  );
+  for (const match of calcMatches) {
+    sizes[match[1]] = parseInt(match[2], 10);
+  }
+
   // Match: --text-xs: 12px; or --text-sm: 13px;
-  const pxMatches = css.matchAll(/--text-(\w+):\s*(\d+)px/g);
+  const pxMatches = css.matchAll(/--text-(\w+):\s*(\d+)px\s*;/g);
   for (const match of pxMatches) {
+    if (sizes[match[1]] !== undefined) continue;
     sizes[match[1]] = parseInt(match[2], 10);
   }
 
   // Match rem values: --text-xl: 1.25rem;
-  const remMatches = css.matchAll(/--text-(\w+):\s*([\d.]+)rem/g);
+  const remMatches = css.matchAll(/--text-(\w+):\s*([\d.]+)rem\s*;/g);
   for (const match of remMatches) {
-    if (!sizes[match[1]]) {
-      sizes[match[1]] = remToPx(match[2] + "rem");
-    }
+    if (sizes[match[1]] !== undefined) continue;
+    sizes[match[1]] = remToPx(match[2] + "rem");
   }
 
   return sizes;

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -592,36 +592,49 @@ export const THEME_CONFIG: ThemeConfig = {
    *
    * Note: Typography is NOT theme-dependent (no light/dark mode).
    * Values are the same across color modes but may differ per theme.
+   *
+   * Scale rationale:
+   * - Weight is the primary hierarchy signal; size is used only for large jumps.
+   * - `base` (13px) is the product default body size — dense-app appropriate.
+   * - `sm` (12px) is for helper/caption text and descriptions.
+   * - `xs` (11px) is an escape hatch for chart labels and dense metadata.
+   * - `lg` (15px) covers long-form body and mid-level section headings.
+   * - `xl` (19px) is the standard page/dialog title.
+   * - `2xl` (24px) is reserved for prominent/hero moments.
    */
   typography: {
     xs: {
       newName: "",
+      description:
+        "Escape hatch: chart labels, dense metadata. Avoid in body copy.",
       theme: {
-        kumo: "12px",
+        kumo: "11px",
       },
     },
     "xs--line-height": {
       newName: "",
       theme: {
-        kumo: "calc(1 / 0.75)",
+        kumo: "1.4",
       },
     },
     sm: {
       newName: "",
+      description: "Caption — helper text, descriptions, table metadata.",
       theme: {
-        kumo: "13px",
+        kumo: "12px",
       },
     },
     "sm--line-height": {
       newName: "",
       theme: {
-        kumo: "calc(1 / 0.85)",
+        kumo: "1.45",
       },
     },
     base: {
       newName: "",
+      description: "Body — default product text size.",
       theme: {
-        kumo: "14px",
+        kumo: "13px",
       },
     },
     "base--line-height": {
@@ -632,8 +645,9 @@ export const THEME_CONFIG: ThemeConfig = {
     },
     lg: {
       newName: "",
+      description: "Body-lg / section heading — long-form content, dialogs.",
       theme: {
-        kumo: "16px",
+        kumo: "15px",
       },
     },
     "lg--line-height": {
@@ -642,6 +656,51 @@ export const THEME_CONFIG: ThemeConfig = {
         kumo: "1.5",
       },
     },
+    xl: {
+      newName: "",
+      description: "Page / dialog title — paired with a description.",
+      theme: {
+        kumo: "19px",
+      },
+    },
+    "xl--line-height": {
+      newName: "",
+      theme: {
+        kumo: "1.4",
+      },
+    },
+    "2xl": {
+      newName: "",
+      description: "Display — hero / prominent moments.",
+      theme: {
+        kumo: "24px",
+      },
+    },
+    "2xl--line-height": {
+      newName: "",
+      theme: {
+        kumo: "1.3",
+      },
+    },
+  },
+
+  /**
+   * Font-scale — exposes `--font-scale` as a hookable multiplier on every
+   * font-size token. Font-size tokens are emitted as
+   * `calc(<rem> * var(--font-scale, 1))`; consumers can override the
+   * variable at any scope to shift the whole scale.
+   *
+   * The library ships no named presets — that's an application-level UX
+   * concern, not a token concern. Consumers who want density modes
+   * declare their own selectors (e.g. `[data-font-scale="compact"]`) in
+   * their own stylesheet.
+   *
+   * Line-heights stay as raw ratios and multiply against the already-
+   * scaled font-size at use time.
+   */
+  fontScale: {
+    default: 1,
+    presets: {},
   },
 };
 

--- a/packages/kumo/scripts/theme-generator/config.ts
+++ b/packages/kumo/scripts/theme-generator/config.ts
@@ -627,7 +627,7 @@ export const THEME_CONFIG: ThemeConfig = {
     "sm--line-height": {
       newName: "",
       theme: {
-        kumo: "1.45",
+        kumo: "1.35",
       },
     },
     base: {
@@ -640,7 +640,7 @@ export const THEME_CONFIG: ThemeConfig = {
     "base--line-height": {
       newName: "",
       theme: {
-        kumo: "1.5",
+        kumo: "1.4",
       },
     },
     lg: {
@@ -653,7 +653,7 @@ export const THEME_CONFIG: ThemeConfig = {
     "lg--line-height": {
       newName: "",
       theme: {
-        kumo: "1.5",
+        kumo: "1.45",
       },
     },
     xl: {

--- a/packages/kumo/scripts/theme-generator/generate-css.ts
+++ b/packages/kumo/scripts/theme-generator/generate-css.ts
@@ -160,6 +160,11 @@ export function generateKumoThemeCSS(
   lines.push("}");
 
   // Typography tokens (font sizes and line heights)
+  //
+  // Font-size tokens are multiplied by `--font-scale` so a single knob can
+  // shift the whole scale. Line-height tokens stay as raw ratios — they'll
+  // multiply against the already-scaled font-size at use time and grow
+  // naturally, so scaling them here would double-apply.
   if (config.typography && Object.keys(config.typography).length > 0) {
     lines.push("");
     lines.push("@theme {");
@@ -168,10 +173,37 @@ export function generateKumoThemeCSS(
     for (const [tokenName, def] of Object.entries(config.typography)) {
       const name = useNewNames && def.newName ? def.newName : tokenName;
       const value = def.theme.kumo;
+      const isLineHeight = tokenName.endsWith("--line-height");
 
-      lines.push(`  --text-${name}: ${value};`);
+      const emitted =
+        config.fontScale && !isLineHeight
+          ? `calc(${value} * var(--font-scale, 1))`
+          : value;
+
+      lines.push(`  --text-${name}: ${emitted};`);
     }
 
+    lines.push("}");
+  }
+
+  // Font-scale presets.
+  //
+  // The library declares no named presets — the default multiplier lives
+  // in the `var(--font-scale, 1)` fallback in the typography block above.
+  // Consumers can override `--font-scale` at any scope (typically on
+  // `<html>` via a `data-*` attribute) to shift the whole scale. Kept as
+  // a hook here in case an internal preset is ever justified.
+  if (config.fontScale && Object.keys(config.fontScale.presets).length > 0) {
+    lines.push("");
+    lines.push("@layer base {");
+    lines.push("  /* Font-scale presets — override --font-scale by selector. */");
+    const fmt = (n: number) =>
+      Number.isInteger(n) ? n.toString() : n.toFixed(4).replace(/\.?0+$/, "");
+    for (const [preset, value] of Object.entries(config.fontScale.presets)) {
+      lines.push(
+        `  [data-font-scale="${preset}"] { --font-scale: ${fmt(value)}; }`,
+      );
+    }
     lines.push("}");
   }
 

--- a/packages/kumo/scripts/theme-generator/index.ts
+++ b/packages/kumo/scripts/theme-generator/index.ts
@@ -10,6 +10,7 @@
  *   pnpm codegen:themes --dry-run # Preview without writing
  */
 
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -146,6 +147,31 @@ async function main() {
   }
 
   if (!args.dryRun) {
+    // Format generated CSS with oxfmt so codegen output stays consistent with
+    // the rest of the repo — otherwise minor whitespace / numeric drift from
+    // the ad-hoc string builder pollutes every regen with unrelated diff.
+    const filenames = [...files.keys()];
+    try {
+      execFileSync(
+        "pnpm",
+        [
+          "exec",
+          "vp",
+          "fmt",
+          ...filenames.map((n) => path.join("src/styles", n)),
+        ],
+        {
+          cwd: path.resolve(__dirname, "../.."),
+          stdio: "inherit",
+        },
+      );
+    } catch (err) {
+      console.warn(
+        "  Warning: oxfmt pass failed; generated CSS may have inconsistent formatting.",
+        err instanceof Error ? err.message : err,
+      );
+    }
+
     console.log("\nTheme generation complete!");
     console.log(
       "\nTip: Run with --dry-run to preview changes without writing files",

--- a/packages/kumo/scripts/theme-generator/types.ts
+++ b/packages/kumo/scripts/theme-generator/types.ts
@@ -65,6 +65,32 @@ export type TypographyTokens = {
   [tokenName: string]: TypographyTokenDefinition;
 };
 
+/**
+ * Font-scale configuration
+ *
+ * Introduces a global multiplier variable (`--font-scale`) applied to every
+ * font-size token (but NOT to line-heights — those stay ratios and grow
+ * naturally because they multiply against the already-scaled font-size).
+ *
+ * `presets` maps arbitrary preset names to multiplier values. Each preset
+ * emits a `[data-font-scale="{name}"] { --font-scale: {multiplier}; }` block.
+ * The `default` multiplier is applied to `:root`.
+ *
+ * Example:
+ * ```ts
+ * fontScale: {
+ *   default: 1,
+ *   presets: { small: 12 / 13, large: 14 / 13 },
+ * }
+ * ```
+ */
+export type FontScaleConfig = {
+  /** Multiplier applied to `:root` (usually 1). */
+  default: number;
+  /** Named presets → multiplier. */
+  presets: Record<string, number>;
+};
+
 /** Complete theme configuration */
 export type ThemeConfig = {
   /** Text color tokens */
@@ -73,6 +99,8 @@ export type ThemeConfig = {
   color: ColorTokens;
   /** Typography tokens (font sizes and line heights) */
   typography?: TypographyTokens;
+  /** Optional font-scale multiplier + named presets */
+  fontScale?: FontScaleConfig;
 };
 
 /** Output options for CSS generation */

--- a/packages/kumo/src/blocks/delete-resource/delete-resource.tsx
+++ b/packages/kumo/src/blocks/delete-resource/delete-resource.tsx
@@ -123,7 +123,7 @@ export function DeleteResource({
                 aria-label="Close"
                 disabled={isDeleting}
               >
-                <XIcon size={18} />
+                <XIcon size="1.25em" />
               </Button>
             )}
           />
@@ -157,14 +157,9 @@ export function DeleteResource({
                   {resourceName}
 
                   {copied ? (
-                    <CheckIcon
-                      size={12}
-                      weight="bold"
-                      className="ml-1.5 inline"
-                    />
+                    <CheckIcon weight="bold" className="ml-1.5 inline" />
                   ) : (
                     <CopyIcon
-                      size={12}
                       weight="bold"
                       className="ml-1.5 inline text-kumo-subtle group-hover:text-kumo-default"
                     />

--- a/packages/kumo/src/components/autocomplete/autocomplete.tsx
+++ b/packages/kumo/src/components/autocomplete/autocomplete.tsx
@@ -1,5 +1,4 @@
 import { Autocomplete as AutocompleteBase } from "@base-ui/react/autocomplete";
-import { CheckIcon } from "@phosphor-icons/react";
 import { createContext, useContext, type ReactNode } from "react";
 import { inputVariants, KUMO_INPUT_VARIANTS } from "../input/input";
 import { cn } from "../../utils/cn";
@@ -242,12 +241,9 @@ function Item({ children, ...props }: AutocompleteBase.Item.Props) {
       data-kumo-component="Autocomplete"
       data-kumo-part="item"
       {...props}
-      className="group mx-1.5 grid cursor-pointer grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-base data-highlighted:bg-kumo-overlay data-selected:font-medium"
+      className="mx-1.5 cursor-pointer rounded px-2 py-1.5 text-base data-highlighted:bg-kumo-overlay"
     >
-      <div className="col-start-1">{children}</div>
-      <span className="col-start-2 hidden items-center group-data-selected:flex">
-        <CheckIcon size={14} />
-      </span>
+      {children}
     </AutocompleteBase.Item>
   );
 }

--- a/packages/kumo/src/components/autocomplete/autocomplete.tsx
+++ b/packages/kumo/src/components/autocomplete/autocomplete.tsx
@@ -25,10 +25,10 @@ export type KumoAutocompleteSize = keyof typeof KUMO_AUTOCOMPLETE_VARIANTS.size;
 export interface KumoAutocompleteVariantsProps {
   /**
    * Size of the autocomplete input. Matches Input component sizes.
-   * - `"xs"` — Extra small for compact UIs (h-5 / 20px)
-   * - `"sm"` — Small for secondary fields (h-6.5 / 26px)
-   * - `"base"` — Default size (h-9 / 36px)
-   * - `"lg"` — Large for prominent fields (h-10 / 40px)
+   * - `"sm"` — Small for secondary fields (26px tall)
+   * - `"base"` — Default size (32px tall)
+   * - `"lg"` — Large for prominent fields (36px tall)
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
    * @default "base"
    */
   size?: KumoAutocompleteSize;
@@ -154,6 +154,14 @@ function InputGroup({
   placeholder?: string;
 }) {
   const { hasError } = useContext(AutocompleteContext);
+
+  if (process.env.NODE_ENV !== "production" && size === "xs") {
+    console.warn(
+      '[Kumo Autocomplete]: size="xs" is deprecated. Use size="sm" instead. ' +
+        "The xs size will be removed in a future major version.",
+    );
+  }
+
   return (
     <AutocompleteBase.Input
       className={cn(

--- a/packages/kumo/src/components/badge/badge.tsx
+++ b/packages/kumo/src/components/badge/badge.tsx
@@ -4,7 +4,7 @@ import { resolveVariant } from "../../utils/resolve-variant";
 
 /** Base styles applied to all badge variants. */
 export const KUMO_BADGE_BASE_STYLES =
-  "inline-flex w-fit flex-none shrink-0 items-center justify-self-start rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap";
+  "inline-flex w-fit flex-none shrink-0 items-center justify-self-start rounded-full px-2 py-0.5 text-sm font-medium whitespace-nowrap";
 
 /** Badge variant definitions mapping variant names to their Tailwind classes and descriptions. */
 export const KUMO_BADGE_VARIANTS = {

--- a/packages/kumo/src/components/banner/banner-action.tsx
+++ b/packages/kumo/src/components/banner/banner-action.tsx
@@ -26,10 +26,10 @@ export type BannerActionVariant = Extract<
 
 /**
  * Size of a `Banner.Action`, matching the equivalent `Button` size specs.
- * - `"xs"` — extra small for dense/compact banners.
- * - `"sm"` — small (default), the standard banner CTA size.
+ * - `"sm"` — small (26px), the standard banner CTA size used by both
+ *   `size="base"` and `size="sm"` banners.
  */
-export type BannerActionSize = Extract<KumoButtonSize, "xs" | "sm">;
+export type BannerActionSize = Extract<KumoButtonSize, "sm">;
 
 /** Value shared from the `Banner` root to its `Banner.Action` children. */
 export interface BannerActionContextValue {
@@ -43,8 +43,8 @@ export interface BannerActionContextValue {
  * Propagates the banner's variant and action size to `Banner.Action`
  * children so each CTA can self-style without prop drilling:
  * - `variant` — selects the matching accent color.
- * - `size` — a compact `size="sm"` banner renders actions at `"xs"`, and a
- *   `"base"` banner renders them at `"sm"`.
+ * - `size` — both `"base"` and compact `"sm"` banners render actions at
+ *   `"sm"` (26px), the smallest Button size in the current scale.
  *
  * The `Banner` root always overrides these defaults via a Provider; the literals
  * mirror a default, base-size banner (kept as literals to avoid a runtime import

--- a/packages/kumo/src/components/banner/banner.test.tsx
+++ b/packages/kumo/src/components/banner/banner.test.tsx
@@ -130,7 +130,8 @@ describe("Banner", () => {
     const cta = screen.getByTestId("cta");
     expect(cta.className).toContain("h-6.5");
     expect(cta.className).toContain("px-2");
-    expect(cta.className).toContain("text-xs");
+    // sm buttons use text-sm (12px) to stay proportional to their 26px height.
+    expect(cta.className).toContain("text-sm");
   });
 
   it("applies compact spacing for the sm banner size", () => {
@@ -146,7 +147,7 @@ describe("Banner", () => {
     expect(className).not.toContain("items-start");
   });
 
-  it("defaults Banner.Action children to xs in an sm banner", () => {
+  it("defaults Banner.Action children to sm in an sm banner", () => {
     render(
       <Banner
         size="sm"
@@ -157,9 +158,10 @@ describe("Banner", () => {
     );
 
     const cta = screen.getByTestId("cta");
-    // Inherits the banner's size => xs (h-5), not the standalone sm default (h-6.5).
-    expect(cta.className).toContain("h-5");
-    expect(cta.className).toContain("px-1.5");
+    // Both base and compact banners now render actions at the sm Button
+    // size (26px) — xs was removed from the Button scale.
+    expect(cta.className).toContain("h-6.5");
+    expect(cta.className).toContain("px-2");
   });
 
   it("matches an icon-only action to the text action height in an sm banner", () => {
@@ -179,9 +181,10 @@ describe("Banner", () => {
     );
 
     const cta = screen.getByTestId("cta");
-    expect(cta.className).toContain("h-5");
-    expect(cta.className).toContain("px-1.5");
-    expect(cta.className).not.toContain("size-3.5");
+    // Icon-only Banner.Action inherits the sm Button size (26px tall). It
+    // doesn't set a compact `shape`, so it stays rectangular.
+    expect(cta.className).toContain("h-6.5");
+    expect(cta.className).toContain("px-2");
   });
 
   it("renders title and description inline in an sm banner", () => {
@@ -217,7 +220,12 @@ describe("Banner", () => {
 
     expect(actionGroup?.parentElement).toBe(description);
     expect(actionGroup?.className).toContain("ml-1.5");
-    expect(description.className).toContain("text-sm");
+    // In an sm banner the description inherits `text-sm` (12px) from the
+    // banner container rather than carrying the class itself. Title and
+    // description share the container size; only the title's font weight
+    // distinguishes them.
+    const banner = description.closest('[class*="text-sm"]');
+    expect(banner).not.toBeNull();
   });
 
   it("keeps a Banner.Action trailing in an sm banner", () => {

--- a/packages/kumo/src/components/banner/banner.tsx
+++ b/packages/kumo/src/components/banner/banner.tsx
@@ -64,24 +64,28 @@ export type KumoBannerSize = keyof typeof KUMO_BANNER_VARIANTS.size;
 /**
  * Per-size render-site classes not carried by `bannerVariants` (which only emits
  * the container classes). `row` is the title↔action flex gap, `icon` the icon
- * wrapper height, `description` the description text size, and `action` the size
- * that child `Banner.Action`s inherit via {@link BannerActionContext}.
+ * wrapper height, and `action` the size that child `Banner.Action`s inherit via
+ * {@link BannerActionContext}.
+ *
+ * The title and description both inherit the container's text size
+ * (`text-base` for `base`, `text-sm` for `sm`) — hierarchy is expressed via
+ * font weight (title `font-medium`, description regular), not size. This
+ * mirrors the `Text` scale's weight-first hierarchy: within a banner, the
+ * title is a `heading` role and the description is `body`.
  */
 const BANNER_SIZE_PARTS: Record<
   KumoBannerSize,
-  { row: string; icon: string; description: string; action: BannerActionSize }
+  { row: string; icon: string; action: BannerActionSize }
 > = {
   base: {
     row: "gap-3",
     icon: "h-[1.375em]",
-    description: "text-sm",
     action: "sm",
   },
   sm: {
     row: "gap-2",
     icon: "h-[1.25em]",
-    description: "text-sm",
-    action: "xs",
+    action: "sm",
   },
 };
 
@@ -186,10 +190,12 @@ export interface BannerProps extends Omit<
    */
   variant?: KumoBannerVariant;
   /**
-   * Size of the banner. A `"sm"` banner uses tighter spacing and `text-sm`,
-   * renders a Kumo `Link` action inline with the description, and sets its
-   * `Banner.Action` children to the `"xs"` size — suited to dialogs and other
-   * tight spaces.
+   * Size of the banner. A `"sm"` banner uses tighter spacing and `text-sm`
+   * (12px) and renders a Kumo `Link` action inline with the description —
+   * suited to dialogs and other tight spaces. In both sizes the title and
+   * description share the container text size (only the title's
+   * `font-medium` weight distinguishes them), and `Banner.Action` children
+   * render at the small (26px) Button size.
    * @default "base"
    */
   size?: KumoBannerSize;
@@ -284,7 +290,7 @@ const BannerRoot = forwardRef<HTMLDivElement, BannerProps>(function BannerRoot(
                   </span>
                 )}
                 {description && (
-                  <span className={cn(sizeParts.description, "leading-snug")}>
+                  <span className="leading-snug">
                     {description}
                     {hasInlineLinkAction && (
                       <span className="ml-1.5 [&_[data-kumo-component=Link]]:inline">
@@ -298,7 +304,7 @@ const BannerRoot = forwardRef<HTMLDivElement, BannerProps>(function BannerRoot(
               <div className="flex flex-col gap-0.5">
                 {title && <p className="leading-snug font-medium">{title}</p>}
                 {description && (
-                  <div className={cn(sizeParts.description, "leading-snug")}>
+                  <div className="leading-snug">
                     {isValidElement(description) ? (
                       description
                     ) : (

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -25,26 +25,27 @@ export const KUMO_BUTTON_VARIANTS = {
   size: {
     xs: {
       classes: "h-5 gap-1 rounded-sm px-1.5 text-xs",
-      description: "Extra small button for compact UIs",
+      description:
+        '@deprecated Use `size="sm"` instead. The `xs` size will be removed in a future major version.',
     },
     sm: {
-      classes: "h-6.5 gap-1 rounded-md px-2 text-xs",
-      description: "Small button for secondary actions",
+      classes: "h-6.5 gap-1 rounded-md px-2 text-sm leading-none",
+      description: "Small button (26px tall) for secondary actions",
     },
     base: {
-      classes: "h-9 gap-1.5 rounded-lg px-3 text-base",
-      description: "Default button size",
+      classes: "h-8 gap-1.5 rounded-lg px-3 text-base",
+      description: "Default button size (32px tall)",
     },
     lg: {
-      classes: "h-10 gap-2 rounded-lg px-4 text-base",
-      description: "Large button for primary CTAs",
+      classes: "h-9 gap-2 rounded-lg px-4 text-base",
+      description: "Large button (36px tall) for primary CTAs",
     },
   },
   compactSize: {
     xs: { classes: "size-3.5" },
     sm: { classes: "size-6.5" },
-    base: { classes: "size-9" },
-    lg: { classes: "size-10" },
+    base: { classes: "size-8" },
+    lg: { classes: "size-9" },
   },
   variant: {
     primary: {
@@ -102,10 +103,10 @@ export interface KumoButtonVariantsProps {
   shape?: KumoButtonShape;
   /**
    * Button size.
-   * - `"xs"` — Extra small for compact UIs
-   * - `"sm"` — Small for secondary actions
-   * - `"base"` — Default size
-   * - `"lg"` — Large for primary CTAs
+   * - `"sm"` — Small for secondary actions (26px tall)
+   * - `"base"` — Default size (32px tall)
+   * - `"lg"` — Large for primary CTAs (36px tall)
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
    * @default "base"
    */
   size?: KumoButtonSize;
@@ -366,6 +367,14 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const { type, ...restProps } = props;
+
+    if (process.env.NODE_ENV !== "production" && size === "xs") {
+      console.warn(
+        '[Kumo Button]: size="xs" is deprecated. Use size="sm" instead. ' +
+          "The xs size will be removed in a future major version.",
+      );
+    }
+
     const emphasisStyle = getEmphasisStyle(variant);
     const titleLabel = getTitleLabel(title);
     const buttonProps = {

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArrowsClockwise, type Icon } from "@phosphor-icons/react";
+import { ArrowsClockwiseIcon, type Icon } from "@phosphor-icons/react";
 import { Loader } from "../loader/loader";
 import { Tooltip } from "../tooltip/tooltip";
 import { cn } from "../../utils/cn";
@@ -385,7 +385,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         titleLabel && { "aria-label": titleLabel }),
     };
     const iconNode = loading ? (
-      <Loader size={size === "lg" ? 16 : 14} />
+      <Loader size={size === "lg" ? 15 : 13} />
     ) : (
       renderIconNode(IconComponent)
     );
@@ -440,7 +440,7 @@ export const RefreshButton = ({
   ...props
 }: RefreshButtonProps) => (
   <Button shape="square" aria-label={ariaLabel} {...props}>
-    <ArrowsClockwise
+    <ArrowsClockwiseIcon
       className={cn({
         "animate-refresh": loading,
         "size-4.5": props.size === "base" || !props.size,

--- a/packages/kumo/src/components/checkbox/checkbox.tsx
+++ b/packages/kumo/src/components/checkbox/checkbox.tsx
@@ -281,13 +281,13 @@ const CheckboxBase = forwardRef<HTMLButtonElement, CheckboxProps>(
       >
         <BaseCheckbox.Indicator
           keepMounted
-          className="flex items-center justify-center text-kumo-inverse data-[unchecked]:invisible"
+          className="flex items-center justify-center text-kumo-inverse data-unchecked:invisible"
           render={(renderProps, state) => (
             <span {...renderProps}>
               {state.indeterminate ? (
-                <MinusIcon weight="bold" size={12} />
+                <MinusIcon weight="bold" size="0.85em" />
               ) : (
-                <CheckIcon weight="bold" size={12} />
+                <CheckIcon weight="bold" size="0.85em" />
               )}
             </span>
           )}
@@ -378,13 +378,13 @@ const CheckboxItem = forwardRef<HTMLButtonElement, CheckboxItemProps>(
         >
           <BaseCheckbox.Indicator
             keepMounted
-            className="flex items-center justify-center text-kumo-inverse data-[unchecked]:invisible"
+            className="flex items-center justify-center text-kumo-inverse data-unchecked:invisible"
             render={(renderProps, state) => (
               <span {...renderProps}>
                 {state.indeterminate ? (
-                  <MinusIcon weight="bold" size={12} />
+                  <MinusIcon weight="bold" size="0.85em" />
                 ) : (
-                  <CheckIcon weight="bold" size={12} />
+                  <CheckIcon weight="bold" size="0.85em" />
                 )}
               </span>
             )}

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -161,12 +161,12 @@ const CollapsibleDefaultTrigger = forwardRef<
         // Defensive resets to prevent global button styles from polluting the trigger
         "m-0 border-none bg-transparent p-0 shadow-none",
         // Base styles for the trigger
-        "flex cursor-pointer items-center gap-1 text-sm text-kumo-link select-none",
+        "flex cursor-pointer items-center gap-1 text-base text-kumo-link select-none",
         className,
       )}
     >
       {children}{" "}
-      <CaretDownIcon className="h-4 w-4 transition-transform [[data-panel-open]_&]:rotate-180" />
+      <CaretDownIcon className="h-3.5 w-3.5 transition-transform [[data-panel-open]_&]:rotate-180" />
     </CollapsibleBase.Trigger>
   );
 });

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -166,7 +166,7 @@ const CollapsibleDefaultTrigger = forwardRef<
       )}
     >
       {children}{" "}
-      <CaretDownIcon className="h-3.5 w-3.5 transition-transform [[data-panel-open]_&]:rotate-180" />
+      <CaretDownIcon className="transition-transform in-data-panel-open:rotate-180" />
     </CollapsibleBase.Trigger>
   );
 });

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -291,7 +291,7 @@ function TriggerValue({
           iconStyles.iconRight,
         )}
       >
-        <CaretDownIcon size={iconStyles.iconSize} className="fill-current" />
+        <CaretDownIcon className="fill-current" />
       </ComboboxBase.Icon>
     </ComboboxBase.Trigger>
   );
@@ -388,7 +388,7 @@ function TriggerInput({
           iconStyles.clearRight,
         )}
       >
-        <XIcon size={iconStyles.clearIconSize} />
+        <XIcon />
       </ComboboxBase.Clear>
 
       <ComboboxBase.Trigger
@@ -402,10 +402,7 @@ function TriggerInput({
         )}
       >
         <ComboboxBase.Icon className="flex items-center">
-          <CaretDownIcon
-            size={iconStyles.caretIconSize}
-            className="fill-current"
-          />
+          <CaretDownIcon className="fill-current" />
         </ComboboxBase.Icon>
       </ComboboxBase.Trigger>
     </div>
@@ -531,7 +528,7 @@ function Chip({
           "flex bg-transparent",
         )}
       >
-        <XIcon size={10} />
+        <XIcon size="0.85em" />
       </ComboboxBase.ChipRemove>
     </ComboboxBase.Chip>
   );

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -54,10 +54,10 @@ export type KumoComboboxInputSide =
 export interface KumoComboboxVariantsProps {
   /**
    * Size of the combobox trigger. Matches Input component sizes.
-   * - `"xs"` — Extra small for compact UIs (h-5 / 20px)
-   * - `"sm"` — Small for secondary fields (h-6.5 / 26px)
-   * - `"base"` — Default size (h-9 / 36px)
-   * - `"lg"` — Large for prominent fields (h-10 / 40px)
+   * - `"sm"` — Small for secondary fields (26px tall)
+   * - `"base"` — Default size (32px tall)
+   * - `"lg"` — Large for prominent fields (36px tall)
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
    * @default "base"
    */
   size?: KumoComboboxSize;
@@ -166,6 +166,13 @@ function Root<Value, Multiple extends boolean | undefined = false>({
   error?: string | { message: ReactNode; match: FieldErrorMatch };
   size?: KumoComboboxSize;
 }) {
+  if (process.env.NODE_ENV !== "production" && size === "xs") {
+    console.warn(
+      '[Kumo Combobox]: size="xs" is deprecated. Use size="sm" instead. ' +
+        "The xs size will be removed in a future major version.",
+    );
+  }
+
   const comboboxControl = (
     <ComboboxContext.Provider value={{ size, hasError: Boolean(error) }}>
       <ComboboxBase.Root {...props}>{children}</ComboboxBase.Root>
@@ -251,10 +258,10 @@ const triggerValueIconStyles: Record<
   KumoComboboxSize,
   { padding: string; iconSize: number; iconRight: string }
 > = {
-  xs: { padding: "pr-5", iconSize: 12, iconRight: "right-1" },
-  sm: { padding: "pr-6", iconSize: 14, iconRight: "right-1.5" },
-  base: { padding: "pr-8", iconSize: 16, iconRight: "right-2" },
-  lg: { padding: "pr-10", iconSize: 18, iconRight: "right-3" },
+  xs: { padding: "pr-5", iconSize: 10, iconRight: "right-1" },
+  sm: { padding: "pr-6", iconSize: 12, iconRight: "right-1.5" },
+  base: { padding: "pr-8", iconSize: 14, iconRight: "right-2" },
+  lg: { padding: "pr-10", iconSize: 16, iconRight: "right-3" },
 };
 
 function TriggerValue({
@@ -290,32 +297,47 @@ function TriggerValue({
   );
 }
 
-// Size-dependent styles for TriggerInput icons
+// Size-dependent styles for TriggerInput icons.
+//
+// The clear X icon renders one step smaller than the caret at every size.
+// Phosphor's `XIcon` has two crossed strokes that carry more optical weight
+// than the single-stroke caret at matching numeric sizes, so shrinking the
+// X keeps the two glyphs visually balanced next to each other.
 const triggerInputIconStyles: Record<
   KumoComboboxSize,
-  { padding: string; iconSize: number; clearRight: string; caretRight: string }
+  {
+    padding: string;
+    clearIconSize: number;
+    caretIconSize: number;
+    clearRight: string;
+    caretRight: string;
+  }
 > = {
   xs: {
     padding: "pr-7",
-    iconSize: 12,
+    clearIconSize: 8,
+    caretIconSize: 10,
     clearRight: "right-5",
     caretRight: "right-1",
   },
   sm: {
     padding: "pr-9",
-    iconSize: 14,
+    clearIconSize: 10,
+    caretIconSize: 12,
     clearRight: "right-6",
     caretRight: "right-1.5",
   },
   base: {
     padding: "pr-12",
-    iconSize: 16,
+    clearIconSize: 12,
+    caretIconSize: 14,
     clearRight: "right-8",
     caretRight: "right-2",
   },
   lg: {
     padding: "pr-14",
-    iconSize: 18,
+    clearIconSize: 14,
+    caretIconSize: 16,
     clearRight: "right-9",
     caretRight: "right-3",
   },
@@ -366,7 +388,7 @@ function TriggerInput({
           iconStyles.clearRight,
         )}
       >
-        <XIcon size={iconStyles.iconSize} />
+        <XIcon size={iconStyles.clearIconSize} />
       </ComboboxBase.Clear>
 
       <ComboboxBase.Trigger
@@ -380,7 +402,10 @@ function TriggerInput({
         )}
       >
         <ComboboxBase.Icon className="flex items-center">
-          <CaretDownIcon size={iconStyles.iconSize} className="fill-current" />
+          <CaretDownIcon
+            size={iconStyles.caretIconSize}
+            className="fill-current"
+          />
         </ComboboxBase.Icon>
       </ComboboxBase.Trigger>
     </div>
@@ -516,8 +541,8 @@ function Chip({
 const sizeToMinHeight: Record<KumoComboboxSize, string> = {
   xs: "min-h-5",
   sm: "min-h-6.5",
-  base: "min-h-9",
-  lg: "min-h-10",
+  base: "min-h-8",
+  lg: "min-h-9",
 };
 
 function TriggerMultipleWithInput<ValueType>({

--- a/packages/kumo/src/components/command-palette/command-palette.tsx
+++ b/packages/kumo/src/components/command-palette/command-palette.tsx
@@ -255,7 +255,7 @@ function InputHeader({
     <div className="flex items-center gap-3 bg-kumo-base px-4 py-3 focus-within:ring-2 focus-within:ring-kumo-brand">
       {leading ?? (
         <MagnifyingGlassIcon
-          className="h-4 w-4 text-kumo-subtle"
+          className="text-lg text-kumo-subtle"
           weight="bold"
         />
       )}
@@ -514,7 +514,7 @@ function ResultItem<T>({
                 className="text-base text-kumo-default"
               />
               <CaretRightIcon
-                className="h-3 w-3 flex-shrink-0 text-kumo-subtle"
+                className="flex-shrink-0 text-xs text-kumo-subtle"
                 weight="bold"
               />
             </span>
@@ -525,7 +525,7 @@ function ResultItem<T>({
             className="text-base text-kumo-default"
           />
           {external && (
-            <ArrowSquareOutIcon className="h-3.5 w-3.5 flex-shrink-0 text-kumo-subtle" />
+            <ArrowSquareOutIcon className="text-sm shrink-0 text-kumo-subtle" />
           )}
           {description && (
             <>
@@ -538,7 +538,7 @@ function ResultItem<T>({
         </div>
       </div>
       {showArrow && !external && !nonInteractive && (
-        <ArrowRightIcon className="h-4 w-4 flex-shrink-0 text-kumo-subtle opacity-0 transition-opacity group-data-[highlighted]:opacity-100" />
+        <ArrowRightIcon className="text-base shrink-0 text-kumo-subtle opacity-0 transition-opacity group-data-highlighted:opacity-100" />
       )}
     </Autocomplete.Item>
   );

--- a/packages/kumo/src/components/date-picker/date-picker.tsx
+++ b/packages/kumo/src/components/date-picker/date-picker.tsx
@@ -17,7 +17,7 @@ import { cn } from "../../utils/cn";
  */
 const Chevron: CustomComponents["Chevron"] = ({ orientation, ...props }) => {
   const Icon = orientation === "left" ? CaretLeftIcon : CaretRightIcon;
-  return <Icon size={16} {...props} />;
+  return <Icon size="0.85em" {...props} />;
 };
 
 /** Base props shared across all DatePicker modes */

--- a/packages/kumo/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/kumo/src/components/date-range-picker/date-range-picker.tsx
@@ -277,7 +277,7 @@ export function DateRangePicker({
             className="absolute top-0 left-0 cursor-pointer rounded bg-kumo-interact/85 p-1.5 hover:bg-kumo-interact"
             onClick={() => adjustMonth(-1)}
           >
-            <CaretLeftIcon size={sizeConfig.iconSize} />
+            <CaretLeftIcon />
           </button>
 
           <DateRangeMonthHeader
@@ -378,7 +378,7 @@ export function DateRangePicker({
             className="absolute top-0 right-0 cursor-pointer rounded bg-kumo-interact/85 p-1.5 hover:bg-kumo-interact"
             onClick={() => adjustMonth(1)}
           >
-            <CaretRightIcon size={sizeConfig.iconSize} />
+            <CaretRightIcon />
           </button>
 
           <DateRangeMonthHeader
@@ -650,7 +650,7 @@ function DateRangeFooter({
         sizeConfig.textSize,
       )}
     >
-      <GlobeHemisphereWestIcon size={sizeConfig.iconSize} />
+      <GlobeHemisphereWestIcon />
       <span className="flex-1">Timezone: {timezone}</span>
       <button
         type="button"

--- a/packages/kumo/src/components/dropdown/dropdown.tsx
+++ b/packages/kumo/src/components/dropdown/dropdown.tsx
@@ -81,9 +81,9 @@ const DropdownMenuSubTrigger = React.forwardRef<
     )}
     {...props}
   >
-    {IconComponent && <IconComponent className="mr-2 h-4 w-4" />}
+    {IconComponent && <IconComponent className="mr-2 size-[1.15em]" />}
     {children}
-    <CaretRight className="ml-auto h-4 w-4" />
+    <CaretRight className="ml-auto" />
   </DropdownMenuPrimitive.SubmenuTrigger>
 ));
 
@@ -142,7 +142,7 @@ const renderIconNode = (IconComponent?: Icon | React.ReactNode) => {
   if (!IconComponent) return null;
   if (React.isValidElement(IconComponent)) return IconComponent;
   const Comp = IconComponent as React.ComponentType<Record<string, unknown>>;
-  return <Comp className="mr-2 h-4 w-4" />;
+  return <Comp className="mr-2 size-[1.15em]" />;
 };
 
 /**
@@ -348,7 +348,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     {...props}
   >
     <DropdownMenuPrimitive.CheckboxItemIndicator className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center text-inherit">
-      <CheckIcon weight="bold" size={12} />
+      <CheckIcon weight="bold" size="0.9em" />
     </DropdownMenuPrimitive.CheckboxItemIndicator>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
@@ -435,7 +435,7 @@ const DropdownMenuRadioItemIndicator = React.forwardRef<
     className={cn("ml-auto", className)}
     {...props}
   >
-    {children ?? <Check className="h-4 w-4" />}
+    {children ?? <Check className="size-[1.15em]" />}
   </DropdownMenuPrimitive.RadioItemIndicator>
 ));
 DropdownMenuRadioItemIndicator.displayName = "DropdownMenuRadioItemIndicator";

--- a/packages/kumo/src/components/empty/empty.tsx
+++ b/packages/kumo/src/components/empty/empty.tsx
@@ -137,12 +137,12 @@ export function Empty({
           >
             {emptyStateCopied ? (
               <CheckIcon
-                size={16}
+                size="1.15em"
                 className="animate-bounce-in text-kumo-success"
               />
             ) : (
               <CopyIcon
-                size={16}
+                size="1.15em"
                 className="text-kumo-inactive group-hover:text-kumo-brand"
               />
             )}

--- a/packages/kumo/src/components/input-group/input-group-addon.tsx
+++ b/packages/kumo/src/components/input-group/input-group-addon.tsx
@@ -46,8 +46,8 @@ export const Addon = forwardRef<HTMLDivElement, InputGroupAddonProps>(
       }
       const props = child.props as { size?: unknown };
       if (props.size !== undefined) return child;
-      return cloneElement(child as ReactElement<{ size?: number }>, {
-        size: tokens.iconSize,
+      return cloneElement(child as ReactElement<{ size?: string }>, {
+        size: "1.15em",
       });
     });
 

--- a/packages/kumo/src/components/input-group/input-group-button.tsx
+++ b/packages/kumo/src/components/input-group/input-group-button.tsx
@@ -113,9 +113,7 @@ export const Button = forwardRef<
     // Addon icon sizing (e.g. 18px at "base"). Without this, Button's
     // internal renderIconNode renders `<Icon />` with no size prop,
     // falling back to CSS font-size (~14px).
-    const contextIconSize = context
-      ? INPUT_GROUP_SIZE[context.size ?? "base"].iconSize
-      : undefined;
+    const contextIconSize = context ? "1.15em" : undefined;
 
     const sizedIcon =
       icon &&
@@ -124,7 +122,7 @@ export const Button = forwardRef<
         (typeof icon === "object" &&
           icon !== null &&
           !React.isValidElement(icon)))
-        ? React.createElement(icon as React.ComponentType<{ size?: number }>, {
+        ? React.createElement(icon as React.ComponentType<{ size?: string }>, {
             size: contextIconSize,
           })
         : icon;

--- a/packages/kumo/src/components/input-group/input-group.test.tsx
+++ b/packages/kumo/src/components/input-group/input-group.test.tsx
@@ -557,9 +557,7 @@ describe("InputGroup", () => {
       );
 
       const icon = screen.getByTestId("mock-icon");
-      expect(icon.getAttribute("data-size")).toBe(
-        String(INPUT_GROUP_SIZE.base.iconSize),
-      );
+      expect(icon.getAttribute("data-size")).toBe("1.15em");
     });
 
     it.each(["xs", "sm", "base", "lg"] as const)(
@@ -575,9 +573,7 @@ describe("InputGroup", () => {
         );
 
         const icon = screen.getByTestId("mock-icon");
-        expect(icon.getAttribute("data-size")).toBe(
-          String(INPUT_GROUP_SIZE[groupSize].iconSize),
-        );
+        expect(icon.getAttribute("data-size")).toBe("1.15em");
       },
     );
 

--- a/packages/kumo/src/components/input-group/input-group.tsx
+++ b/packages/kumo/src/components/input-group/input-group.tsx
@@ -29,20 +29,21 @@ export { type InputGroupSuffixProps } from "./input-group-suffix";
 export const KUMO_INPUT_GROUP_VARIANTS = {
   size: {
     xs: {
-      classes: "h-6 text-xs",
-      description: "Extra small size.",
+      classes: "h-5 text-xs",
+      description:
+        "@deprecated Use `size=\"sm\"` instead. The `xs` size will be removed in a future major version.",
     },
     sm: {
-      classes: "h-7 text-xs",
-      description: "Small size.",
+      classes: "h-6.5 text-sm",
+      description: "Small size (26px tall).",
     },
     base: {
-      classes: "h-9 text-base",
-      description: "Default size.",
+      classes: "h-8 text-base",
+      description: "Default size (32px tall).",
     },
     lg: {
-      classes: "h-11 text-base",
-      description: "Large size.",
+      classes: "h-9 text-base",
+      description: "Large size (36px tall).",
     },
   },
 } as const;
@@ -102,6 +103,13 @@ const Root = forwardRef<
   ) => {
     const inputId = useId();
     const focusMode = detectFocusMode(children);
+
+    if (process.env.NODE_ENV !== "production" && size === "xs") {
+      console.warn(
+        '[Kumo InputGroup]: size="xs" is deprecated. Use size="sm" instead. ' +
+          "The xs size will be removed in a future major version.",
+      );
+    }
 
     const contextValue = useMemo(
       () => ({

--- a/packages/kumo/src/components/input/input-area.tsx
+++ b/packages/kumo/src/components/input/input-area.tsx
@@ -174,6 +174,13 @@ export const InputArea = React.forwardRef<HTMLTextAreaElement, InputAreaProps>(
       );
     }
 
+    if (process.env.NODE_ENV !== "production" && size === "xs") {
+      console.warn(
+        '[Kumo InputArea]: size="xs" is deprecated. Use size="sm" instead. ' +
+          "The xs size will be removed in a future major version.",
+      );
+    }
+
     // Auto-apply error styling when error prop is truthy
     // Explicit variant prop takes precedence for backwards compatibility
     const variant = variantProp ?? (error ? "error" : "default");

--- a/packages/kumo/src/components/input/input.test.tsx
+++ b/packages/kumo/src/components/input/input.test.tsx
@@ -59,12 +59,15 @@ describe("Input", () => {
   // Size variants
   it("renders with default size 'base'", () => {
     render(<Input aria-label="Test" />);
-    expect(screen.getByRole("textbox").className).toContain("h-9");
+    expect(screen.getByRole("textbox").className).toContain("h-8");
   });
 
-  it("renders with size 'xs'", () => {
+  it("renders with size 'xs' (deprecated)", () => {
+    // xs is deprecated but still functional; assertion covers the legacy path.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     render(<Input aria-label="Test" size="xs" />);
     expect(screen.getByRole("textbox").className).toContain("h-5");
+    warn.mockRestore();
   });
 
   it("renders with size 'sm'", () => {
@@ -74,7 +77,7 @@ describe("Input", () => {
 
   it("renders with size 'lg'", () => {
     render(<Input aria-label="Test" size="lg" />);
-    expect(screen.getByRole("textbox").className).toContain("h-10");
+    expect(screen.getByRole("textbox").className).toContain("h-9");
   });
 
   // Variant styles
@@ -193,7 +196,7 @@ describe("Input", () => {
 
   it("applies size classes from KUMO_INPUT_VARIANTS", () => {
     const classes = inputVariants({ size: "lg" });
-    expect(classes).toContain("h-10");
+    expect(classes).toContain("h-9");
     expect(classes).toContain("px-4");
   });
 

--- a/packages/kumo/src/components/input/input.tsx
+++ b/packages/kumo/src/components/input/input.tsx
@@ -17,19 +17,20 @@ export const KUMO_INPUT_VARIANTS = {
   size: {
     xs: {
       classes: "h-5 gap-1 rounded-sm px-1.5 text-xs",
-      description: "Extra small input for compact UIs",
+      description:
+        "@deprecated Use `size=\"sm\"` instead. The `xs` size will be removed in a future major version.",
     },
     sm: {
-      classes: "h-6.5 gap-1 rounded-md px-2 text-xs",
-      description: "Small input for secondary fields",
+      classes: "h-6.5 gap-1 rounded-md px-2 text-sm",
+      description: "Small input (26px tall) for secondary fields",
     },
     base: {
-      classes: "h-9 gap-1.5 rounded-lg px-3 text-base",
-      description: "Default input size",
+      classes: "h-8 gap-1.5 rounded-lg px-3 text-base",
+      description: "Default input size (32px tall)",
     },
     lg: {
-      classes: "h-10 gap-2 rounded-lg px-4 text-base",
-      description: "Large input for prominent fields",
+      classes: "h-9 gap-2 rounded-lg px-4 text-base",
+      description: "Large input (36px tall) for prominent fields",
     },
   },
   variant: {
@@ -51,16 +52,16 @@ export const KUMO_INPUT_DEFAULT_VARIANTS = {
 
 export const KUMO_INPUT_STYLING = {
   dimensions: {
-    xs: { height: 20, paddingX: 6, fontSize: 12, borderRadius: 2, width: 160 },
-    sm: { height: 26, paddingX: 8, fontSize: 12, borderRadius: 6, width: 200 },
+    xs: { height: 20, paddingX: 6, fontSize: 11, borderRadius: 2, width: 160 },
+    sm: { height: 26, paddingX: 8, fontSize: 13, borderRadius: 6, width: 200 },
     base: {
-      height: 36,
+      height: 32,
       paddingX: 12,
-      fontSize: 16,
+      fontSize: 13,
       borderRadius: 8,
       width: 280,
     },
-    lg: { height: 40, paddingX: 16, fontSize: 16, borderRadius: 8, width: 320 },
+    lg: { height: 36, paddingX: 16, fontSize: 13, borderRadius: 8, width: 320 },
   },
   baseTokens: {
     background: "color-secondary",
@@ -82,10 +83,10 @@ export type KumoInputVariant = keyof typeof KUMO_INPUT_VARIANTS.variant;
 export interface KumoInputVariantsProps {
   /**
    * Input size.
-   * - `"xs"` — Extra small for compact UIs
-   * - `"sm"` — Small for secondary fields
-   * - `"base"` — Default size
-   * - `"lg"` — Large for prominent fields
+   * - `"sm"` — Small for secondary fields (26px tall)
+   * - `"base"` — Default size (32px tall)
+   * - `"lg"` — Large for prominent fields (36px tall)
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
    * @default "base"
    */
   size?: KumoInputSize;
@@ -157,6 +158,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       '[Kumo Input]: variant="error" is deprecated. ' +
         "Error styling is now automatically applied when the `error` prop is truthy. " +
         "Simply remove the variant prop and pass an error message instead.",
+    );
+  }
+
+  if (process.env.NODE_ENV !== "production" && size === "xs") {
+    console.warn(
+      '[Kumo Input]: size="xs" is deprecated. Use size="sm" instead. ' +
+        "The xs size will be removed in a future major version.",
     );
   }
 

--- a/packages/kumo/src/components/label/label.tsx
+++ b/packages/kumo/src/components/label/label.tsx
@@ -104,7 +104,7 @@ export function Label({
           render={
             <Button
               variant="ghost"
-              size="xs"
+              size="sm"
               shape="square"
               aria-label="More information"
             >

--- a/packages/kumo/src/components/menubar/menubar.tsx
+++ b/packages/kumo/src/components/menubar/menubar.tsx
@@ -55,7 +55,7 @@ const MenuOption = ({
       )}
       onClick={onClick}
     >
-      <IconContext.Provider value={{ size: 18 }} {...({} as any)}>
+      <IconContext.Provider value={{ size: "var(--text-lg)" }} {...({} as any)}>
         {icon}
       </IconContext.Provider>
     </button>

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -267,7 +267,7 @@ function PaginationControls({
                 setEditingPage(1);
               }}
             >
-              <CaretDoubleLeftIcon size={16} />
+              <CaretDoubleLeftIcon />
             </InputGroup.Button>
           )}
           <InputGroup.Button
@@ -280,7 +280,7 @@ function PaginationControls({
               setEditingPage(previousPage);
             }}
           >
-            <CaretLeftIcon size={16} />
+            <CaretLeftIcon />
           </InputGroup.Button>
           {controls === "full" &&
             (pageSelector === "dropdown" ? (
@@ -338,7 +338,7 @@ function PaginationControls({
               setEditingPage(nextPage);
             }}
           >
-            <CaretRightIcon size={16} />
+            <CaretRightIcon />
           </InputGroup.Button>
           {controls === "full" && (
             <InputGroup.Button
@@ -350,7 +350,7 @@ function PaginationControls({
                 setEditingPage(maxPage);
               }}
             >
-              <CaretDoubleRightIcon size={16} />
+              <CaretDoubleRightIcon />
             </InputGroup.Button>
           )}
         </InputGroup>

--- a/packages/kumo/src/components/select/select.test.tsx
+++ b/packages/kumo/src/components/select/select.test.tsx
@@ -5,7 +5,9 @@ import { Select } from "./select";
 
 describe("Select", () => {
   describe("size", () => {
-    it("applies size classes to the trigger", () => {
+    it("applies size classes to the trigger (deprecated xs)", () => {
+      // xs is deprecated but still functional; assertion covers the legacy path.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { container } = render(
         <Select aria-label="Pick one" size="xs">
           <Select.Option value="a">Option A</Select.Option>
@@ -17,6 +19,19 @@ describe("Select", () => {
       expect(trigger?.className).toContain("h-5");
       expect(trigger?.className).toContain("px-1.5");
       expect(trigger?.className).toContain("text-xs");
+      warn.mockRestore();
+    });
+
+    it("applies size classes to the trigger (base)", () => {
+      const { container } = render(
+        <Select aria-label="Pick one" size="base">
+          <Select.Option value="a">Option A</Select.Option>
+        </Select>,
+      );
+
+      const trigger = container.querySelector('[role="combobox"]');
+      expect(trigger?.className).toContain("h-8");
+      expect(trigger?.className).toContain("text-base");
     });
   });
 

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -28,13 +28,13 @@ export const KUMO_SELECT_DEFAULT_VARIANTS = {
  */
 export const KUMO_SELECT_STYLING = {
   trigger: {
-    height: 36, // h-9
+    height: 32, // h-8
     paddingX: 12, // px-3
     borderRadius: 8, // rounded-lg
     background: "bg-kumo-elevated",
     text: "text-color-surface",
     ring: "color-border",
-    fontSize: 16, // text-base
+    fontSize: 13, // text-base
     fontWeight: 400, // font-normal
   },
   stateTokens: {
@@ -42,8 +42,8 @@ export const KUMO_SELECT_STYLING = {
     disabled: { opacity: 0.5 },
   },
   icons: {
-    caret: { name: "ph-caret-up-down", size: 20 },
-    check: { name: "ph-check", size: 20 },
+    caret: { name: "ph-caret-up-down", size: 14 },
+    check: { name: "ph-check", size: 14 },
   },
   popup: {
     background: "bg-kumo-elevated",
@@ -55,7 +55,7 @@ export const KUMO_SELECT_STYLING = {
     paddingX: 8, // px-2
     paddingY: 6, // py-1.5
     borderRadius: 4, // rounded
-    fontSize: 16, // text-base
+    fontSize: 13, // text-base
     highlightBackground: "color-surface-secondary",
   },
 } as const;
@@ -66,10 +66,10 @@ export type KumoSelectSize = keyof typeof KUMO_SELECT_VARIANTS.size;
 export interface KumoSelectVariantsProps {
   /**
    * Size of the select trigger. Matches Input component sizes.
-   * - `"xs"` — Extra small for compact UIs (h-5 / 20px)
-   * - `"sm"` — Small for secondary fields (h-6.5 / 26px)
-   * - `"base"` — Default size (h-9 / 36px)
-   * - `"lg"` — Large for prominent fields (h-10 / 40px)
+   * - `"sm"` — Small for secondary fields (26px tall)
+   * - `"base"` — Default size (32px tall)
+   * - `"lg"` — Large for prominent fields (36px tall)
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
    * @default "base"
    */
   size?: KumoSelectSize;
@@ -89,10 +89,10 @@ const triggerIconStyles: Record<
   KumoInputSize,
   { iconSize: number; className: string }
 > = {
-  xs: { iconSize: 12, className: "text-kumo-subtle" },
-  sm: { iconSize: 14, className: "text-kumo-subtle" },
-  base: { iconSize: 16, className: "text-kumo-subtle" },
-  lg: { iconSize: 18, className: "text-kumo-subtle" },
+  xs: { iconSize: 10, className: "text-kumo-subtle" },
+  sm: { iconSize: 12, className: "text-kumo-subtle" },
+  base: { iconSize: 14, className: "text-kumo-subtle" },
+  lg: { iconSize: 16, className: "text-kumo-subtle" },
 };
 
 /**
@@ -376,6 +376,13 @@ export function Select<T, Multiple extends boolean | undefined = false>({
         "  Migration:\n" +
         '  - For visible labels: <Select label="Country" /> (hideLabel no longer needed)\n' +
         '  - For hidden labels: <Select aria-label="Select a country" /> (remove label and hideLabel)',
+    );
+  }
+
+  if (process.env.NODE_ENV !== "production" && size === "xs") {
+    console.warn(
+      '[Kumo Select]: size="xs" is deprecated. Use size="sm" instead. ' +
+        "The xs size will be removed in a future major version.",
     );
   }
 

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -85,14 +85,11 @@ export function selectVariants({
   );
 }
 
-const triggerIconStyles: Record<
-  KumoInputSize,
-  { iconSize: number; className: string }
-> = {
-  xs: { iconSize: 10, className: "text-kumo-subtle" },
-  sm: { iconSize: 12, className: "text-kumo-subtle" },
-  base: { iconSize: 14, className: "text-kumo-subtle" },
-  lg: { iconSize: 16, className: "text-kumo-subtle" },
+const triggerIconStyles: Record<KumoInputSize, { className: string }> = {
+  xs: { className: "text-kumo-subtle" },
+  sm: { className: "text-kumo-subtle" },
+  base: { className: "text-kumo-subtle" },
+  lg: { className: "text-kumo-subtle" },
 };
 
 /**
@@ -486,10 +483,7 @@ export function Select<T, Multiple extends boolean | undefined = false>({
             triggerIconStyles[size].className,
           )}
         >
-          <CaretUpDownIcon
-            size={triggerIconStyles[size].iconSize}
-            className="fill-current"
-          />
+          <CaretUpDownIcon className="fill-current" />
         </SelectBase.Icon>
       </SelectBase.Trigger>
       <SelectBase.Portal container={container}>

--- a/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
+++ b/packages/kumo/src/components/sensitive-input/sensitive-input.tsx
@@ -421,7 +421,7 @@ export const SensitiveInput = forwardRef<HTMLInputElement, SensitiveInputProps>(
             size === "sm" && "right-2",
             size === "base" && "right-3",
             size === "lg" && "right-4",
-            iconSize,
+            "size-[1.15em]",
             !showEyeButton && "pointer-events-none opacity-0",
           )}
         >

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1014,7 +1014,7 @@ const SidebarGroupLabel = forwardRef<
     <div className="min-h-0 min-w-0">
       <div
         className={cn(
-          "mt-4 mb-2 truncate px-3 text-sm font-medium text-kumo-subtle",
+          "mt-4 mb-2 truncate px-3 text-base font-medium text-kumo-subtle",
           // First group: less top margin
           "[[data-sidebar=group]:first-child_&]:mt-2",
         )}
@@ -1241,8 +1241,8 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
       "group/menu-button relative flex w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg outline-none",
       "before:absolute before:inset-x-0 before:-inset-y-px",
       // Sizing
-      size === "base" && "min-h-8.5 px-3 py-0 text-sm font-medium",
-      size === "sm" && "min-h-7 px-2 py-0 text-sm",
+      size === "base" && "min-h-8.5 px-3 py-0 text-base font-medium",
+      size === "sm" && "min-h-7 px-2 py-0 text-base",
       "text-kumo-default",
       "transition-[color,box-shadow,outline] duration-(--sidebar-animation-duration)",
       !active && "hover:bg-(--sidebar-active-bg)",
@@ -1467,7 +1467,7 @@ const SidebarMenuSubButton = forwardRef<
   const isInsideMenuSubItem = useContext(MenuSubItemContext);
 
   const buttonClasses = cn(
-    "group/menu-button relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-sm font-medium outline-none",
+    "group/menu-button relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-base font-medium outline-none",
     "before:absolute before:inset-x-0 before:-inset-y-px",
     "text-kumo-default transition-[color] duration-150",
     !active && "hover:bg-(--sidebar-active-bg)",

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1201,14 +1201,7 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
       if (!IconProp) return null;
       if (React.isValidElement(IconProp)) return IconProp;
       const Comp = IconProp as React.ComponentType<{ className?: string }>;
-      return (
-        <Comp
-          className={cn(
-            "shrink-0 opacity-40",
-            size === "base" ? "size-4" : "size-3.5",
-          )}
-        />
-      );
+      return <Comp className={cn("shrink-0 opacity-40 size-[1.25em]")} />;
     })();
 
     const content = (
@@ -1355,7 +1348,7 @@ const SidebarMenuBadge = forwardRef<
     data-sidebar="menu-badge"
     className={cn(
       "inline-flex shrink-0 items-center rounded-full border border-dashed border-kumo-line",
-      "px-1.5 py-0.5 text-[11px]/none font-medium text-kumo-strong select-none",
+      "px-1.5 py-0.5 text-xs/none font-medium text-kumo-strong select-none",
       // Hidden when collapsed
       "group-data-[state=collapsed]/sidebar:hidden",
       className,
@@ -2167,7 +2160,7 @@ function SidebarMenuChevron({ className }: { className?: string }) {
 
   return (
     <CaretRightIcon
-      size={12}
+      size="0.9em"
       weight="bold"
       className={cn(
         "ml-auto shrink-0 opacity-40 transition-[transform,rotate,opacity] duration-200 group-hover/menu-button:opacity-100",

--- a/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
+++ b/packages/kumo/src/components/table-of-contents/table-of-contents.tsx
@@ -24,7 +24,7 @@ export type KumoTableOfContentsState =
   keyof typeof KUMO_TABLE_OF_CONTENTS_VARIANTS.state;
 
 const ITEM_BASE =
-  "block w-full truncate border-l-2 border-transparent py-0.5 pl-4 text-sm text-left no-underline";
+  "block w-full truncate border-l-2 border-transparent py-0.5 pl-4 text-base text-left no-underline";
 
 export type TableOfContentsProps = React.HTMLAttributes<HTMLElement>;
 
@@ -186,7 +186,7 @@ const TableOfContentsGroup = forwardRef<
         className={cn("-ml-0.5 flex flex-col gap-2", className)}
         {...props}
       >
-        <p className="py-0.5 pl-4 text-sm leading-5 font-medium text-kumo-subtle">
+        <p className="py-0.5 pl-4 text-base leading-5 font-medium text-kumo-subtle">
           {label}
         </p>
         <ul className={cn(NESTED_UL_CLASSES)}>{children}</ul>

--- a/packages/kumo/src/components/table/table.tsx
+++ b/packages/kumo/src/components/table/table.tsx
@@ -135,7 +135,7 @@ const TableRoot = forwardRef<
     ).classes,
     "[&_td]:border-b [&_td]:border-kumo-fill [&_tr:last-child_td]:border-b-0", // Row border
     "[&_td]:p-3", // Cell padding
-    "[&_th]:border-b [&_th]:border-kumo-fill [&_th]:p-3 [&_th]:text-base [&_th]:font-semibold", // Header styles
+    "[&_th]:border-b [&_th]:border-kumo-fill [&_th]:p-3 [&_th]:text-base [&_th]:font-medium", // Header styles (heading role: 13px medium)
     "[&_th]:bg-kumo-base", // Header background color
     "text-left text-base text-kumo-default",
     props.className,
@@ -159,7 +159,7 @@ const TableHeader = forwardRef<
   const isCompact = variant === "compact";
   const className = cn(
     "group/header",
-    isCompact && "text-xs text-kumo-strong [&_th]:bg-kumo-elevated [&_th]:py-2",
+    isCompact && "text-sm text-kumo-strong [&_th]:bg-kumo-elevated [&_th]:py-2",
     sticky && "[&_th]:sticky [&_th]:top-0 [&_th]:z-1",
     props.className,
   );

--- a/packages/kumo/src/components/text/text.test.tsx
+++ b/packages/kumo/src/components/text/text.test.tsx
@@ -1,15 +1,47 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { render } from "@testing-library/react";
 import { Text } from "./text";
 
 describe("Text", () => {
-  it("renders heading variant with the required `as` element", () => {
+  it("renders display variant with the required `as` element", () => {
     const { container } = render(
-      <Text variant="heading1" as="h1">
-        Page Title
+      <Text variant="display" as="h1">
+        Welcome
       </Text>,
     );
     expect(container.querySelector("h1")).toBeTruthy();
+  });
+
+  it("renders page-title variant", () => {
+    const { container } = render(
+      <Text variant="page-title" as="h1">
+        Account settings
+      </Text>,
+    );
+    expect(container.querySelector("h1")).toBeTruthy();
+    expect(container.querySelector("h1")?.className).toContain("text-xl");
+  });
+
+  it("renders section-title variant", () => {
+    const { container } = render(
+      <Text variant="section-title" as="h2">
+        General
+      </Text>,
+    );
+    expect(container.querySelector("h2")).toBeTruthy();
+    expect(container.querySelector("h2")?.className).toContain("text-lg");
+  });
+
+  it("renders heading variant (the small inline one)", () => {
+    const { container } = render(
+      <Text variant="heading" as="h3">
+        API tokens
+      </Text>,
+    );
+    const el = container.querySelector("h3");
+    expect(el).toBeTruthy();
+    expect(el?.className).toContain("text-base");
+    expect(el?.className).toContain("font-medium");
   });
 
   it("renders body variant as <p> by default", () => {
@@ -29,7 +61,7 @@ describe("Text", () => {
 
   it("allows heading variants to opt out of semantic heading via as='span'", () => {
     const { container } = render(
-      <Text variant="heading2" as="span">
+      <Text variant="page-title" as="span">
         Decorative big text
       </Text>,
     );
@@ -69,6 +101,82 @@ describe("Text", () => {
       </Text>,
     );
     expect(container.querySelector("pre")).toBeTruthy();
+  });
+
+  describe("deprecated heading aliases", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("heading1 still renders (same classes as display) and warns", () => {
+      const { container } = render(
+        <Text variant="heading1" as="h1">
+          Legacy
+        </Text>,
+      );
+      const el = container.querySelector("h1");
+      expect(el).toBeTruthy();
+      expect(el?.className).toContain("text-2xl");
+      expect(el?.className).toContain("font-semibold");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('variant="heading1" is deprecated'),
+      );
+    });
+
+    it("heading2 warns and maps to page-title classes", () => {
+      const { container } = render(
+        <Text variant="heading2" as="h2">
+          Legacy
+        </Text>,
+      );
+      const el = container.querySelector("h2");
+      expect(el?.className).toContain("text-xl");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("page-title"),
+      );
+    });
+
+    it("heading3 warns and maps to section-title classes", () => {
+      const { container } = render(
+        <Text variant="heading3" as="h3">
+          Legacy
+        </Text>,
+      );
+      const el = container.querySelector("h3");
+      expect(el?.className).toContain("text-lg");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("section-title"),
+      );
+    });
+  });
+
+  describe("bold prop", () => {
+    it("applies font-medium on default body variant", () => {
+      const { container } = render(<Text bold>Bumped</Text>);
+      expect(container.querySelector("p")?.className).toContain("font-medium");
+    });
+
+    it("applies font-medium on secondary variant", () => {
+      const { container } = render(
+        <Text variant="secondary" bold>
+          Bumped
+        </Text>,
+      );
+      expect(container.querySelector("p")?.className).toContain("font-medium");
+    });
+
+    it("does not apply font-medium when bold is falsy", () => {
+      const { container } = render(<Text>Plain</Text>);
+      expect(container.querySelector("p")?.className).not.toContain(
+        "font-medium",
+      );
+    });
   });
 
   // Type-level enforcement of the required `as` prop for heading variants

--- a/packages/kumo/src/components/text/text.tsx
+++ b/packages/kumo/src/components/text/text.tsx
@@ -9,20 +9,52 @@ import {
 import { cn } from "../../utils/cn";
 import { resolveVariant } from "../../utils/resolve-variant";
 
-/** Text variant and size definitions mapping names to their Tailwind classes. */
+/**
+ * Text variant and size definitions mapping names to their Tailwind classes.
+ *
+ * Heading variants are role-based:
+ *   display        24px semibold — hero / prominent moments
+ *   page-title     19px medium   — the single title of a page or dialog
+ *   section-title  15px medium   — card / panel / section headings
+ *   heading        13px medium   — inline / row / list-item headings
+ *
+ * `heading1`, `heading2`, `heading3` are retained as deprecated aliases of
+ * `display`, `page-title`, `section-title` respectively.
+ *
+ * Sizes: sm=12px, base=13px (default). `xs` and `lg` are deprecated.
+ */
 export const KUMO_TEXT_VARIANTS = {
   variant: {
+    display: {
+      classes: "text-2xl font-semibold",
+      description: "Display heading — hero / prominent moments (24px semibold)",
+    },
+    "page-title": {
+      classes: "text-xl font-medium",
+      description: "Page or dialog title (19px medium)",
+    },
+    "section-title": {
+      classes: "text-lg font-medium",
+      description: "Card / panel / section heading (15px medium)",
+    },
+    heading: {
+      classes: "text-base font-medium",
+      description:
+        "Inline / row / list-item heading (13px medium). The small, most-used heading.",
+    },
+    // Deprecated aliases — kept for backwards compatibility. Emit a runtime
+    // warning in dev when used. Same classes as their replacements.
     heading1: {
-      classes: "text-3xl font-semibold",
-      description: "Large heading for page titles",
+      classes: "text-2xl font-semibold",
+      description: "@deprecated Use variant=\"display\" instead.",
     },
     heading2: {
-      classes: "text-2xl font-semibold",
-      description: "Medium heading for section titles",
+      classes: "text-xl font-medium",
+      description: "@deprecated Use variant=\"page-title\" instead.",
     },
     heading3: {
-      classes: "text-lg font-semibold",
-      description: "Small heading for subsections",
+      classes: "text-lg font-medium",
+      description: "@deprecated Use variant=\"section-title\" instead.",
     },
     body: {
       classes: "text-kumo-default",
@@ -50,21 +82,26 @@ export const KUMO_TEXT_VARIANTS = {
     },
   },
   size: {
-    xs: {
-      classes: "text-xs",
-      description: "Extra small text",
-    },
     sm: {
       classes: "text-sm",
-      description: "Small text",
+      description: "Small (12px) — caption / helper text",
     },
     base: {
       classes: "text-base",
-      description: "Default text size",
+      description: "Default body size (13px)",
+    },
+    // Deprecated sizes — kept for backwards compatibility. Emit a runtime
+    // warning in dev when used. Same classes as before to avoid layout
+    // shifts on existing usages.
+    xs: {
+      classes: "text-xs",
+      description:
+        '@deprecated Use `size="sm"` instead. The `xs` size will be removed in a future major version.',
     },
     lg: {
       classes: "text-lg",
-      description: "Large text",
+      description:
+        '@deprecated Use `size="base"` instead. The `lg` size will be removed in a future major version.',
     },
   },
 } as const;
@@ -75,24 +112,22 @@ export const KUMO_TEXT_DEFAULT_VARIANTS = {
 } as const;
 
 /**
- * KUMO_TEXT_STYLING - Typography metadata for Figma generator
+ * KUMO_TEXT_STYLING - Typography metadata for Figma generator.
  *
- * This export provides structured styling information extracted from text.tsx
- * for use by the Figma plugin generator. It documents font sizes, weights,
- * colors, and font families used across all Text variants.
+ * Documents the actual pixel sizes and weights emitted by each token so the
+ * Figma plugin can generate matching styles.
  *
  * Source of truth chain:
  * text.tsx (this file) → component-registry.json → text.ts (Figma generator)
  */
 export const KUMO_TEXT_STYLING = {
   fontSizes: {
-    xs: 12,
-    sm: 14,
-    base: 16,
-    lg: 18,
-    xl: 20,
+    xs: 11,
+    sm: 12,
+    base: 13,
+    lg: 15,
+    xl: 17,
     "2xl": 24,
-    "3xl": 30,
   },
   fontWeights: {
     normal: 400,
@@ -141,12 +176,31 @@ export function textVariants({
   );
 }
 
-// Legacy types for backwards compatibility
-type Heading = "heading1" | "heading2" | "heading3";
+// Heading variants (role-based) + deprecated numeric aliases.
+type HeadingRole = "display" | "page-title" | "section-title" | "heading";
+type HeadingDeprecated = "heading1" | "heading2" | "heading3";
+type Heading = HeadingRole | HeadingDeprecated;
 type Copy = "body" | "secondary" | "success" | "error";
 type Monospace = "mono" | "mono-secondary";
 type TextSize = KumoTextSize;
 type TextVariant = KumoTextVariant;
+
+/** Map deprecated heading variant names to their replacements. */
+const DEPRECATED_HEADING_MAP: Record<HeadingDeprecated, HeadingRole> = {
+  heading1: "display",
+  heading2: "page-title",
+  heading3: "section-title",
+};
+
+const HEADING_VARIANTS = new Set<string>([
+  "display",
+  "page-title",
+  "section-title",
+  "heading",
+  "heading1",
+  "heading2",
+  "heading3",
+]);
 
 /** Valid HTML elements for the Text component's `as` prop. */
 export type TextElement =
@@ -184,8 +238,15 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
   (Variant extends Copy
     ? {
         variant?: Variant;
-        bold?: boolean;
         size?: TextSize;
+        /**
+         * Bumps the weight of body copy to `font-medium` (500). Only
+         * applies to copy variants (`body`, `secondary`, `success`,
+         * `error`); heading variants already carry their role's weight.
+         * For structural hierarchy inside a document outline reach for
+         * `variant="heading"` instead; `bold` is for inline emphasis.
+         */
+        bold?: boolean;
         truncate?: boolean;
         /** Optional element override. Defaults to `<p>`. */
         as?: TextElement;
@@ -193,8 +254,9 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
     : Variant extends Monospace
       ? {
           variant?: Variant;
-          bold?: never;
+          /** @deprecated `size="lg"` is deprecated. Monospace text always renders at 12px. */
           size?: "lg";
+          bold?: never;
           truncate?: boolean;
           /** Optional element override. Defaults to `<span>`. */
           as?: TextElement;
@@ -202,18 +264,14 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
       : Variant extends Heading
         ? {
             variant: Variant;
-            bold?: never;
             size?: never;
+            bold?: never;
             truncate?: boolean;
             /**
              * Required for heading variants. Pick the element that reflects
              * this text's place in the document outline (`"h1"` for a page
              * title, `"h2"` for a section title, etc.) or `"span"` for
              * decorative heading-styled text that is NOT a section heading.
-             *
-             * Previously optional (defaulted to `<span>`), which silently
-             * excluded real section headings from the document outline.
-             * Making it required surfaces the decision at the type level.
              */
             as: TextElement;
           }
@@ -224,7 +282,10 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
  *
  * @example
  * ```tsx
- * <Text variant="heading1" as="h1">Page Title</Text>
+ * <Text variant="display" as="h1">Welcome</Text>
+ * <Text variant="page-title" as="h1">Account settings</Text>
+ * <Text variant="section-title" as="h2">General</Text>
+ * <Text variant="heading" as="h3">API tokens</Text>
  * <Text variant="body">Default paragraph text.</Text>
  * <Text variant="secondary" size="sm">Muted helper text</Text>
  * <Text variant="error">Something went wrong</Text>
@@ -233,29 +294,47 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
  */
 export interface TextProps {
   /**
-   * Text style variant. Determines color, font, and weight.
-   * - `"heading1"` — Large page title (30px, semibold)
-   * - `"heading2"` — Section title (24px, semibold)
-   * - `"heading3"` — Subsection title (18px, semibold)
-   * - `"body"` — Default body text
+   * Text style variant.
+   *
+   * Heading variants (role-based, weight-first hierarchy):
+   * - `"display"` — Hero / prominent moments (24px semibold)
+   * - `"page-title"` — The single title of a page or dialog (19px medium)
+   * - `"section-title"` — Card / panel / section heading (15px medium)
+   * - `"heading"` — Inline / row / list-item heading (13px medium)
+   *
+   * Body variants:
+   * - `"body"` — Default body text (13px)
    * - `"secondary"` — Muted text for secondary information
    * - `"success"` — Success state text
    * - `"error"` — Error state text
    * - `"mono"` — Monospace text for code
    * - `"mono-secondary"` — Muted monospace text
+   *
+   * Deprecated (use the role-based names above):
+   * - `"heading1"` → use `"display"`
+   * - `"heading2"` → use `"page-title"`
+   * - `"heading3"` → use `"section-title"`
+   *
    * @default "body"
    */
   variant?: KumoTextVariant;
   /**
    * Text size (only applies to body/secondary/success/error variants).
-   * - `"xs"` — 12px
-   * - `"sm"` — 14px
-   * - `"base"` — 16px
-   * - `"lg"` — 18px
+   * - `"sm"` — 12px (caption / helper text)
+   * - `"base"` — 13px (default body)
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
+   * - `"lg"` — **Deprecated.** Use `"base"` instead.
    * @default "base"
    */
   size?: KumoTextSize;
-  /** Whether to use bold font weight (only applies to body variants). */
+  /**
+   * Bumps body copy weight to `font-medium` (500). Only applies to copy
+   * variants (`body`, `secondary`, `success`, `error`); heading variants
+   * already carry their role's weight and disallow this prop at the type
+   * level. For structural hierarchy inside a document outline reach for
+   * `variant="heading"` instead — `bold` is for inline emphasis.
+   * @default false
+   */
   bold?: boolean;
   /** Whether to truncate overflowing text with an ellipsis. Adds `truncate min-w-0` classes. */
   truncate?: boolean;
@@ -265,10 +344,10 @@ export interface TextProps {
    * `"small"`, `"abbr"`, `"time"`), form-related (`"label"`, `"legend"`),
    * list/definition (`"dt"`, `"dd"`, `"li"`), and `"figcaption"`.
    *
-   * - **Required** for heading variants (`"heading1"`, `"heading2"`,
-   *   `"heading3"`) — pick the element that reflects this text's place in
-   *   the document outline, or `"span"` for decorative heading-styled text
-   *   that is not a section heading.
+   * - **Required** for heading variants (`"display"`, `"page-title"`,
+   *   `"section-title"`, `"heading"`) — pick the element that reflects this
+   *   text's place in the document outline, or `"span"` for decorative
+   *   heading-styled text that is not a section heading.
    * - **Optional** for body variants (defaults to `"p"`) and monospace
    *   variants (defaults to `"span"`).
    */
@@ -284,16 +363,18 @@ export interface TextProps {
  *
  * @example
  * ```tsx
- * <Text variant="heading1" as="h1">Page Title</Text>
- * <Text variant="heading2" as="h2">Section Title</Text>
+ * <Text variant="display" as="h1">Welcome</Text>
+ * <Text variant="page-title" as="h1">Account settings</Text>
+ * <Text variant="section-title" as="h2">General</Text>
+ * <Text variant="heading" as="h3">API tokens</Text>
  * <Text>Default body text</Text>
  * ```
  */
 function _Text<Variant extends TextVariant = "body">(
   {
     variant = "body" as Variant,
-    bold = false,
     size = "base",
+    bold,
     truncate = false,
     children,
     DANGEROUS_className,
@@ -306,16 +387,42 @@ function _Text<Variant extends TextVariant = "body">(
   const isCopy = ["body", "secondary", "success", "error"].includes(variant);
   const isMono = ["mono", "mono-secondary"].includes(variant);
 
+  // Deprecation warning for legacy heading variant names.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    (variant === "heading1" || variant === "heading2" || variant === "heading3")
+  ) {
+    const replacement = DEPRECATED_HEADING_MAP[variant];
+    console.warn(
+      `[Kumo Text]: variant="${variant}" is deprecated. Use variant="${replacement}" instead.`,
+    );
+  }
+
+  // Deprecation warnings for legacy sizes on Copy variants.
+  // Mono variants intentionally still accept `size="lg"` as a step-up hint
+  // but render at the same 12px — no warning there.
+  if (process.env.NODE_ENV !== "production" && isCopy) {
+    if (size === "xs") {
+      console.warn(
+        '[Kumo Text]: size="xs" is deprecated. Use size="sm" instead. The xs size will be removed in a future major version.',
+      );
+    } else if (size === "lg") {
+      console.warn(
+        '[Kumo Text]: size="lg" is deprecated. Use size="base" instead. The lg size will be removed in a future major version.',
+      );
+    }
+  }
+
   // Heading variants no longer auto-select h1/h2/h3 to avoid coupling visual
   // presentation to semantic HTML. Use the `as` prop to set the appropriate
   // heading level for your document outline (e.g., as="h2").
   const Component = useMemo(() => {
     if (as) return as;
-    if (["mono", "mono-secondary"].includes(variant)) return "span";
-    // Headings and body text default to span; use `as` for semantic elements
-    if (["heading1", "heading2", "heading3"].includes(variant)) return "span";
+    if (isMono) return "span";
+    // Headings default to span; use `as` for semantic elements
+    if (HEADING_VARIANTS.has(variant)) return "span";
     return "p";
-  }, [variant, as]);
+  }, [variant, as, isMono]);
 
   return (
     <Component
@@ -337,12 +444,13 @@ function _Text<Variant extends TextVariant = "body">(
               KUMO_TEXT_DEFAULT_VARIANTS.size,
             ).classes
           : "",
-        isCopy && bold ? "font-medium" : "",
-        // Monospace fonts need to be 1pt smaller than body text to optically match
-        isMono &&
-          (size === "lg"
-            ? KUMO_TEXT_VARIANTS.size.base.classes
-            : KUMO_TEXT_VARIANTS.size.sm.classes),
+        // Monospace fonts render one size step down from body text so they
+        // optically match — always text-sm (12px).
+        isMono && KUMO_TEXT_VARIANTS.size.sm.classes,
+        // `bold` on copy variants bumps body copy from the default 400 to
+        // font-medium (500). Type-narrowed to `never` on headings and mono,
+        // so this only ever fires on copy.
+        isCopy && bold && "font-medium",
         truncate && "min-w-0 truncate",
         DANGEROUS_className,
       )}

--- a/packages/kumo/src/components/text/text.type-spec.tsx
+++ b/packages/kumo/src/components/text/text.type-spec.tsx
@@ -18,7 +18,29 @@ import { Text } from "./text";
 // Positive cases — these MUST compile cleanly.
 // ---------------------------------------------------------------------------
 
-// Heading variant with required `as`.
+// Role-based heading variants with required `as`.
+const _display = (
+  <Text variant="display" as="h1">
+    Welcome
+  </Text>
+);
+const _pageTitle = (
+  <Text variant="page-title" as="h1">
+    Account settings
+  </Text>
+);
+const _sectionTitle = (
+  <Text variant="section-title" as="h2">
+    General
+  </Text>
+);
+const _heading = (
+  <Text variant="heading" as="h3">
+    API tokens
+  </Text>
+);
+
+// Deprecated numeric aliases still compile (soft deprecation).
 const _headingH1 = (
   <Text variant="heading1" as="h1">
     Page Title
@@ -37,7 +59,7 @@ const _headingH3 = (
 
 // Heading variant using `as="span"` for decorative (non-section) usage.
 const _decorativeHeading = (
-  <Text variant="heading1" as="span">
+  <Text variant="display" as="span">
     Big bold label
   </Text>
 );
@@ -90,7 +112,7 @@ const _small = (
 );
 const _time = <Text as="time">2026-04-27</Text>;
 const _headingAsLabel = (
-  <Text variant="heading2" as="label">
+  <Text variant="page-title" as="label">
     Form heading
   </Text>
 );
@@ -101,21 +123,80 @@ const _headingAsLabel = (
 // tsc itself fails the typecheck with "Unused '@ts-expect-error' directive".
 // ---------------------------------------------------------------------------
 
-// Missing `as` on heading1 → type error.
+// Missing `as` on new role-based heading variants → type error.
+// @ts-expect-error — heading variants require `as`
+const _missingAsDisplay = <Text variant="display">Missing as</Text>;
+// @ts-expect-error — heading variants require `as`
+const _missingAsPageTitle = <Text variant="page-title">Missing as</Text>;
+// @ts-expect-error — heading variants require `as`
+const _missingAsSectionTitle = <Text variant="section-title">Missing as</Text>;
+// @ts-expect-error — heading variants require `as`
+const _missingAsHeading = <Text variant="heading">Missing as</Text>;
+
+// Missing `as` on deprecated aliases still errors.
 // @ts-expect-error — heading variants require `as`
 const _missingAsH1 = <Text variant="heading1">Missing as</Text>;
-
-// Missing `as` on heading2 → type error.
 // @ts-expect-error — heading variants require `as`
 const _missingAsH2 = <Text variant="heading2">Missing as</Text>;
-
-// Missing `as` on heading3 → type error.
 // @ts-expect-error — heading variants require `as`
 const _missingAsH3 = <Text variant="heading3">Missing as</Text>;
+
+// `bold` prop is allowed on copy variants (body, secondary, success, error)
+// where it bumps weight to font-medium. Reject on headings (already carry
+// their role's weight) and mono (design decision — mono stays regular).
+const _boldBody = <Text bold>Bold body</Text>;
+const _boldSecondary = (
+  <Text variant="secondary" bold>
+    Bold secondary
+  </Text>
+);
+const _boldSuccess = (
+  <Text variant="success" bold>
+    Bold success
+  </Text>
+);
+const _boldError = (
+  <Text variant="error" bold>
+    Bold error
+  </Text>
+);
+const _boldHeading = (
+  <Text
+    variant="heading"
+    as="h3"
+    // @ts-expect-error — bold is disallowed on heading variants; already medium/semibold
+    bold
+  >
+    Bold heading
+  </Text>
+);
+const _boldSectionTitle = (
+  <Text
+    variant="section-title"
+    as="h2"
+    // @ts-expect-error — bold is disallowed on section-title
+    bold
+  >
+    Bold section title
+  </Text>
+);
+const _boldMono = (
+  <Text
+    variant="mono"
+    // @ts-expect-error — bold is disallowed on mono
+    bold
+  >
+    Bold mono
+  </Text>
+);
 
 // Silence unused-variable warnings for all the sentinels above.
 // This file is never executed; it exists purely for type checking.
 export const __typeSpec = {
+  _display,
+  _pageTitle,
+  _sectionTitle,
+  _heading,
   _headingH1,
   _headingH2,
   _headingH3,
@@ -141,7 +222,18 @@ export const __typeSpec = {
   _small,
   _time,
   _headingAsLabel,
+  _missingAsDisplay,
+  _missingAsPageTitle,
+  _missingAsSectionTitle,
+  _missingAsHeading,
   _missingAsH1,
   _missingAsH2,
   _missingAsH3,
+  _boldBody,
+  _boldSecondary,
+  _boldSuccess,
+  _boldError,
+  _boldHeading,
+  _boldSectionTitle,
+  _boldMono,
 };

--- a/packages/kumo/src/components/toast/toast.tsx
+++ b/packages/kumo/src/components/toast/toast.tsx
@@ -214,7 +214,8 @@ function wrapManagerMethods<
     add: (options: KumoToastManagerAddOptions<any>) => {
       if (options.id) {
         const toasts = (manager as any).toasts as
-          Array<ToastObject<any>> | undefined;
+          | Array<ToastObject<any>>
+          | undefined;
 
         if (toasts) {
           const existingToast = toasts.find((toast) => toast.id === options.id);
@@ -399,7 +400,7 @@ function ToastList() {
                 "absolute top-2 right-2 size-5 rounded text-kumo-subtle hover:bg-current/15",
                 toast.variant && TOAST_CLOSE_CLASSES[toast.variant],
               )}
-              icon={<XIcon className="h-3 w-3" />}
+              icon={<XIcon />}
             />
           }
         />
@@ -443,7 +444,5 @@ function ToastIcon({ variant }: { variant?: KumoToastVariant }) {
   );
   if (!("icon" in variantConfig)) return null;
   const Icon = variantConfig.icon;
-  return (
-    <Icon data-toast-icon className="mt-0.5 h-4 w-4 shrink-0" weight="fill" />
-  );
+  return <Icon data-toast-icon className="mt-0.5 shrink-0" weight="fill" />;
 }

--- a/packages/kumo/src/components/toast/toast.tsx
+++ b/packages/kumo/src/components/toast/toast.tsx
@@ -30,12 +30,13 @@ export const KUMO_TOAST_VARIANTS = {
     description: "Toast container with background, border, and shadow",
   },
   title: {
-    classes: "text-[0.975rem] leading-5 font-medium text-kumo-default",
-    description: "Toast title with primary text color",
+    classes: "text-lg leading-5 font-medium text-kumo-default",
+    description:
+      "Toast title — role: section-title (15px medium). Pairs with body-lg description.",
   },
   description: {
-    classes: "text-[0.925rem] leading-5 text-kumo-subtle",
-    description: "Toast description with muted text color",
+    classes: "text-lg leading-5 text-kumo-subtle",
+    description: "Toast description — body-lg (15px regular), muted color.",
   },
   close: {
     classes:
@@ -93,7 +94,7 @@ export const KUMO_TOAST_STYLING = {
     gap: 4,
   },
   title: {
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: 500,
     color: "text-color-surface",
   },
@@ -370,9 +371,9 @@ function ToastList() {
               <div className="flex flex-col gap-1 overflow-hidden">
                 <Toast.Title
                   data-toast-title
-                  className="text-[0.975rem] leading-5 font-medium text-kumo-default"
+                  className="text-lg leading-5 font-medium text-kumo-default"
                 />
-                <Toast.Description className="text-[0.925rem] leading-5 text-kumo-default/70" />
+                <Toast.Description className="text-lg leading-5 text-kumo-default/70" />
 
                 {!!toast.actions && (
                   <div className="mt-2 flex min-w-0 flex-nowrap gap-2 overflow-x-auto p-px">

--- a/packages/kumo/src/components/toolbar/toolbar.test.tsx
+++ b/packages/kumo/src/components/toolbar/toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Input } from "../input/input";
@@ -19,7 +19,7 @@ describe("Toolbar", () => {
 
     expect(toolbarInput.className).toContain("h-6.5");
     expect(toolbarInput.className).toContain("rounded-none");
-    expect(directInput.className).toContain("h-10");
+    expect(directInput.className).toContain("h-9");
     expect(directInput.className).not.toContain("rounded-none");
   });
 
@@ -93,5 +93,47 @@ describe("Toolbar", () => {
 
     await user.keyboard("{ArrowRight}");
     expect(document.activeElement).toBe(visit);
+  });
+
+  describe("deprecated xs size", () => {
+    it("emits a single deprecation warning at the Toolbar level", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      render(
+        <Toolbar size="xs">
+          <Toolbar.Input aria-label="Toolbar input" />
+        </Toolbar>,
+      );
+
+      const toolbarWarnings = warn.mock.calls.filter((args) =>
+        String(args[0]).includes('[Kumo Toolbar]: size="xs" is deprecated'),
+      );
+      expect(toolbarWarnings).toHaveLength(1);
+      warn.mockRestore();
+    });
+
+    it("does not emit child Button/Input xs deprecation warnings (remapped to sm)", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      render(
+        <Toolbar size="xs">
+          <Toolbar.Input aria-label="Toolbar input" />
+          <Toolbar.Button aria-label="Action">A</Toolbar.Button>
+        </Toolbar>,
+      );
+
+      const childWarnings = warn.mock.calls.filter((args) => {
+        const msg = String(args[0]);
+        return (
+          msg.includes('[Kumo Button]: size="xs" is deprecated') ||
+          msg.includes('[Kumo Input]: size="xs" is deprecated')
+        );
+      });
+      expect(childWarnings).toHaveLength(0);
+
+      // Child Input should render at sm height (26px), not xs (20px).
+      const input = screen.getByRole("textbox", { name: "Toolbar input" });
+      expect(input.className).toContain("h-6.5");
+      expect(input.className).not.toContain("h-5");
+      warn.mockRestore();
+    });
   });
 });

--- a/packages/kumo/src/components/toolbar/toolbar.tsx
+++ b/packages/kumo/src/components/toolbar/toolbar.tsx
@@ -15,10 +15,11 @@ export const KUMO_TOOLBAR_VARIANTS = {
   size: {
     xs: {
       classes: "text-xs",
-      description: "Extra small toolbar for compact UIs",
+      description:
+        '@deprecated Use `size="sm"` instead. Toolbar `xs` warns once at the Toolbar level and remaps to `sm` internally, so child Button/Input never see the deprecated size.',
     },
     sm: {
-      classes: "text-xs",
+      classes: "text-sm",
       description: "Small toolbar for secondary controls",
     },
     base: {
@@ -41,7 +42,14 @@ export type ToolbarSize = keyof typeof KUMO_TOOLBAR_VARIANTS.size;
 export interface ToolbarProps extends Omit<ToolbarBase.Root.Props, "children"> {
   /** Toolbar controls rendered as one grouped card. */
   children: React.ReactNode;
-  /** Locks every toolbar item to this size. */
+  /**
+   * Locks every toolbar item to this size.
+   * - `"sm"` — Small toolbar for secondary controls
+   * - `"base"` — Default toolbar size
+   * - `"lg"` — Large toolbar for prominent controls
+   * - `"xs"` — **Deprecated.** Use `"sm"` instead.
+   * @default "base"
+   */
   size?: ToolbarSize;
 }
 
@@ -101,6 +109,18 @@ const Root = React.forwardRef<HTMLDivElement, ToolbarProps>(
     },
     ref,
   ) => {
+    if (process.env.NODE_ENV !== "production" && size === "xs") {
+      console.warn(
+        '[Kumo Toolbar]: size="xs" is deprecated. Use size="sm" instead. ' +
+          "The xs size will be removed in a future major version.",
+      );
+    }
+
+    // Remap deprecated `xs` to `sm` internally so child Button/Input/InputGroup
+    // don't emit their own duplicate deprecation warnings. Toolbar renders the
+    // single, coherent warning above; children receive the migrated value.
+    const forwardedSize = size === "xs" ? "sm" : size;
+
     return (
       <ToolbarBase.Root
         ref={ref}
@@ -112,7 +132,7 @@ const Root = React.forwardRef<HTMLDivElement, ToolbarProps>(
         )}
         {...props}
       >
-        <ToolbarSizeContext.Provider value={{ size }}>
+        <ToolbarSizeContext.Provider value={{ size: forwardedSize }}>
           {children}
         </ToolbarSizeContext.Provider>
       </ToolbarBase.Root>

--- a/packages/kumo/src/primitives/index.ts
+++ b/packages/kumo/src/primitives/index.ts
@@ -37,10 +37,7 @@ export * from "@base-ui/react/meter";
 export * from "@base-ui/react/navigation-menu";
 export * from "@base-ui/react/number-field";
 export * from "@base-ui/react/otp-field";
-export {
-  OTPField,
-  OTPField as OTPFieldPreview,
-} from "@base-ui/react/otp-field";
+export { OTPField, OTPField as OTPFieldPreview } from "@base-ui/react/otp-field";
 export * from "@base-ui/react/popover";
 export * from "@base-ui/react/preview-card";
 export * from "@base-ui/react/progress";

--- a/packages/kumo/src/primitives/otp-field.ts
+++ b/packages/kumo/src/primitives/otp-field.ts
@@ -11,7 +11,4 @@
  */
 
 export * from "@base-ui/react/otp-field";
-export {
-  OTPField,
-  OTPField as OTPFieldPreview,
-} from "@base-ui/react/otp-field";
+export { OTPField, OTPField as OTPFieldPreview } from "@base-ui/react/otp-field";

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -282,11 +282,11 @@
   --text-xs: calc(11px * var(--font-scale, 1));
   --text-xs--line-height: 1.4;
   --text-sm: calc(12px * var(--font-scale, 1));
-  --text-sm--line-height: 1.45;
+  --text-sm--line-height: 1.35;
   --text-base: calc(13px * var(--font-scale, 1));
-  --text-base--line-height: 1.5;
+  --text-base--line-height: 1.4;
   --text-lg: calc(15px * var(--font-scale, 1));
-  --text-lg--line-height: 1.5;
+  --text-lg--line-height: 1.45;
   --text-xl: calc(19px * var(--font-scale, 1));
   --text-xl--line-height: 1.4;
   --text-2xl: calc(24px * var(--font-scale, 1));

--- a/packages/kumo/src/styles/theme-kumo.css
+++ b/packages/kumo/src/styles/theme-kumo.css
@@ -279,14 +279,18 @@
 
 @theme {
   /* Typography - text sizes and line heights */
-  --text-xs: 12px;
-  --text-xs--line-height: calc(1 / 0.75);
-  --text-sm: 13px;
-  --text-sm--line-height: calc(1 / 0.85);
-  --text-base: 14px;
+  --text-xs: calc(11px * var(--font-scale, 1));
+  --text-xs--line-height: 1.4;
+  --text-sm: calc(12px * var(--font-scale, 1));
+  --text-sm--line-height: 1.45;
+  --text-base: calc(13px * var(--font-scale, 1));
   --text-base--line-height: 1.5;
-  --text-lg: 16px;
+  --text-lg: calc(15px * var(--font-scale, 1));
   --text-lg--line-height: 1.5;
+  --text-xl: calc(19px * var(--font-scale, 1));
+  --text-xl--line-height: 1.4;
+  --text-2xl: calc(24px * var(--font-scale, 1));
+  --text-2xl--line-height: 1.3;
 }
 
 @layer base {


### PR DESCRIPTION
## Font scale refresh 

**Body baseline moves 14px → 13px.** `text-sm` was the de-facto default across the library and downstream usage; renaming so the most-used size is called `base`. New scale: `text-xs/sm/base/lg/xl/2xl` = 11/12/13/15/19/24px.

**`--font-scale` CSS multiplier.** For products that want a user-facing "bigger text" preference:

- Browser zoom scales the viewport (layout grows too).
- Native browser font-size prefs would work if the library used `rem` only for font-size. It doesn't — Tailwind emits `rem` for spacing (padding, margin, gap), so those scale too.
- `--font-scale` multiplies only font-size tokens. Every font-size is emitted as `calc(<px> * var(--font-scale, 1))`. Consumers override at any scope; spacing stays put.

Full separation of type and layout scaling requires a `rem`-for-font / `px`-for-spacing convention shift. Out of scope here; this PR lands the infrastructure.

**Em-relative icon sizing.** Icons across ~20 components moved from hardcoded pixels (`size={12}`, `h-4 w-4`) to em ratios, following Apple's font scaling pattern — a UI icon is a glyph in its text's context and scales with the surrounding font-size. This:
- collapses per-component-per-variant size tables into a single ratio rule,
- makes icons respond to `--font-scale` automatically.

Ratios in use:

| Ratio                | Where                                                  |
| -------------------- | ------------------------------------------------------ |
| `1em` (bare)         | Carets / chevrons in form controls, buttons, pagination |
| `0.85em`             | Inline glyphs in chips, badges, checkboxes             |
| `1.15em`             | Leading icons in dropdown / menu items                 |
| `1.25em`             | Sidebar menu icons                                     |
| `var(--text-lg)`     | Nested-scope one-offs                                  |

## What's in it

- Body baseline 13px. Scale = 11/12/13/15/19/24px.
- Role-based `Text` variants: `display` (24px semibold), `page-title` (19px medium), `section-title` (15px medium), `heading` (13px medium). `heading1/2/3` soft-deprecated.
- `Text.size="xs"` and `size="lg"` on body variants soft-deprecated. `bold` narrowed to copy variants only.
- Button + form controls: `sm` = 26px / `text-sm`, `base` = 32px / `text-base`, `lg` = 36px / `text-base`. `xs` deprecated across all of them.
- Em-relative icon sizing across ~20 components.
- `--font-scale` multiplier on every font-size token.
- Line-height ratios re-tuned (`sm`/`base`/`lg` = 1.35/1.4/1.45) so dense components keep their dense feel.
- Cascading token updates in Banner, Toolbar, Label, Toast, Table, Collapsible, Sidebar, TableOfContents, Badge, LayerCard.

## Changesets

14 changesets. Aggregated bump: `minor`.

| Changeset                        | Bump  | What                                                                |
| -------------------------------- | ----- | ------------------------------------------------------------------- |
| `text-role-based-variants`       | minor | Role-based heading variants + `Text` deprecations                   |
| `button-sizes-refresh`           | minor | Button heights/fonts + `xs` deprecation                             |
| `form-controls-size-refresh`     | minor | Input, InputArea, Select, Combobox, Autocomplete, InputGroup        |
| `banner-typography-weight-first` | minor | Banner title/description weight-first refactor                      |
| `font-scale-multiplier`          | minor | `--font-scale` CSS var                                              |
| `icons-em-relative-sizing`       | minor | Em-based icon sizing across ~20 components                          |
| `token-refresh-class-swaps`      | minor | Badge / Sidebar / TableOfContents token renames, no rendered change |
| `line-height-ratios-tighten`     | patch | `sm` / `base` / `lg` line-height ratios tightened                   |
| `toolbar-deprecate-xs`           | patch | Toolbar `xs` deprecation with single-warning remap                  |
| `banner-action-sm-size`          | patch | `Banner.Action` size narrowed to `"sm"`                             |
| `collapsible-trigger-text-base`  | patch | Collapsible caret shrinks 16→14px                                   |
| `label-tooltip-button-sm`        | patch | Label help button `xs → sm`                                         |
| `table-header-weight`            | patch | Table th `semibold → medium`; compact header `xs → sm`              |
| `toast-typography-role-based`    | patch | Toast at 15px                                                       |

## ⚠️ Known breakage: Figma generation

Figma plugin is out of sync with the library. Sources:

- **CSS parser** (`packages/kumo-figma/src/build-theme-data.ts`) — updated to handle the new `calc(<px> * var(--font-scale, 1))` wrapper. Working.
- **`KUMO_*_STYLING` metadata** — updated for control-size changes but `KUMO_TEXT_STYLING.fontSizes.xl` still reads `17`, needs `19`.
- **Em-relative icons** — no Figma equivalent; generators still expect absolute pixel sizes.
- **Figma generators** — hardcoded font sizes / control heights / snapshot fixtures not resynced.

`pnpm --filter @cloudflare/kumo-figma test` fails with 22 tests across `tailwind-to-figma`, drift-detection, and generator snapshots. Build still succeeds.

## Testing

- 1250 kumo unit tests pass.
- `pnpm typecheck` clean.
- `pnpm lint` clean.
- Docs `FontScaleToggle` manually exercised.
- Figma plugin tests fail — see above.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: draft for downstream-app preview; will request review after real-world trial
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->
