### PR TITLE
fix(docs): remove duplicate kumo-hairline reference in docs

### DIFF
--- a/packages/kumo-docs-astro/src/pages/colors.mdx
+++ b/packages/kumo-docs-astro/src/pages/colors.mdx
@@ -329,13 +329,12 @@ Use the solid token `bg-kumo-*` for status dots, `fill-kumo-*` for icons, and `b
         <td>
           <span className="inline-flex items-center gap-2">
             <code>kumo-hairline</code>
-            <Badge variant="info">New</Badge>
           </span>
         </td>
         <td>A border/ring color to distinguish between flat surfaces where no shadow is present (i.e. <code>LayerCard</code>).</td>
       </tr>
       <tr>
-        <td><code>kumo-hairline</code></td>
+        <td><code>kumo-line</code></td>
         <td>A thicker border/ring color that defines the edge of an elevated surface alongside a shadow.</td>
       </tr>
     </tbody>


### PR DESCRIPTION
Fixes the duplicate `kumo-hairline` reference in docs by replacing one with `kumo-line`

### Before
<img width="1476" height="470" alt="image" src="https://github.com/user-attachments/assets/7241a9bd-f9d0-439f-adec-f14c25d901f9" />

### After
<img width="1570" height="550" alt="CleanShot 2026-08-04 at 15 37 27@2x" src="https://github.com/user-attachments/assets/48ac9ced-0416-444d-b7cd-0e637bef8611" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: Docs changes.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
