### PR TITLE
feat(docs): add system theme selector

### DIFF
--- a/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
+++ b/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
@@ -1,28 +1,33 @@
 import { useState, useEffect } from "react";
-import { Button } from "@cloudflare/kumo";
-import { SunIcon, MoonIcon } from "@phosphor-icons/react";
+import { Button, DropdownMenu } from "@cloudflare/kumo";
+import { DesktopIcon, MoonIcon, SunIcon } from "@phosphor-icons/react";
+
+type ThemePreference = "light" | "dark" | "system";
+
+const themeOptions = [
+  { value: "light", label: "Light", icon: SunIcon },
+  { value: "dark", label: "Dark", icon: MoonIcon },
+  { value: "system", label: "System", icon: DesktopIcon },
+] as const;
+
+function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "light" || value === "dark" || value === "system";
+}
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [theme, setTheme] = useState<ThemePreference>("system");
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     const getCurrentTheme = () => {
-      const mode = document.documentElement.getAttribute("data-mode");
-      if (mode === "dark" || mode === "light") return mode;
-
       const stored = localStorage.getItem("theme");
-      if (stored === "dark" || stored === "light") return stored;
-
-      return window.matchMedia("(prefers-color-scheme: dark)").matches
-        ? "dark"
-        : "light";
+      return isThemePreference(stored) ? stored : "system";
     };
 
     const handleThemeChange = (event: Event) => {
-      const nextTheme = (event as CustomEvent<{ theme?: "light" | "dark" }>)
-        .detail?.theme;
-      if (nextTheme === "dark" || nextTheme === "light") {
+      const nextTheme = (event as CustomEvent<{ theme?: string }>).detail
+        ?.theme;
+      if (isThemePreference(nextTheme)) {
         setTheme(nextTheme);
       }
     };
@@ -36,34 +41,68 @@ export function ThemeToggle() {
     };
   }, []);
 
-  const toggleTheme = () => {
-    const newTheme = theme === "light" ? "dark" : "light";
+  const selectTheme = (newTheme: string) => {
+    if (!isThemePreference(newTheme)) return;
+
+    const resolvedTheme =
+      newTheme === "system"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : newTheme;
+
     setTheme(newTheme);
     localStorage.setItem("theme", newTheme);
-    document.documentElement.setAttribute("data-mode", newTheme);
+    document.documentElement.setAttribute("data-mode", resolvedTheme);
     window.dispatchEvent(
-      new CustomEvent("kumo:theme-change", { detail: { theme: newTheme } }),
+      new CustomEvent("kumo:theme-change", {
+        detail: { theme: newTheme, resolvedTheme },
+      }),
     );
   };
 
   // Prevent hydration mismatch
   if (!mounted) {
     return (
-      <Button variant="ghost" shape="square" aria-label="Toggle theme">
-        <SunIcon size={20} />
+      <Button variant="ghost" shape="square" aria-label="Select theme">
+        <DesktopIcon size={20} />
       </Button>
     );
   }
 
+  const ActiveIcon = themeOptions.find(
+    (option) => option.value === theme,
+  )!.icon;
+
   return (
-    <Button
-      variant="ghost"
-      shape="square"
-      aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
-      title="Toggle theme (D)"
-      onClick={toggleTheme}
-    >
-      {theme === "light" ? <MoonIcon size={20} /> : <SunIcon size={20} />}
-    </Button>
+    <DropdownMenu>
+      <DropdownMenu.Trigger
+        render={
+          <Button
+            variant="ghost"
+            shape="square"
+            aria-label={`Select theme, current theme is ${theme}`}
+            title="Select theme"
+          >
+            <ActiveIcon size={20} />
+          </Button>
+        }
+      />
+      <DropdownMenu.Content align="end">
+        <DropdownMenu.Label>Theme</DropdownMenu.Label>
+        <DropdownMenu.RadioGroup value={theme} onValueChange={selectTheme}>
+          {themeOptions.map((option) => (
+            <DropdownMenu.RadioItem
+              key={option.value}
+              value={option.value}
+              icon={option.icon}
+            >
+              {option.label}
+              <DropdownMenu.RadioItemIndicator />
+            </DropdownMenu.RadioItem>
+          ))}
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu>
   );
 }

--- a/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
+++ b/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
@@ -82,15 +82,14 @@ export function ThemeToggle() {
             variant="ghost"
             shape="square"
             aria-label={`Select theme, current theme is ${theme}`}
-            title="Select theme"
           >
             <ActiveIcon size={20} />
           </Button>
         }
       />
       <DropdownMenu.Content align="end">
