### PR TITLE
feat(toolbar): add Toolbar.Link

### DIFF
--- a/.changeset/curvy-tools-link.md
+++ b/.changeset/curvy-tools-link.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add `Toolbar.Link`, which renders a `LinkButton` with toolbar sizing, styling, and keyboard navigation.

--- a/packages/kumo-docs-astro/src/components/demos/ToolbarDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ToolbarDemo.tsx
@@ -1,5 +1,6 @@
 import { Combobox, InputGroup, Select, Toolbar } from "@cloudflare/kumo";
 import {
+  BookOpenIcon,
   DownloadSimpleIcon,
   FunnelSimpleIcon,
   GearSixIcon,
@@ -76,6 +77,18 @@ export function ToolbarActionsDemo() {
   return (
     <Toolbar>
       <Toolbar.Button icon={UploadSimpleIcon}>Upload</Toolbar.Button>
+      <Toolbar.Button icon={DownloadSimpleIcon}>Download</Toolbar.Button>
+    </Toolbar>
+  );
+}
+
+/** Toolbar links use LinkButton for navigation with toolbar styling. */
+export function ToolbarLinksDemo() {
+  return (
+    <Toolbar>
+      <Toolbar.Link href="/components/button" icon={BookOpenIcon}>
+        Button documentation
+      </Toolbar.Link>
       <Toolbar.Button icon={DownloadSimpleIcon}>Download</Toolbar.Button>
     </Toolbar>
   );

--- a/packages/kumo-docs-astro/src/pages/components/toolbar.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/toolbar.mdx
@@ -14,6 +14,7 @@ import {
   ToolbarMixedControlsDemo,
   ToolbarInputGroupDemo,
   ToolbarActionsDemo,
+  ToolbarLinksDemo,
   ToolbarLabelsDemo,
   ToolbarSelectDemo,
   ToolbarComboboxDemo,
@@ -46,9 +47,9 @@ import {
 ## Usage
 
 Use `Toolbar` when multiple controls should read as one compact toolbar or
-filter card. Use `Toolbar.Button`, `Toolbar.Input`, and `Toolbar.InputGroup`
-directly. Compose Select and Combobox triggers with those toolbar controls
-through their `render` props.
+filter card. Use `Toolbar.Button`, `Toolbar.Link`, `Toolbar.Input`, and
+`Toolbar.InputGroup` directly. Compose Select and Combobox triggers with those
+toolbar controls through their `render` props.
 
 ```tsx
 import { InputGroup, Toolbar } from "@cloudflare/kumo";
@@ -80,6 +81,8 @@ Toolbar item components intentionally own grouped control presentation:
 - Every `Toolbar.*` control uses the `base` size by default.
 - The Toolbar `size` prop remains available for compatibility but is deprecated; omit it for the base size.
 - `Toolbar.Button` always renders with quiet toolbar button styling.
+- `Toolbar.Link` renders a `LinkButton` with quiet toolbar styling and
+  participates in arrow-key navigation.
 - `Toolbar.InputGroup` passes props directly to `InputGroup` with the resolved toolbar size.
 - Give Select `render={<Toolbar.Button />}` to compose its trigger into the toolbar.
 - Give `Combobox.TriggerInput` `render={<Toolbar.Input />}` for an editable toolbar combobox.
@@ -150,6 +153,15 @@ visually quiet and consistent.
 
 <ComponentExample demo="ToolbarActionsDemo">
   <ToolbarActionsDemo client:visible />
+</ComponentExample>
+
+### Links
+
+Use `Toolbar.Link` for navigation actions. It accepts `LinkButton` props except
+for `size` and `variant`, which are controlled by the Toolbar.
+
+<ComponentExample demo="ToolbarLinksDemo">
+  <ToolbarLinksDemo client:visible />
 </ComponentExample>
 
 ### Accessible Labels

--- a/packages/kumo/src/components/toolbar/index.ts
+++ b/packages/kumo/src/components/toolbar/index.ts
@@ -5,6 +5,7 @@ export {
   type ToolbarProps,
   type ToolbarSize,
   type ToolbarButtonProps,
+  type ToolbarLinkProps,
   type ToolbarInputProps,
   type ToolbarInputGroupProps,
 } from "./toolbar";

--- a/packages/kumo/src/components/toolbar/toolbar.browser.test.tsx
+++ b/packages/kumo/src/components/toolbar/toolbar.browser.test.tsx
@@ -76,6 +76,37 @@ describe("Toolbar.Button interactions", () => {
   });
 });
 
+describe("Toolbar.Link interactions", () => {
+  test("renders a LinkButton and participates in toolbar focus movement", async () => {
+    const { getByRole } = await render(
+      <Toolbar>
+        <Toolbar.Button>Before</Toolbar.Button>
+        <Toolbar.Link href="#docs" external>
+          Documentation
+        </Toolbar.Link>
+        <Toolbar.Button>After</Toolbar.Button>
+      </Toolbar>,
+    );
+
+    const before = getByRole("button", { name: "Before" });
+    const link = getByRole("link", { name: "Documentation" });
+    const after = getByRole("button", { name: "After" });
+
+    await expect
+      .element(link)
+      .toHaveAttribute("data-kumo-component", "Toolbar.Link");
+    await expect.element(link).toHaveAttribute("href", "#docs");
+    await expect.element(link).toHaveAttribute("target", "_blank");
+    await expect.element(link).toHaveAttribute("rel", "noopener noreferrer");
+
+    await before.click();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect.element(link).toHaveFocus();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect.element(after).toHaveFocus();
+  });
+});
+
 describe("Toolbar popup control interactions", () => {
   test("Select opens and selects through a rendered Toolbar.Button", async () => {
     const { getByRole } = await render(

--- a/packages/kumo/src/components/toolbar/toolbar.browser.test.tsx
+++ b/packages/kumo/src/components/toolbar/toolbar.browser.test.tsx
@@ -1,3 +1,4 @@
+import { GearSixIcon } from "@phosphor-icons/react";
 import { describe, expect, test, vi } from "vite-plus/test";
 import { userEvent } from "vite-plus/test/browser";
 import { render } from "vitest-browser-react";
@@ -104,6 +105,24 @@ describe("Toolbar.Link interactions", () => {
     await expect.element(link).toHaveFocus();
     await userEvent.keyboard("{ArrowRight}");
     await expect.element(after).toHaveFocus();
+  });
+
+  test("uses a square shape for an icon-only link", async () => {
+    const { getByRole } = await render(
+      <Toolbar>
+        <Toolbar.Link
+          href="#settings"
+          icon={GearSixIcon}
+          aria-label="Settings"
+        />
+      </Toolbar>,
+    );
+
+    const link = getByRole("link", { name: "Settings" });
+    const className = (link.element() as HTMLAnchorElement).className;
+
+    expect(className).toContain("size-9");
+    expect(className).toContain("p-0");
   });
 });
 

--- a/packages/kumo/src/components/toolbar/toolbar.tsx
+++ b/packages/kumo/src/components/toolbar/toolbar.tsx
@@ -7,7 +7,12 @@ import React, {
 import { Toolbar as ToolbarBase } from "@base-ui/react/toolbar";
 import type { InputState } from "@base-ui/react/input";
 import { cn } from "../../utils/cn";
-import { Button as KumoButton, type ButtonProps } from "../button/button";
+import {
+  Button as KumoButton,
+  LinkButton as KumoLinkButton,
+  type ButtonProps,
+  type LinkButtonProps,
+} from "../button/button";
 import { Input as KumoInput, type InputProps } from "../input/input";
 import { InputGroup } from "../input-group/input-group";
 
@@ -53,6 +58,8 @@ export interface ToolbarProps extends Omit<ToolbarBase.Root.Props, "children"> {
 
 export type ToolbarButtonProps = Omit<ButtonProps, "size" | "variant"> &
   Pick<ToolbarBase.Button.Props, "focusableWhenDisabled">;
+
+export type ToolbarLinkProps = Omit<LinkButtonProps, "size" | "variant">;
 
 export type ToolbarInputProps = Omit<
   InputProps,
@@ -179,6 +186,26 @@ const Button = React.forwardRef<HTMLButtonElement, ToolbarButtonProps>(
 
 Button.displayName = "Toolbar.Button";
 
+const Link = React.forwardRef<HTMLAnchorElement, ToolbarLinkProps>(
+  ({ children, className, ...props }, ref) => {
+    const toolbar = React.useContext(ToolbarSizeContext);
+
+    return (
+      <ToolbarBase.Link
+        ref={ref}
+        data-kumo-component="Toolbar.Link"
+        className={cn(className, TOOLBAR_CONTROL_STYLES)}
+        render={<KumoLinkButton size={toolbar.size} variant="ghost" />}
+        {...props}
+      >
+        {children}
+      </ToolbarBase.Link>
+    );
+  },
+);
+
+Link.displayName = "Toolbar.Link";
+
 const Input = React.forwardRef<HTMLInputElement, ToolbarInputProps>(
   ({ className, style, ...props }, ref) => {
     const toolbar = React.useContext(ToolbarSizeContext);
@@ -247,6 +274,7 @@ InputGroupRoot.displayName = "Toolbar.InputGroup";
 
 export const Toolbar = Object.assign(Root, {
   Button,
+  Link,
   Input,
   InputGroup: InputGroupRoot,
 });

--- a/packages/kumo/src/components/toolbar/toolbar.tsx
+++ b/packages/kumo/src/components/toolbar/toolbar.tsx
@@ -187,15 +187,24 @@ const Button = React.forwardRef<HTMLButtonElement, ToolbarButtonProps>(
 Button.displayName = "Toolbar.Button";
 
 const Link = React.forwardRef<HTMLAnchorElement, ToolbarLinkProps>(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, shape, icon: IconComponent, ...props }, ref) => {
     const toolbar = React.useContext(ToolbarSizeContext);
+    const resolvedShape =
+      shape ?? (children == null && IconComponent ? "square" : "base");
 
     return (
       <ToolbarBase.Link
         ref={ref}
         data-kumo-component="Toolbar.Link"
         className={cn(className, TOOLBAR_CONTROL_STYLES)}
-        render={<KumoLinkButton size={toolbar.size} variant="ghost" />}
+        render={
+          <KumoLinkButton
+            icon={IconComponent}
+            shape={resolvedShape}
+            size={toolbar.size}
+            variant="ghost"
+          />
+        }
         {...props}
       >
         {children}

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -59,6 +59,7 @@ export {
   type ToolbarProps,
   type ToolbarSize,
   type ToolbarButtonProps,
+  type ToolbarLinkProps,
   type ToolbarInputProps,
   type ToolbarInputGroupProps,
 } from "./components/toolbar";


### PR DESCRIPTION
## Summary

- add `Toolbar.Link`, backed by `LinkButton` with toolbar-controlled sizing and styling
- include links in toolbar roving keyboard navigation
- document the new API and add a demo and browser coverage

## Testing

- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo test:unit`
- `pnpm --filter @cloudflare/kumo exec vp test run --config=vitest.browser.config.ts src/components/toolbar/toolbar.browser.test.tsx`
- `pnpm --filter @cloudflare/kumo test:exports`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: automated review was not available in the local coding environment
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because:
