### PR TITLE
chore: bump pnpm to 10.34.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ Cross-package dependency: registry codegen requires docs demo metadata. Run `cod
 | Tool       | Version   | Notes                                                     |
 | ---------- | --------- | --------------------------------------------------------- |
 | Node       | ^24.12.0  | Engine constraint (`.node-version`)                       |
-| pnpm       | >=10.21.0 | Workspace manager                                         |
+| pnpm       | >=10.26.0 | Workspace manager                                         |
 | Vite+      | 0.2.2     | Unified toolchain (`vp` CLI): build, test, lint, fmt      |
 | TypeScript | 5.9.2     | Via pnpm catalog                                          |
 | Vite       | 8.x       | Bundled via vite-plus; library mode (kumo), docs server   |

--- a/ci/AGENTS.md
+++ b/ci/AGENTS.md
@@ -104,4 +104,4 @@ deploy-docs-preview.sh → write-kumo-docs-report.ts → ci/reports/kumo-docs-pr
 - **Required secrets**: `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `GITHUB_TOKEN`, `FIGMA_TOKEN` (optional)
 - **Visual regression**: Creates ephemeral `vr-screenshots-{pr}-{runId}` branches for diff images
 - **Fork PR security**: `preview-deploy.yml` handles fork PRs via `workflow_run` (no secrets in fork context)
-- **Composite action**: `.github/actions/install-dependencies/action.yml` installs pnpm 10.22.0, Node 24, with optional filter
+- **Composite action**: `.github/actions/install-dependencies/action.yml` installs pnpm 10.34.0, Node 24, with optional filter

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "packageManager": {
       "name": "pnpm",
       "onFail": "warn",
-      "version": ">=10.21.0"
+      "version": ">=10.26.0"
     },
     "runtime": {
       "name": "node",
@@ -54,7 +54,7 @@
   },
   "engines": {
     "node": "^24.12.0",
-    "pnpm": ">=10.21.0"
+    "pnpm": ">=10.26.0"
   },
-  "packageManager": "pnpm@10.22.0"
+  "packageManager": "pnpm@10.34.0"
 }

--- a/packages/kumo-docs-astro/src/pages/contributing.mdx
+++ b/packages/kumo-docs-astro/src/pages/contributing.mdx
@@ -26,7 +26,7 @@ pnpm build
 Requirements:
 
 - Node `^24.12.0`
-- pnpm `>=10.21.0`
+- pnpm `>=10.26.0`
 
 Recommended local setup:
 


### PR DESCRIPTION
This PRs bump the pinned pnpm version from 10.22.0 to 10.34.0 and raise the supported minimum to 10.26.0, where `pnpm pack --dry-run` was introduced.
Also I updated contributor and toolchain documentation

- Reviews
	- [ ] bonk has reviewed the change
	- [x] automated review not possible because: this tooling-only PR has not yet received automated review
- Tests
	- [ ] Tests included/updated
	- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
	- [x] Additional testing not necessary because: the existing build, typecheck, and 1,246-test suite passed under pnpm 10.34.0