### PR TITLE
ci(bonk): bump opencode + action, switch model to kimi-k2.7-code

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -42,15 +42,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Lil Bonk
-        uses: ask-bonk/ask-bonk/github@8c7a8314f4f4865e2e41e5718dfabc4ab7a2274b # main
+        uses: ask-bonk/ask-bonk/github@5d4fe8f4a557afb1b73ec8c0ffcf60359a28865f # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code"
           agent: kumo
           mentions: "/bonk"
-          opencode_version: "1.15.11"
+          opencode_version: "1.18.23"
           permissions: write


### PR DESCRIPTION
## Summary

The Bonk CI job on PRs has been failing immediately. Investigating [run 33092898816](https://github.com/cloudflare/kumo/actions/runs/33092898816) showed the job dies ~1s into the first LLM call, at `session.prompt step: 0`, right after runtime selection:

- Configured model was `workers-ai/@cf/moonshotai/kimi-k2.6`, but opencode resolved the runtime to `anthropic/claude-haiku-4.5` (a fallback), which then errored on the first request.
- The `kumo` agent (`.opencode/agents/kumo.md`) does **not** pin a model, so the fallback came from the action, not the agent.

This bumps stale versions and switches to a valid model:

- `ask-bonk/ask-bonk/github`: `8c7a8314…` → `5d4fe8f4…` (latest `main`)
- `opencode_version`: `1.15.11` → `1.18.23` (latest)
- `model`: `@cf/moonshotai/kimi-k2.6` → `@cf/moonshotai/kimi-k2.7-code`

## Testing

CI-only change. Real validation is re-triggering `/bonk` on a PR once merged (or against this branch).

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is the fix for the broken bonk workflow itself
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: CI workflow config change; validated by inspecting the failing run logs and cannot be unit-tested. Requires a live `/bonk` invocation to confirm.