### PR TITLE
docs: fix broken "View source" link on SkeletonLine page

### DIFF
--- a/.changeset/fix-skeleton-line-source-link.md
+++ b/.changeset/fix-skeleton-line-source-link.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Fix the broken "View source" link on the SkeletonLine docs page. It pointed at `primitives/skeleton-line`, which resolved to a non-existent file; the component lives at `components/loader/skeleton-line.tsx`.

--- a/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/skeleton-line.mdx
@@ -2,7 +2,7 @@
 layout: ~/layouts/MdxDocLayout.astro
 title: "Skeleton Line"
 description: "A skeleton loading placeholder for text content."
-sourceFile: "primitives/skeleton-line"
+sourceFile: "components/loader/skeleton-line.tsx"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";


### PR DESCRIPTION
The **View source on GitHub** link on the [SkeletonLine](https://kumo.pages.dev/components/skeleton-line) docs page dead-ends in a 404.

`skeleton-line.mdx` sets `sourceFile: "primitives/skeleton-line"`. `DocLayout.astro` turns an extension-less `sourceFile` into `packages/kumo/src/{sourceFile}/{lastSegment}.tsx`, producing:

```
packages/kumo/src/primitives/skeleton-line/skeleton-line.tsx  → 404
```

There is no `skeleton-line` under `src/primitives/`. The component actually lives at `packages/kumo/src/components/loader/skeleton-line.tsx` (exported from `src/index.ts`: `export { Loader, SkeletonLine } from "./components/loader";`).

This sets `sourceFile` to the real file path (with extension, which `DocLayout` uses as-is per its own `/\.\w+$/` branch), so the source link resolves. Added a patch changeset per the repo convention.

Docs-only, no functional change.