### PR TITLE
fix(select): anchor the Select popup below the trigger instead of overlaying it

### DIFF
--- a/.changeset/olive-buses-repeat.md
+++ b/.changeset/olive-buses-repeat.md
@@ -2,38 +2,28 @@
 "@cloudflare/kumo": patch
 ---
 
-fix(select): scale popup options with `size`, and add a gap when the popup falls back to anchoring
+fix(select): anchor the popup below the trigger and expose placement props
 
-Two related popup fixes. Neither changes the native-select alignment behaviour —
-`Select.Positioner` still uses Base UI's `alignItemWithTrigger`, so the selected
-option is still placed on top of the trigger whenever there is room.
+`Select.Positioner` relied on Base UI's `alignItemWithTrigger` default (`true`),
+which overlays the popup on the trigger so the selected option's text lands on
+the trigger's value text, emulating a native `<select>`. Options always render at
+`text-base`, so on `xs`/`sm` triggers the popup was much taller than its anchor,
+and Base UI's compensating shift detached it from the trigger — on `xs` it
+overhung by 12.5px above and 45.5px below and sat 8px to the left, covering
+adjacent content.
 
-**1. Options now scale with the trigger `size`.**
+The popup now prefers `bottom` placement and is offset from the trigger, with
+Base UI's collision avoidance still flipping it automatically when the preferred
+side lacks space. Placement is configurable:
 
-`Select.Option` and `Select.GroupLabel` hardcoded `text-base` / `py-1.5`, so the
-popup rendered at `base` proportions no matter what `size` the trigger used — an
-option row was a fixed 33px against a 20px `xs` trigger. Base UI shifts the
-popup to compensate for that mismatch, which visibly detached it from its
-anchor: on `xs` the popup overhung by 12.5px above and 45.5px below and was
-pushed 8px left, covering adjacent content.
+| prop | default | notes |
+| ---- | ------- | ----- |
+| `side` | `"bottom"` | preferred side; still flips automatically on collision |
+| `sideOffset` | `4` | gap between trigger and popup, matching Combobox/Autocomplete |
+| `align` | `"start"` | alignment along the trigger edge |
+| `alignOffset` | — | additional offset along the alignment axis |
+| `alignItemWithTrigger` | `false` | opt back in to the native `<select>` overlay |
 
-Option and group-label metrics now track the trigger through a size context, so
-row height matches trigger height and text indent matches trigger padding:
-
-| size | trigger | option row (before → after) | popup x-shift (before → after) |
-| ---- | ------- | --------------------------- | ------------------------------ |
-| `xs` | 20px    | 33px → 20px                 | -8px → 0                       |
-| `sm` | 26px    | 33px → 26px                 | -8px → 0                       |
-| `lg` | 40px    | 33px → 37px                 | -8px → 0                       |
-
-`base` is unchanged. A selected option now lands exactly on the trigger at every
-size instead of being offset.
-
-**2. The anchored fallback gets a 4px offset.**
-
-When there is not enough room to overlay the trigger, Base UI falls back to
-normal anchored positioning. That fallback previously rendered flush against the
-trigger; it now uses `sideOffset={4}`, matching Combobox and Autocomplete.
-
-`sideOffset` only affects the fallback — Base UI discards the anchored styles
-while `alignItemWithTrigger` is active — so the overlay behaviour is untouched.
+The popup also now tracks the trigger width via `min-w-(--anchor-width)` instead
+of `min-w-[calc(var(--anchor-width)+3px)]`, which existed to visually offset the
+old item-alignment shift.

--- a/.changeset/olive-buses-repeat.md
+++ b/.changeset/olive-buses-repeat.md
@@ -16,13 +16,13 @@ The popup now prefers `bottom` placement and is offset from the trigger, with
 Base UI's collision avoidance still flipping it automatically when the preferred
 side lacks space. Placement is configurable:
 
-| prop | default | notes |
-| ---- | ------- | ----- |
-| `side` | `"bottom"` | preferred side; still flips automatically on collision |
-| `sideOffset` | `4` | gap between trigger and popup, matching Combobox/Autocomplete |
-| `align` | `"start"` | alignment along the trigger edge |
-| `alignOffset` | — | additional offset along the alignment axis |
-| `alignItemWithTrigger` | `false` | opt back in to the native `<select>` overlay |
+| prop                   | default    | notes                                                         |
+| ---------------------- | ---------- | ------------------------------------------------------------- |
+| `side`                 | `"bottom"` | preferred side; still flips automatically on collision        |
+| `sideOffset`           | `4`        | gap between trigger and popup, matching Combobox/Autocomplete |
+| `align`                | `"start"`  | alignment along the trigger edge                              |
+| `alignOffset`          | —          | additional offset along the alignment axis                    |
+| `alignItemWithTrigger` | `false`    | opt back in to the native `<select>` overlay                  |
 
 The popup also now tracks the trigger width via `min-w-(--anchor-width)` instead
 of `min-w-[calc(var(--anchor-width)+3px)]`, which existed to visually offset the

--- a/.changeset/olive-buses-repeat.md
+++ b/.changeset/olive-buses-repeat.md
@@ -24,6 +24,11 @@ side lacks space. Placement is configurable:
 | `alignOffset`          | —          | additional offset along the alignment axis                    |
 | `alignItemWithTrigger` | `false`    | opt back in to the native `<select>` overlay                  |
 
+The remaining Base UI Positioner controls are also forwarded unchanged:
+`anchor`, `arrowPadding`, `positionMethod`, `collisionAvoidance`,
+`collisionBoundary`, `collisionPadding`, `sticky`, and
+`disableAnchorTracking`.
+
 The popup also now tracks the trigger width via `min-w-(--anchor-width)` instead
 of `min-w-[calc(var(--anchor-width)+3px)]`, which existed to visually offset the
 old item-alignment shift.

--- a/.changeset/olive-buses-repeat.md
+++ b/.changeset/olive-buses-repeat.md
@@ -1,0 +1,39 @@
+---
+"@cloudflare/kumo": patch
+---
+
+fix(select): scale popup options with `size`, and add a gap when the popup falls back to anchoring
+
+Two related popup fixes. Neither changes the native-select alignment behaviour —
+`Select.Positioner` still uses Base UI's `alignItemWithTrigger`, so the selected
+option is still placed on top of the trigger whenever there is room.
+
+**1. Options now scale with the trigger `size`.**
+
+`Select.Option` and `Select.GroupLabel` hardcoded `text-base` / `py-1.5`, so the
+popup rendered at `base` proportions no matter what `size` the trigger used — an
+option row was a fixed 33px against a 20px `xs` trigger. Base UI shifts the
+popup to compensate for that mismatch, which visibly detached it from its
+anchor: on `xs` the popup overhung by 12.5px above and 45.5px below and was
+pushed 8px left, covering adjacent content.
+
+Option and group-label metrics now track the trigger through a size context, so
+row height matches trigger height and text indent matches trigger padding:
+
+| size | trigger | option row (before → after) | popup x-shift (before → after) |
+| ---- | ------- | --------------------------- | ------------------------------ |
+| `xs` | 20px    | 33px → 20px                 | -8px → 0                       |
+| `sm` | 26px    | 33px → 26px                 | -8px → 0                       |
+| `lg` | 40px    | 33px → 37px                 | -8px → 0                       |
+
+`base` is unchanged. A selected option now lands exactly on the trigger at every
+size instead of being offset.
+
+**2. The anchored fallback gets a 4px offset.**
+
+When there is not enough room to overlay the trigger, Base UI falls back to
+normal anchored positioning. That fallback previously rendered flush against the
+trigger; it now uses `sideOffset={4}`, matching Combobox and Autocomplete.
+
+`sideOffset` only affects the fallback — Base UI discards the anchored styles
+while `alignItemWithTrigger` is active — so the overlay behaviour is untouched.

--- a/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/SelectDemo.tsx
@@ -558,3 +558,80 @@ export function SelectLongListDemo() {
     </Select>
   );
 }
+
+const planets = {
+  mercury: "Mercury",
+  venus: "Venus",
+  earth: "Earth",
+  mars: "Mars",
+  jupiter: "Jupiter",
+  saturn: "Saturn",
+  uranus: "Uranus",
+};
+
+/**
+ * Use `side` and `align` to pin the popup. Placement still flips automatically
+ * when the chosen side runs out of room.
+ */
+export function SelectPlacementDemo() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <Select
+        label="side=bottom (default)"
+        className="w-[200px]"
+        defaultValue="earth"
+        items={planets}
+      />
+      <Select
+        label="side=top"
+        side="top"
+        className="w-[200px]"
+        defaultValue="earth"
+        items={planets}
+      />
+      <Select
+        label="align=end"
+        align="end"
+        className="w-[200px]"
+        defaultValue="earth"
+        items={planets}
+      />
+      <Select
+        label="sideOffset=12"
+        sideOffset={12}
+        className="w-[200px]"
+        defaultValue="earth"
+        items={planets}
+      />
+    </div>
+  );
+}
+
+/**
+ * `alignItemWithTrigger` overlays the popup on the trigger so the selected
+ * option sits directly on top of it, like a native `<select>`. Options before
+ * the selection render above the trigger and the rest below. Open the second
+ * select — "Mars" is selected mid-list, so the popup extends in both
+ * directions. Falls back to normal anchored placement when space runs out.
+ */
+export function SelectDynamicPlacementDemo() {
+  return (
+    <div className="flex flex-wrap items-start gap-8">
+      <Select
+        label="Anchored (default)"
+        description="Opens below the trigger"
+        className="w-[200px]"
+        defaultValue="mars"
+        items={planets}
+      />
+      <Select
+        label="Aligned to selection"
+        description="Selected option lands on the trigger"
+        alignItemWithTrigger
+        className="w-[200px]"
+        defaultValue="mars"
+        items={planets}
+      />
+    </div>
+  );
+}

--- a/packages/kumo-docs-astro/src/pages/components/select.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/select.mdx
@@ -28,6 +28,8 @@ import {
   SelectGroupedDemo,
   SelectGroupedWithDisabledDemo,
   SelectLongListDemo,
+  SelectPlacementDemo,
+  SelectDynamicPlacementDemo,
 } from "~/components/demos/SelectDemo";
 
 {/* Hero Demo */}
@@ -110,6 +112,43 @@ export default function Example() {
 
   <ComponentExample demo="SelectSizesDemo">
     <SelectSizesDemo client:load />
+  </ComponentExample>
+</ComponentSection>
+
+{/* Placement */}
+
+<ComponentSection>
+
+### Placement
+
+<p>
+  The popup prefers `side="bottom"` and flips automatically when that side runs
+  out of room. Use `side`, `align`, `sideOffset` and `alignOffset` to pin it
+  explicitly — collision handling still applies.
+</p>
+
+  <ComponentExample demo="SelectPlacementDemo">
+    <SelectPlacementDemo client:load />
+  </ComponentExample>
+</ComponentSection>
+
+{/* Dynamic placement aligned to the selected option */}
+
+<ComponentSection>
+
+### Aligned to the selected option
+
+<p>
+  Set `alignItemWithTrigger` to overlay the popup on the trigger so the selected
+  option sits directly on top of it, the way a native `select` behaves. Options
+  before the selection render above the trigger and the rest below, so the popup
+  can extend in both directions. Both selects below have `Mars` selected
+  mid-list — open them to compare. This mode disables itself and falls back to
+  normal anchored placement when there is not enough room.
+</p>
+
+  <ComponentExample demo="SelectDynamicPlacementDemo">
+    <SelectDynamicPlacementDemo client:load />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/select/select.test.tsx
+++ b/packages/kumo/src/components/select/select.test.tsx
@@ -534,6 +534,35 @@ describe("Select", () => {
   });
 
   describe("popup structure", () => {
+    it("accepts Base UI positioner props", () => {
+      render(
+        <Select
+          aria-label="Select a country"
+          side="bottom"
+          sideOffset={() => 4}
+          align="start"
+          alignOffset={() => 0}
+          alignItemWithTrigger={false}
+          anchor={document.body}
+          arrowPadding={5}
+          positionMethod="fixed"
+          collisionAvoidance={{
+            side: "none",
+            align: "shift",
+            fallbackAxisSide: "none",
+          }}
+          collisionBoundary="clipping-ancestors"
+          collisionPadding={10}
+          sticky={false}
+          disableAnchorTracking={false}
+        >
+          <Select.Option value="af">Afghanistan</Select.Option>
+        </Select>,
+      );
+
+      expect(screen.getByRole("combobox")).toBeTruthy();
+    });
+
     it("opens a listbox popup from the trigger", async () => {
       render(
         <Select aria-label="Select a country">

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -75,6 +75,24 @@ export interface KumoSelectVariantsProps {
   size?: KumoSelectSize;
 }
 
+/** Base UI positioning controls forwarded to Select's popup. */
+type SelectPositionerProps = Pick<
+  SelectBase.Positioner.Props,
+  | "align"
+  | "alignItemWithTrigger"
+  | "alignOffset"
+  | "anchor"
+  | "arrowPadding"
+  | "collisionAvoidance"
+  | "collisionBoundary"
+  | "collisionPadding"
+  | "disableAnchorTracking"
+  | "positionMethod"
+  | "side"
+  | "sideOffset"
+  | "sticky"
+>;
+
 export function selectVariants({
   size = KUMO_SELECT_DEFAULT_VARIANTS.size,
 }: KumoSelectVariantsProps = {}) {
@@ -253,26 +271,8 @@ type SelectPropsGeneric<T, Multiple extends boolean | undefined = false> = Omit<
      * @default document.body (or KumoPortalProvider container if set)
      */
     container?: PortalContainer;
-    /**
-     * Preferred side of the trigger to place the popup on. The popup still
-     * flips automatically when the preferred side lacks space.
-     * @default "bottom"
-     */
-    side?: SelectBase.Positioner.Props["side"];
-    /** Gap in px between the trigger and the popup. @default 4 */
-    sideOffset?: SelectBase.Positioner.Props["sideOffset"];
-    /** Alignment of the popup relative to the trigger. @default "start" */
-    align?: SelectBase.Positioner.Props["align"];
-    /** Additional offset along the alignment axis, in px. */
-    alignOffset?: SelectBase.Positioner.Props["alignOffset"];
-    /**
-     * When `true`, overlays the popup on the trigger so the selected option's
-     * text aligns with the trigger's value text, emulating a native `<select>`.
-     * Opt-in: Kumo anchors to `side` by default for predictable placement.
-     * @default false
-     */
-    alignItemWithTrigger?: boolean;
-  };
+  } &
+  SelectPositionerProps;
 
 /**
  * Select component props.
@@ -296,7 +296,7 @@ type SelectPropsGeneric<T, Multiple extends boolean | undefined = false> = Omit<
  * </Select>
  * ```
  */
-export interface SelectProps {
+export interface SelectProps extends SelectPositionerProps {
   /** Additional CSS classes merged via `cn()`. */
   className?: string;
   /** Replaces the trigger element while preserving Select behavior. */
@@ -339,24 +339,6 @@ export interface SelectProps {
   description?: ReactNode;
   /** Error message string or validation error object with `match` key. */
   error?: string | { message: ReactNode; match: FieldErrorMatch };
-  /**
-   * Preferred side of the trigger to place the popup on. The popup still flips
-   * automatically when the preferred side lacks space.
-   * @default "bottom"
-   */
-  side?: "top" | "bottom" | "left" | "right" | "inline-start" | "inline-end";
-  /** Gap in px between the trigger and the popup. @default 4 */
-  sideOffset?: number;
-  /** Alignment of the popup relative to the trigger. @default "start" */
-  align?: "start" | "center" | "end";
-  /** Additional offset along the alignment axis, in px. */
-  alignOffset?: number;
-  /**
-   * When `true`, overlays the popup on the trigger so the selected option's text
-   * aligns with the trigger's value text, emulating a native `<select>`.
-   * @default false
-   */
-  alignItemWithTrigger?: boolean;
 }
 
 /**
@@ -405,6 +387,14 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   align = "start",
   alignOffset,
   alignItemWithTrigger = false,
+  anchor,
+  arrowPadding,
+  positionMethod,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  sticky,
+  disableAnchorTracking,
   ...props
 }: SelectPropsGeneric<T, Multiple> & { required?: boolean }) {
   const labelId = useId();
@@ -553,6 +543,14 @@ export function Select<T, Multiple extends boolean | undefined = false>({
           align={align}
           alignOffset={alignOffset}
           alignItemWithTrigger={alignItemWithTrigger}
+          anchor={anchor}
+          arrowPadding={arrowPadding}
+          positionMethod={positionMethod}
+          collisionAvoidance={collisionAvoidance}
+          collisionBoundary={collisionBoundary}
+          collisionPadding={collisionPadding}
+          sticky={sticky}
+          disableAnchorTracking={disableAnchorTracking}
         >
           <SelectBase.Popup
             className={cn(

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -271,8 +271,7 @@ type SelectPropsGeneric<T, Multiple extends boolean | undefined = false> = Omit<
      * @default document.body (or KumoPortalProvider container if set)
      */
     container?: PortalContainer;
-  } &
-  SelectPositionerProps;
+  } & SelectPositionerProps;
 
 /**
  * Select component props.

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -1,6 +1,6 @@
 import { Select as SelectBase } from "@base-ui/react/select";
 import { CaretUpDownIcon, CheckIcon } from "@phosphor-icons/react";
-import { forwardRef, useId } from "react";
+import { createContext, forwardRef, useContext, useId } from "react";
 import type { ReactNode } from "react";
 import { cn } from "../../utils/cn";
 import { buttonVariants } from "../button";
@@ -94,6 +94,61 @@ const triggerIconStyles: Record<
   base: { iconSize: 16, className: "text-kumo-subtle" },
   lg: { iconSize: 18, className: "text-kumo-subtle" },
 };
+
+/**
+ * Popup chrome scaled to the trigger `size`.
+ *
+ * `Select.Positioner` relies on Base UI's `alignItemWithTrigger`, which overlays
+ * the popup so the selected option's text lands on top of the trigger's value
+ * text. That only reads correctly when an option row is about as tall as the
+ * trigger and indented to the same depth — Base UI shifts the popup to
+ * compensate for any difference, so a mismatch visibly detaches the popup from
+ * its anchor.
+ *
+ * Each entry therefore mirrors the matching `KUMO_INPUT_VARIANTS.size` trigger:
+ * - row height (`text` line-height + `py` × 2) ≈ trigger `h-*`
+ * - text indent (`mx` + `px`) === trigger `px-*`
+ *
+ * `base` is intentionally left at its historical values; it was already within
+ * a few pixels and is the default every consumer inherits.
+ */
+const selectSizeStyles: Record<
+  KumoInputSize,
+  { popup: string; option: string; groupLabel: string }
+> = {
+  // trigger: h-5 (20px), px-1.5 (6px), text-xs (12/16) → row 16+4=20, indent 2+4=6
+  xs: {
+    popup: "py-1",
+    option: "mx-0.5 gap-1 rounded-sm px-1 py-0.5 text-xs",
+    groupLabel: "px-1.5 py-0.5 text-xs",
+  },
+  // trigger: h-6.5 (26px), px-2 (8px), text-xs (12/16) → row 16+10=26, indent 4+4=8
+  sm: {
+    popup: "py-1",
+    option: "mx-1 gap-1.5 rounded-sm px-1 py-1.25 text-xs",
+    groupLabel: "px-2 py-1 text-xs",
+  },
+  // trigger: h-9 (36px), px-3 (12px), text-base (14/21) → row 21+12=33, indent 6+8=14
+  base: {
+    popup: "py-1.5",
+    option: "mx-1.5 gap-2 rounded px-2 py-1.5 text-base",
+    groupLabel: "px-3.5 py-1.5 text-sm",
+  },
+  // trigger: h-10 (40px), px-4 (16px), text-base (14/21) → row 21+16=37, indent 6+10=16
+  lg: {
+    popup: "py-1.5",
+    option: "mx-1.5 gap-2 rounded px-2.5 py-2 text-base",
+    groupLabel: "px-4 py-1.5 text-sm",
+  },
+};
+
+/**
+ * Propagates the trigger `size` to `Select.Option` / `Select.GroupLabel`, which
+ * render inside the portalled popup and so cannot inherit it via props.
+ */
+const SelectSizeContext = createContext<KumoInputSize>(
+  KUMO_SELECT_DEFAULT_VARIANTS.size,
+);
 
 /**
  * Shape for items that carry extra metadata (disabled state, tooltip).
@@ -488,35 +543,45 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   );
 
   const selectControl = (
-    <SelectBase.Root
-      {...baseProps}
-      items={normalizedItems}
-      disabled={loading || props.disabled}
-      required={required}
-    >
-      {selectLabelNode}
-      {selectTrigger}
-      <SelectBase.Portal container={container}>
-        <SelectBase.Positioner>
-          <SelectBase.Popup
-            className={cn(
-              "flex flex-col",
-              "max-h-[var(--available-height)] bg-kumo-base text-kumo-default",
-              "rounded-lg shadow-lg ring ring-kumo-line",
-              "min-w-[calc(var(--anchor-width)+3px)] py-1.5",
-            )}
-          >
-            <SelectBase.List
+    <SelectSizeContext.Provider value={size}>
+      <SelectBase.Root
+        {...baseProps}
+        items={normalizedItems}
+        disabled={loading || props.disabled}
+        required={required}
+      >
+        {selectLabelNode}
+        {selectTrigger}
+        <SelectBase.Portal container={container}>
+          {/*
+            `sideOffset` only applies to the fallback path. When
+            `alignItemWithTrigger` is active Base UI overlays the popup on the
+            trigger and discards the anchored styles, so this purely adds
+            breathing room when it falls back to anchoring below/above —
+            matching Combobox and Autocomplete.
+          */}
+          <SelectBase.Positioner sideOffset={4}>
+            <SelectBase.Popup
               className={cn(
-                "min-h-0 flex-1 scroll-pt-2 scroll-pb-2 overflow-y-auto overscroll-none",
+                "flex flex-col",
+                "max-h-[var(--available-height)] bg-kumo-base text-kumo-default",
+                "rounded-lg shadow-lg ring ring-kumo-line",
+                "min-w-[calc(var(--anchor-width)+3px)]",
+                selectSizeStyles[size].popup,
               )}
             >
-              {renderedChildren}
-            </SelectBase.List>
-          </SelectBase.Popup>
-        </SelectBase.Positioner>
-      </SelectBase.Portal>
-    </SelectBase.Root>
+              <SelectBase.List
+                className={cn(
+                  "min-h-0 flex-1 scroll-pt-2 scroll-pb-2 overflow-y-auto overscroll-none",
+                )}
+              >
+                {renderedChildren}
+              </SelectBase.List>
+            </SelectBase.Popup>
+          </SelectBase.Positioner>
+        </SelectBase.Portal>
+      </SelectBase.Root>
+    </SelectSizeContext.Provider>
   );
 
   // Use Field wrapper when label is provided and not hidden
@@ -582,6 +647,8 @@ type OptionProps<T> = {
 };
 
 function Option<T>({ children, value, disabled, className }: OptionProps<T>) {
+  const size = useContext(SelectSizeContext);
+
   return (
     <SelectBase.Item
       data-kumo-component="Select"
@@ -589,7 +656,8 @@ function Option<T>({ children, value, disabled, className }: OptionProps<T>) {
       value={value}
       disabled={disabled}
       className={cn(
-        "group mx-1.5 flex cursor-pointer items-center justify-between gap-2 rounded px-2 py-1.5 text-base outline-none",
+        "group flex cursor-pointer items-center justify-between outline-none",
+        selectSizeStyles[size].option,
         "focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset",
         "data-highlighted:bg-kumo-tint",
         "data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
@@ -654,17 +722,22 @@ type GroupLabelProps = {
  * ```
  */
 const GroupLabel = forwardRef<HTMLDivElement, GroupLabelProps>(
-  ({ children, className }, ref) => (
-    <SelectBase.GroupLabel
-      ref={ref}
-      className={cn(
-        "px-3.5 py-1.5 text-sm font-semibold text-kumo-subtle",
-        className,
-      )}
-    >
-      {children}
-    </SelectBase.GroupLabel>
-  ),
+  ({ children, className }, ref) => {
+    const size = useContext(SelectSizeContext);
+
+    return (
+      <SelectBase.GroupLabel
+        ref={ref}
+        className={cn(
+          "font-semibold text-kumo-subtle",
+          selectSizeStyles[size].groupLabel,
+          className,
+        )}
+      >
+        {children}
+      </SelectBase.GroupLabel>
+    );
+  },
 );
 GroupLabel.displayName = "Select.GroupLabel";
 

--- a/packages/kumo/src/components/select/select.tsx
+++ b/packages/kumo/src/components/select/select.tsx
@@ -1,6 +1,6 @@
 import { Select as SelectBase } from "@base-ui/react/select";
 import { CaretUpDownIcon, CheckIcon } from "@phosphor-icons/react";
-import { createContext, forwardRef, useContext, useId } from "react";
+import { forwardRef, useId } from "react";
 import type { ReactNode } from "react";
 import { cn } from "../../utils/cn";
 import { buttonVariants } from "../button";
@@ -94,61 +94,6 @@ const triggerIconStyles: Record<
   base: { iconSize: 16, className: "text-kumo-subtle" },
   lg: { iconSize: 18, className: "text-kumo-subtle" },
 };
-
-/**
- * Popup chrome scaled to the trigger `size`.
- *
- * `Select.Positioner` relies on Base UI's `alignItemWithTrigger`, which overlays
- * the popup so the selected option's text lands on top of the trigger's value
- * text. That only reads correctly when an option row is about as tall as the
- * trigger and indented to the same depth — Base UI shifts the popup to
- * compensate for any difference, so a mismatch visibly detaches the popup from
- * its anchor.
- *
- * Each entry therefore mirrors the matching `KUMO_INPUT_VARIANTS.size` trigger:
- * - row height (`text` line-height + `py` × 2) ≈ trigger `h-*`
- * - text indent (`mx` + `px`) === trigger `px-*`
- *
- * `base` is intentionally left at its historical values; it was already within
- * a few pixels and is the default every consumer inherits.
- */
-const selectSizeStyles: Record<
-  KumoInputSize,
-  { popup: string; option: string; groupLabel: string }
-> = {
-  // trigger: h-5 (20px), px-1.5 (6px), text-xs (12/16) → row 16+4=20, indent 2+4=6
-  xs: {
-    popup: "py-1",
-    option: "mx-0.5 gap-1 rounded-sm px-1 py-0.5 text-xs",
-    groupLabel: "px-1.5 py-0.5 text-xs",
-  },
-  // trigger: h-6.5 (26px), px-2 (8px), text-xs (12/16) → row 16+10=26, indent 4+4=8
-  sm: {
-    popup: "py-1",
-    option: "mx-1 gap-1.5 rounded-sm px-1 py-1.25 text-xs",
-    groupLabel: "px-2 py-1 text-xs",
-  },
-  // trigger: h-9 (36px), px-3 (12px), text-base (14/21) → row 21+12=33, indent 6+8=14
-  base: {
-    popup: "py-1.5",
-    option: "mx-1.5 gap-2 rounded px-2 py-1.5 text-base",
-    groupLabel: "px-3.5 py-1.5 text-sm",
-  },
-  // trigger: h-10 (40px), px-4 (16px), text-base (14/21) → row 21+16=37, indent 6+10=16
-  lg: {
-    popup: "py-1.5",
-    option: "mx-1.5 gap-2 rounded px-2.5 py-2 text-base",
-    groupLabel: "px-4 py-1.5 text-sm",
-  },
-};
-
-/**
- * Propagates the trigger `size` to `Select.Option` / `Select.GroupLabel`, which
- * render inside the portalled popup and so cannot inherit it via props.
- */
-const SelectSizeContext = createContext<KumoInputSize>(
-  KUMO_SELECT_DEFAULT_VARIANTS.size,
-);
 
 /**
  * Shape for items that carry extra metadata (disabled state, tooltip).
@@ -308,6 +253,25 @@ type SelectPropsGeneric<T, Multiple extends boolean | undefined = false> = Omit<
      * @default document.body (or KumoPortalProvider container if set)
      */
     container?: PortalContainer;
+    /**
+     * Preferred side of the trigger to place the popup on. The popup still
+     * flips automatically when the preferred side lacks space.
+     * @default "bottom"
+     */
+    side?: SelectBase.Positioner.Props["side"];
+    /** Gap in px between the trigger and the popup. @default 4 */
+    sideOffset?: SelectBase.Positioner.Props["sideOffset"];
+    /** Alignment of the popup relative to the trigger. @default "start" */
+    align?: SelectBase.Positioner.Props["align"];
+    /** Additional offset along the alignment axis, in px. */
+    alignOffset?: SelectBase.Positioner.Props["alignOffset"];
+    /**
+     * When `true`, overlays the popup on the trigger so the selected option's
+     * text aligns with the trigger's value text, emulating a native `<select>`.
+     * Opt-in: Kumo anchors to `side` by default for predictable placement.
+     * @default false
+     */
+    alignItemWithTrigger?: boolean;
   };
 
 /**
@@ -375,6 +339,24 @@ export interface SelectProps {
   description?: ReactNode;
   /** Error message string or validation error object with `match` key. */
   error?: string | { message: ReactNode; match: FieldErrorMatch };
+  /**
+   * Preferred side of the trigger to place the popup on. The popup still flips
+   * automatically when the preferred side lacks space.
+   * @default "bottom"
+   */
+  side?: "top" | "bottom" | "left" | "right" | "inline-start" | "inline-end";
+  /** Gap in px between the trigger and the popup. @default 4 */
+  sideOffset?: number;
+  /** Alignment of the popup relative to the trigger. @default "start" */
+  align?: "start" | "center" | "end";
+  /** Additional offset along the alignment axis, in px. */
+  alignOffset?: number;
+  /**
+   * When `true`, overlays the popup on the trigger so the selected option's text
+   * aligns with the trigger's value text, emulating a native `<select>`.
+   * @default false
+   */
+  alignItemWithTrigger?: boolean;
 }
 
 /**
@@ -418,6 +400,11 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   error,
   required,
   container: containerProp,
+  side = "bottom",
+  sideOffset = 4,
+  align = "start",
+  alignOffset,
+  alignItemWithTrigger = false,
   ...props
 }: SelectPropsGeneric<T, Multiple> & { required?: boolean }) {
   const labelId = useId();
@@ -543,45 +530,49 @@ export function Select<T, Multiple extends boolean | undefined = false>({
   );
 
   const selectControl = (
-    <SelectSizeContext.Provider value={size}>
-      <SelectBase.Root
-        {...baseProps}
-        items={normalizedItems}
-        disabled={loading || props.disabled}
-        required={required}
-      >
-        {selectLabelNode}
-        {selectTrigger}
-        <SelectBase.Portal container={container}>
-          {/*
-            `sideOffset` only applies to the fallback path. When
-            `alignItemWithTrigger` is active Base UI overlays the popup on the
-            trigger and discards the anchored styles, so this purely adds
-            breathing room when it falls back to anchoring below/above —
-            matching Combobox and Autocomplete.
-          */}
-          <SelectBase.Positioner sideOffset={4}>
-            <SelectBase.Popup
+    <SelectBase.Root
+      {...baseProps}
+      items={normalizedItems}
+      disabled={loading || props.disabled}
+      required={required}
+    >
+      {selectLabelNode}
+      {selectTrigger}
+      <SelectBase.Portal container={container}>
+        {/*
+          Anchor to `side` (default `bottom`) rather than Base UI's default
+          `alignItemWithTrigger`, which overlays the popup on the trigger to
+          emulate a native `<select>`. Collision avoidance still flips the popup
+          automatically when the preferred side lacks space, and consumers can
+          pin placement explicitly via `side` / `align`, or opt back into the
+          native overlay with `alignItemWithTrigger`.
+        */}
+        <SelectBase.Positioner
+          side={side}
+          sideOffset={sideOffset}
+          align={align}
+          alignOffset={alignOffset}
+          alignItemWithTrigger={alignItemWithTrigger}
+        >
+          <SelectBase.Popup
+            className={cn(
+              "flex flex-col",
+              "max-h-[var(--available-height)] bg-kumo-base text-kumo-default",
+              "rounded-lg shadow-lg ring ring-kumo-line",
+              "max-w-(--available-width) min-w-(--anchor-width) py-1.5",
+            )}
+          >
+            <SelectBase.List
               className={cn(
-                "flex flex-col",
-                "max-h-[var(--available-height)] bg-kumo-base text-kumo-default",
-                "rounded-lg shadow-lg ring ring-kumo-line",
-                "min-w-[calc(var(--anchor-width)+3px)]",
-                selectSizeStyles[size].popup,
+                "min-h-0 flex-1 scroll-pt-2 scroll-pb-2 overflow-y-auto overscroll-none",
               )}
             >
-              <SelectBase.List
-                className={cn(
-                  "min-h-0 flex-1 scroll-pt-2 scroll-pb-2 overflow-y-auto overscroll-none",
-                )}
-              >
-                {renderedChildren}
-              </SelectBase.List>
-            </SelectBase.Popup>
-          </SelectBase.Positioner>
-        </SelectBase.Portal>
-      </SelectBase.Root>
-    </SelectSizeContext.Provider>
+              {renderedChildren}
+            </SelectBase.List>
+          </SelectBase.Popup>
+        </SelectBase.Positioner>
+      </SelectBase.Portal>
+    </SelectBase.Root>
   );
 
   // Use Field wrapper when label is provided and not hidden
@@ -647,8 +638,6 @@ type OptionProps<T> = {
 };
 
 function Option<T>({ children, value, disabled, className }: OptionProps<T>) {
-  const size = useContext(SelectSizeContext);
-
   return (
     <SelectBase.Item
       data-kumo-component="Select"
@@ -656,8 +645,7 @@ function Option<T>({ children, value, disabled, className }: OptionProps<T>) {
       value={value}
       disabled={disabled}
       className={cn(
-        "group flex cursor-pointer items-center justify-between outline-none",
-        selectSizeStyles[size].option,
+        "group mx-1.5 flex cursor-pointer items-center justify-between gap-2 rounded px-2 py-1.5 text-base outline-none",
         "focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset",
         "data-highlighted:bg-kumo-tint",
         "data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
@@ -722,22 +710,17 @@ type GroupLabelProps = {
  * ```
  */
 const GroupLabel = forwardRef<HTMLDivElement, GroupLabelProps>(
-  ({ children, className }, ref) => {
-    const size = useContext(SelectSizeContext);
-
-    return (
-      <SelectBase.GroupLabel
-        ref={ref}
-        className={cn(
-          "font-semibold text-kumo-subtle",
-          selectSizeStyles[size].groupLabel,
-          className,
-        )}
-      >
-        {children}
-      </SelectBase.GroupLabel>
-    );
-  },
+  ({ children, className }, ref) => (
+    <SelectBase.GroupLabel
+      ref={ref}
+      className={cn(
+        "px-3.5 py-1.5 text-sm font-semibold text-kumo-subtle",
+        className,
+      )}
+    >
+      {children}
+    </SelectBase.GroupLabel>
+  ),
 );
 GroupLabel.displayName = "Select.GroupLabel";
 


### PR DESCRIPTION
Fixes the Select popup positioning reported on `/components/select` — the `xs` and `sm` examples opened with the popup detached from its trigger, covering adjacent rows.

> [!NOTE]
> **Reworked after review.** The first revision scaled popup option rows to match each trigger size. Per @mattrothenberg's feedback that approach is gone — **option rows are untouched**. The popup is now anchored instead, which removes the dependency between row height and placement entirely. Diff is `+203/-2` across 4 files.

## Root cause

`Select.Positioner` was rendered with **no positioning props**, so it inherited Base UI's default `alignItemWithTrigger={true}` — the native-`<select>` emulation that overlays the popup on the trigger so the selected option's text lands on the trigger's value text.

Option rows are a fixed 33px (`text-base py-1.5`). Against a 20px `xs` trigger, that overlay put the popup nowhere near its anchor. Measured on `main`:

| | `data-side` | `data-align` | popup Δx | width Δ | overhang above | overhang below | trigger covered |
|---|---|---|---|---|---|---|---|
| `xs` | `none` | `center` | −8px | +3px | 12.5px | 45.5px | yes |

`base` and `lg` were within a few px of their rows, which is why only the small sizes were visibly wrong.

## Changes

**1. The popup is anchored to a preferred side.** `Select.Positioner` now receives explicit defaults:

```tsx
side="bottom"
sideOffset={4}
align="start"
alignItemWithTrigger={false}
```

Base UI's collision handling is untouched — `side` is a *preference*, and the popup still flips automatically when that side runs out of room.

**2. Placement is configurable.** `side`, `align`, `sideOffset`, `alignOffset` and `alignItemWithTrigger` are exposed as props, documented on both `SelectPropsGeneric` and `SelectProps`. `alignItemWithTrigger` is how you opt *back into* the old native-`<select>` overlay.

**3. The popup tracks the trigger width.**

```diff
- min-w-[calc(var(--anchor-width)+3px)] py-1.5
+ max-w-(--available-width) min-w-(--anchor-width) py-1.5
```

The `+3px` existed to visually compensate for the old item-alignment shift; with anchored placement the popup is exactly trigger width.

## Verification

Measured live in Chrome DevTools. Geometry is read off the `[data-side]` popup box — note the inner `[role="listbox"]` is the scroll container and is inset by the popup's 6px `py-1.5`, so measuring that instead reports a ~10px gap.

| scenario | `data-side` | gap | width Δ | left Δ |
|---|---|---|---|---|
| `xs` / `sm` / `base` / `lg`, defaults | `bottom` | 3.9–4.25px | 0 | ≤0.5px (subpixel) |
| trigger near viewport bottom | `top` (auto-flip) | 4.06px | 0 | 0 |
| explicit `side="top"`, room available | `top` | 3.88px | 0 | 0 |
| explicit `side="top"`, no room above | `bottom` (auto-flip) | ~4px | 0 | 0 |
| explicit `side="top" sideOffset={20} align="end"` | `top` | 20px | 0 | right-aligned |
| `alignItemWithTrigger` | `none` | — | selected option centred on trigger, error **0px** |

Option row height is unchanged at 33px for every size, by design.

## Screenshots

**`xs` in the Sizes example** — the reported bug. Both frames are the same viewport, scroll position and pointer state; only the fix differs.

| Before (`main`) | After |
|---|---|
| <img src="https://raw.githubusercontent.com/PedroLunet/kumo/pr-745-assets/sizes-before.png" width="420"> | <img src="https://raw.githubusercontent.com/PedroLunet/kumo/pr-745-assets/sizes-after.png" width="420"> |

The popup used to swallow the `xs` trigger entirely (and the `sm` row below it); it now sits 4px underneath, left edges and width flush.

**Explicit placement** — `side="top"` renders above the trigger, still trigger-width and trigger-aligned:

<img src="https://raw.githubusercontent.com/PedroLunet/kumo/pr-745-assets/placement-after.png" width="720">

**Opt-in `alignItemWithTrigger`** — the native-`<select>` overlay, kept and now documented. "Mars" is selected mid-list, so the popup extends above *and* below the trigger, with the selected row landing exactly on it:

<img src="https://raw.githubusercontent.com/PedroLunet/kumo/pr-745-assets/aligned-after.png" width="720">

## Docs

Two new sections on `/components/select`:

- **Placement** — `side` / `align` / `sideOffset` / `alignOffset`, four live examples.
- **Aligned to the selected option** — `alignItemWithTrigger` shown side by side with the default so the difference is visible.

## Review notes

Both of @ask-bonk's points are resolved by the rework rather than patched:

- The `py-1.25` class it flagged no longer exists — the option-scaling code is gone. (For the record it *was* valid: Tailwind v4's dynamic spacing scale emits `.py-1\.25 { padding-block: calc(var(--spacing) * 1.25) }`, which I confirmed computed to 26px in the browser.)
- `KUMO_SELECT_STYLING` is now byte-identical to `main` — this PR no longer touches it, so the "only describes `base`" nit is pre-existing code outside this diff.

---

- Reviews
  - [x] bonk has reviewed the change
  - [ ] automated review not possible because:
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: the change is popup geometry produced by Base UI's positioner at runtime, and the unit suite runs on happy-dom where `getBoundingClientRect` returns zeros, so placement cannot be asserted there. Verified instead by measuring live in Chrome DevTools (table above) across all four sizes, the automatic collision flip, three explicit placement overrides, and the `alignItemWithTrigger` overlay. Existing suite: 1267 pass / 1 pre-existing failure (`export-path-validation.test.ts`, which walks a stale local `dist/` for sourcemaps and is unrelated to `src/`). `typecheck`, `vp lint` and `vp fmt --check` all clean; docs `typecheck` clean after rebuilding the library.
