### PR TITLE
fix(catalog): await schema loading in initCatalog

### DIFF
--- a/.changeset/init-catalog-load-schemas.md
+++ b/.changeset/init-catalog-load-schemas.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix `initCatalog` so it actually loads the validation schemas.
+
+Previously it triggered a synchronous validation whose "schemas not loaded" error was swallowed, so `await initCatalog(catalog)` could resolve while `hasComponent`, `componentNames`, and the other synchronous catalog APIs still reported no components. It now awaits `loadSchemas()` directly.

--- a/.changeset/init-catalog-load-schemas.md
+++ b/.changeset/init-catalog-load-schemas.md
@@ -5,3 +5,5 @@
 Fix `initCatalog` so it actually loads the validation schemas.
 
 Previously it triggered a synchronous validation whose "schemas not loaded" error was swallowed, so `await initCatalog(catalog)` could resolve while `hasComponent`, `componentNames`, and the other synchronous catalog APIs still reported no components. It now awaits `loadSchemas()` directly.
+
+A failed schema load is also no longer cached: retrying `initCatalog` (or `loadSchemas`) after a transient failure now re-attempts the import instead of returning the stale rejection.

--- a/packages/kumo/src/catalog/catalog.test.ts
+++ b/packages/kumo/src/catalog/catalog.test.ts
@@ -2,7 +2,7 @@
  * Tests for Kumo catalog module
  */
 
-import { describe, it, expect } from "vite-plus/test";
+import { describe, it, expect, vi } from "vite-plus/test";
 import {
   getByPath,
   setByPath,
@@ -253,5 +253,22 @@ describe("visibility evaluation", () => {
       };
       expect(evaluateVisibility(condition, ctx)).toBe(true);
     });
+  });
+});
+
+describe("initCatalog", () => {
+  it("makes synchronous validation available after awaiting", async () => {
+    // Fresh module so the module-level schema cache from other tests
+    // cannot mask a broken initCatalog.
+    vi.resetModules();
+    const { createKumoCatalog, initCatalog } = await import("./catalog");
+    const catalog = createKumoCatalog();
+
+    expect(catalog.hasComponent("Button")).toBe(false);
+
+    await initCatalog(catalog);
+
+    expect(catalog.hasComponent("Button")).toBe(true);
+    expect(catalog.componentNames.length).toBeGreaterThan(0);
   });
 });

--- a/packages/kumo/src/catalog/catalog.test.ts
+++ b/packages/kumo/src/catalog/catalog.test.ts
@@ -258,8 +258,7 @@ describe("visibility evaluation", () => {
 
 describe("initCatalog", () => {
   it("makes synchronous validation available after awaiting", async () => {
-    // Fresh module so the module-level schema cache from other tests
-    // cannot mask a broken initCatalog.
+    // Fresh module — schemas cached by other tests would mask a broken init
     vi.resetModules();
     const { createKumoCatalog, initCatalog } = await import("./catalog");
     const catalog = createKumoCatalog();
@@ -270,5 +269,29 @@ describe("initCatalog", () => {
 
     expect(catalog.hasComponent("Button")).toBe(true);
     expect(catalog.componentNames.length).toBeGreaterThan(0);
+  });
+
+  it("retries schema loading after a failed load", async () => {
+    vi.resetModules();
+    let failLoad = true;
+    vi.doMock("../../ai/schemas", async (importActual) => {
+      if (failLoad) throw new Error("chunk load failed");
+      return importActual();
+    });
+
+    try {
+      const { createKumoCatalog, initCatalog } = await import("./catalog");
+      const catalog = createKumoCatalog();
+
+      // Vitest wraps factory errors, so only the rejection itself is asserted
+      await expect(initCatalog(catalog)).rejects.toThrow();
+      expect(catalog.hasComponent("Button")).toBe(false);
+
+      failLoad = false;
+      await initCatalog(catalog);
+      expect(catalog.hasComponent("Button")).toBe(true);
+    } finally {
+      vi.doUnmock("../../ai/schemas");
+    }
   });
 });

--- a/packages/kumo/src/catalog/catalog.ts
+++ b/packages/kumo/src/catalog/catalog.ts
@@ -49,10 +49,16 @@ export async function loadSchemas(): Promise<SchemasModule> {
   if (schemasModule) return schemasModule;
   if (schemasLoadPromise) return schemasLoadPromise;
 
-  schemasLoadPromise = import("../../ai/schemas").then((mod: unknown) => {
-    schemasModule = mod as unknown as SchemasModule;
-    return schemasModule;
-  });
+  schemasLoadPromise = import("../../ai/schemas")
+    .then((mod: unknown) => {
+      schemasModule = mod as unknown as SchemasModule;
+      return schemasModule;
+    })
+    .catch((err: unknown) => {
+      // Failures are usually transient — don't cache them, so retries work
+      schemasLoadPromise = null;
+      throw err;
+    });
 
   return schemasLoadPromise;
 }

--- a/packages/kumo/src/catalog/catalog.ts
+++ b/packages/kumo/src/catalog/catalog.ts
@@ -276,7 +276,6 @@ export function createKumoCatalog(config: CatalogConfig = {}): KumoCatalog {
  * Initialize the catalog by loading schemas.
  * Call this before using synchronous validation methods.
  */
-export async function initCatalog(catalog: KumoCatalog): Promise<void> {
-  // Trigger a validation to load schemas
-  catalog.validateTree({});
+export async function initCatalog(_catalog?: KumoCatalog): Promise<void> {
+  await loadSchemas();
 }


### PR DESCRIPTION
This PR fixes `initCatalog` so awaiting it actually loads the generated Zod schemas. It was only calling `catalog.validateTree({})` before and the "schemas not loaded" error was just swallowed. In turn, every sync catalog API (`hasComponent, `componentNames`, etc.) was broken!

Instead, `initCatalog` now does await `loadSchemas()` directly.

As a small addition, it also does *not* cache failed schema loads anymore.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
