### PR TITLE
fix(docs): remove unnecessary fixed width from Toolbar home grid demo

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/HomeGrid.tsx
@@ -179,7 +179,7 @@ export function HomeGrid() {
       name: "Toolbar",
       id: "toolbar",
       Component: (
-        <Toolbar className="w-[260px]">
+        <Toolbar>
           <Toolbar.Input
             aria-label="Search DNS records"
             placeholder="Search..."


### PR DESCRIPTION
Removes the hard-coded `w-[260px]` on the Toolbar demo rendered on the docs homepage to eliminate extra right-hand space.

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: trivial docs demo width fix
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [x] Additional testing not necessary because: docs-only home grid demo width change
