### PR TITLE
fix(input-group): tighten large addon button inset

### DIFF
--- a/.changeset/tidy-large-input-group-spacing.md
+++ b/.changeset/tidy-large-input-group-spacing.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Reduce the trailing inset for buttons inside large InputGroup addons.

--- a/packages/kumo/src/components/input-group/context.ts
+++ b/packages/kumo/src/components/input-group/context.ts
@@ -85,7 +85,7 @@ export const INPUT_GROUP_SIZE: Record<KumoInputSize, InputGroupSizeTokens> = {
     addonOuterStart: "pl-2.5",
     addonOuterEnd: "pr-2.5",
     addonButtonOuterStart: "pl-1.5",
-    addonButtonOuterEnd: "pr-1.5",
+    addonButtonOuterEnd: "pr-0.5",
     suffixPad: "pr-4",
     fontSize: "text-base",
     iconSize: 20,

--- a/packages/kumo/src/components/input-group/input-group.test.tsx
+++ b/packages/kumo/src/components/input-group/input-group.test.tsx
@@ -372,6 +372,23 @@ describe("InputGroup", () => {
       },
     );
 
+    it("uses compact end spacing for a button in a large group", () => {
+      render(
+        <InputGroup size="lg" label="Search">
+          <InputGroup.Input />
+          <InputGroup.Addon align="end">
+            <InputGroup.Button aria-label="Clear" shape="square" />
+          </InputGroup.Addon>
+        </InputGroup>,
+      );
+
+      const button = screen.getByRole("button", { name: "Clear" });
+      const addon = button.closest("[data-slot=input-group-addon-end]")!;
+
+      expect(INPUT_GROUP_SIZE.lg.addonButtonOuterEnd).toBe("pr-0.5");
+      expect(addon.className).toContain("pr-0.5");
+    });
+
     // Ensure all addonOuter tokens are static directional classes
     // (not symmetric px- that would need runtime string replacement)
     it("all addon tokens use static pl-/pr- classes (not px-)", () => {


### PR DESCRIPTION
Large `InputGroup` controls currently reserve more trailing space for an addon button than the other sizes. This tightens the end inset for button addons while leaving text, icon, and suffix addon spacing unchanged.

A focused regression test verifies both the size token and the class applied to the rendered end addon.

Validation:
- `pnpm --filter @cloudflare/kumo exec vitest run src/components/input-group/input-group.test.tsx`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm exec vp fmt --check packages/kumo/src/components/input-group/context.ts packages/kumo/src/components/input-group/input-group.test.tsx .changeset/tidy-large-input-group-spacing.md`

---

- Reviews
  - [x] automated review not possible because: final optical spacing should be confirmed in the generated component preview
- Tests
  - [x] Tests included/updated
