### PR TITLE
ci(bonk): register kimi-k2.6 model in opencode.jsonc (fixes model:undefined)

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -56,14 +56,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # - permission:allow auto-approves tool calls in CI so Bonk doesn't
-          #   block on approval prompts.
-          # - small_model pins the lightweight/title model to the same gateway
-          #   model. opencode's default small_model for cloudflare-ai-gateway is
-          #   anthropic/claude-haiku-4.5, which this gateway stopped serving
-          #   (returns not_found_error) and which killed every run on the first
-          #   (title-generation) call before the main model was ever used.
-          OPENCODE_CONFIG_CONTENT: '{"permission":"allow","small_model":"cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"}'
+          # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
+          # approval prompts. The model itself is registered in ./opencode.jsonc.
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,10 +47,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
-          # approval prompts. This is intentionally not in opencode.jsonc so
-          # local/interactive sessions keep their normal permission prompts.
-          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
+          # - permission:allow auto-approves tool calls in CI so Bonk doesn't
+          #   block on approval prompts.
+          # - small_model pins the lightweight/title model to the same gateway
+          #   model. opencode's default small_model for cloudflare-ai-gateway is
+          #   anthropic/claude-haiku-4.5, which this gateway stopped serving
+          #   (returns not_found_error) and which killed every run on the first
+          #   (title-generation) call before the main model was ever used.
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow","small_model":"cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -7,11 +7,6 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-  # TEMPORARY (remove before merge): lets us test the workflow from the PR
-  # branch itself. pull_request runs the branch's workflow definition, unlike
-  # issue_comment which always runs main's. Scoped to this branch only.
-  pull_request:
-    types: [opened, synchronize]
 
 concurrency:
   # intentionally hardcoded so that all Bonk workflows coexist peacefully
@@ -20,11 +15,7 @@ concurrency:
 
 jobs:
   bonk:
