### PR TITLE
feat(pagination): support unknown totals

### DIFF
--- a/.changeset/bright-pagination-next-page.md
+++ b/.changeset/bright-pagination-next-page.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add unknown-total pagination support through `hasNextPage`.

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -220,9 +220,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
-      "integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
       "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.4"

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.15.11"
+        "@opencode-ai/plugin": "1.17.7"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,19 +87,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.11.tgz",
-      "integrity": "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.7.tgz",
+      "integrity": "sha512-/MXRdz5z5tDySwMM4v02cN0om1QgALyE8FTXFU93zKV4I/oW5a0IjQ7dK8Iue3NpRc9e5UHhgO5ELeNLqnpWPA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.15.11",
-        "effect": "4.0.0-beta.66",
+        "@opencode-ai/sdk": "1.17.7",
+        "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.2.15",
-        "@opentui/keymap": ">=0.2.15",
-        "@opentui/solid": ">=0.2.15"
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.11.tgz",
-      "integrity": "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.7.tgz",
+      "integrity": "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -153,21 +153,21 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
-      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+      "version": "4.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
+      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
@@ -199,12 +199,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -220,12 +220,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
-      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+      "integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Pagination } from "@cloudflare/kumo";
+import { useState } from 'react';
+import { Pagination } from '@cloudflare/kumo';
 
 export function PaginationBasicDemo() {
   const [page, setPage] = useState(1);
@@ -19,6 +19,21 @@ export function PaginationSimpleDemo() {
       perPage={10}
       totalCount={100}
       controls="simple"
+    />
+  );
+}
+
+/** Pagination for an API that reports whether another page exists, but not a total. */
+export function PaginationUnknownTotalDemo() {
+  const [page, setPage] = useState(1);
+  const hasNextPage = page < 3;
+
+  return (
+    <Pagination
+      text={() => `Page ${page}`}
+      page={page}
+      setPage={setPage}
+      hasNextPage={hasNextPage}
     />
   );
 }
