### PR TITLE
feat(dialog): position dialogs near viewport top

### DIFF
--- a/.changeset/calm-dialog-position.md
+++ b/.changeset/calm-dialog-position.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Position dialogs near the top of the viewport instead of vertically centering them.

--- a/packages/kumo/src/components/dialog/dialog.test.tsx
+++ b/packages/kumo/src/components/dialog/dialog.test.tsx
@@ -2,11 +2,12 @@ import { describe, expect, it } from "vite-plus/test";
 import { dialogVariants } from "./dialog";
 
 describe("dialogVariants", () => {
-  it("positions dialogs near the top of the viewport", () => {
-    const classes = dialogVariants();
+  it("positions dialogs closer to the top on small viewports", () => {
+    const classes = dialogVariants().split(" ");
 
     expect(classes).toContain("fixed");
-    expect(classes).toContain("top-16");
+    expect(classes).toContain("top-8");
+    expect(classes).toContain("sm:top-16");
     expect(classes).not.toContain("top-1/2");
     expect(classes).not.toContain("-translate-y-1/2");
   });

--- a/packages/kumo/src/components/dialog/dialog.test.tsx
+++ b/packages/kumo/src/components/dialog/dialog.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vite-plus/test";
+import { dialogVariants } from "./dialog";
+
+describe("dialogVariants", () => {
+  it("positions dialogs near the top of the viewport", () => {
+    const classes = dialogVariants();
+
+    expect(classes).toContain("fixed");
+    expect(classes).toContain("top-16");
+    expect(classes).not.toContain("top-1/2");
+    expect(classes).not.toContain("-translate-y-1/2");
+  });
+});

--- a/packages/kumo/src/components/dialog/dialog.tsx
+++ b/packages/kumo/src/components/dialog/dialog.tsx
@@ -143,7 +143,7 @@ export function dialogVariants({
 }: KumoDialogVariantsProps = {}) {
   return cn(
     // Base styles
-    "shadow-m ring ring-kumo-line fixed top-16 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
+    "shadow-m ring ring-kumo-line fixed top-8 left-1/2 sm:top-16 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
     // Apply size from KUMO_DIALOG_VARIANTS
     resolveVariant(
       KUMO_DIALOG_VARIANTS.size,

--- a/packages/kumo/src/components/dialog/dialog.tsx
+++ b/packages/kumo/src/components/dialog/dialog.tsx
@@ -143,7 +143,7 @@ export function dialogVariants({
 }: KumoDialogVariantsProps = {}) {
   return cn(
     // Base styles
-    "shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
+    "shadow-m ring ring-kumo-line fixed top-16 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0",
     // Apply size from KUMO_DIALOG_VARIANTS
     resolveVariant(
       KUMO_DIALOG_VARIANTS.size,


### PR DESCRIPTION
## Summary

- position Kumo dialogs at `top-8` below the `sm` breakpoint and `top-16` at larger sizes
- remove the obsolete vertical translation
- add regression coverage for the responsive viewport positioning classes

<img width="2710" height="1316" alt="CleanShot 2026-08-24 at 14 02 40@2x" src="https://github.com/user-attachments/assets/8ac527ae-e57c-438c-9d7f-3cb7e639a5b7" />

<img width="1062" height="788" alt="CleanShot 2026-08-24 at 14 02 45@2x" src="https://github.com/user-attachments/assets/8bc9814f-4efc-48b9-9dd3-c2270f079f8b" />

## Testing

- Not run locally because dependencies are not installed in this worktree (`node_modules` is missing).

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: bonk is not available in this agent session
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: Not applicable; regression coverage was added
  - [ ] Additional testing not necessary because: Not applicable; regression coverage was added