### PR TITLE
[kumo-docs-astro] Prevent Figma table overflow on mobile

### DIFF
--- a/packages/kumo-docs-astro/src/pages/figma.mdx
+++ b/packages/kumo-docs-astro/src/pages/figma.mdx
@@ -68,11 +68,15 @@ cp packages/kumo-figma/scripts/.env.example packages/kumo-figma/scripts/.env
 
 ### Required Variables
 
+<div style="overflow-x: auto;">
+
 | Variable                | Required | Description                                                       |
 | ----------------------- | -------- | ----------------------------------------------------------------- |
 | `FIGMA_TOKEN`           | Yes      | Your Figma personal access token for API authentication           |
 | `FIGMA_FILE_KEY`        | Yes      | The file key from your Figma URL: `figma.com/file/{FILE_KEY}/...` |
 | `FIGMA_COLLECTION_NAME` | No       | Variable collection name in Figma. Defaults to `kumo-colors`      |
+
+</div>
 
 ```bash
 


### PR DESCRIPTION
No issue linked; this is a small docs-only fix.

## Summary

Wrap the Figma Resources environment-variable table in the existing `overflow-x: auto` pattern used throughout the docs. This prevents the table from widening the page on narrow viewports without changing shared table styles or other pages.

## Before

<img width="424" height="906" alt="Screenshot 2026-08-27 at 19 18 47" src="https://github.com/user-attachments/assets/5716515e-6df1-4bf0-b99b-39bb92bd0e2c" />

## After

<img width="421" height="863" alt="Screenshot 2026-08-27 at 19 19 09" src="https://github.com/user-attachments/assets/4289bd0b-bc5f-47cc-a3b8-1184b99fc60a" />


## Validation

- `git diff --check` passes.
- The code change is limited to `packages/kumo-docs-astro/src/pages/figma.mdx`.

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: this docs-only change has no automated reviewer available
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [x] Additional testing not necessary because: this is a scoped documentation markup change using an existing site pattern

Have you read the Contributing guide? Yes.