### PR TITLE
fix(tabs): reset overflow control background

### DIFF
--- a/.changeset/tabs-transparent-scrim.md
+++ b/.changeset/tabs-transparent-scrim.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Reset the Tabs overflow control background so host button styles do not show through the scrim gradient.

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -320,7 +320,7 @@ function TabsOverflowControl({
       tabIndex={visible ? 0 : -1}
       onClick={onClick}
       className={cn(
-        "absolute inset-y-0 z-3 flex items-center border-0 p-0 transition-opacity duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
+        "absolute inset-y-0 z-3 flex items-center border-0 bg-transparent p-0 transition-opacity duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
         isStart
           ? "left-0 justify-start bg-linear-to-r"
           : "right-0 justify-end bg-linear-to-l",

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -315,6 +315,9 @@ function TabsOverflowControl({
   return (
     <button
       type="button"
+      data-kumo-component="Tabs"
+      data-kumo-part="overflow-control"
+      data-side={side}
       aria-label={label}
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}


### PR DESCRIPTION
## Summary
- Reset the Tabs overflow control button background to transparent so host-app button styles do not show through transparent gradient stops.
- Add stable targeting attributes to the overflow control: `data-kumo-component="Tabs"`, `data-kumo-part="overflow-control"`, and `data-side`.
- Add a patch changeset for `@cloudflare/kumo`.

## Context
Dash dark mode exposed a host-app button background through the Tabs overflow scrim. The scrim gradient itself matched Kumo docs, but the gradient ends at `transparent`, and the raw overflow `button` did not reset `background-color`.

## Testing
- Ran `pnpm format`.
- Ran `git diff --check`.
- Verified from browser computed styles that Dash and Kumo docs use the same gradient, and Dash's host button background was the visible difference.

## Screenshots & Videos
Not applicable. This is a small style reset for the overflow control.

- Reviews
- [x] bonk has reviewed the change
- [ ] automated review not possible because: 
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: 
- [x] Additional testing not necessary because: this only adds a background reset and stable data attributes; manual computed-style inspection confirmed the host button background was the source of the visual issue.
