### PR TITLE
fix(combobox): expose all positioner props on Combobox.Content

### DIFF
--- a/.changeset/combobox-content-collision-avoidance.md
+++ b/.changeset/combobox-content-collision-avoidance.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Expose all positioner props on Combobox.Content (`anchor`, `positionMethod`, `collisionAvoidance`, `collisionBoundary`, `collisionPadding`, `sticky`, `disableAnchorTracking`).

--- a/packages/kumo/src/components/combobox/combobox.test.tsx
+++ b/packages/kumo/src/components/combobox/combobox.test.tsx
@@ -41,6 +41,37 @@ describe("Combobox", () => {
     expect(screen.getByPlaceholderText("Pick a fruit…")).toBeTruthy();
   });
 
+  it("accepts positioner props on content", () => {
+    render(
+      <Combobox items={fruits}>
+        <Combobox.TriggerInput placeholder="Pick a fruit…" />
+        <Combobox.Content
+          side="bottom"
+          positionMethod="fixed"
+          collisionAvoidance={{
+            side: "none",
+            align: "shift",
+            fallbackAxisSide: "none",
+          }}
+          collisionBoundary="clipping-ancestors"
+          collisionPadding={10}
+          sticky={false}
+          disableAnchorTracking={false}
+        >
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Content>
+      </Combobox>,
+    );
+
+    expect(screen.getByPlaceholderText("Pick a fruit…")).toBeTruthy();
+  });
+
   // Variants export
 
   it("exports KUMO_COMBOBOX_VARIANTS with size and inputSide axes", () => {

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -206,6 +206,13 @@ function Content({
   sideOffset = 4,
   alignOffset,
   side,
+  anchor,
+  positionMethod,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  sticky,
+  disableAnchorTracking,
   container: containerProp,
 }: PropsWithChildren<{
   className?: string;
@@ -213,6 +220,13 @@ function Content({
   alignOffset?: ComboboxBase.Positioner.Props["alignOffset"];
   side?: ComboboxBase.Positioner.Props["side"];
   sideOffset?: ComboboxBase.Positioner.Props["sideOffset"];
+  anchor?: ComboboxBase.Positioner.Props["anchor"];
+  positionMethod?: ComboboxBase.Positioner.Props["positionMethod"];
+  collisionAvoidance?: ComboboxBase.Positioner.Props["collisionAvoidance"];
+  collisionBoundary?: ComboboxBase.Positioner.Props["collisionBoundary"];
+  collisionPadding?: ComboboxBase.Positioner.Props["collisionPadding"];
+  sticky?: ComboboxBase.Positioner.Props["sticky"];
+  disableAnchorTracking?: ComboboxBase.Positioner.Props["disableAnchorTracking"];
   /**
    * Container element for the portal. Use this to render the combobox inside
    * a Shadow DOM or custom container. Overrides `KumoPortalProvider` context.
@@ -231,6 +245,13 @@ function Content({
         sideOffset={sideOffset}
         alignOffset={alignOffset}
         side={side}
+        anchor={anchor}
+        positionMethod={positionMethod}
+        collisionAvoidance={collisionAvoidance}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        sticky={sticky}
+        disableAnchorTracking={disableAnchorTracking}
       >
         <ComboboxBase.Popup
           className={cn(


### PR DESCRIPTION
## Summary

Forwards all Base UI positioner props from `Combobox.Content` to the underlying `ComboboxBase.Positioner`, giving callers full control over positioning behavior.

### Problem

`Combobox.Content` only forwarded `align`, `alignOffset`, `side`, and `sideOffset` to the positioner. Other useful positioning props like `collisionAvoidance`, `collisionBoundary`, `positionMethod`, etc. were not exposed, so callers couldn't opt out of side-flipping or customize collision behavior.

### Solution

Expose all `UseAnchorPositioningSharedParameters` props on `Combobox.Content` (except `arrowPadding`, which doesn't apply since Combobox has no arrow):

| Prop | Description |
|------|-------------|
| `anchor` | Position against a custom element or virtual element |
| `positionMethod` | `'absolute'` or `'fixed'` (escape stacking contexts) |
| `collisionAvoidance` | Control side-flipping and alignment shifting behavior |
| `collisionBoundary` | Custom boundary element for collision detection |
| `collisionPadding` | Padding from the collision boundary |
| `sticky` | Keep popup in viewport after anchor scrolls away |
| `disableAnchorTracking` | Disable layout-shift tracking |

Example — prevent side flipping:

```tsx
<Combobox.Content
  side="bottom"
  collisionAvoidance={{
    side: "none",
    align: "shift",
    fallbackAxisSide: "none",
  }}
>
```

### Changes

- `combobox.tsx`: destructure and forward 7 new positioner props
- `combobox.test.tsx`: add test exercising the new props
- changeset: patch

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: straightforward prop forwarding, needs human sign-off
- Tests
  - [x] Tests included/updated
