### PR TITLE
fix(input, input-group): prevent Safari auto-zoom on mobile by setting font-size to 16px

### DIFF
--- a/.changeset/prevent-input-autozoom-mobile.md
+++ b/.changeset/prevent-input-autozoom-mobile.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Prevent Safari auto-zoom on mobile by setting input and input-group font size to 16px below the `sm` breakpoint.

--- a/packages/kumo/src/components/input-group/input-group.tsx
+++ b/packages/kumo/src/components/input-group/input-group.tsx
@@ -29,19 +29,19 @@ export { type InputGroupSuffixProps } from "./input-group-suffix";
 export const KUMO_INPUT_GROUP_VARIANTS = {
   size: {
     xs: {
-      classes: "h-6 text-xs",
+      classes: "h-6 text-[16px] sm:text-xs",
       description: "Extra small size.",
     },
     sm: {
-      classes: "h-7 text-xs",
+      classes: "h-7 text-[16px] sm:text-xs",
       description: "Small size.",
     },
     base: {
-      classes: "h-9 text-base",
+      classes: "h-9 text-[16px] sm:text-base",
       description: "Default size.",
     },
     lg: {
-      classes: "h-11 text-base",
+      classes: "h-11 text-[16px] sm:text-base",
       description: "Large size.",
     },
   },

--- a/packages/kumo/src/components/input/input.tsx
+++ b/packages/kumo/src/components/input/input.tsx
@@ -16,19 +16,19 @@ import {
 export const KUMO_INPUT_VARIANTS = {
   size: {
     xs: {
-      classes: "h-5 gap-1 rounded-sm px-1.5 text-xs",
+      classes: "h-5 gap-1 rounded-sm px-1.5 text-[16px] sm:text-xs",
       description: "Extra small input for compact UIs",
     },
     sm: {
-      classes: "h-6.5 gap-1 rounded-md px-2 text-xs",
+      classes: "h-6.5 gap-1 rounded-md px-2 text-[16px] sm:text-xs",
       description: "Small input for secondary fields",
     },
     base: {
-      classes: "h-9 gap-1.5 rounded-lg px-3 text-base",
+      classes: "h-9 gap-1.5 rounded-lg px-3 text-[16px] sm:text-base",
       description: "Default input size",
     },
     lg: {
-      classes: "h-10 gap-2 rounded-lg px-4 text-base",
+      classes: "h-10 gap-2 rounded-lg px-4 text-[16px] sm:text-base",
       description: "Large input for prominent fields",
     },
   },


### PR DESCRIPTION
Safari on iOS automatically zooms in when focusing on input elements with a font-size smaller than 16px. This behavior disrupts the user experience, especially in forms where users expect the page layout to remain stable.

This change sets the font-size to 16px on mobile viewports for both the `Input` and `InputGroup` components, preventing the unwanted auto-zoom while maintaining the intended visual styling via the existing scale transform.

### Changes
- Updated `packages/kumo/src/components/input/input.tsx`
- Updated `packages/kumo/src/components/input-group/input-group.tsx`

---

- Reviews
- [ ] bonk has reviewed the change
- [ ] automated review not possible because:
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:
