### PR TITLE
fix(text): inherit line height for non-heading variants

### DIFF
--- a/.changeset/text-inherit-line-height.md
+++ b/.changeset/text-inherit-line-height.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Allow non-heading Text variants to inherit line height from their surrounding context.

--- a/packages/kumo/src/components/text/text.test.tsx
+++ b/packages/kumo/src/components/text/text.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { render } from "@testing-library/react";
-import { Text } from "./text";
+import { Text, textVariants } from "./text";
 
 describe("Text", () => {
   it("renders heading as a 16px semibold span by default", () => {
@@ -44,6 +44,50 @@ describe("Text", () => {
   it("renders body variant as <p> by default", () => {
     const { container } = render(<Text>Body copy</Text>);
     expect(container.querySelector("p")).toBeTruthy();
+  });
+
+  it("inherits line height for every body font size", () => {
+    expect(textVariants({ variant: "body", size: "xs" })).toContain(
+      "text-xs/[inherit]",
+    );
+    expect(textVariants({ variant: "body", size: "sm" })).toContain(
+      "text-sm/[inherit]",
+    );
+    expect(textVariants({ variant: "body", size: "base" })).toContain(
+      "text-base/[inherit]",
+    );
+    expect(textVariants({ variant: "body", size: "lg" })).toContain(
+      "text-lg/[inherit]",
+    );
+    expect(textVariants({ variant: "secondary" })).toContain(
+      "text-base/[inherit]",
+    );
+    expect(textVariants({ variant: "success" })).toContain(
+      "text-base/[inherit]",
+    );
+    expect(textVariants({ variant: "error" })).toContain("text-base/[inherit]");
+    expect(textVariants({ variant: "mono" })).toContain("text-sm/[inherit]");
+    expect(textVariants({ variant: "mono-secondary" })).toContain(
+      "text-sm/[inherit]",
+    );
+  });
+
+  it("keeps the configured line height for heading variants", () => {
+    expect(textVariants({ variant: "heading" }).split(" ")).toContain(
+      "text-lg",
+    );
+    expect(
+      textVariants({ variant: "heading", size: "lg" }).split(" "),
+    ).toContain("text-xl");
+    expect(textVariants({ variant: "heading1" }).split(" ")).toContain(
+      "text-3xl",
+    );
+    expect(textVariants({ variant: "heading2" }).split(" ")).toContain(
+      "text-2xl",
+    );
+    expect(textVariants({ variant: "heading3" }).split(" ")).toContain(
+      "text-lg",
+    );
   });
 
   it("body variant supports optional `as` override", () => {

--- a/packages/kumo/src/components/text/text.tsx
+++ b/packages/kumo/src/components/text/text.tsx
@@ -61,19 +61,19 @@ export const KUMO_TEXT_VARIANTS = {
   },
   size: {
     xs: {
-      classes: "text-xs",
+      classes: "text-xs/[inherit]",
       description: "Extra small text",
     },
     sm: {
-      classes: "text-sm",
+      classes: "text-sm/[inherit]",
       description: "Small text",
     },
     base: {
-      classes: "text-base",
+      classes: "text-base/[inherit]",
       description: "Default text size",
     },
     lg: {
-      classes: "text-lg",
+      classes: "text-lg/[inherit]",
       description: "Large text",
     },
   },


### PR DESCRIPTION
## Summary

- make non-heading `Text` variants inherit line height from their rendering context
- preserve the configured line heights for heading variants
- add regression coverage for body, semantic, monospace, and heading variants

## Tests

- `pnpm --filter @cloudflare/kumo test:unit`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm exec vp fmt --check packages/kumo/src/components/text/text.tsx packages/kumo/src/components/text/text.test.tsx .changeset/text-inherit-line-height.md`

## Jira

[DESENG-1446](https://jira.cfdata.org/browse/DESENG-1446)

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: automated review is not available in this workflow
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:
