### PR TITLE
[kumo] Fix InputGroup accessible-name warning

### DIFF
--- a/.changeset/quiet-input-groups.md
+++ b/.changeset/quiet-input-groups.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Fix the accessible-name warning for InputGroup inputs named by the parent label.

--- a/packages/kumo/src/components/input-group/context.ts
+++ b/packages/kumo/src/components/input-group/context.ts
@@ -140,6 +140,8 @@ export interface InputGroupContextValue {
   focusMode: "container" | "individual" | "hybrid";
   disabled: boolean;
   error?: FieldProps["error"];
+  /** ID of visible label content supplied by InputGroup. */
+  labelId?: string;
   /** Auto-generated id for the input element; used by the invisible label overlay. */
   inputId: string;
 }

--- a/packages/kumo/src/components/input-group/input-group-input.tsx
+++ b/packages/kumo/src/components/input-group/input-group-input.tsx
@@ -51,6 +51,9 @@ export const Input = forwardRef<HTMLInputElement, InputGroupInputProps>(
     // Use explicit id if provided, otherwise fall back to context id
     // (links the input to the invisible label overlay for click-to-focus).
     const inputId = props.id ?? context?.inputId;
+    const ariaLabelledBy =
+      props["aria-labelledby"] ??
+      (props["aria-label"] ? undefined : context?.labelId);
 
     return (
       <InputExternal
@@ -59,6 +62,7 @@ export const Input = forwardRef<HTMLInputElement, InputGroupInputProps>(
         disabled={context?.disabled || (props as any).disabled}
         aria-invalid={hasError || props["aria-invalid"]}
         {...props}
+        aria-labelledby={ariaLabelledBy}
         id={inputId}
         className={cn(
           // Base input layout: fill height, allow shrinking, strip native border/radius

--- a/packages/kumo/src/components/input-group/input-group.test.tsx
+++ b/packages/kumo/src/components/input-group/input-group.test.tsx
@@ -384,6 +384,42 @@ describe("InputGroup", () => {
   });
 
   describe("accessibility", () => {
+    it("does not warn when the parent InputGroup provides the input label", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { container } = render(
+        <InputGroup label="Search">
+          <InputGroup.Input placeholder="Search..." />
+        </InputGroup>,
+      );
+
+      const input = screen.getByRole("textbox", { name: "Search" });
+      const labelledBy = input.getAttribute("aria-labelledby");
+
+      expect(input.getAttribute("aria-label")).toBeNull();
+      expect(labelledBy).toBeTruthy();
+      expect(document.getElementById(labelledBy!)?.textContent).toBe("Search");
+      expect(container.querySelectorAll("label label")).toHaveLength(0);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("[Kumo Input]"),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("warns when InputGroup.Input has no accessible name", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      render(
+        <InputGroup>
+          <InputGroup.Input />
+        </InputGroup>,
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[Kumo Input]"),
+      );
+      warnSpy.mockRestore();
+    });
+
     it("input has accessible name via aria-label", () => {
       render(
         <InputGroup>

--- a/packages/kumo/src/components/input-group/input-group.tsx
+++ b/packages/kumo/src/components/input-group/input-group.tsx
@@ -101,6 +101,8 @@ const Root = forwardRef<
     forwardedRef,
   ) => {
     const inputId = useId();
+    const labelId = useId();
+    const hasLabel = Boolean(label);
     const focusMode = detectFocusMode(children);
 
     const contextValue = useMemo(
@@ -109,9 +111,10 @@ const Root = forwardRef<
         focusMode,
         disabled,
         error,
+        labelId: hasLabel ? labelId : undefined,
         inputId,
       }),
-      [size, focusMode, disabled, error, inputId],
+      [size, focusMode, disabled, error, hasLabel, inputId, labelId],
     );
 
     // When label is provided, Field already renders a <label> with htmlFor
@@ -250,7 +253,7 @@ const Root = forwardRef<
       if (label) {
         return (
           <Field
-            label={label}
+            label={<span id={labelId}>{label}</span>}
             description={description}
             error={error}
             required={required}
@@ -313,7 +316,7 @@ const Root = forwardRef<
     if (label) {
       return (
         <Field
-          label={label}
+          label={<span id={labelId}>{label}</span>}
           description={description}
           error={error}
           required={required}


### PR DESCRIPTION
## Issue

The documented `<InputGroup label="Search">` composition gives its input an accessible name but still emits `[Kumo Input]: Input must have an accessible name` in development.

```tsx
<InputGroup label="Search">
  <InputGroup.Input placeholder="Search..." />
</InputGroup>
```

`InputGroup` renders the parent label through `Field`, while `InputGroup.Input` delegates to `Input`. The inner validator sees only naming props passed directly to the input, so it misses the valid label supplied by the group.

## Solution

- Pass the parent label ID through InputGroup context and apply it as `aria-labelledby` only when the input has no explicit `aria-label` or `aria-labelledby`.
- Preserve explicit naming precedence and the warning for a genuinely unnamed `<InputGroup><InputGroup.Input /></InputGroup>`.
- Add focused regression coverage for both cases and a patch changeset for `@cloudflare/kumo`.

## Validation

- `node_modules/.bin/vp run --filter @cloudflare/kumo test`: 52 files and 1,277 tests passed, including 95 InputGroup tests.
- `node_modules/.bin/vp run test:ci`: 9 tests passed.
- `node_modules/.bin/vp run build:kumo`: passed.
- `node_modules/.bin/vp exec tsx ci/scripts/validate-kumo-changeset.ts`: passed.

## AI disclosure

This change and pull request description were prepared by an AI coding agent at the contributor's direction.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: Repository bonk review requires collaborator invocation after the pull request opens
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
