### PR TITLE
fix(button): allow selecting LinkButton text

### DIFF
--- a/.changeset/calm-links-select.md
+++ b/.changeset/calm-links-select.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Allow users to select and copy LinkButton text while preserving Button text selection behavior.

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -59,6 +59,13 @@ describe("Button", () => {
     expect(button.hasAttribute("disabled")).toBe(true);
   });
 
+  it("prevents text selection", () => {
+    render(<Button>Save</Button>);
+    const button = screen.getByRole("button");
+    expect(button.classList.contains("select-none")).toBe(true);
+    expect(button.classList.contains("select-text")).toBe(false);
+  });
+
   it("forwards ref to the <button> DOM node", () => {
     const ref = React.createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Click</Button>);
@@ -207,6 +214,13 @@ describe("LinkButton", () => {
     expect(link.getAttribute("href")).toBe("/home");
   });
 
+  it("allows text selection", () => {
+    render(<LinkButton href="/home">Home</LinkButton>);
+    const link = screen.getByRole("link");
+    expect(link.classList.contains("select-text")).toBe(true);
+    expect(link.classList.contains("select-none")).toBe(false);
+  });
+
   it("external sets target='_blank' and rel='noopener noreferrer'", () => {
     render(
       <LinkButton href="https://example.com" external>
@@ -281,6 +295,17 @@ describe("LinkButton", () => {
       );
       const button = screen.getByRole("button", { name: "Home" });
       expect(button.getAttribute("data-kumo-component")).toBe("LinkButton");
+    });
+
+    it("allows text selection", () => {
+      render(
+        <LinkButton href="/home" disabled>
+          Home
+        </LinkButton>,
+      );
+      const button = screen.getByRole("button", { name: "Home" });
+      expect(button.classList.contains("select-text")).toBe(true);
+      expect(button.classList.contains("select-none")).toBe(false);
     });
 
     it("wraps a title in an enabled tooltip trigger around the disabled button", () => {

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -480,7 +480,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
       return (
         <Button
           {...toDisabledButtonProps(props)}
-          className={className}
+          className={cn("select-text", className)}
           data-kumo-component="LinkButton"
           disabled
           icon={IconComponent}
@@ -501,7 +501,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
         data-kumo-component="LinkButton"
         className={cn(
           buttonVariants({ variant, size, shape }),
-          "flex items-center no-underline!",
+          "flex items-center no-underline! select-text",
           className,
         )}
         href={href}


### PR DESCRIPTION
Fixes https://gitlab.cfdata.org/cloudflare/fe/stratus/-/merge_requests/42286

Similar to https://x.com/BraydenWilmoth/status/2087555344184521063, text should be selectable, right-clickable, and copy-able via keyboard.
> <img width="599" height="666" alt="Screenshot 2026-08-13 at 5 21 28 PM" src="https://github.com/user-attachments/assets/75e9cf9b-83b7-4009-84d8-d1c6ce28b460" />



The a11y implications are:

* Motor impaired users who need to copy the text to transfer to other apps (e.g. Slack, gChat, Docs, etc.) currently have to retype.
* Low vision users currently can't highlight for readability.
* Screen-reader users are unaffected.
* Keyboard users still get link activation (e.g. via tab), but gain caret-based selection with this MR.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
