### PR TITLE
fix(sidebar): preserve peeking during sliding views

### DIFF
--- a/.changeset/fix-sidebar-peeking-sliding-views.md
+++ b/.changeset/fix-sidebar-peeking-sliding-views.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Sidebar peeking state during SlidingViews transitions.

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -479,6 +479,28 @@ describe("Sidebar.SlidingViews", () => {
     );
   }
 
+  function PeekingSlidingTest({ activeKey = "a" }: { activeKey?: string }) {
+    return (
+      <TestSidebar defaultOpen={false} peekable>
+        <StateReader />
+        <SidebarSlidingViews activeKey={activeKey}>
+          <SidebarSlidingView value="a">
+            <SidebarContent>
+              <button type="button" data-testid="view-a-button">
+                Go to B
+              </button>
+            </SidebarContent>
+          </SidebarSlidingView>
+          <SidebarSlidingView value="b">
+            <SidebarContent>
+              <button type="button">Go to A</button>
+            </SidebarContent>
+          </SidebarSlidingView>
+        </SidebarSlidingViews>
+      </TestSidebar>
+    );
+  }
+
   it("should show the active view", () => {
     render(<SlidingTest activeKey="a" />);
     const viewA = screen
@@ -509,6 +531,25 @@ describe("Sidebar.SlidingViews", () => {
       .closest("[data-sidebar='sliding-view']")!;
     expect(viewA.getAttribute("aria-hidden")).toBe("true");
     expect(viewB.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("should keep peeking when a view change blurs the active item under the pointer", () => {
+    const { rerender } = render(<PeekingSlidingTest activeKey="a" />);
+
+    const peekZone = document.querySelector("[data-sidebar='peek-zone']")!;
+    fireEvent.mouseEnter(peekZone);
+
+    const activeButton = screen.getByTestId("view-a-button");
+    fireEvent.focus(activeButton);
+    expect(screen.getByTestId("state-reader").dataset.state).toBe("peeking");
+
+    rerender(<PeekingSlidingTest activeKey="b" />);
+    fireEvent.blur(activeButton, { relatedTarget: null });
+
+    expect(screen.getByTestId("state-reader").dataset.state).toBe("peeking");
+
+    fireEvent.mouseLeave(peekZone);
+    expect(screen.getByTestId("state-reader").dataset.state).toBe("collapsed");
   });
 });
 

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -494,6 +494,7 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
     const triggerRef = useRef<Element | null>(null);
     const mobileNodeRef = useRef<HTMLElement | null>(null);
     const shouldRestoreFocusRef = useRef(false);
+    const isPointerInPeekZoneRef = useRef(false);
 
     // Escape key closes the mobile sidebar
     useEffect(() => {
@@ -537,12 +538,25 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
 
     const handlePeekBlur = useCallback(
       (e: React.FocusEvent<HTMLDivElement>) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        if (
+          !e.currentTarget.contains(e.relatedTarget as Node) &&
+          !isPointerInPeekZoneRef.current
+        ) {
           stopPeek();
         }
       },
       [stopPeek],
     );
+
+    const handlePeekMouseEnter = useCallback(() => {
+      isPointerInPeekZoneRef.current = true;
+      startPeek();
+    }, [startPeek]);
+
+    const handlePeekMouseLeave = useCallback(() => {
+      isPointerInPeekZoneRef.current = false;
+      stopPeek();
+    }, [stopPeek]);
 
     if (collapsible === "none") {
       return (
@@ -725,8 +739,8 @@ const SidebarRoot = forwardRef<HTMLElement, SidebarRootProps>(
                 <div
                   data-sidebar="peek-zone"
                   className="flex min-h-0 flex-1 flex-col"
-                  onMouseEnter={startPeek}
-                  onMouseLeave={stopPeek}
+                  onMouseEnter={handlePeekMouseEnter}
+                  onMouseLeave={handlePeekMouseLeave}
                   onFocus={startPeek}
                   onBlur={handlePeekBlur}
                 >

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -837,6 +837,7 @@ const SidebarContent = forwardRef<
         "flex w-1.5 touch-none p-px select-none",
         "opacity-0 transition-opacity duration-150",
         "data-[hovering]:opacity-100 data-[scrolling]:opacity-100",
+        "group-data-[state=collapsed]/sidebar:hidden",
       )}
     >
       <ScrollAreaBase.Thumb className="flex-1 rounded-full bg-kumo-line" />


### PR DESCRIPTION
## Summary

Fixes #685.

- Preserve Sidebar peeking while a focused item blurs during a SlidingViews surface change if the pointer is still inside the peek zone.
- Keep existing collapse behavior when the pointer leaves the peek zone.
- Add regression coverage for peeking through a SlidingViews active view change.

## Tests

- pnpm --filter @cloudflare/kumo test src/components/sidebar/sidebar.test.tsx
- pnpm --filter @cloudflare/kumo lint

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: targeted interaction regression requires human visual confirmation in the docs demo
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: tested the Sidebar Full docs demo locally by collapsing, hovering to peek, and switching views
- [ ] Additional testing not necessary because: covered by focused Sidebar regression test and package lint