### PR TITLE
fix(tabs): refresh overflow state after tab changes

### DIFF
--- a/.changeset/fuzzy-tabs-wait.md
+++ b/.changeset/fuzzy-tabs-wait.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix Tabs overflow controls when tabs are removed and the remaining tabs fit.

--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -1,6 +1,22 @@
 import { useState } from "react";
 import { Tabs } from "@cloudflare/kumo";
 
+const productionLikeTabs = [
+  { value: "overview", label: "Overview" },
+  { value: "metrics", label: "Metrics" },
+  { value: "deployments", label: "Deployments" },
+  { value: "observability", label: "Observability" },
+  { value: "domains", label: "Domains" },
+  { value: "access", label: "Access" },
+  { value: "settings", label: "Settings" },
+];
+
+const productionLikeExtraTabs = [
+  { value: "analytics", label: "Analytics" },
+  { value: "logs", label: "Logs" },
+  { value: "security", label: "Security" },
+];
+
 export function TabsDefaultDemo() {
   return (
     <div className="flex flex-col gap-6">
@@ -117,6 +133,31 @@ export function TabsOverflowDemo() {
         ]}
         selectedValue="overview"
       />
+    </div>
+  );
+}
+
+export function TabsDynamicCountDemo() {
+  const [showExtraTabs, setShowExtraTabs] = useState(true);
+  const tabs = showExtraTabs
+    ? [...productionLikeTabs, ...productionLikeExtraTabs]
+    : productionLikeTabs;
+
+  return (
+    <div className="space-y-3">
+      <div className="w-full max-w-[588px]">
+        <Tabs tabs={tabs} selectedValue="settings" />
+      </div>
+      <div className="flex items-center gap-3 text-sm text-kumo-subtle">
+        <button
+          type="button"
+          className="rounded-md border border-kumo-line bg-kumo-base px-2.5 py-1 text-kumo-default hover:bg-kumo-tint focus:ring-2 focus:ring-kumo-brand focus:outline-none"
+          onClick={() => setShowExtraTabs((current) => !current)}
+        >
+          Toggle extra tabs
+        </button>
+        <span>{showExtraTabs ? "10 tabs" : "7 tabs"}</span>
+      </div>
     </div>
   );
 }

--- a/packages/kumo-docs-astro/src/pages/components/tabs.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/tabs.mdx
@@ -16,6 +16,7 @@ import {
   TabsControlledDemo,
   TabsManyDemo,
   TabsOverflowDemo,
+  TabsDynamicCountDemo,
 } from "~/components/demos/TabsDemo";
 
 {/* Hero Demo */}
