### PR TITLE
fix(table): update row styling

### DIFF
--- a/.changeset/striped-tables.md
+++ b/.changeset/striped-tables.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Update Table rows to use borderless, alternating background styling.

--- a/packages/kumo/src/components/table/table.test.tsx
+++ b/packages/kumo/src/components/table/table.test.tsx
@@ -2,6 +2,33 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import { Table } from "./table";
 
+describe("Table styling", () => {
+  it("uses alternating row backgrounds without body row borders", () => {
+    const { container } = render(
+      <Table>
+        <Table.Body>
+          <Table.Row data-testid="default-row">
+            <Table.Cell>Default</Table.Cell>
+          </Table.Row>
+          <Table.Row data-testid="selected-row" variant="selected">
+            <Table.Cell>Selected</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    );
+
+    expect(screen.getByTestId("default-row").className).toContain(
+      "even:bg-kumo-tint",
+    );
+    expect(screen.getByTestId("selected-row").className).not.toContain(
+      "even:bg-kumo-tint",
+    );
+    expect(container.querySelector("table")?.className).not.toContain(
+      "[&_td]:border",
+    );
+  });
+});
+
 describe("Table.CheckCell / Table.CheckHead", () => {
   it("calls onCheckedChange with the new checked state", async () => {
     const onCheckedChange = vi.fn();

--- a/packages/kumo/src/components/table/table.tsx
+++ b/packages/kumo/src/components/table/table.tsx
@@ -18,11 +18,12 @@ export const KUMO_TABLE_VARIANTS = {
   },
   variant: {
     default: {
-      classes: "",
+      classes:
+        "even:bg-kumo-tint [--kumo-table-row-bg:var(--color-kumo-base)] even:[--kumo-table-row-bg:var(--color-kumo-tint)]",
       description: "Default row variant",
     },
     selected: {
-      classes: "bg-kumo-tint",
+      classes: "bg-kumo-tint [--kumo-table-row-bg:var(--color-kumo-tint)]",
       description: "Selected row variant",
     },
   },
@@ -66,12 +67,19 @@ const stickyColumnClasses = (
     "before:pointer-events-none before:absolute before:inset-y-0 before:w-6";
 
   if (element === "cell") {
-    // Body cells always use kumo-base
+    // Body cells match their row, including striped and selected backgrounds
     const fade =
       side === "right"
-        ? "before:bg-gradient-to-r before:from-transparent before:to-kumo-base"
-        : "before:bg-gradient-to-l before:from-transparent before:to-kumo-base";
-    return cn(base, z, "bg-kumo-base", fadeBase, fadePosition, fade);
+        ? "before:bg-gradient-to-r before:from-transparent before:to-(--kumo-table-row-bg)"
+        : "before:bg-gradient-to-l before:from-transparent before:to-(--kumo-table-row-bg)";
+    return cn(
+      base,
+      z,
+      "bg-(--kumo-table-row-bg)",
+      fadeBase,
+      fadePosition,
+      fade,
+    );
   }
 
   // Header cells: use kumo-base by default, kumo-elevated when in compact header
@@ -94,7 +102,7 @@ export type KumoTableRowVariant = keyof typeof KUMO_TABLE_VARIANTS.variant;
 export type KumoTableLayout = keyof typeof KUMO_TABLE_VARIANTS.layout;
 
 /**
- * Table root — applies layout, borders, padding, and header styles.
+ * Table root — applies layout, padding, and header styles.
  *
  * @example
  * ```tsx
@@ -133,7 +141,6 @@ const TableRoot = forwardRef<
       layout,
       KUMO_TABLE_DEFAULT_VARIANTS.layout,
     ).classes,
-    "[&_td]:border-b [&_td]:border-kumo-fill [&_tr:last-child_td]:border-b-0", // Row border
     "[&_td]:p-3", // Cell padding
     "[&_th]:border-b [&_th]:border-kumo-fill [&_th]:p-3 [&_th]:text-base [&_th]:font-semibold", // Header styles
     "[&_th]:bg-kumo-base", // Header background color


### PR DESCRIPTION
## Summary

Change the table component to use alternating background colors instead of borders:

<img width="1604" height="874" alt="CleanShot 2026-08-12 at 12 47 03@2x" src="https://github.com/user-attachments/assets/6a847591-f81a-4d43-9c54-931e369f8f1a" />

- remove borders between table body rows
- use `bg-kumo-tint` for even rows
- keep sticky cell backgrounds and fades aligned with striped and selected rows

## Validation

- `pnpm --filter @cloudflare/kumo test --run src/components/table/table.test.tsx`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo build`

## Reviews

- [ ] bonk has reviewed the change
- [x] automated review not possible because: this visual styling change requires maintainer review
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: tests were added