### PR TITLE
fix(tooltip): prevent nested text clipping

### DIFF
--- a/.changeset/calm-tooltips-smile.md
+++ b/.changeset/calm-tooltips-smile.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Prevent default Tooltip triggers from clipping child text that inherits line height.

--- a/.changeset/calm-tooltips-smile.md
+++ b/.changeset/calm-tooltips-smile.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": patch
 ---
 
-Prevent default Tooltip triggers from clipping child text that inherits line height.
+Allow default Tooltip trigger children to control their line height, preventing inherited text from being clipped.

--- a/packages/kumo/src/components/tooltip/tooltip.test.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { Text } from "../text/text";
+import { Tooltip } from "./tooltip";
+
+describe("Tooltip", () => {
+  it("preserves a visible line height for nested text", () => {
+    render(
+      <Tooltip content="More information">
+        <Text as="span" size="sm">
+          Trigger label
+        </Text>
+      </Tooltip>,
+    );
+
+    const trigger = screen
+      .getByText("Trigger label")
+      .closest("[data-base-ui-tooltip-trigger]");
+
+    expect(trigger).not.toBeNull();
+    expect(trigger?.classList.contains("leading-none")).toBe(true);
+    expect(trigger?.classList.contains("leading-[0]")).toBe(false);
+  });
+});

--- a/packages/kumo/src/components/tooltip/tooltip.test.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.test.tsx
@@ -4,7 +4,7 @@ import { Text } from "../text/text";
 import { Tooltip } from "./tooltip";
 
 describe("Tooltip", () => {
-  it("preserves a visible line height for nested text", () => {
+  it("does not override the line height of nested text", () => {
     render(
       <Tooltip content="More information">
         <Text as="span" size="sm">
@@ -18,7 +18,6 @@ describe("Tooltip", () => {
       .closest("[data-base-ui-tooltip-trigger]");
 
     expect(trigger).not.toBeNull();
-    expect(trigger?.classList.contains("leading-none")).toBe(true);
-    expect(trigger?.classList.contains("leading-[0]")).toBe(false);
+    expect(trigger?.className).not.toMatch(/\bleading-/);
   });
 });

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -171,7 +171,7 @@ export function Tooltip({
           // These prevent global button styles from polluting the trigger
           // Consumer styles passed via className will override these.
           !shouldUseRender &&
-            "m-0 inline-flex h-auto min-h-0 items-center border-none bg-transparent p-0 leading-[0] shadow-none",
+            "m-0 inline-flex h-auto min-h-0 items-center border-none bg-transparent p-0 leading-none shadow-none",
           // Tooltip triggers are disclosure elements, not actions — override
           // cursor: pointer (e.g. from Button used via render prop) so the
           // trigger doesn't appear clickable

--- a/packages/kumo/src/components/tooltip/tooltip.tsx
+++ b/packages/kumo/src/components/tooltip/tooltip.tsx
@@ -171,7 +171,7 @@ export function Tooltip({
           // These prevent global button styles from polluting the trigger
           // Consumer styles passed via className will override these.
           !shouldUseRender &&
-            "m-0 inline-flex h-auto min-h-0 items-center border-none bg-transparent p-0 leading-none shadow-none",
+            "m-0 inline-flex h-auto min-h-0 items-center border-none bg-transparent p-0 shadow-none",
           // Tooltip triggers are disclosure elements, not actions — override
           // cursor: pointer (e.g. from Button used via render prop) so the
           // trigger doesn't appear clickable


### PR DESCRIPTION
Related to https://gitlab.cfdata.org/cloudflare/fe/stratus/-/merge_requests/43382.

Tooltip's default trigger sets `line-height: 0`, which causes nested `Text` content that inherits line height to collapse and become clipped inside overflow-constrained consumers. Remove the trigger's line-height utility so children control their own typography, and add regression coverage for nested text.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: no automated reviewer is available in this environment
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->