### PR TITLE
Make CommandPalette demo in home page interactive

### DIFF
--- a/.changeset/fix-home-command-palette.md
+++ b/.changeset/fix-home-command-palette.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo-docs-astro": patch
+---
+
+Fix the home page CommandPalette demo so it opens when clicked.

--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -40,6 +40,7 @@ import {
   useKumoToastManager,
 } from "@cloudflare/kumo";
 import { ShikiProvider, CodeHighlighted } from "@cloudflare/kumo/code";
+import { CommandPaletteBasicDemo } from "~/components/demos/CommandPaletteDemo";
 import { InputGroupDemo } from "~/components/demos/InputGroupDemo";
 import {
   MagnifyingGlassIcon,
@@ -560,9 +561,7 @@ export function HomeGrid() {
     {
       name: "CommandPalette",
       id: "command-palette",
-      Component: (
-        <Button icon={MagnifyingGlassIcon}>Open Command Palette</Button>
-      ),
+      Component: <CommandPaletteBasicDemo />,
     },
     {
       name: "Flow",


### PR DESCRIPTION
Fix broken CommandPalette component on the home page demo.

---

- Reviews
- [x] bonk has reviewed the change
- [x] automated review not possible because: bonk runs after the pull request is opened.
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not run.
- [x] Additional testing not necessary because: this reuses existing menu behavior.