@@ -128,6 +129,17 @@ export default function Example() {
 </p>
 <ComponentExample demo="TabsOverflowDemo">
   <TabsOverflowDemo client:visible />
+</ComponentExample>
+
+### Dynamic Tab Count
+
+<p>
+  This example toggles between an overflowing tab set and the production-like
+  seven-tab set. When the extra tabs disappear, the end overflow control should
+  hide once the remaining tabs fit.
+</p>
+<ComponentExample demo="TabsDynamicCountDemo">
+  <TabsDynamicCountDemo client:visible />
 </ComponentExample>
 
 </ComponentSection>

--- a/packages/kumo/src/components/tabs/tabs.test.tsx
+++ b/packages/kumo/src/components/tabs/tabs.test.tsx
@@ -1,6 +1,22 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Tabs } from "./tabs";
+
+const baseTabs = [
+  { value: "overview", label: "Overview" },
+  { value: "metrics", label: "Metrics" },
+  { value: "deployments", label: "Deployments" },
+  { value: "observability", label: "Observability" },
+  { value: "domains", label: "Domains" },
+  { value: "access", label: "Access" },
+  { value: "settings", label: "Settings" },
+];
+
+const extraTabs = [
+  { value: "analytics", label: "Analytics" },
+  { value: "logs", label: "Logs" },
+  { value: "security", label: "Security" },
+];
 
 describe("Tabs", () => {
   it("forwards nativeButton=false for link-rendered tabs", () => {
@@ -38,4 +54,54 @@ describe("Tabs", () => {
 
     warnSpy.mockRestore();
   });
+
+  it("hides overflow controls when removed tabs leave the remaining tabs fitting", async () => {
+    const { container, rerender } = render(
+      <Tabs selectedValue="settings" tabs={[...baseTabs, ...extraTabs]} />,
+    );
+    const list = screen.getByRole("tablist");
+
+    setTabListSize(list, {
+      clientWidth: 600,
+      scrollWidth: 800,
+    });
+    fireEvent.scroll(list);
+
+    const endControl = container.querySelector(
+      '[data-kumo-part="overflow-control"][data-side="end"]',
+    );
+
+    await waitFor(() =>
+      expect(endControl?.getAttribute("aria-hidden")).toBe("false"),
+    );
+
+    setTabListSize(list, {
+      clientWidth: 588,
+      scrollWidth: 588,
+    });
+    rerender(<Tabs selectedValue="settings" tabs={baseTabs} />);
+
+    await waitFor(() =>
+      expect(endControl?.getAttribute("aria-hidden")).toBe("true"),
+    );
+  });
 });
+
+function setTabListSize(
+  list: HTMLElement,
+  { clientWidth, scrollWidth }: { clientWidth: number; scrollWidth: number },
+) {
+  defineReadonlyNumber(list, "clientWidth", clientWidth);
+  defineReadonlyNumber(list, "scrollWidth", scrollWidth);
+}
+
+function defineReadonlyNumber(
+  element: HTMLElement,
+  property: "clientWidth" | "scrollWidth",
+  value: number,
+) {
+  Object.defineProperty(element, property, {
+    configurable: true,
+    value,
+  });
+}

--- a/packages/kumo/src/components/tabs/tabs.tsx
+++ b/packages/kumo/src/components/tabs/tabs.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type MouseEvent,
@@ -179,12 +180,13 @@ export function Tabs({
   const isUnderline = variant === "underline";
   const isSm = size === "sm";
   const labels = { ...DEFAULT_LABELS, ...labelsProp };
+  const overflowWatchKey = items.map((item) => item.value).join("|");
   const {
     ref: listRef,
     isOverflowing,
     canScrollStart,
     canScrollEnd,
-  } = useOverflowDetect(true);
+  } = useOverflowDetect(true, overflowWatchKey);
   const bindDrag = useHorizontalDragScroll(listRef, isOverflowing);
 
   return (
@@ -506,7 +508,7 @@ function useHorizontalDragScroll(
  * Returns a ref to attach and a boolean for conditional rendering.
  * The `data-overflowing` attribute drives the scroll-fade CSS.
  */
-function useOverflowDetect(enabled: boolean) {
+function useOverflowDetect(enabled: boolean, watchKey: string) {
   const ref = useRef<HTMLDivElement>(null);
   const [overflowState, setOverflowState] = useState({
     isOverflowing: false,
@@ -514,27 +516,21 @@ function useOverflowDetect(enabled: boolean) {
     canScrollEnd: false,
   });
 
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+
+    setOverflowState((prevState) => getNextOverflowState(el, prevState));
+  }, [enabled, watchKey]);
+
   useEffect(() => {
     if (!enabled) return;
     const el = ref.current;
     if (!el) return;
 
     const check = () => {
-      const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth);
-      const scrollLeft = Math.min(Math.max(0, el.scrollLeft), maxScrollLeft);
-      const nextState = {
-        isOverflowing: maxScrollLeft > 1,
-        canScrollStart: scrollLeft > 1,
-        canScrollEnd: maxScrollLeft - scrollLeft > 1,
-      };
-
-      setOverflowState((prevState) =>
-        prevState.isOverflowing === nextState.isOverflowing &&
-        prevState.canScrollStart === nextState.canScrollStart &&
-        prevState.canScrollEnd === nextState.canScrollEnd
-          ? prevState
-          : nextState,
-      );
+      setOverflowState((prevState) => getNextOverflowState(el, prevState));
     };
 
     const ro = new ResizeObserver(check);
@@ -552,4 +548,27 @@ function useOverflowDetect(enabled: boolean) {
   }, [enabled]);
 
   return { ref, ...overflowState };
+}
+
+function getNextOverflowState(
+  el: HTMLElement,
+  prevState: {
+    isOverflowing: boolean;
+    canScrollStart: boolean;
+    canScrollEnd: boolean;
+  },
+) {
+  const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth);
+  const scrollLeft = Math.min(Math.max(0, el.scrollLeft), maxScrollLeft);
+  const nextState = {
+    isOverflowing: maxScrollLeft > 1,
+    canScrollStart: scrollLeft > 1,
+    canScrollEnd: maxScrollLeft - scrollLeft > 1,
+  };
+
+  return prevState.isOverflowing === nextState.isOverflowing &&
+    prevState.canScrollStart === nextState.canScrollStart &&
+    prevState.canScrollEnd === nextState.canScrollEnd
+    ? prevState
+    : nextState;
 }


### PR DESCRIPTION
## Summary

Fixes stale Tabs overflow controls when the rendered tab set changes and the remaining tabs no longer overflow. Adds a manual docs example for toggling between a larger tab set and the production-like seven-tab set.

## Testing

- `pnpm --filter @cloudflare/kumo test src/components/tabs/tabs.test.tsx`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a targeted UI state bug that needs preview/prod verification
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: preview validation pending
- [ ] Additional testing not necessary because: n/a