### PR TITLE
fix(tabs): flatten overflow control caret

### DIFF
--- a/.changeset/quiet-tabs-overflow-caret.md
+++ b/.changeset/quiet-tabs-overflow-caret.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Remove the elevated chip styling from Tabs overflow scroll controls.

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -339,7 +339,7 @@ function TabsOverflowControl({
     >
       <span
         className={cn(
-          "flex items-center justify-center rounded-full bg-kumo-elevated text-kumo-subtle shadow-sm ring ring-kumo-line transition-colors hover:bg-kumo-base hover:text-kumo-default",
+          "flex items-center justify-center text-kumo-subtle transition-colors hover:text-kumo-default",
           size === "sm" ? "size-5" : "size-6",
           isStart ? "ml-1" : "mr-1",
         )}


### PR DESCRIPTION
## Summary
- remove the elevated chip background, shadow, and ring from the Tabs overflow caret wrapper
- keep the overflow control button's transparent background, zero padding, gradient fade, hover text colour, and focus-visible ring
- add a patch changeset for @cloudflare/kumo

## Tests
- pnpm --filter @cloudflare/kumo lint

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual-only styling adjustment to an existing control
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: visually checked Tabs overflow control in docs dev server
- [x] Additional testing not necessary because: targeted lint passed and the change only removes decorative wrapper styles