### PR TITLE
fix(text): suppress production deprecation warnings

### DIFF
--- a/.changeset/silent-production-text-warnings.md
+++ b/.changeset/silent-production-text-warnings.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Suppress deprecated `Text` heading variant warnings in production while retaining them during development.

--- a/packages/kumo/src/components/text/text.test.tsx
+++ b/packages/kumo/src/components/text/text.test.tsx
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { render } from "@testing-library/react";
 import { Text, textVariants } from "./text";
 
 describe("Text", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
   it("renders heading as a 16px semibold span by default", () => {
     const { container } = render(<Text variant="heading">Heading</Text>);
     const heading = container.querySelector("span");
@@ -26,20 +31,39 @@ describe("Text", () => {
     expect(heading?.classList.contains("font-semibold")).toBe(true);
   });
 
-  it("warns when a deprecated heading variant is used", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it.each(["heading1", "heading2", "heading3"] as const)(
+    "warns in development when deprecated variant %s is used",
+    (variant) => {
+      vi.stubEnv("NODE_ENV", "development");
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    render(
-      <Text variant="heading1" as="h1">
-        Legacy heading
-      </Text>,
-    );
+      render(
+        <Text variant={variant} as="h1">
+          Legacy heading
+        </Text>,
+      );
 
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('variant="heading1" is deprecated'),
-    );
-    warn.mockRestore();
-  });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(`variant="${variant}" is deprecated`),
+      );
+    },
+  );
+
+  it.each(["heading1", "heading2", "heading3"] as const)(
+    "does not warn in production when deprecated variant %s is used",
+    (variant) => {
+      vi.stubEnv("NODE_ENV", "production");
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      render(
+        <Text variant={variant} as="h1">
+          Legacy heading
+        </Text>,
+      );
+
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
 
   it("renders body variant as <p> by default", () => {
     const { container } = render(<Text>Body copy</Text>);

--- a/packages/kumo/tests/build/production-behavior.test.ts
+++ b/packages/kumo/tests/build/production-behavior.test.ts
@@ -1,0 +1,28 @@
+import { createElement } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { existsSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const textEntryPath = join(__dirname, "../../dist/components/text.js");
+const isBuilt = existsSync(textEntryPath);
+
+describe.skipIf(!isBuilt)("Production behavior (Post-Build)", () => {
+  it("does not emit deprecated Text variant warnings", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { Text } = await import("../../dist/components/text.js");
+
+    render(
+      createElement(Text, {
+        variant: "heading1",
+        as: "h1",
+        children: "Legacy heading",
+      }),
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -196,6 +196,9 @@ export default defineConfig({
       platform: "browser",
       outDir: "dist",
       dts: false,
+      // Published artifacts are production builds. Define NODE_ENV explicitly
+      // so Rolldown removes development-only warnings and their message strings.
+      define: { "process.env.NODE_ENV": '"production"' },
       // The dts pass emits declarations this pass can't see — pair them by
       // co-location; asset entries aren't chunks, so re-attach them here.
       exports: {


### PR DESCRIPTION
## Summary

- define `process.env.NODE_ENV` as `production` during Kumo's published JavaScript build
- preserve development-only deprecated `Text` heading warnings in source while removing them from production bundles
- add source coverage for all deprecated heading variants in development and production environments
- add a post-build regression test that imports the generated Text entry and verifies it does not warn

## Context

`@cloudflare/kumo@2.12.0` intended to guard deprecated `heading1`–`heading3` warnings with `process.env.NODE_ENV !== "production"`. During packaging, that condition was evaluated incorrectly and the published artifact contained an unconditional `console.warn`.

This fixes the issue at Kumo's package boundary rather than filtering warnings in consumers such as Stratus.

## Validation

- fresh uncached `@cloudflare/kumo` production build
- full Kumo unit suite: 1,278 tests passed
- Kumo lint
- Kumo typecheck
- changeset validation
- verified the emitted production JavaScript contains neither the Text deprecation warning nor `process.env.NODE_ENV`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this change requires review of build-time environment replacement and generated package behavior
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [ ] Additional testing not necessary because: not applicable
