### PR TITLE
ci(bonk): fix "Model not found" — mirror cloudflare-docs config

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,9 +47,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          # Registers the model with the cloudflare-ai-gateway provider (without
+          # this, opencode reports "Model not found") and auto-approves tool
+          # calls in CI so Bonk doesn't block on approval prompts.
+          OPENCODE_CONFIG_CONTENT: >-
+            {"permission":"allow","provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/zai-org/glm-5.2":{"reasoning":true,"tool_call":true,"temperature":true,"limit":{"context":262144,"output":262144}}}}}}
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code"
+          model: "cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2"
           agent: kumo
           mentions: "/bonk"
           opencode_version: "1.18.23"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,15 +47,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # Registers the model with the cloudflare-ai-gateway provider (without
-          # this, opencode reports "Model not found") and auto-approves tool
-          # calls in CI so Bonk doesn't block on approval prompts.
-          OPENCODE_CONFIG_CONTENT: >-
-            {"permission":"allow","provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/zai-org/glm-5.2":{"reasoning":true,"tool_call":true,"temperature":true,"limit":{"context":262144,"output":262144}}}}}}
+          # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
+          # approval prompts. This is intentionally not in opencode.jsonc so
+          # local/interactive sessions keep their normal permission prompts.
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
-          model: "cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2"
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: kumo
           mentions: "/bonk"
-          opencode_version: "1.18.23"
+          opencode_version: "1.17.7"
           permissions: write


### PR DESCRIPTION
## Summary

Follow-up to #753. After bumping opencode, Bonk failed with:

```
Model not found: cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code.
Did you mean: moonshotai/kimi-k3, anthropic/claude-haiku-4.5, openai/gpt-4.1?
```

Root cause: `kimi-k2.7-code` is **not in opencode's built-in `cloudflare-ai-gateway` model catalog**, so the provider rejects it as unknown.

## Fix — mirror the proven cloudflare-docs Bonk config

`cloudflare/cloudflare-docs` runs Bonk successfully today (verified green runs within the same window kumo was failing). This aligns kumo's workflow with that known-good config:

| Setting | Value |
| --- | --- |
| `model` | `cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6` |
| `opencode_version` | `1.17.7` |
| `OPENCODE_CONFIG_CONTENT` | `{"permission":"allow"}` (auto-approve tool calls in CI) |

`kimi-k2.6` is a known model to the provider, so no `provider.models` registration block is needed.

## Debugging trail (each fix uncovered the next layer)

1. #753 — old opencode 1.15.11 silently fell back to `claude-haiku-4.5`; bumped action + opencode.
2. Transient pre-flight `AbortError` — traced to the bonk backend Worker (`ask-bonk.cloudflare-exponent.workers.dev`) behind Cloudflare Access/Gateway. Bonk-service-side; not fixable here.
3. `Model not found` — unknown model to the provider → **this PR**, resolved by using `kimi-k2.6` + opencode `1.17.7` per the cloudflare-docs config.

## Testing

CI-only. Validated against cloudflare-docs' currently-green Bonk config. Final confirmation requires a live `/bonk` on a PR after this merges to `main` (the workflow always runs the default-branch definition).

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is the fix for the broken bonk workflow itself
- Tests
- [ ] Tests included/updated
- [x] Additional testing not necessary because: CI workflow config change mirroring a proven-working sibling repo; requires a live /bonk to confirm