### PR TITLE
Preserve docs nav scroll position after page change

### DIFF
--- a/packages/kumo-docs-astro/src/layouts/MainLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/MainLayout.astro
@@ -29,7 +29,7 @@ const currentPath = Astro.url.pathname;
               el.scrollTop = pos;
             }
           } catch {
-            // Storage can be unavailable in privacy-restricted contexts.
+            // no-op
           }
         }
 

--- a/packages/kumo-docs-astro/src/layouts/MainLayout.astro
+++ b/packages/kumo-docs-astro/src/layouts/MainLayout.astro
@@ -29,12 +29,12 @@ const currentPath = Astro.url.pathname;
               el.scrollTop = pos;
             }
           } catch {
-            // no-op
+            // Storage can be unavailable in privacy-restricted contexts.
           }
         }
 
         restore();
-        window.addEventListener("astro:after-swap", restore);
+        document.addEventListener("astro:after-swap", restore);
       })();
     </script>
 


### PR DESCRIPTION
Preserve docs navigation scroll position across client-side page transitions.

https://github.com/user-attachments/assets/4ae1baa5-9b05-43ea-9c2d-3604e9f6a93a

---

- Reviews
- [x] automated review not possible because: no automated code-review tooling was used
- Tests
- [x] Additional testing not necessary because: focused lint and diff checks passed; browser validation was intentionally not performed