### PR TITLE
fix: forward link props in Tabs and Sidebar

### DIFF
--- a/.changeset/clean-link-prop-forwarding.md
+++ b/.changeset/clean-link-prop-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Forward link-specific props in Tabs and Sidebar so link-rendered tabs can opt out of native button semantics, and Sidebar link buttons preserve attributes like `aria-current`.

--- a/.changeset/gentle-tabs-link-render.md
+++ b/.changeset/gentle-tabs-link-render.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Forward `nativeButton` from Tabs items to support link-rendered tabs without Base UI warnings.
+Forward link-specific props in Tabs and Sidebar link rendering paths.

--- a/.changeset/gentle-tabs-link-render.md
+++ b/.changeset/gentle-tabs-link-render.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Forward `nativeButton` from Tabs items to support link-rendered tabs without Base UI warnings.

--- a/.changeset/gentle-tabs-link-render.md
+++ b/.changeset/gentle-tabs-link-render.md
@@ -1,5 +1,0 @@
----
-"@cloudflare/kumo": patch
----
-
-Forward link-specific props in Tabs and Sidebar link rendering paths.

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -165,11 +165,13 @@ export function TabsRenderPropDemo() {
         {
           value: "tab2",
           label: "Link Tab",
+          nativeButton: false,
           render: (props) => <a {...props} href="#tab2" />,
         },
         {
           value: "tab3",
           label: "Cloudflare",
+          nativeButton: false,
           render: (props) => (
             <a {...props} href="https://cloudflare.com" target="_blank" />
           ),

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -167,6 +167,16 @@ export default function Example() {
         <td class="px-4 py-3 font-mono text-xs">string</td>
         <td class="px-4 py-3 font-mono text-xs">No</td>
       </tr>
+      <tr class="border-b border-kumo-hairline">
+        <td class="px-4 py-3 font-mono text-xs">render</td>
+        <td class="px-4 py-3 font-mono text-xs">TabsTab.Props["render"]</td>
+        <td class="px-4 py-3 font-mono text-xs">No</td>
+      </tr>
+      <tr class="border-b border-kumo-hairline">
+        <td class="px-4 py-3 font-mono text-xs">nativeButton</td>
+        <td class="px-4 py-3 font-mono text-xs">boolean</td>
+        <td class="px-4 py-3 font-mono text-xs">No</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -585,6 +585,25 @@ describe("Sidebar.MenuButton", () => {
     expect(link).toBeTruthy();
     expect(link!.getAttribute("href")).toBe("/home");
   });
+
+  it("should preserve extra link attributes when href provided", () => {
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuButton href="/tenants" active aria-current="true">
+              Tenants
+            </SidebarMenuButton>
+          </SidebarMenu>
+        </SidebarContent>
+      </TestSidebar>,
+    );
+
+    const link = screen.getByText("Tenants").closest("a");
+    expect(link!.getAttribute("aria-current")).toBe("true");
+    expect(link!.getAttribute("data-active")).toBe("true");
+    expect(link!.getAttribute("data-kumo-part")).toBe("menu-button-link");
+  });
 });
 
 describe("Sidebar.MenuSubButton", () => {
@@ -619,6 +638,29 @@ describe("Sidebar.MenuSubButton", () => {
     );
     const link = screen.getByText("External").closest("a");
     expect(link!.getAttribute("target")).toBe("_self");
+  });
+
+  it("should preserve extra link attributes when href provided", () => {
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuSubButton
+              href="/observability"
+              active
+              aria-current="page"
+            >
+              Observability
+            </SidebarMenuSubButton>
+          </SidebarMenu>
+        </SidebarContent>
+      </TestSidebar>,
+    );
+
+    const link = screen.getByText("Observability").closest("a");
+    expect(link!.getAttribute("aria-current")).toBe("page");
+    expect(link!.getAttribute("data-active")).toBe("true");
+    expect(link!.getAttribute("data-kumo-part")).toBe("menu-sub-button-link");
   });
 });
 

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -1261,6 +1261,7 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
       button = (
         <LinkComponent
           ref={ref as React.Ref<HTMLAnchorElement>}
+          {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
           className={cn(buttonClasses, "no-underline!")}
           href={href}
           to={href}
@@ -1270,9 +1271,6 @@ const SidebarMenuButton = forwardRef<HTMLButtonElement, SidebarMenuButtonProps>(
           data-kumo-component="Sidebar"
           data-kumo-part="menu-button-link"
           data-size={size}
-          onClick={
-            props.onClick as unknown as React.MouseEventHandler<HTMLAnchorElement>
-          }
         >
           {content}
         </LinkComponent>
@@ -1494,6 +1492,7 @@ const SidebarMenuSubButton = forwardRef<
     button = (
       <LinkComponent
         ref={ref as React.Ref<HTMLAnchorElement>}
+        {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
         className={cn(buttonClasses, "no-underline!")}
         href={href}
         to={href}
@@ -1502,9 +1501,6 @@ const SidebarMenuSubButton = forwardRef<
         data-sidebar="menu-sub-button"
         data-kumo-component="Sidebar"
         data-kumo-part="menu-sub-button-link"
-        onClick={
-          props.onClick as unknown as React.MouseEventHandler<HTMLAnchorElement>
-        }
       >
         {content}
       </LinkComponent>

--- a/packages/kumo/src/components/tabs/tabs.test.tsx
+++ b/packages/kumo/src/components/tabs/tabs.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import { Tabs } from "./tabs";
+
+describe("Tabs", () => {
+  it("forwards nativeButton=false for link-rendered tabs", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <Tabs
+        variant="underline"
+        selectedValue="overview"
+        tabs={[
+          {
+            value: "overview",
+            label: "Overview",
+            nativeButton: false,
+            render: (props) => <a {...props} href="/settings/overview" />,
+          },
+          {
+            value: "members",
+            label: "Members",
+            nativeButton: false,
+            render: (props) => <a {...props} href="/settings/members" />,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("tab", { name: "Overview" }).getAttribute("href"),
+    ).toBe("/settings/overview");
+    expect(
+      warnSpy.mock.calls.some(([message]) =>
+        String(message).includes("nativeButton"),
+      ),
+    ).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -89,6 +89,11 @@ export type TabsItem = {
    * When using a function, it receives the props to spread on the element and the tab's state.
    */
   render?: TabsTab.Props["render"];
+  /**
+   * Whether the rendered tab is a native button. Set to `false` when `render` produces a non-button element, such as a link.
+   * @default true
+   */
+  nativeButton?: TabsTab.Props["nativeButton"];
 };
 
 /**
@@ -229,6 +234,7 @@ export function Tabs({
             data-kumo-part="tab"
             value={tab.value}
             render={tab.render}
+            nativeButton={tab.nativeButton}
             onClick={(e) => {
               e.currentTarget.scrollIntoView({
                 behavior: "smooth",


### PR DESCRIPTION
## Summary
- add `nativeButton` to `TabsItem` and forward it to Base UI `Tabs.Tab` so link-rendered tabs can opt out of native button semantics
- preserve extra props in Sidebar link branches so attributes like `aria-current` reach `MenuButton` and `MenuSubButton` anchors
- update the Tabs render-prop demo/docs for link-rendered tabs
- add regression tests for Tabs link rendering and Sidebar link attribute forwarding

Closes #690

## Tests
- pnpm --filter @cloudflare/kumo test:unit src/components/tabs/tabs.test.tsx src/components/sidebar/sidebar.test.tsx
- pnpm --filter @cloudflare/kumo lint
- pnpm format:check

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: targeted component API fixes with regression tests
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable