### PR TITLE
fix(docs): improve home grid dialog example

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -49,6 +49,7 @@ import {
   TranslateIcon,
   WarningIcon,
   WarningOctagonIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 
 const componentRoutes: Record<string, string> = {
@@ -269,10 +270,45 @@ export function HomeGrid() {
       id: "dialog",
       Component: (
         <Dialog.Root>
-          <Dialog.Trigger render={(p) => <Button {...p}>Click me!</Button>} />
-          <Dialog>
-            <Dialog.Title>Hello!</Dialog.Title>
-            <Dialog.Description>I'm a dialog.</Dialog.Description>
+          <Dialog.Trigger render={(p) => <Button {...p}>Delete</Button>} />
+          <Dialog className="p-8">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <Dialog.Title className="text-2xl font-semibold">
+                Delete Resource?
+              </Dialog.Title>
+              <Dialog.Close
+                aria-label="Close"
+                render={(props) => (
+                  <Button
+                    {...props}
+                    variant="secondary"
+                    shape="square"
+                    icon={<XIcon />}
+                    aria-label="Close"
+                  />
+                )}
+              />
+            </div>
+            <Dialog.Description className="text-kumo-subtle">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Dialog.Description>
+            <div className="mt-8 flex justify-end gap-2">
+              <Dialog.Close
+                render={(props) => (
+                  <Button variant="secondary" {...props}>
+                    Cancel
+                  </Button>
+                )}
+              />
+              <Dialog.Close
+                render={(props) => (
+                  <Button variant="destructive" {...props}>
+                    Delete
+                  </Button>
+                )}
+              />
+            </div>
           </Dialog>
         </Dialog.Root>
       ),


### PR DESCRIPTION
## Summary

- Updates the home components grid Dialog preview to use a more representative delete confirmation example.
- Aligns the preview structure with the dedicated Dialog docs example, including header, close control, description styling, and actions.

## Testing

- `pnpm --filter @cloudflare/kumo-docs-astro exec vp lint src/components/demos/HomeGrid.tsx`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: small docs-only example update
- Tests
- [ ] Tests included/updated
- [x] Automated tests not possible - manual testing has been completed as follows: targeted lint was run for the edited home grid demo file
- [ ] Additional testing not necessary because: <your reason here>