### PR TITLE
[kumo] fix hydration mismatch in Sidebar useIsMobile hook

### DIFF
--- a/.changeset/tidy-sidebars-mobile.md
+++ b/.changeset/tidy-sidebars-mobile.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix hydration mismatch in the Sidebar's `useIsMobile` hook on SSR frameworks like Next.js. The hook now uses `useSyncExternalStore` with a desktop `getServerSnapshot`, so the server-rendered HTML (desktop `<aside>`) hydrates cleanly on mobile viewports before switching to the mobile overlay.

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -11,6 +11,8 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { renderToString } from "react-dom/server";
+import { hydrateRoot } from "react-dom/client";
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import {
   Sidebar,
@@ -881,5 +883,84 @@ describe("Sidebar.Loading", () => {
     expect(
       screen.getByRole("status").classList.contains("custom-loading"),
     ).toBe(true);
+  });
+});
+
+// ============================================================================
+// Mobile detection (useIsMobile) — SSR / hydration safety
+// ============================================================================
+//
+// useIsMobile must be SSR-safe: during server rendering and hydration it must
+// report desktop (getServerSnapshot), so the SSR HTML (desktop <aside>) can be
+// hydrated without a mismatch even on a mobile viewport, then switch to the
+// mobile overlay once the client subscribes to matchMedia.
+describe("Sidebar mobile detection (useIsMobile)", () => {
+  it("should render the desktop <aside> during SSR regardless of viewport", () => {
+    setMobileMatchMedia(true);
+
+    const html = renderToString(
+      <SidebarProvider mobileBreakpoint={768}>
+        <Sidebar>
+          <SidebarHeader>Header</SidebarHeader>
+        </Sidebar>
+      </SidebarProvider>,
+    );
+
+    expect(html).toContain("<aside");
+    expect(html).not.toContain("data-mobile");
+  });
+
+  it("should hydrate the SSR output without a hydration mismatch on a mobile viewport", () => {
+    setMobileMatchMedia(true);
+
+    const ui = (
+      <SidebarProvider mobileBreakpoint={768}>
+        <Sidebar>
+          <SidebarHeader>Header</SidebarHeader>
+        </Sidebar>
+      </SidebarProvider>
+    );
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(ui);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => {
+      hydrateRoot(container, ui);
+    });
+
+    const hydrationErrors = errorSpy.mock.calls.filter((args) =>
+      /hydration|did not match|hydrate/i.test(args.map(String).join(" ")),
+    );
+    expect(hydrationErrors).toEqual([]);
+
+    errorSpy.mockRestore();
+  });
+
+  it("should render the mobile overlay on the client when the viewport matches", () => {
+    setMobileMatchMedia(true);
+
+    render(
+      <TestSidebar mobileBreakpoint={768}>
+        <SidebarHeader>Header</SidebarHeader>
+      </TestSidebar>,
+    );
+
+    expect(document.querySelector('[data-mobile="true"]')).not.toBeNull();
+  });
+
+  it("should render the desktop aside on the client on a desktop viewport", () => {
+    setMobileMatchMedia(false);
+
+    render(
+      <TestSidebar mobileBreakpoint={768}>
+        <SidebarHeader>Header</SidebarHeader>
+      </TestSidebar>,
+    );
+
+    expect(
+      document.querySelector('aside[data-sidebar="sidebar"]'),
+    ).not.toBeNull();
+    expect(document.querySelector('[data-mobile="true"]')).toBeNull();
   });
 });

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -11,6 +11,7 @@ import React, {
   useId,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { ScrollArea as ScrollAreaBase } from "@base-ui/react/scroll-area";
 
@@ -104,20 +105,22 @@ const FOCUSABLE_SELECTOR =
 // ============================================================================
 
 function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
-  const [isMobile, setIsMobile] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches;
-  });
+  const query = `(max-width: ${breakpoint - 1}px)`;
 
-  useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
-    const onChange = () => setIsMobile(mql.matches);
-    mql.addEventListener("change", onChange);
-    setIsMobile(mql.matches);
-    return () => mql.removeEventListener("change", onChange);
-  }, [breakpoint]);
+  const subscribe = useCallback((callback: () => void) => {
+    const mql = window.matchMedia(query);
+    mql.addEventListener("change", callback);
+    return () => mql.removeEventListener("change", callback);
+  }, [query]);
 
-  return isMobile;
+  const getSnapshot = useCallback(
+    () => window.matchMedia(query).matches,
+    [query],
+  );
+
+  const getServerSnapshot = useCallback(() => false, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 // ============================================================================

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -107,11 +107,14 @@ const FOCUSABLE_SELECTOR =
 function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
   const query = `(max-width: ${breakpoint - 1}px)`;
 
-  const subscribe = useCallback((callback: () => void) => {
-    const mql = window.matchMedia(query);
-    mql.addEventListener("change", callback);
-    return () => mql.removeEventListener("change", callback);
-  }, [query]);
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", callback);
+      return () => mql.removeEventListener("change", callback);
+    },
+    [query],
+  );
 
   const getSnapshot = useCallback(
     () => window.matchMedia(query).matches,


### PR DESCRIPTION
## Problem

`Sidebar.useIsMobile` reads `window.matchMedia` inside a `useState` initializer:

```ts
const [isMobile, setIsMobile] = useState(() => {
  if (typeof window === "undefined") return false;
  return window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches;
});
```

During SSR `window` is undefined, so `isMobile` is `false` (desktop) and the server renders the desktop `<aside>`. On a mobile viewport the client's first hydration render evaluates `matchMedia` → `true`, producing the **mobile overlay DOM** (a structurally different tree: backdrop + `<nav data-mobile>`). The SSR HTML and the client hydration render don't match → React logs a hard hydration mismatch error and re-renders client-side, discarding the SSR output.

This affects any SSR framework (e.g. Next.js) mounting `Sidebar` on a mobile viewport. Confirmed still present on `main` and in the latest published versions (2.9.2 / 2.10.0).

## Fix

Switch `useIsMobile` to `useSyncExternalStore` with a desktop `getServerSnapshot`:

- **Hydration is SSR-safe**: React renders with `getServerSnapshot` (`false`) during hydration, matching the SSR HTML, then switches to the real viewport once subscribed to `matchMedia`.
- **No re-subscribe churn**: `subscribe`/`getSnapshot` are memoized on the query, so the `matchMedia` listener only re-binds when the `breakpoint` changes — same behavior as the previous `useEffect([breakpoint])`.

```ts
function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
  const query = `(max-width: ${breakpoint - 1}px)`;

  const subscribe = useCallback((callback: () => void) => {
    const mql = window.matchMedia(query);
    mql.addEventListener("change", callback);
    return () => mql.removeEventListener("change", callback);
  }, [query]);

  const getSnapshot = useCallback(
    () => window.matchMedia(query).matches,
    [query],
  );

  const getServerSnapshot = useCallback(() => false, []);

  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
}
```

## Tests

Added 4 unit tests in `sidebar.test.tsx` covering the SSR/hydration contract:

- SSR renders the desktop `<aside>` regardless of the viewport (fails with the previous implementation).
- `hydrateRoot` over the SSR output produces no hydration mismatch on a mobile viewport.
- Client render on a mobile viewport yields the mobile overlay.
- Client render on a desktop viewport yields the desktop `<aside>`.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: external contribution
- Tests
  - [x] Tests included/updated