### PR TITLE
fix(toast): match background radius to root to stop ring clip

### DIFF
--- a/.changeset/fix-toast-border-cutoff.md
+++ b/.changeset/fix-toast-border-cutoff.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Toast background clipping the ring outline at the corners — the inner background layer's radius (11px) was smaller than the root's `rounded-xl` (12px), painting over the ring at the corners. Matched them up.

--- a/packages/kumo/src/components/toast/toast.tsx
+++ b/packages/kumo/src/components/toast/toast.tsx
@@ -426,7 +426,7 @@ function ToastBackground({ variant }: { variant?: KumoToastVariant }) {
   return (
     <div
       className={cn(
-        "absolute inset-0 rounded-[11px] bg-kumo-base/90",
+        "absolute inset-0 rounded-xl bg-kumo-base/90",
         background,
       )}
     />


### PR DESCRIPTION
Toast background layer was rounded-[11px] while the root is rounded-xl (12px), so it was painting over the ring at the four corners. Bumped it to rounded-xl to match.

Before:
<img width="667" height="521" alt="Screenshot 2026-08-05 at 15 49 00" src="https://github.com/user-attachments/assets/89a9a94f-69b4-4686-bd0f-865087d3816d" />

After:
<img width="501" height="440" alt="Screenshot 2026-08-05 at 15 49 51" src="https://github.com/user-attachments/assets/7c0c55b2-be1c-488f-bf35-804616269bae" />



<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [X] Additional testing not necessary because: one-line CSS class swap, verified visually against the demo

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