-        <DropdownMenu.Label>Theme</DropdownMenu.Label>
         <DropdownMenu.RadioGroup value={theme} onValueChange={selectTheme}>
+          <DropdownMenu.Label>Theme</DropdownMenu.Label>
           {themeOptions.map((option) => (
             <DropdownMenu.RadioItem
               key={option.value}

--- a/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
+++ b/packages/kumo-docs-astro/src/components/ThemeToggle.tsx
@@ -4,10 +4,16 @@ import { DesktopIcon, MoonIcon, SunIcon } from "@phosphor-icons/react";
 
 type ThemePreference = "light" | "dark" | "system";
 
+const themeIcons: Record<ThemePreference, typeof SunIcon> = {
+  light: SunIcon,
+  dark: MoonIcon,
+  system: DesktopIcon,
+};
+
 const themeOptions = [
-  { value: "light", label: "Light", icon: SunIcon },
-  { value: "dark", label: "Dark", icon: MoonIcon },
-  { value: "system", label: "System", icon: DesktopIcon },
+  { value: "light", label: "Light", icon: themeIcons.light },
+  { value: "dark", label: "Dark", icon: themeIcons.dark },
+  { value: "system", label: "System", icon: themeIcons.system },
 ] as const;
 
 function isThemePreference(value: unknown): value is ThemePreference {
@@ -70,9 +76,7 @@ export function ThemeToggle() {
     );
   }
 
-  const ActiveIcon = themeOptions.find(
-    (option) => option.value === theme,
-  )!.icon;
+  const ActiveIcon = themeIcons[theme];
 
   return (
     <DropdownMenu>

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -139,8 +139,14 @@ const buildDate =
             }
 
             event.preventDefault();
-            const current = document.documentElement.getAttribute("data-mode");
-            setTheme(current === "dark" ? "light" : "dark");
+            const current = localStorage.getItem("theme");
+            const nextTheme =
+              current === "light"
+                ? "dark"
+                : current === "dark"
+                  ? "system"
+                  : "light";
+            setTheme(nextTheme);
           });
         }
       })();

--- a/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/BaseLayout.astro
@@ -75,21 +75,38 @@ const buildDate =
       // must be re-applied after each view-transition swap because the <html>
       // attributes are replaced during navigation.
       (function () {
+        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
+
         function setTheme(theme) {
+          const resolvedTheme =
+            theme === "system"
+              ? systemTheme.matches
+                ? "dark"
+                : "light"
+              : theme;
+
           localStorage.setItem("theme", theme);
-          document.documentElement.setAttribute("data-mode", theme);
+          document.documentElement.setAttribute("data-mode", resolvedTheme);
           window.dispatchEvent(
-            new CustomEvent("kumo:theme-change", { detail: { theme } }),
+            new CustomEvent("kumo:theme-change", {
+              detail: { theme, resolvedTheme },
+            }),
           );
         }
 
         function applyStoredTheme() {
           const stored = localStorage.getItem("theme");
-          if (stored) {
-            document.documentElement.setAttribute("data-mode", stored);
-          } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-            document.documentElement.setAttribute("data-mode", "dark");
-          }
+          const theme = ["light", "dark", "system"].includes(stored)
+            ? stored
+            : "system";
+          const resolvedTheme =
+            theme === "system"
+              ? systemTheme.matches
+                ? "dark"
+                : "light"
+              : theme;
+
+          document.documentElement.setAttribute("data-mode", resolvedTheme);
         }
 
         // Apply on this (initial or freshly-swapped) document immediately.
@@ -102,6 +119,10 @@ const buildDate =
           // Reapply theme before each swap paints, so there's no light flash.
           document.addEventListener("astro:before-swap", applyStoredTheme);
           document.addEventListener("astro:after-swap", applyStoredTheme);
+          systemTheme.addEventListener("change", function () {
+            const stored = localStorage.getItem("theme");
+            if (!stored || stored === "system") setTheme("system");
+          });
 
           document.addEventListener("keydown", function (event) {
             if (event.defaultPrevented || event.repeat) return;


### PR DESCRIPTION
## Summary

- replace the binary theme toggle with a compact Light, Dark, and System dropdown
- persist the selected preference while resolving System against the operating system theme
- update System mode when the operating system preference changes

## Testing

- `astro build`
- `astro check`
- `vp test run` (10 tests passed)
- focused Vite+ lint and formatting checks

- Reviews
- [x] bonk has reviewed the change
- [x] automated review not possible because: the automated reviewer runs after PR creation
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [x] Additional testing not necessary because: existing docs build, typecheck, and test coverage exercise this focused UI change