### PR TITLE
[kumo] Align Combobox popup input with content edges

### DIFF
--- a/.changeset/tidy-combobox-input.md
+++ b/.changeset/tidy-combobox-input.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Make `Combobox.Input` sit flush with the top and sides of `Combobox.Content` and remove its bottom corner rounding.

--- a/packages/kumo/src/components/combobox/combobox.test.tsx
+++ b/packages/kumo/src/components/combobox/combobox.test.tsx
@@ -41,6 +41,29 @@ describe("Combobox", () => {
     expect(screen.getByPlaceholderText("Pick a fruit…")).toBeTruthy();
   });
 
+  it("styles an input inside content flush with the popup edges", () => {
+    render(
+      <Combobox items={fruits} defaultOpen>
+        <Combobox.TriggerValue placeholder="Select a fruit" />
+        <Combobox.Content>
+          <Combobox.Input placeholder="Search fruits…" />
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Content>
+      </Combobox>,
+    );
+
+    const input = screen.getByPlaceholderText("Search fruits…");
+    expect(input.classList.contains("mx-0")).toBe(true);
+    expect(input.classList.contains("-mt-1.5")).toBe(true);
+    expect(input.classList.contains("rounded-b-none")).toBe(true);
+  });
+
   it("accepts positioner props on content", () => {
     render(
       <Combobox items={fruits}>

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -462,7 +462,7 @@ function Input(props: ComboboxBase.Input.Props) {
       {...props}
       className={cn(
         inputVariants(),
-        "mx-1.5 w-[calc(100%-0.75rem)] shrink-0 first:mb-2",
+        "mx-0 -mt-1.5 w-full shrink-0 rounded-b-none first:mb-2",
         props.className,
       )}
     />


### PR DESCRIPTION
Fixes DESENG-1560.

Updates the combobox input styling when rendered inside combobox content:

<img width="868" height="1220" alt="CleanShot 2026-09-01 at 12 24 52@2x" src="https://github.com/user-attachments/assets/c26760c0-3f07-496d-a2dc-cbd0878cef67" />

## Summary

- make `Combobox.Input` flush with the top and horizontal edges of `Combobox.Content`
- remove the input's bottom corner rounding so it joins the option list cleanly
- add regression coverage for the popup input classes

## Testing

- `pnpm --filter @cloudflare/kumo exec vp test run --project=unit src/components/combobox/combobox.test.tsx`
- `pnpm exec vp lint packages/kumo/src/components/combobox/combobox.tsx packages/kumo/src/components/combobox/combobox.test.tsx`
- `pnpm exec vp fmt --check packages/kumo/src/components/combobox/combobox.tsx packages/kumo/src/components/combobox/combobox.test.tsx .changeset/tidy-combobox-input.md`

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: this is a focused styling adjustment covered by a regression test
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
  - [ ] Additional testing not necessary because: not applicable