-    # TEMPORARY (remove before merge): also run on pull_request events from this
-    # test branch so we can validate the config without the main-branch comment loop.
-    if: |
-      (github.event_name == 'pull_request' && github.head_ref == 'mrothenberg/bonk-fix-model-id') ||
-      (github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk') && !contains(github.event.comment.body, '/bigbonk'))
+    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk') && !contains(github.event.comment.body, '/bigbonk')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -58,7 +49,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
           # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
           # approval prompts. The model itself is registered in ./opencode.jsonc.
-          OPENCODE_CONFIG_CONTENT: '{"permission":"allow","small_model":"cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"}'
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
@@ -66,6 +57,3 @@ jobs:
           mentions: "/bonk"
           opencode_version: "1.17.7"
           permissions: write
-          # TEMPORARY (remove before merge): canned prompt for the pull_request
-          # test path, which has no triggering comment body.
-          prompt: ${{ github.event_name == 'pull_request' && 'Reply with a short pong to confirm the model works, then stop.' || '' }}

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -58,7 +58,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
           # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
           # approval prompts. The model itself is registered in ./opencode.jsonc.
-          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow","small_model":"cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"}'
         with:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -7,6 +7,11 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  # TEMPORARY (remove before merge): lets us test the workflow from the PR
+  # branch itself. pull_request runs the branch's workflow definition, unlike
+  # issue_comment which always runs main's. Scoped to this branch only.
+  pull_request:
+    types: [opened, synchronize]
 
 concurrency:
   # intentionally hardcoded so that all Bonk workflows coexist peacefully
@@ -15,7 +20,11 @@ concurrency:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk') && !contains(github.event.comment.body, '/bigbonk')
+    # TEMPORARY (remove before merge): also run on pull_request events from this
+    # test branch so we can validate the config without the main-branch comment loop.
+    if: |
+      (github.event_name == 'pull_request' && github.head_ref == 'mrothenberg/bonk-fix-model-id') ||
+      (github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk') && !contains(github.event.comment.body, '/bigbonk'))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -62,3 +71,6 @@ jobs:
           mentions: "/bonk"
           opencode_version: "1.17.7"
           permissions: write
+          # TEMPORARY (remove before merge): canned prompt for the pull_request
+          # test path, which has no triggering comment body.
+          prompt: ${{ github.event_name == 'pull_request' && 'Reply with a short pong to confirm the model works, then stop.' || '' }}

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.17.7"
+        "@opencode-ai/plugin": "1.15.11"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,19 +87,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.7.tgz",
-      "integrity": "sha512-/MXRdz5z5tDySwMM4v02cN0om1QgALyE8FTXFU93zKV4I/oW5a0IjQ7dK8Iue3NpRc9e5UHhgO5ELeNLqnpWPA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.11.tgz",
+      "integrity": "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.7",
-        "effect": "4.0.0-beta.74",
+        "@opencode-ai/sdk": "1.15.11",
+        "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.3.4",
-        "@opentui/keymap": ">=0.3.4",
-        "@opentui/solid": ">=0.3.4"
+        "@opentui/core": ">=0.2.15",
+        "@opentui/keymap": ">=0.2.15",
+        "@opentui/solid": ">=0.2.15"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.7.tgz",
-      "integrity": "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.11.tgz",
+      "integrity": "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -153,21 +153,21 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.74",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
-      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
+      "version": "4.0.0-beta.66",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
+      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.8.0",
+        "fast-check": "^4.6.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^7.0.0",
+        "ini": "^6.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^2.0.1",
+        "msgpackr": "^1.11.9",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.9.0"
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/fast-check": {
@@ -199,12 +199,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
-      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "license": "ISC",
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/isexe": {
@@ -220,12 +220,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
-      "integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.4"
+        "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
-      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.15.11"
+        "@opencode-ai/plugin": "1.17.7"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,19 +87,19 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.11.tgz",
-      "integrity": "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.7.tgz",
+      "integrity": "sha512-/MXRdz5z5tDySwMM4v02cN0om1QgALyE8FTXFU93zKV4I/oW5a0IjQ7dK8Iue3NpRc9e5UHhgO5ELeNLqnpWPA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.15.11",
-        "effect": "4.0.0-beta.66",
+        "@opencode-ai/sdk": "1.17.7",
+        "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.2.15",
-        "@opentui/keymap": ">=0.2.15",
-        "@opentui/solid": ">=0.2.15"
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.11.tgz",
-      "integrity": "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.7.tgz",
+      "integrity": "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -153,21 +153,21 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
-      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+      "version": "4.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
+      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "fast-check": "^4.6.0",
+        "fast-check": "^4.8.0",
         "find-my-way-ts": "^0.1.6",
-        "ini": "^6.0.0",
+        "ini": "^7.0.0",
         "kubernetes-types": "^1.30.0",
-        "msgpackr": "^1.11.9",
+        "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
         "toml": "^4.1.1",
-        "uuid": "^13.0.0",
-        "yaml": "^2.8.3"
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/fast-check": {
@@ -199,12 +199,12 @@
       "license": "MIT"
     },
     "node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "license": "ISC",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/isexe": {
@@ -220,12 +220,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
-      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+      "integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://opencode.ai/config.json",
+	"experimental": {
+		"continue_loop_on_deny": true,
+	},
+	"provider": {
+		"cloudflare-ai-gateway": {
+			"models": {
+				"workers-ai/@cf/moonshotai/kimi-k2.6": {
+					"name": "Kimi K2.6",
+					"attachment": true,
+					"reasoning": true,
+					"tool_call": true,
+					"temperature": true,
+					"interleaved": {
+						"field": "reasoning_content",
+					},
+					"modalities": {
+						"input": ["text", "image"],
+						"output": ["text"],
+					},
+					"limit": {
+						"context": 256000,
+						"output": 64000,
+					},
+					"options": {
+						"temperature": 1.0,
+						"top_p": 0.95,
+						"max_tokens": 64000,
+						"parallel_tool_calls": true,
+					},
+				},
+			},
+		},
+	},
+}

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,36 +1,36 @@
 {
-	"$schema": "https://opencode.ai/config.json",
-	"experimental": {
-		"continue_loop_on_deny": true,
-	},
-	"provider": {
-		"cloudflare-ai-gateway": {
-			"models": {
-				"workers-ai/@cf/moonshotai/kimi-k2.6": {
-					"name": "Kimi K2.6",
-					"attachment": true,
-					"reasoning": true,
-					"tool_call": true,
-					"temperature": true,
-					"interleaved": {
-						"field": "reasoning_content",
-					},
-					"modalities": {
-						"input": ["text", "image"],
-						"output": ["text"],
-					},
-					"limit": {
-						"context": 256000,
-						"output": 64000,
-					},
-					"options": {
-						"temperature": 1.0,
-						"top_p": 0.95,
-						"max_tokens": 64000,
-						"parallel_tool_calls": true,
-					},
-				},
-			},
-		},
-	},
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "continue_loop_on_deny": true,
+  },
+  "provider": {
+    "cloudflare-ai-gateway": {
+      "models": {
+        "workers-ai/@cf/moonshotai/kimi-k2.6": {
+          "name": "Kimi K2.6",
+          "attachment": true,
+          "reasoning": true,
+          "tool_call": true,
+          "temperature": true,
+          "interleaved": {
+            "field": "reasoning_content",
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"],
+          },
+          "limit": {
+            "context": 256000,
+            "output": 64000,
+          },
+          "options": {
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "max_tokens": 64000,
+            "parallel_tool_calls": true,
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Summary

Bonk stopped working: every run died immediately with `model: undefined` despite the workflow passing `model: cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6`. Root cause: **opencode had no provider/model registration for that model string, so it couldn't resolve it** and aborted before the first call. Fix: add a root `opencode.jsonc` registering the model under the `cloudflare-ai-gateway` provider (mirrors cloudflare-docs' known-green setup).

## Proof (controlled A/B on this branch)

I temporarily added a `pull_request` trigger so the branch's workflow ran directly (issue_comment always runs main's copy), then isolated variables:

| Run | `opencode.jsonc` | `small_model` override | Result |
|---|---|---|---|
| [33103536424](https://github.com/cloudflare/kumo/actions/runs/33103536424) | absent | present | **FAIL** — `model: undefined` |
| [33103762109](https://github.com/cloudflare/kumo/actions/runs/33103762109) | present | absent | **PASS** — resolved kimi-k2.6, replied `pong` |
| [33104105762](https://github.com/cloudflare/kumo/actions/runs/33104105762) | present | present | **PASS** — resolved kimi-k2.6, replied `pong` |

Conclusions:
- `opencode.jsonc` is the **only** variable that flips fail -> pass. It is the fix.
- The `small_model` / haiku theory was wrong: haiku is still called as small_model and succeeds; `small_model` changes nothing (row 3 passes with it, row 1 fails with it). Not included in the final change.

## Final change

- **`opencode.jsonc`** (new): registers `workers-ai/@cf/moonshotai/kimi-k2.6` under the `cloudflare-ai-gateway` provider.
- **`bonk.yml`**: comment-only tweak; `OPENCODE_CONFIG_CONTENT` stays `{"permission":"allow"}`.

All temporary test scaffolding (pull_request trigger, canned prompt, small_model) has been reverted.

## Testing

Verified end-to-end on the branch (runs above): model resolves and Bonk completes a full round-trip. Post-merge, `/bonk` on a PR should work.

- Reviews
- [x] automated review not possible because: this is the fix for the broken Bonk workflow itself
- Tests
- [x] Additional testing not necessary because: verified end-to-end via branch CI runs (see A/B table); requires a live /bonk post-merge to reconfirm