@@ -84,7 +99,7 @@ export function PaginationPageSizeSelectorDemo() {
       <Pagination.Separator />
       <Pagination.PageSize
         value={perPage}
-        onChange={(size) => {
+        onChange={size => {
           setPerPage(size);
           setPage(1);
         }}
@@ -110,7 +125,7 @@ export function PaginationCustomPageSizeOptionsDemo() {
       <Pagination.Separator />
       <Pagination.PageSize
         value={perPage}
-        onChange={(size) => {
+        onChange={size => {
           setPerPage(size);
           setPage(1);
         }}
@@ -153,7 +168,7 @@ export function PaginationDropdownSelectorDemo() {
       <Pagination.Separator />
       <Pagination.PageSize
         value={perPage}
-        onChange={(size) => {
+        onChange={size => {
           setPerPage(size);
           setPage(1);
         }}
@@ -181,7 +196,7 @@ export function PaginationPageSizeRightDemo() {
         <Pagination.Separator />
         <Pagination.PageSize
           value={perPage}
-          onChange={(size) => {
+          onChange={size => {
             setPerPage(size);
             setPage(1);
           }}
@@ -202,19 +217,19 @@ export function PaginationI18nDemo() {
       perPage={10}
       totalCount={100}
       labels={{
-        firstPage: "Première page",
-        previousPage: "Page précédente",
-        nextPage: "Page suivante",
-        lastPage: "Dernière page",
-        pageNumber: "Numéro de page",
-        pageSize: "Taille de page",
+        firstPage: 'Première page',
+        previousPage: 'Page précédente',
+        nextPage: 'Page suivante',
+        lastPage: 'Dernière page',
+        pageNumber: 'Numéro de page',
+        pageSize: 'Taille de page'
       }}
     >
       <Pagination.Info>
         {({ pageShowingRange, totalCount }) => (
           <>
-            Affichage de{" "}
-            <span className="tabular-nums">{pageShowingRange}</span> sur{" "}
+            Affichage de{' '}
+            <span className="tabular-nums">{pageShowingRange}</span> sur{' '}
             <span className="tabular-nums">{totalCount}</span>
           </>
         )}

--- a/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/PaginationDemo.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Pagination } from '@cloudflare/kumo';
+import { useState } from "react";
+import { Pagination } from "@cloudflare/kumo";
 
 export function PaginationBasicDemo() {
   const [page, setPage] = useState(1);
@@ -99,7 +99,7 @@ export function PaginationPageSizeSelectorDemo() {
       <Pagination.Separator />
       <Pagination.PageSize
         value={perPage}
-        onChange={size => {
+        onChange={(size) => {
           setPerPage(size);
           setPage(1);
         }}
@@ -125,7 +125,7 @@ export function PaginationCustomPageSizeOptionsDemo() {
       <Pagination.Separator />
       <Pagination.PageSize
         value={perPage}
-        onChange={size => {
+        onChange={(size) => {
           setPerPage(size);
           setPage(1);
         }}
@@ -168,7 +168,7 @@ export function PaginationDropdownSelectorDemo() {
       <Pagination.Separator />
       <Pagination.PageSize
         value={perPage}
-        onChange={size => {
+        onChange={(size) => {
           setPerPage(size);
           setPage(1);
         }}
@@ -196,7 +196,7 @@ export function PaginationPageSizeRightDemo() {
         <Pagination.Separator />
         <Pagination.PageSize
           value={perPage}
-          onChange={size => {
+          onChange={(size) => {
             setPerPage(size);
             setPage(1);
           }}
@@ -217,19 +217,19 @@ export function PaginationI18nDemo() {
       perPage={10}
       totalCount={100}
       labels={{
-        firstPage: 'Première page',
-        previousPage: 'Page précédente',
-        nextPage: 'Page suivante',
-        lastPage: 'Dernière page',
-        pageNumber: 'Numéro de page',
-        pageSize: 'Taille de page'
+        firstPage: "Première page",
+        previousPage: "Page précédente",
+        nextPage: "Page suivante",
+        lastPage: "Dernière page",
+        pageNumber: "Numéro de page",
+        pageSize: "Taille de page",
       }}
     >
       <Pagination.Info>
         {({ pageShowingRange, totalCount }) => (
           <>
-            Affichage de{' '}
-            <span className="tabular-nums">{pageShowingRange}</span> sur{' '}
+            Affichage de{" "}
+            <span className="tabular-nums">{pageShowingRange}</span> sur{" "}
             <span className="tabular-nums">{totalCount}</span>
           </>
         )}

--- a/packages/kumo-docs-astro/src/pages/components/pagination.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/pagination.mdx
@@ -11,6 +11,7 @@ import PropsTable from "~/components/docs/PropsTable.astro";
 import {
   PaginationBasicDemo,
   PaginationSimpleDemo,
+  PaginationUnknownTotalDemo,
   PaginationFullDemo,
   PaginationMidPageDemo,
   PaginationLargeDatasetDemo,
@@ -96,6 +97,42 @@ export default function Example() {
 </p>
 <ComponentExample demo="PaginationSimpleDemo">
   <PaginationSimpleDemo client:visible />
+</ComponentExample>
+
+### Unknown Totals
+
+<p>
+  Use `hasNextPage` when the data source does not return a total count. This is
+  common for cursor-based APIs, where calculating the total can be expensive or
+  unavailable. Set it from the response's next-page signal to keep Next enabled
+  only while another result set exists.
+</p>
+<p>
+  Without a total, users can only move sequentially, so Pagination hides the
+  first, last, and page-selector controls. The `page` value remains useful for
+  the UI, but your application is responsible for storing and sending the
+  cursor or continuation token for each request.
+</p>
+
+```tsx
+const [page, setPage] = useState(1);
+const { data } = useQuery({
+  queryKey: ["events", page],
+  queryFn: () => getEvents({ cursor: cursors[page - 1] }),
+});
+
+return (
+  <Pagination
+    page={page}
+    setPage={setPage}
+    hasNextPage={data.hasMore}
+    text={() => `Page ${page}`}
+  />
+);
+```
+
+<ComponentExample demo="PaginationUnknownTotalDemo">
+  <PaginationUnknownTotalDemo client:visible />
 </ComponentExample>
 
 ### Mid-Page State

--- a/packages/kumo/src/components/pagination/pagination.test.tsx
+++ b/packages/kumo/src/components/pagination/pagination.test.tsx
@@ -3,27 +3,34 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Pagination } from "./pagination";
 
-function renderPagination({
-  page = 1,
-  perPage = 10,
-  totalCount = 100,
-  setPage = vi.fn(),
-  controls = "full" as const,
-  pageSelector,
-}: {
-  page?: number;
-  perPage?: number;
-  totalCount?: number;
-  setPage?: (page: number) => void;
-  controls?: "full" | "simple";
-  pageSelector?: "input" | "dropdown";
-} = {}) {
+function renderPagination(
+  options: {
+    page?: number;
+    perPage?: number;
+    totalCount?: number;
+    hasNextPage?: boolean;
+    setPage?: (page: number) => void;
+    controls?: "full" | "simple";
+    pageSelector?: "input" | "dropdown";
+  } = {},
+) {
+  const {
+    page = 1,
+    perPage = 10,
+    hasNextPage,
+    setPage = vi.fn(),
+    controls = "full" as const,
+    pageSelector,
+  } = options;
+  const totalCount = "totalCount" in options ? options.totalCount : 100;
+
   return render(
     <Pagination
       page={page}
       setPage={setPage}
       perPage={perPage}
       totalCount={totalCount}
+      hasNextPage={hasNextPage}
     >
       <Pagination.Info />
       <Pagination.Controls controls={controls} pageSelector={pageSelector} />
@@ -196,6 +203,42 @@ describe("Pagination", () => {
 
       expect(screen.getByLabelText("Previous page")).toBeTruthy();
       expect(screen.getByLabelText("Next page")).toBeTruthy();
+    });
+
+    it("uses hasNextPage when the total count is unknown", () => {
+      const setPage = vi.fn();
+      renderPagination({
+        page: 3,
+        totalCount: undefined,
+        hasNextPage: true,
+        controls: "simple",
+        setPage,
+      });
+
+      fireEvent.click(screen.getByLabelText("Next page"));
+
+      expect(setPage).toHaveBeenCalledWith(4);
+    });
+
+    it("disables next when an unknown-total list has no following page", () => {
+      renderPagination({
+        page: 3,
+        totalCount: undefined,
+        hasNextPage: false,
+        controls: "simple",
+      });
+
+      expect(screen.getByLabelText("Next page").hasAttribute("disabled")).toBe(
+        true,
+      );
+    });
+
+    it("limits unknown-total pagination to sequential controls", () => {
+      renderPagination({ totalCount: undefined, hasNextPage: true });
+
+      expect(screen.queryByLabelText("First page")).toBeNull();
+      expect(screen.queryByLabelText("Page number")).toBeNull();
+      expect(screen.queryByLabelText("Last page")).toBeNull();
     });
   });
 

--- a/packages/kumo/src/components/pagination/pagination.tsx
+++ b/packages/kumo/src/components/pagination/pagination.tsx
@@ -110,6 +110,7 @@ interface PaginationContextValue {
   page: number;
   perPage?: number;
   totalCount?: number;
+  hasNextPage?: boolean;
   maxPage: number;
   pageShowingRange: string;
   setPage: (page: number) => void;
@@ -247,8 +248,22 @@ function PaginationControls({
   pageSelector = "input",
   className,
 }: PaginationControlsProps) {
-  const { page, maxPage, setPage, editingPage, setEditingPage, labels } =
-    usePaginationContext();
+  const {
+    page,
+    totalCount,
+    hasNextPage,
+    maxPage,
+    setPage,
+    editingPage,
+    setEditingPage,
+    labels,
+  } = usePaginationContext();
+  const hasKnownTotal = totalCount != null;
+  const isUnknownTotal = !hasKnownTotal && hasNextPage !== undefined;
+  const showFullControls = controls === "full" && !isUnknownTotal;
+  const isNextDisabled = hasKnownTotal
+    ? page === maxPage
+    : hasNextPage !== true;
 
   return (
     <div
@@ -257,7 +272,7 @@ function PaginationControls({
     >
       <nav aria-label={labels.navigation}>
         <InputGroup>
-          {controls === "full" && (
+          {showFullControls && (
             <InputGroup.Button
               variant="secondary"
               aria-label={labels.firstPage}
@@ -282,7 +297,7 @@ function PaginationControls({
           >
             <CaretLeftIcon size={16} />
           </InputGroup.Button>
-          {controls === "full" &&
+          {showFullControls &&
             (pageSelector === "dropdown" ? (
               <Select
                 aria-label={labels.pageNumber}
@@ -331,16 +346,18 @@ function PaginationControls({
           <InputGroup.Button
             variant="secondary"
             aria-label={labels.nextPage}
-            disabled={page === maxPage}
+            disabled={isNextDisabled}
             onClick={() => {
-              const nextPage = Math.min(page + 1, maxPage);
+              const nextPage = hasKnownTotal
+                ? Math.min(page + 1, maxPage)
+                : page + 1;
               setPage(nextPage);
               setEditingPage(nextPage);
             }}
           >
             <CaretRightIcon size={16} />
           </InputGroup.Button>
-          {controls === "full" && (
+          {showFullControls && (
             <InputGroup.Button
               variant="secondary"
               aria-label={labels.lastPage}
@@ -398,6 +415,11 @@ interface PaginationBaseProps {
   perPage?: number;
   /** Total number of items across all pages. */
   totalCount?: number;
+  /**
+   * Whether another page exists when the total count is unknown. Ignored when
+   * `totalCount` is provided. Unknown totals use sequential controls only.
+   */
+  hasNextPage?: boolean;
   /** Additional CSS classes for the container */
   className?: string;
   /**
@@ -518,6 +540,7 @@ function PaginationRoot(props: PaginationProps) {
     page = 1,
     perPage,
     totalCount,
+    hasNextPage,
     setPage,
     children,
     className,
@@ -560,6 +583,7 @@ function PaginationRoot(props: PaginationProps) {
     page,
     perPage,
     totalCount,
+    hasNextPage,
     maxPage,
     pageShowingRange,
     setPage,


### PR DESCRIPTION
## Summary
Add `hasNextPage` support for paginated sources that do not return a total count. Unknown-total pagination uses sequential controls and does not fabricate a total.

## Testing
- `pnpm --filter @cloudflare/kumo exec vp test run --project=unit src/components/pagination/pagination.test.tsx`
- `pnpm --filter @cloudflare/kumo typecheck`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this introduces a small public component API.
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable