### PR TITLE
Add Text heading variant

### DIFF
--- a/.changeset/add-text-heading-variant.md
+++ b/.changeset/add-text-heading-variant.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add the `Text` `heading` variant with a 16px semibold default and a 20px
+`size="lg"` option. The variant defaults to a `span`, so callers choose heading
+semantics explicitly with `as`. Deprecate the numbered `heading1`, `heading2`,
+and `heading3` variants.

--- a/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TextDemo.tsx
@@ -4,22 +4,14 @@ export function TextVariantsDemo() {
   return (
     <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading1" as="h1">
-          Heading 1
-        </Text>
-        <Text variant="mono-secondary">text-3xl (30px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading2" as="h2">
-          Heading 2
-        </Text>
-        <Text variant="mono-secondary">text-2xl (24px)</Text>
-      </div>
-      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
-        <Text variant="heading3" as="h3">
-          Heading 3
-        </Text>
+        <Text variant="heading">Heading</Text>
         <Text variant="mono-secondary">text-lg (16px)</Text>
+      </div>
+      <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
+        <Text variant="heading" size="lg" as="h2">
+          Heading large
+        </Text>
+        <Text variant="mono-secondary">text-xl (20px)</Text>
       </div>
       <div className="flex flex-col justify-end gap-1 rounded-lg border border-kumo-hairline bg-kumo-base p-4">
         <Text>Body</Text>

--- a/packages/kumo-docs-astro/src/components/skill/CollapseSizeExample.tsx
+++ b/packages/kumo-docs-astro/src/components/skill/CollapseSizeExample.tsx
@@ -32,7 +32,7 @@ export function CollapseSizeExample({
             preserveContentSize ? "w-64" : "w-full min-w-0",
           )}
         >
-          <Text as="h3" variant="heading3">
+          <Text as="h3" variant="heading">
             Web Analytics
           </Text>
           <Text variant="secondary">

--- a/packages/kumo-docs-astro/src/components/skill/design-tips.tsx
+++ b/packages/kumo-docs-astro/src/components/skill/design-tips.tsx
@@ -43,7 +43,7 @@ export const designTips = [
         exampleCode: `<Text>Content text</Text>`,
         jsx: (
           <LayerCard className="grid w-full gap-1 p-5">
-            <Text as="h3" variant="heading3">
+            <Text as="h3" variant="heading">
               API tokens
             </Text>
             <Text>Production token expires in 30 days.</Text>
@@ -55,7 +55,7 @@ export const designTips = [
         exampleCode: `<Text size="lg">Content text</Text>`,
         jsx: (
           <LayerCard className="grid w-full gap-1 p-5">
-            <Text as="h3" variant="heading3">
+            <Text as="h3" variant="heading">
               API tokens
             </Text>
             <Text size="lg">Production token expires in 30 days.</Text>
@@ -130,11 +130,11 @@ export const designTips = [
     examples: [
       {
         variant: "good",
-        exampleCode: `<Text as="h3" variant="heading3">Account settings</Text>
+        exampleCode: `<Text as="h3" variant="heading">Account settings</Text>
 <Text as="strong" bold>required</Text>`,
         jsx: (
           <div className="grid gap-1">
-            <Text as="h3" variant="heading3">
+            <Text as="h3" variant="heading">
               Account settings
             </Text>
             <Text>
@@ -178,7 +178,7 @@ export const designTips = [
         variant: "good",
         exampleCode: `<div className="grid gap-6">
   <div className="grid gap-1.5">
-    <Text as="h3">Web Analytics</Text>
+    <Text as="h3" variant="heading">Web Analytics</Text>
     <Text>Measure site traffic without changing your code.</Text>
   </div>
   <Button>Configure</Button>
@@ -187,7 +187,7 @@ export const designTips = [
           <LayerCard className="w-full p-5">
             <div className="grid gap-6">
               <div className="grid gap-1.5">
-                <Text as="h3" variant="heading3">
+                <Text as="h3" variant="heading">
                   Web Analytics
                 </Text>
                 <Text variant="secondary" DANGEROUS_className="text-pretty">
@@ -202,14 +202,14 @@ export const designTips = [
       {
         variant: "bad",
         exampleCode: `<div className="grid gap-4">
-  <Text as="h3">Web Analytics</Text>
+  <Text as="h3" variant="heading">Web Analytics</Text>
   <Text>Measure site traffic without changing your code.</Text>
   <Button>Configure</Button>
 </div>`,
         jsx: (
           <LayerCard className="w-full p-5">
             <div className="grid gap-4">
-              <Text as="h3" variant="heading3">
+              <Text as="h3" variant="heading">
                 Web Analytics
               </Text>
               <Text variant="secondary" DANGEROUS_className="text-pretty">
@@ -292,7 +292,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full shadow-md ring ring-kumo-line">
             <LayerCard.Primary className="grid gap-1 p-5">
-              <Text as="h3" variant="heading3">
+              <Text as="h3" variant="heading">
                 Workers API
               </Text>
               <Text variant="secondary">Last deployed 4 minutes ago</Text>
@@ -306,7 +306,7 @@ export const designTips = [
         jsx: (
           <LayerCard className="w-full border border-kumo-line shadow-md ring-0">
             <LayerCard.Primary className="grid gap-1 p-5 ring-0">
-              <Text as="h3" variant="heading3">
+              <Text as="h3" variant="heading">
                 Workers API
               </Text>
               <Text variant="secondary">Last deployed 4 minutes ago</Text>

--- a/packages/kumo-docs-astro/src/pages/changelog/[...page].astro
+++ b/packages/kumo-docs-astro/src/pages/changelog/[...page].astro
@@ -161,7 +161,7 @@ const GITHUB_RELEASE_URL = "https://github.com/cloudflare/kumo/releases/tag/%40c
             >
               <LinkSimple className="size-4 text-kumo-subtle" />
             </span>
-            <Text as="span" variant="heading2">{v.version}</Text>
+            <Text as="span" variant="heading" size="lg">{v.version}</Text>
           </a>
           <Badge variant={badgeConfig[v.bump].variant}>{badgeConfig[v.bump].label}</Badge>
           <a

--- a/packages/kumo-figma/src/generators/text.test.ts
+++ b/packages/kumo-figma/src/generators/text.test.ts
@@ -234,6 +234,7 @@ describe("Text Generator - getAllVariantData", () => {
       expect(variant.combinedClasses).toBeDefined();
       expect(variant.parsed).toBeDefined();
       expect(variant.description).toBeDefined();
+      expect(typeof variant.isHeadingVariant).toBe("boolean");
       expect(typeof variant.isCopyVariant).toBe("boolean");
       expect(typeof variant.isMonoVariant).toBe("boolean");
     }
@@ -255,16 +256,26 @@ describe("Text Generator - getAllVariantData", () => {
     }
   });
 
-  it("should have size=null for non-copy, non-mono variants (headings)", () => {
+  it("should expose the heading variant's supported size combinations", () => {
     const data = getAllVariantData();
-    const headingVariants = data.variants.filter(
-      (v) => !v.isCopyVariant && !v.isMonoVariant,
+    const headingVariants = data.variants.filter((v) => v.isHeadingVariant);
+
+    expect(headingVariants.length).toBeGreaterThan(0);
+    expect(headingVariants.some((variant) => variant.size === null)).toBe(true);
+    expect(headingVariants.some((variant) => variant.size !== null)).toBe(true);
+  });
+
+  it("should keep fixed-size variants at size=null", () => {
+    const data = getAllVariantData();
+    const fixedSizeVariants = data.variants.filter(
+      (variant) =>
+        !variant.isHeadingVariant &&
+        !variant.isCopyVariant &&
+        !variant.isMonoVariant,
     );
 
-    // Should have at least some heading variants
-    expect(headingVariants.length).toBeGreaterThan(0);
-
-    for (const variant of headingVariants) {
+    expect(fixedSizeVariants.length).toBeGreaterThan(0);
+    for (const variant of fixedSizeVariants) {
       expect(variant.size).toBeNull();
     }
   });

--- a/packages/kumo-figma/src/generators/text.ts
+++ b/packages/kumo-figma/src/generators/text.ts
@@ -3,8 +3,8 @@ import { logComplete } from "../logger";
  * Text Component Generator
  *
  * Generates a single Text ComponentSet in Figma with properties:
- * - variant: heading1, heading2, heading3, body, secondary, success, error, mono, mono-secondary
- * - size: xs, sm, base, lg (only applies to body/secondary/success/error variants)
+ * - variant: heading, heading1, heading2, heading3, body, secondary, success, error, mono, mono-secondary
+ * - size: heading supports default/lg; body variants support xs/sm/base/lg
  *
  * Reads variant definitions from component-registry.json (the source of truth).
  *
@@ -14,7 +14,8 @@ import { logComplete } from "../logger";
  * Unlike Button or Badge, Text components are purely typographic - no backgrounds or borders.
  *
  * ### Variant Categories (derived from text.tsx source)
- * - Headings (heading1, heading2, heading3): Fixed sizes, semibold weight, no size prop
+ * - Heading: Semibold at 16px by default and 20px with size=lg
+ * - Deprecated headings (heading1, heading2, heading3): Fixed sizes
  * - Copy (body, secondary, success, error): Supports size variants
  * - Monospace (mono, mono-secondary): Special optical sizing (lg→base, default→sm)
  *
@@ -64,8 +65,16 @@ const TEXT_BASE_CLASS = "text-kumo-default";
  * Variant categories derived from text.tsx source code (lines 162-163)
  * These determine which variants support size and special optical sizing
  */
+const HEADING_VARIANT = "heading";
 const COPY_VARIANTS = ["body", "secondary", "success", "error"];
 const MONO_VARIANTS = ["mono", "mono-secondary"];
+
+/**
+ * Check if variant is the preferred heading variant (supports default/lg).
+ */
+function isHeadingVariant(variant: string): boolean {
+  return variant === HEADING_VARIANT;
+}
 
 /**
  * Check if variant is a copy variant (supports size)
@@ -110,13 +119,21 @@ async function createTextComponent(
 
   // Determine effective size classes based on variant type
   // From text.tsx lines 180-186:
+  // - Heading: variant classes provide 16px; lg overrides it to 20px
   // - Copy variants: use the size prop directly
   // - Mono variants: lg→base, default→sm (optical sizing)
-  // - Headings: no size classes
+  // - Deprecated headings: no additional size classes
   let effectiveSizeClasses = "";
   let sizeDesc = "";
 
-  if (isCopyVariant(variant) && size) {
+  if (isHeadingVariant(variant)) {
+    if (size === "lg") {
+      effectiveSizeClasses = "text-xl";
+      sizeDesc = "Large heading text";
+    } else {
+      sizeDesc = "Default heading text";
+    }
+  } else if (isCopyVariant(variant) && size) {
     effectiveSizeClasses = sizeProp.classes[size] || "";
     sizeDesc = sizeProp.descriptions[size] || "";
   } else if (isMonoVariant(variant)) {
@@ -129,7 +146,7 @@ async function createTextComponent(
       sizeDesc = "Default text (optically adjusted to small)";
     }
   }
-  // Headings: no size classes applied
+  // Deprecated headings: no additional size classes applied
 
   // Combine base + variant + size classes for parsing
   const combinedClasses =
@@ -247,7 +264,23 @@ export async function generateTextComponents(
       text: "variant=" + variant,
     });
 
-    if (isCopyVariant(variant)) {
+    if (isHeadingVariant(variant)) {
+      // Heading: generate the default 16px and large 20px combinations.
+      let currentX = labelColumnWidth;
+
+      const defaultComponent = await createTextComponent(variant, null);
+      defaultComponent.x = currentX;
+      defaultComponent.y = currentRow * rowHeight + headerRowHeight;
+      currentX = currentX + defaultComponent.width + componentGap;
+      components.push(defaultComponent);
+
+      const lgComponent = await createTextComponent(variant, "lg");
+      lgComponent.x = currentX;
+      lgComponent.y = currentRow * rowHeight + headerRowHeight;
+      components.push(lgComponent);
+
+      currentRow++;
+    } else if (isCopyVariant(variant)) {
       // Copy variants: generate all size combinations
       let currentX = labelColumnWidth;
       for (let j = 0; j < sizes.length; j++) {
@@ -287,7 +320,7 @@ export async function generateTextComponents(
 
       currentRow++;
     } else {
-      // Headings: no size variants (from text.tsx lines 125-129: size?: never)
+      // Deprecated headings retain their fixed sizes for compatibility.
       const component = await createTextComponent(variant, null);
       component.x = labelColumnWidth;
       component.y = currentRow * rowHeight + headerRowHeight;
@@ -466,6 +499,7 @@ export function getAllVariantData() {
     combinedClasses: string;
     parsed: ReturnType<typeof parseTailwindClasses>;
     description: string;
+    isHeadingVariant: boolean;
     isCopyVariant: boolean;
     isMonoVariant: boolean;
   }> = [];
@@ -473,10 +507,45 @@ export function getAllVariantData() {
   for (const variant of variantConfig.variants) {
     const variantClasses = variantConfig.variantClasses[variant] || "";
     const variantDesc = variantConfig.variantDescriptions[variant] || "";
+    const isHeading = isHeadingVariant(variant);
     const isCopy = isCopyVariant(variant);
     const isMono = isMonoVariant(variant);
 
-    if (isCopy) {
+    if (isHeading) {
+      const defaultCombined = `${TEXT_BASE_CLASS} ${variantClasses}`.trim();
+      const defaultParsed = parseTailwindClasses(defaultCombined);
+
+      variants.push({
+        variant,
+        size: null,
+        variantClasses,
+        sizeClasses: "",
+        combinedClasses: defaultCombined,
+        parsed: defaultParsed,
+        description: `${variantDesc}. Default heading text`,
+        isHeadingVariant: true,
+        isCopyVariant: false,
+        isMonoVariant: false,
+      });
+
+      const lgSizeClasses = "text-xl";
+      const lgCombined =
+        `${TEXT_BASE_CLASS} ${variantClasses} ${lgSizeClasses}`.trim();
+      const lgParsed = parseTailwindClasses(lgCombined);
+
+      variants.push({
+        variant,
+        size: "lg",
+        variantClasses,
+        sizeClasses: lgSizeClasses,
+        combinedClasses: lgCombined,
+        parsed: lgParsed,
+        description: `${variantDesc}. Large heading text`,
+        isHeadingVariant: true,
+        isCopyVariant: false,
+        isMonoVariant: false,
+      });
+    } else if (isCopy) {
       // Copy variants: all sizes
       for (const size of variantConfig.sizes) {
         const sizeClasses = variantConfig.sizeClasses[size] || "";
@@ -493,6 +562,7 @@ export function getAllVariantData() {
           combinedClasses,
           parsed,
           description: `${variantDesc}. ${sizeDesc}`,
+          isHeadingVariant: false,
           isCopyVariant: true,
           isMonoVariant: false,
         });
@@ -513,6 +583,7 @@ export function getAllVariantData() {
         combinedClasses: defaultCombined,
         parsed: defaultParsed,
         description: `${variantDesc}. Default text (optically adjusted to small)`,
+        isHeadingVariant: false,
         isCopyVariant: false,
         isMonoVariant: true,
       });
@@ -531,11 +602,12 @@ export function getAllVariantData() {
         combinedClasses: lgCombined,
         parsed: lgParsed,
         description: `${variantDesc}. Large text (optically adjusted to base)`,
+        isHeadingVariant: false,
         isCopyVariant: false,
         isMonoVariant: true,
       });
     } else {
-      // Headings: no size variants
+      // Deprecated headings retain their fixed sizes.
       const combinedClasses = `${TEXT_BASE_CLASS} ${variantClasses}`.trim();
       const parsed = parseTailwindClasses(combinedClasses);
 
@@ -547,6 +619,7 @@ export function getAllVariantData() {
         combinedClasses,
         parsed,
         description: variantDesc,
+        isHeadingVariant: false,
         isCopyVariant: false,
         isMonoVariant: false,
       });

--- a/packages/kumo/src/components/text/text.test.tsx
+++ b/packages/kumo/src/components/text/text.test.tsx
@@ -1,15 +1,44 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { render } from "@testing-library/react";
 import { Text } from "./text";
 
 describe("Text", () => {
-  it("renders heading variant with the required `as` element", () => {
+  it("renders heading as a 16px semibold span by default", () => {
+    const { container } = render(<Text variant="heading">Heading</Text>);
+    const heading = container.querySelector("span");
+
+    expect(heading).toBeTruthy();
+    expect(heading?.classList.contains("text-lg")).toBe(true);
+    expect(heading?.classList.contains("font-semibold")).toBe(true);
+    expect(container.querySelector("h1, h2, h3, h4, h5, h6")).toBeNull();
+  });
+
+  it("renders a large heading at 20px using the requested element", () => {
     const { container } = render(
-      <Text variant="heading1" as="h1">
-        Page Title
+      <Text variant="heading" size="lg" as="h2">
+        Section title
       </Text>,
     );
-    expect(container.querySelector("h1")).toBeTruthy();
+    const heading = container.querySelector("h2");
+
+    expect(heading).toBeTruthy();
+    expect(heading?.classList.contains("text-xl")).toBe(true);
+    expect(heading?.classList.contains("font-semibold")).toBe(true);
+  });
+
+  it("warns when a deprecated heading variant is used", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <Text variant="heading1" as="h1">
+        Legacy heading
+      </Text>,
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('variant="heading1" is deprecated'),
+    );
+    warn.mockRestore();
   });
 
   it("renders body variant as <p> by default", () => {
@@ -27,10 +56,10 @@ describe("Text", () => {
     expect(container.querySelector("p")).toBeNull();
   });
 
-  it("allows heading variants to opt out of semantic heading via as='span'", () => {
+  it("allows heading to opt out of semantic heading via as='span'", () => {
     const { container } = render(
-      <Text variant="heading2" as="span">
-        Decorative big text
+      <Text variant="heading" as="span">
+        Decorative heading text
       </Text>,
     );
     expect(container.querySelector("span")).toBeTruthy();

--- a/packages/kumo/src/components/text/text.tsx
+++ b/packages/kumo/src/components/text/text.tsx
@@ -12,17 +12,27 @@ import { resolveVariant } from "../../utils/resolve-variant";
 /** Text variant and size definitions mapping names to their Tailwind classes. */
 export const KUMO_TEXT_VARIANTS = {
   variant: {
+    heading: {
+      classes: "text-lg font-semibold",
+      description: "Heading text (16px by default, 20px at large size)",
+    },
+    /** @deprecated Use `heading` and set `size` and `as` explicitly. */
     heading1: {
       classes: "text-3xl font-semibold",
-      description: "Large heading for page titles",
+      description:
+        "Deprecated large heading for page titles; use heading instead",
     },
+    /** @deprecated Use `heading` and set `size` and `as` explicitly. */
     heading2: {
       classes: "text-2xl font-semibold",
-      description: "Medium heading for section titles",
+      description:
+        "Deprecated medium heading for section titles; use heading instead",
     },
+    /** @deprecated Use `heading` and set `size` and `as` explicitly. */
     heading3: {
       classes: "text-lg font-semibold",
-      description: "Small heading for subsections",
+      description:
+        "Deprecated small heading for subsections; use heading instead",
     },
     body: {
       classes: "text-kumo-default",
@@ -118,6 +128,50 @@ export const KUMO_TEXT_STYLING = {
 export type KumoTextVariant = keyof typeof KUMO_TEXT_VARIANTS.variant;
 export type KumoTextSize = keyof typeof KUMO_TEXT_VARIANTS.size;
 
+type Heading = "heading";
+type DeprecatedHeading = "heading1" | "heading2" | "heading3";
+type Copy = "body" | "secondary" | "success" | "error";
+type Monospace = "mono" | "mono-secondary";
+type TextSize = KumoTextSize;
+type TextVariant = KumoTextVariant;
+
+const DEPRECATED_HEADING_VARIANTS: readonly DeprecatedHeading[] = [
+  "heading1",
+  "heading2",
+  "heading3",
+];
+
+function isDeprecatedHeadingVariant(
+  variant: TextVariant,
+): variant is DeprecatedHeading {
+  return (DEPRECATED_HEADING_VARIANTS as readonly TextVariant[]).includes(
+    variant,
+  );
+}
+
+function resolveTextSizeClasses(variant: TextVariant, size: TextSize) {
+  if (variant === "heading") {
+    return size === "lg" ? "text-xl" : "";
+  }
+
+  if (isDeprecatedHeadingVariant(variant)) {
+    return "";
+  }
+
+  if (["mono", "mono-secondary"].includes(variant)) {
+    // Monospace fonts need to be 1pt smaller than body text to optically match.
+    return size === "lg"
+      ? KUMO_TEXT_VARIANTS.size.base.classes
+      : KUMO_TEXT_VARIANTS.size.sm.classes;
+  }
+
+  return resolveVariant(
+    KUMO_TEXT_VARIANTS.size,
+    size,
+    KUMO_TEXT_DEFAULT_VARIANTS.size,
+  ).classes;
+}
+
 export interface KumoTextVariantsProps {
   variant?: KumoTextVariant;
   size?: KumoTextSize;
@@ -133,20 +187,9 @@ export function textVariants({
       variant,
       KUMO_TEXT_DEFAULT_VARIANTS.variant,
     ).classes,
-    resolveVariant(
-      KUMO_TEXT_VARIANTS.size,
-      size,
-      KUMO_TEXT_DEFAULT_VARIANTS.size,
-    ).classes,
+    resolveTextSizeClasses(variant, size),
   );
 }
-
-// Legacy types for backwards compatibility
-type Heading = "heading1" | "heading2" | "heading3";
-type Copy = "body" | "secondary" | "success" | "error";
-type Monospace = "mono" | "mono-secondary";
-type TextSize = KumoTextSize;
-type TextVariant = KumoTextVariant;
 
 /** Valid HTML elements for the Text component's `as` prop. */
 export type TextElement =
@@ -203,28 +246,37 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
         ? {
             variant: Variant;
             bold?: never;
-            size?: never;
+            size?: "lg";
             truncate?: boolean;
             /**
-             * Required for heading variants. Pick the element that reflects
-             * this text's place in the document outline (`"h1"` for a page
-             * title, `"h2"` for a section title, etc.) or `"span"` for
-             * decorative heading-styled text that is NOT a section heading.
-             *
-             * Previously optional (defaulted to `<span>`), which silently
-             * excluded real section headings from the document outline.
-             * Making it required surfaces the decision at the type level.
+             * Optional element override. Defaults to `<span>`. Pass the
+             * appropriate heading element (`"h1"`–`"h6"`) when this text
+             * belongs in the document outline.
              */
-            as: TextElement;
+            as?: TextElement;
           }
-        : never);
+        : Variant extends DeprecatedHeading
+          ? {
+              variant: Variant;
+              bold?: never;
+              size?: never;
+              truncate?: boolean;
+              /**
+               * Required for deprecated heading variants. Pick the element
+               * that reflects this text's place in the document outline, or
+               * `"span"` for decorative heading-styled text.
+               */
+              as: TextElement;
+            }
+          : never);
 
 /**
  * Text component props.
  *
  * @example
  * ```tsx
- * <Text variant="heading1" as="h1">Page Title</Text>
+ * <Text variant="heading" size="lg" as="h1">Page Title</Text>
+ * <Text variant="heading">Decorative heading text</Text>
  * <Text variant="body">Default paragraph text.</Text>
  * <Text variant="secondary" size="sm">Muted helper text</Text>
  * <Text variant="error">Something went wrong</Text>
@@ -234,9 +286,10 @@ type TextPropsInternal<Variant extends TextVariant = "body"> = BaseTextProps &
 export interface TextProps {
   /**
    * Text style variant. Determines color, font, and weight.
-   * - `"heading1"` — Large page title (30px, semibold)
-   * - `"heading2"` — Section title (24px, semibold)
-   * - `"heading3"` — Subsection title (18px, semibold)
+   * - `"heading"` — Heading text (16px by default, 20px with `size="lg"`; semibold)
+   * - `"heading1"` — Deprecated; use `"heading"` (30px, semibold)
+   * - `"heading2"` — Deprecated; use `"heading"` (24px, semibold)
+   * - `"heading3"` — Deprecated; use `"heading"` (16px, semibold)
    * - `"body"` — Default body text
    * - `"secondary"` — Muted text for secondary information
    * - `"success"` — Success state text
@@ -247,11 +300,11 @@ export interface TextProps {
    */
   variant?: KumoTextVariant;
   /**
-   * Text size (only applies to body/secondary/success/error variants).
-   * - `"xs"` — 12px
-   * - `"sm"` — 14px
-   * - `"base"` — 16px
-   * - `"lg"` — 18px
+   * Text size. Supported values depend on the variant:
+   * - `"heading"` — 16px when omitted, or 20px with `"lg"`
+   * - Body variants — `"xs"` (12px), `"sm"` (13px), `"base"` (14px),
+   *   or `"lg"` (16px)
+   * - Monospace variants — 13px when omitted, or 14px with `"lg"`
    * @default "base"
    */
   size?: KumoTextSize;
@@ -265,10 +318,10 @@ export interface TextProps {
    * `"small"`, `"abbr"`, `"time"`), form-related (`"label"`, `"legend"`),
    * list/definition (`"dt"`, `"dd"`, `"li"`), and `"figcaption"`.
    *
-   * - **Required** for heading variants (`"heading1"`, `"heading2"`,
-   *   `"heading3"`) — pick the element that reflects this text's place in
-   *   the document outline, or `"span"` for decorative heading-styled text
-   *   that is not a section heading.
+   * - **Optional** for `"heading"` (defaults to `"span"`). Pass the heading
+   *   element that reflects this text's place in the document outline.
+   * - **Required** for deprecated heading variants (`"heading1"`,
+   *   `"heading2"`, `"heading3"`).
    * - **Optional** for body variants (defaults to `"p"`) and monospace
    *   variants (defaults to `"span"`).
    */
@@ -284,8 +337,8 @@ export interface TextProps {
  *
  * @example
  * ```tsx
- * <Text variant="heading1" as="h1">Page Title</Text>
- * <Text variant="heading2" as="h2">Section Title</Text>
+ * <Text variant="heading" size="lg" as="h1">Page Title</Text>
+ * <Text variant="heading" as="h2">Section Title</Text>
  * <Text>Default body text</Text>
  * ```
  */
@@ -304,16 +357,22 @@ function _Text<Variant extends TextVariant = "body">(
   ref: ForwardedRef<HTMLElement>,
 ) {
   const isCopy = ["body", "secondary", "success", "error"].includes(variant);
-  const isMono = ["mono", "mono-secondary"].includes(variant);
+  const isDeprecatedHeading = isDeprecatedHeadingVariant(variant);
 
-  // Heading variants no longer auto-select h1/h2/h3 to avoid coupling visual
-  // presentation to semantic HTML. Use the `as` prop to set the appropriate
-  // heading level for your document outline (e.g., as="h2").
+  if (process.env.NODE_ENV !== "production" && isDeprecatedHeading) {
+    console.warn(
+      `[Kumo Text]: variant="${variant}" is deprecated. Use variant="heading" and set size and as explicitly.`,
+    );
+  }
+
+  // Heading variants do not auto-select h1/h2/h3, keeping visual presentation
+  // separate from the document outline. Use `as` to opt into semantic HTML.
   const Component = useMemo(() => {
     if (as) return as;
     if (["mono", "mono-secondary"].includes(variant)) return "span";
-    // Headings and body text default to span; use `as` for semantic elements
-    if (["heading1", "heading2", "heading3"].includes(variant)) return "span";
+    if (variant === "heading" || isDeprecatedHeadingVariant(variant)) {
+      return "span";
+    }
     return "p";
   }, [variant, as]);
 
@@ -330,19 +389,8 @@ function _Text<Variant extends TextVariant = "body">(
           variant,
           KUMO_TEXT_DEFAULT_VARIANTS.variant,
         ).classes,
-        isCopy
-          ? resolveVariant(
-              KUMO_TEXT_VARIANTS.size,
-              size,
-              KUMO_TEXT_DEFAULT_VARIANTS.size,
-            ).classes
-          : "",
+        resolveTextSizeClasses(variant, size),
         isCopy && bold ? "font-medium" : "",
-        // Monospace fonts need to be 1pt smaller than body text to optically match
-        isMono &&
-          (size === "lg"
-            ? KUMO_TEXT_VARIANTS.size.base.classes
-            : KUMO_TEXT_VARIANTS.size.sm.classes),
         truncate && "min-w-0 truncate",
         DANGEROUS_className,
       )}

--- a/packages/kumo/src/components/text/text.type-spec.tsx
+++ b/packages/kumo/src/components/text/text.type-spec.tsx
@@ -18,27 +18,33 @@ import { Text } from "./text";
 // Positive cases — these MUST compile cleanly.
 // ---------------------------------------------------------------------------
 
-// Heading variant with required `as`.
+// Heading has no implied semantic element and supports an optional large size.
+const _headingDefault = <Text variant="heading">Decorative heading</Text>;
 const _headingH1 = (
-  <Text variant="heading1" as="h1">
-    Page Title
+  <Text variant="heading" size="lg" as="h1">
+    Page title
   </Text>
 );
 const _headingH2 = (
-  <Text variant="heading2" as="h2">
-    Section Title
-  </Text>
-);
-const _headingH3 = (
-  <Text variant="heading3" as="h3">
-    Subsection
+  <Text variant="heading" as="h2">
+    Section title
   </Text>
 );
 
-// Heading variant using `as="span"` for decorative (non-section) usage.
-const _decorativeHeading = (
-  <Text variant="heading1" as="span">
-    Big bold label
+// Deprecated heading variants remain available for backwards compatibility.
+const _deprecatedHeadingH1 = (
+  <Text variant="heading1" as="h1">
+    Legacy page title
+  </Text>
+);
+const _deprecatedHeadingH2 = (
+  <Text variant="heading2" as="h2">
+    Legacy section title
+  </Text>
+);
+const _deprecatedHeadingH3 = (
+  <Text variant="heading3" as="h3">
+    Legacy subsection
   </Text>
 );
 
@@ -90,7 +96,7 @@ const _small = (
 );
 const _time = <Text as="time">2026-04-27</Text>;
 const _headingAsLabel = (
-  <Text variant="heading2" as="label">
+  <Text variant="heading" as="label">
     Form heading
   </Text>
 );
@@ -101,25 +107,33 @@ const _headingAsLabel = (
 // tsc itself fails the typecheck with "Unused '@ts-expect-error' directive".
 // ---------------------------------------------------------------------------
 
-// Missing `as` on heading1 → type error.
-// @ts-expect-error — heading variants require `as`
+// Heading only supports its default size and `lg`.
+const _invalidHeadingSize = (
+  // @ts-expect-error — heading does not support body text sizes
+  <Text variant="heading" size="base">
+    Invalid
+  </Text>
+);
+
+// Deprecated heading variants continue to require `as`.
+// @ts-expect-error — deprecated heading variants require `as`
 const _missingAsH1 = <Text variant="heading1">Missing as</Text>;
 
-// Missing `as` on heading2 → type error.
-// @ts-expect-error — heading variants require `as`
+// @ts-expect-error — deprecated heading variants require `as`
 const _missingAsH2 = <Text variant="heading2">Missing as</Text>;
 
-// Missing `as` on heading3 → type error.
-// @ts-expect-error — heading variants require `as`
+// @ts-expect-error — deprecated heading variants require `as`
 const _missingAsH3 = <Text variant="heading3">Missing as</Text>;
 
 // Silence unused-variable warnings for all the sentinels above.
 // This file is never executed; it exists purely for type checking.
 export const __typeSpec = {
+  _headingDefault,
   _headingH1,
   _headingH2,
-  _headingH3,
-  _decorativeHeading,
+  _deprecatedHeadingH1,
+  _deprecatedHeadingH2,
+  _deprecatedHeadingH3,
   _bodyDefault,
   _bodyExplicit,
   _bodyInline,
@@ -141,6 +155,7 @@ export const __typeSpec = {
   _small,
   _time,
   _headingAsLabel,
+  _invalidHeadingSize,
   _missingAsH1,
   _missingAsH2,
   _missingAsH3,


### PR DESCRIPTION
## Summary

Adds a new `heading` variant to text with `base` and `lg` sizes:

```tsx
<Text variant="heading">Heading base</Text>
<Text variant="heading" size="lg">Heading large</Text>
```

<img width="1106" height="422" alt="CleanShot 2026-08-19 at 11 28 22@2x" src="https://github.com/user-attachments/assets/ad66d119-e3ac-4f95-aec1-f2c01928a872" />

Deprecates the current `heading1`, `heading2`, and `heading3` variants.

## Testing

- `pnpm --filter @cloudflare/kumo test`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo-figma exec vp test run src/generators/text.test.ts`
- `pnpm --filter @cloudflare/kumo-figma exec tsc --noEmit`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: an automated reviewer was not available in this environment
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:
