### PR TITLE
fix(docs): make checkbox group error demo interactive

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
@@ -109,12 +109,14 @@ export function CheckboxLegendCustomDemo() {
 }
 
 export function CheckboxGroupErrorDemo() {
+  const [preferences, setPreferences] = useState<string[]>([]);
+
   return (
     <Checkbox.Group
       legend="Required preferences"
       error="Please select at least one notification method"
-      value={[]}
-      onValueChange={() => {}}
+      value={preferences}
+      onValueChange={setPreferences}
     >
       <Checkbox.Item value="email" label="Email" variant="error" />
       <Checkbox.Item value="sms" label="SMS" variant="error" />

--- a/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
@@ -110,16 +110,27 @@ export function CheckboxLegendCustomDemo() {
 
 export function CheckboxGroupErrorDemo() {
   const [preferences, setPreferences] = useState<string[]>([]);
+  const hasError = preferences.length === 0;
 
   return (
     <Checkbox.Group
       legend="Required preferences"
-      error="Please select at least one notification method"
+      error={
+        hasError ? "Please select at least one notification method" : undefined
+      }
       value={preferences}
       onValueChange={setPreferences}
     >
-      <Checkbox.Item value="email" label="Email" variant="error" />
-      <Checkbox.Item value="sms" label="SMS" variant="error" />
+      <Checkbox.Item
+        value="email"
+        label="Email"
+        variant={hasError ? "error" : undefined}
+      />
+      <Checkbox.Item
+        value="sms"
+        label="SMS"
+        variant={hasError ? "error" : undefined}
+      />
     </Checkbox.Group>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
@@ -118,6 +118,9 @@ export function CheckboxGroupErrorDemo() {
       error={
         hasError ? "Please select at least one notification method" : undefined
       }
+      description={
+        hasError ? undefined : "At least one notification method selected"
+      }
       value={preferences}
       onValueChange={setPreferences}
     >

--- a/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx
@@ -113,27 +113,31 @@ export function CheckboxGroupErrorDemo() {
   const hasError = preferences.length === 0;
 
   return (
-    <Checkbox.Group
-      legend="Required preferences"
-      error={
-        hasError ? "Please select at least one notification method" : undefined
-      }
-      description={
-        hasError ? undefined : "At least one notification method selected"
-      }
-      value={preferences}
-      onValueChange={setPreferences}
-    >
-      <Checkbox.Item
-        value="email"
-        label="Email"
-        variant={hasError ? "error" : undefined}
-      />
-      <Checkbox.Item
-        value="sms"
-        label="SMS"
-        variant={hasError ? "error" : undefined}
-      />
-    </Checkbox.Group>
+    <div className="w-full max-w-xs">
+      <Checkbox.Group
+        legend="Required preferences"
+        error={
+          hasError
+            ? "Please select at least one notification method"
+            : undefined
+        }
+        description={
+          hasError ? undefined : "At least one notification method selected"
+        }
+        value={preferences}
+        onValueChange={setPreferences}
+      >
+        <Checkbox.Item
+          value="email"
+          label="Email"
+          variant={hasError ? "error" : undefined}
+        />
+        <Checkbox.Item
+          value="sms"
+          label="SMS"
+          variant={hasError ? "error" : undefined}
+        />
+      </Checkbox.Group>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Store the error-group selection in React state instead of freezing its value to an empty array.
- Clear the validation message and error styling once at least one option is selected.
- Replace the resolved error with same-height helper text so the demo layout remains stable.
- Give the centred demo group a stable responsive width so different message lengths do not move it horizontally.

## Before and after

| Before | After |
| --- | --- |
| Clicking **Email** does not retain the checked state. | Clicking **Email** displays the tick and swaps the error for helper text without moving the layout. |
| ![Before: Email remains unchecked and the error persists](https://raw.githubusercontent.com/pranavkatariain/kumo/fc260fd9eae945b2fe1e172a8a30338d7f2a53ba/.github/pr-assets/checkbox-group-error-demo/before.jpg) | ![After: Email is checked and the error is replaced by helper text](https://raw.githubusercontent.com/pranavkatariain/kumo/fc260fd9eae945b2fe1e172a8a30338d7f2a53ba/.github/pr-assets/checkbox-group-error-demo/after.jpg) |

## Verification

- `pnpm --filter @cloudflare/kumo build`
- `pnpm exec vp lint packages/kumo-docs-astro/src/components/demos/CheckboxDemo.tsx`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`
- Manually verified locally that **Email** changes from `aria-checked="false"` to `aria-checked="true"`, the error swaps to helper text, the ring returns to its default style, and the preview remains stable on both axes.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because:
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: clicked Email in the local error-group demo and confirmed its checked state persists while the error swaps to helper text without shifting the preview vertically or horizontally
  - [ ] Additional testing not necessary because: <!-- explain why -->
