### PR TITLE
fix(collapsible): update default styling

### DIFF
--- a/.changeset/collapsible-default-styling.md
+++ b/.changeset/collapsible-default-styling.md
@@ -3,3 +3,5 @@
 ---
 
 Update the default collapsible trigger and panel styling.
+
+`Collapsible.DefaultPanel` now uses an inner content wrapper so the outer panel can animate height smoothly while clipping overflow during the transition. Consumers applying custom layout or spacing classes directly to `DefaultPanel` may need to move those styles to their content, or use `Collapsible.Panel` for a fully custom layout.

--- a/.changeset/collapsible-default-styling.md
+++ b/.changeset/collapsible-default-styling.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update the default collapsible trigger and panel styling.

--- a/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
@@ -122,7 +122,9 @@ export function CollapsibleFormDemo() {
   return (
     <div className="w-full">
       <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
-        <Collapsible.DefaultTrigger>Contact settings</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultTrigger>
+          Contact settings
+        </Collapsible.DefaultTrigger>
         <Collapsible.DefaultPanel>
           <form
             className="flex max-w-sm flex-col gap-4"

--- a/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CollapsibleDemo.tsx
@@ -115,6 +115,30 @@ export function CollapsibleKeepMountedDemo() {
 }
 
 /**
+ * Form controls inside DefaultPanel for testing focus ring clipping.
+ */
+export function CollapsibleFormDemo() {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <div className="w-full">
+      <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Collapsible.DefaultTrigger>Contact settings</Collapsible.DefaultTrigger>
+        <Collapsible.DefaultPanel>
+          <form
+            className="flex max-w-sm flex-col gap-4"
+            onSubmit={(event) => event.preventDefault()}
+          >
+            <Input label="Email" placeholder="user@example.com" type="email" />
+            <Input label="Team name" placeholder="Design engineering" />
+            <Button type="submit">Save settings</Button>
+          </form>
+        </Collapsible.DefaultPanel>
+      </Collapsible.Root>
+    </div>
+  );
+}
+
+/**
  * Accordion pattern where only one item can be open at a time.
  */
 export function CollapsibleAccordionDemo() {

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -327,7 +327,7 @@ export function HomeGrid() {
         >
           <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
           <Collapsible.DefaultPanel>
-            Kumo is Cloudflare's component library.
+            <Text>Kumo is Cloudflare's component library.</Text>
           </Collapsible.DefaultPanel>
         </Collapsible.Root>
       ),

--- a/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/collapsible.mdx
@@ -15,6 +15,7 @@ import {
   CollapsibleMultipleDemo,
   CollapsibleCustomTriggerDemo,
   CollapsibleKeepMountedDemo,
+  CollapsibleFormDemo,
   CollapsibleAccordionDemo,
 } from "~/components/demos/CollapsibleDemo";
 
@@ -124,6 +125,14 @@ Use `keepMounted` on `DefaultPanel` (or `Panel`) to preserve internal state — 
 
 <ComponentExample demo="CollapsibleKeepMountedDemo">
   <CollapsibleKeepMountedDemo client:load />
+</ComponentExample>
+
+### Form Content
+
+Use `DefaultPanel` with form controls to verify focus rings have enough room inside the animated panel:
+
+<ComponentExample demo="CollapsibleFormDemo">
+  <CollapsibleFormDemo client:load />
 </ComponentExample>
 
 ### Accordion Pattern

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -171,7 +171,7 @@ const CollapsibleDefaultTrigger = forwardRef<
           aria-hidden
           size={12}
           weight="bold"
-          className="block size-3 origin-center transition-transform duration-150 ease-out [[data-panel-open]_&]:rotate-180"
+          className="block size-3 origin-center transition-transform duration-100 ease-out [[data-panel-open]_&]:rotate-180"
         />
       </span>
     </CollapsibleBase.Trigger>
@@ -213,7 +213,7 @@ const CollapsibleDefaultPanel = forwardRef<
     <CollapsibleBase.Panel
       ref={ref}
       className={cn(
-        "h-[var(--collapsible-panel-height)] overflow-hidden transition-[height,opacity] duration-150 ease-out data-ending-style:h-0 data-ending-style:opacity-0 data-starting-style:h-0 data-starting-style:opacity-0 [&[hidden]:not([hidden='until-found'])]:hidden",
+        "h-[var(--collapsible-panel-height)] overflow-hidden transition-[height,opacity] duration-100 ease-out data-ending-style:h-0 data-ending-style:opacity-0 data-starting-style:h-0 data-starting-style:opacity-0 [&[hidden]:not([hidden='until-found'])]:hidden",
         className,
       )}
       {...props}

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -165,12 +165,15 @@ const CollapsibleDefaultTrigger = forwardRef<
         className,
       )}
     >
-      {children}{" "}
-      <CaretDownIcon
-        size={12}
-        weight="bold"
-        className="transition-transform duration-250 [[data-panel-open]_&]:rotate-180"
-      />
+      <span>{children}</span>
+      <span className="inline-grid w-4 shrink-0 place-items-center">
+        <CaretDownIcon
+          aria-hidden
+          size={12}
+          weight="bold"
+          className="block size-3 origin-center transition-transform duration-150 ease-out [[data-panel-open]_&]:rotate-180"
+        />
+      </span>
     </CollapsibleBase.Trigger>
   );
 });
@@ -210,12 +213,14 @@ const CollapsibleDefaultPanel = forwardRef<
     <CollapsibleBase.Panel
       ref={ref}
       className={cn(
-        "my-2 space-y-4 border-l-2 border-kumo-fill pl-4 transition-opacity duration-250 ease-out [&[hidden]:not([hidden='until-found'])]:hidden data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "h-[var(--collapsible-panel-height)] overflow-hidden transition-[height,opacity] duration-150 ease-out [&[hidden]:not([hidden='until-found'])]:hidden data-ending-style:h-0 data-ending-style:opacity-0 data-starting-style:h-0 data-starting-style:opacity-0",
         className,
       )}
       {...props}
     >
-      {children}
+      <div className="my-2 space-y-4 border-l-2 border-kumo-fill py-1 pr-1 pl-4">
+        {children}
+      </div>
     </CollapsibleBase.Panel>
   );
 });

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -213,7 +213,7 @@ const CollapsibleDefaultPanel = forwardRef<
     <CollapsibleBase.Panel
       ref={ref}
       className={cn(
-        "h-[var(--collapsible-panel-height)] overflow-hidden transition-[height,opacity] duration-150 ease-out [&[hidden]:not([hidden='until-found'])]:hidden data-ending-style:h-0 data-ending-style:opacity-0 data-starting-style:h-0 data-starting-style:opacity-0",
+        "h-[var(--collapsible-panel-height)] overflow-hidden transition-[height,opacity] duration-150 ease-out data-ending-style:h-0 data-ending-style:opacity-0 data-starting-style:h-0 data-starting-style:opacity-0 [&[hidden]:not([hidden='until-found'])]:hidden",
         className,
       )}
       {...props}

--- a/packages/kumo/src/components/collapsible/collapsible.tsx
+++ b/packages/kumo/src/components/collapsible/collapsible.tsx
@@ -161,12 +161,16 @@ const CollapsibleDefaultTrigger = forwardRef<
         // Defensive resets to prevent global button styles from polluting the trigger
         "m-0 border-none bg-transparent p-0 shadow-none",
         // Base styles for the trigger
-        "flex cursor-pointer items-center gap-1 text-sm text-kumo-link select-none",
+        "flex cursor-pointer items-center gap-1 text-base text-kumo-link select-none",
         className,
       )}
     >
       {children}{" "}
-      <CaretDownIcon className="h-4 w-4 transition-transform [[data-panel-open]_&]:rotate-180" />
+      <CaretDownIcon
+        size={12}
+        weight="bold"
+        className="transition-transform duration-250 [[data-panel-open]_&]:rotate-180"
+      />
     </CollapsibleBase.Trigger>
   );
 });
@@ -206,7 +210,7 @@ const CollapsibleDefaultPanel = forwardRef<
     <CollapsibleBase.Panel
       ref={ref}
       className={cn(
-        "my-2 space-y-4 border-l-2 border-kumo-fill pl-4",
+        "my-2 space-y-4 border-l-2 border-kumo-fill pl-4 transition-opacity duration-250 ease-out [&[hidden]:not([hidden='until-found'])]:hidden data-ending-style:opacity-0 data-starting-style:opacity-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
Updates the default Collapsible styling to better match the intended Kumo presentation.

- Updates `Collapsible.DefaultTrigger` typography and caret styling.
- Updates the homepage collapsible example to wrap panel copy in `Text` for consistent typography.

| Before | After |
| --- | --- |
| <img width="358" height="361" alt="Screenshot 2026-07-30 at 3 28 11 PM" src="https://github.com/user-attachments/assets/a4582470-7b50-4ae7-98d1-dd6facfd546a" /> | <img width="359" height="360" alt="Screenshot 2026-07-30 at 3 27 56 PM" src="https://github.com/user-attachments/assets/0df740ad-72e2-45d3-9a5d-84876f81560b" /> |

- Smooth open/close transition to `Collapsible.DefaultPanel`.

<img width="770" height="158" alt="Jul-31-2026 10-54-53" src="https://github.com/user-attachments/assets/bf0b0367-952a-46a8-9c1c-f93949592338" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because:  small styling-only component update
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: automated lint, typecheck, and test validation passed

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
