### PR TITLE
fix(tabs): limit overflow controls to segmented tabs

### DIFF
--- a/.changeset/tidy-tabs-overflow-focus.md
+++ b/.changeset/tidy-tabs-overflow-focus.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Constrain Tabs overflow controls to segmented tabs and focus the caret target.

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -122,8 +122,9 @@ export default function Example() {
 ### Horizontal Overflow
 
 <p>
-  When tabs overflow their container, scroll buttons appear at the clipped edge.
-  Use them, horizontal scrolling, or mouse drag to reveal off-screen tabs.
+  When segmented tabs overflow their container, scroll buttons appear at the
+  clipped edge. Use them, horizontal scrolling, or mouse drag to reveal
+  off-screen tabs.
 </p>
 <ComponentExample demo="TabsOverflowDemo">
   <TabsOverflowDemo client:visible />

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -345,7 +345,11 @@ function TabsOverflowControl({
         className={cn(
           "flex items-center justify-center text-kumo-subtle transition-colors hover:text-kumo-default",
           size === "sm" ? "size-5" : "size-6",
-          isSegmented ? (size === "sm" ? "rounded-sm" : "rounded-md") : "rounded",
+          isSegmented
+            ? size === "sm"
+              ? "rounded-sm"
+              : "rounded-md"
+            : "rounded",
           isStart ? "ml-1" : "mr-1",
         )}
       >

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -274,22 +274,26 @@ export function Tabs({
           )}
         />
       </TabsPrimitive.List>
-      <TabsOverflowControl
-        side="start"
-        visible={canScrollStart}
-        variant={variant}
-        size={size}
-        label={labels.scrollStart}
-        onClick={() => scrollTabs(listRef, "start")}
-      />
-      <TabsOverflowControl
-        side="end"
-        visible={canScrollEnd}
-        variant={variant}
-        size={size}
-        label={labels.scrollEnd}
-        onClick={() => scrollTabs(listRef, "end")}
-      />
+      {isSegmented && (
+        <>
+          <TabsOverflowControl
+            side="start"
+            visible={canScrollStart}
+            variant={variant}
+            size={size}
+            label={labels.scrollStart}
+            onClick={() => scrollTabs(listRef, "start")}
+          />
+          <TabsOverflowControl
+            side="end"
+            visible={canScrollEnd}
+            variant={variant}
+            size={size}
+            label={labels.scrollEnd}
+            onClick={() => scrollTabs(listRef, "end")}
+          />
+        </>
+      )}
     </TabsPrimitive.Root>
   );
 }
@@ -323,7 +327,7 @@ function TabsOverflowControl({
       tabIndex={visible ? 0 : -1}
       onClick={onClick}
       className={cn(
-        "absolute inset-y-0 z-3 flex items-center border-0 bg-transparent p-0 transition-opacity duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
+        "absolute inset-y-0 z-3 flex items-center border-0 bg-transparent p-0 transition-opacity duration-150 focus:outline-none focus-visible:[&>span]:ring-2 focus-visible:[&>span]:ring-kumo-brand",
         isStart
           ? "left-0 justify-start bg-linear-to-r"
           : "right-0 justify-end bg-linear-to-l",
@@ -341,6 +345,7 @@ function TabsOverflowControl({
         className={cn(
           "flex items-center justify-center text-kumo-subtle transition-colors hover:text-kumo-default",
           size === "sm" ? "size-5" : "size-6",
+          isSegmented ? (size === "sm" ? "rounded-sm" : "rounded-md") : "rounded",
           isStart ? "ml-1" : "mr-1",
         )}
       >


### PR DESCRIPTION
## Summary
- render Tabs overflow caret controls only for segmented tabs
- keep underline tabs scrollable without the edge caret controls
- constrain segmented overflow focus styling to the caret target
- update Tabs docs copy to describe segmented overflow controls

## Tests
- pnpm --filter @cloudflare/kumo lint

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: visual behavior change for overflow controls needs human review
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: visually checked segmented and underline tab overflow states in docs
- [x] Additional testing not necessary because: targeted lint passed and behavior is limited to rendering existing controls only for segmented tabs