### PR TITLE
[kumo] remove inherited ghost button background

### DIFF
--- a/.changeset/quiet-ghost-buttons.md
+++ b/.changeset/quiet-ghost-buttons.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Remove the inherited resting background from ghost buttons so translucent parent surfaces do not appear darker beneath them.

--- a/packages/kumo/src/components/button/button.test.tsx
+++ b/packages/kumo/src/components/button/button.test.tsx
@@ -66,6 +66,13 @@ describe("Button", () => {
     expect(button.classList.contains("select-text")).toBe(false);
   });
 
+  it("does not paint a resting background for ghost buttons", () => {
+    const className = buttonVariants({ variant: "ghost" });
+
+    expect(className).toContain("hover:bg-kumo-tint");
+    expect(className).not.toContain("bg-inherit");
+  });
+
   it("forwards ref to the <button> DOM node", () => {
     const ref = React.createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Click</Button>);

--- a/packages/kumo/src/components/button/button.tsx
+++ b/packages/kumo/src/components/button/button.tsx
@@ -58,7 +58,7 @@ export const KUMO_BUTTON_VARIANTS = {
       description: "Default button style for most actions",
     },
     ghost: {
-      classes: "text-kumo-default hover:bg-kumo-tint shadow-none bg-inherit",
+      classes: "text-kumo-default hover:bg-kumo-tint shadow-none",
       description: "Minimal button with no background",
     },
     destructive: {


### PR DESCRIPTION
Ghost buttons are documented as having no background, but `bg-inherit` paints the parent background inside the button. On translucent surfaces, this composites the alpha color twice and creates a darker local fill.

This removes the resting background utility while retaining `hover:bg-kumo-tint`. It also adds a focused regression test for the variant class contract.

Shadcn use this same no-bg-classname pattern for its ghost variant.

Verification:

- `pnpm --filter @cloudflare/kumo exec vp test run --project=unit src/components/button/button.test.tsx`
- `pnpm --filter @cloudflare/kumo build`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`

AI disclosure: This change, test, changeset, and pull request description were prepared by an AI coding agent under contributor direction.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: the repository's automated reviewer runs after pull request submission
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
