### PR TITLE
fix(input-group): align addon button padding

### DIFF
--- a/.changeset/even-input-button-padding.md
+++ b/.changeset/even-input-button-padding.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Align the right inset of base InputGroup addon buttons with their vertical inset.

--- a/packages/kumo/src/components/input-group/context.ts
+++ b/packages/kumo/src/components/input-group/context.ts
@@ -75,7 +75,7 @@ export const INPUT_GROUP_SIZE: Record<KumoInputSize, InputGroupSizeTokens> = {
     addonOuterStart: "pl-2",
     addonOuterEnd: "pr-2",
     addonButtonOuterStart: "pl-1",
-    addonButtonOuterEnd: "pr-1",
+    addonButtonOuterEnd: "pr-1.25",
     suffixPad: "pr-3",
     fontSize: "text-base",
     iconSize: 18,

--- a/packages/kumo/src/components/input-group/input-group.test.tsx
+++ b/packages/kumo/src/components/input-group/input-group.test.tsx
@@ -372,6 +372,25 @@ describe("InputGroup", () => {
       },
     );
 
+    it("gives a base end button equal horizontal and vertical insets", () => {
+      render(
+        <InputGroup label="Password">
+          <InputGroup.Input type="password" />
+          <InputGroup.Addon align="end">
+            <InputGroup.Button aria-label="Show password" />
+          </InputGroup.Addon>
+        </InputGroup>,
+      );
+
+      const button = screen.getByRole("button", { name: "Show password" });
+      const addon = button.closest("[data-slot=input-group-addon-end]")!;
+
+      // A base group is 36px tall and its compact button is 26px tall,
+      // leaving a 5px inset on the top and bottom.
+      expect(INPUT_GROUP_SIZE.base.addonButtonOuterEnd).toBe("pr-1.25");
+      expect(addon.className).toContain("pr-1.25");
+    });
+
     // Ensure all addonOuter tokens are static directional classes
     // (not symmetric px- that would need runtime string replacement)
     it("all addon tokens use static pl-/pr- classes (not px-)", () => {


### PR DESCRIPTION
A base `InputGroup` is 36px tall and renders addon buttons at 26px tall, leaving 5px above and below the button. The end-addon spacing token previously used 4px of right padding, making the right inset visibly tighter on controls such as Stratus's new login password field.

This updates the base end-button inset to 5px and adds a regression test for the token and rendered addon class.

Validation:
- `pnpm --filter @cloudflare/kumo exec vitest run src/components/input-group/input-group.test.tsx` (94 tests passed)
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm exec vp fmt --check packages/kumo/src/components/input-group/context.ts packages/kumo/src/components/input-group/input-group.test.tsx .changeset/even-input-button-padding.md`

---

- Reviews
  - [x] automated review not possible because: the one-pixel optical alignment requires visual confirmation in the preview
- Tests
  - [x] Tests included/updated
