### PR TITLE
fix(table): elevate even rows

### DIFF
--- a/.changeset/elevate-even-table-rows.md
+++ b/.changeset/elevate-even-table-rows.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Use the elevated surface color for even rows in the default Table variant.

--- a/packages/kumo/src/components/table/table.test.tsx
+++ b/packages/kumo/src/components/table/table.test.tsx
@@ -18,10 +18,10 @@ describe("Table styling", () => {
     );
 
     expect(screen.getByTestId("default-row").className).toContain(
-      "even:bg-kumo-tint",
+      "even:bg-kumo-elevated",
     );
     expect(screen.getByTestId("selected-row").className).not.toContain(
-      "even:bg-kumo-tint",
+      "even:bg-kumo-elevated",
     );
     expect(container.querySelector("table")?.className).not.toContain(
       "[&_td]:border",

--- a/packages/kumo/src/components/table/table.tsx
+++ b/packages/kumo/src/components/table/table.tsx
@@ -19,7 +19,7 @@ export const KUMO_TABLE_VARIANTS = {
   variant: {
     default: {
       classes:
-        "even:bg-kumo-tint [--kumo-table-row-bg:var(--color-kumo-base)] even:[--kumo-table-row-bg:var(--color-kumo-tint)]",
+        "even:bg-kumo-elevated [--kumo-table-row-bg:var(--color-kumo-base)] even:[--kumo-table-row-bg:var(--color-kumo-elevated)]",
       description: "Default row variant",
     },
     selected: {


### PR DESCRIPTION
## Summary

Lowers the contrast for the new striped Kumo table by using `bg-kumo-elevated` over `bg-kumo-tint`.

Before:

<img width="992" height="626" alt="CleanShot 2026-08-24 at 08 50 19@2x" src="https://github.com/user-attachments/assets/a00cf422-69e0-4d50-b3f6-e7a2d15526e8" />

After:

<img width="992" height="626" alt="CleanShot 2026-08-24 at 08 50 04@2x" src="https://github.com/user-attachments/assets/51f1a031-1717-4345-b56b-fe7888682ba8" />


## Testing

- `pnpm --filter @cloudflare/kumo test src/components/table/table.test.tsx --run`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: This is a small semantic-token substitution with focused test coverage.
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: N/A
- [ ] Additional testing not necessary because: N/A
