### PR TITLE
fix(docs): remove extra tabs demo spacing

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/TabsDemo.tsx
@@ -19,7 +19,7 @@ const productionLikeExtraTabs = [
 
 export function TabsDefaultDemo() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col items-start gap-6">
       <div>
         <p className="mb-2 text-sm text-kumo-subtle">Segmented (default)</p>
         <Tabs
@@ -164,7 +164,7 @@ export function TabsDynamicCountDemo() {
 
 export function TabsSmDemo() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col items-start gap-6">
       <div>
         <p className="mb-2 text-sm text-kumo-subtle">Segmented sm</p>
         <Tabs


### PR DESCRIPTION
## Summary

- Keep segmented Tabs demos sized to their own content instead of stretching to the wider underline variant
- Apply the alignment fix to both default and small-size examples

## Testing

- `pnpm --filter @cloudflare/kumo-docs-astro exec vp lint src/components/demos/TabsDemo.tsx`
- `pnpm --filter @cloudflare/kumo test src/components/tabs/tabs.test.tsx`
- Verified the rendered page at desktop and 375px mobile widths with no document overflow

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a docs-only visual alignment change
- Tests
- [ ] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows: not applicable
- [x] Additional testing not necessary because: targeted lint and existing Tabs tests pass, and the layout was verified at desktop and mobile widths