### PR TITLE
[kumo] Add a footer to TimeseriesChart tooltips

### DIFF
--- a/.changeset/soft-chart-footers.md
+++ b/.changeset/soft-chart-footers.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add support for footer content below `TimeseriesChart` tooltip values.

--- a/.changeset/soft-chart-footers.md
+++ b/.changeset/soft-chart-footers.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": minor
 ---
 
-Add support for footer content below `TimeseriesChart` tooltip values.
+Add support for footer text below `TimeseriesChart` tooltip values.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -720,6 +720,7 @@ export function ChartExampleDemo() {
           isDarkMode={isDarkMode}
           data={data}
           height={300}
+          tooltipFooter="Percentiles use a five-minute rolling window."
         />
       </LayerCard.Primary>
     </LayerCard>

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -20,6 +20,7 @@ import {
   LoadingChartDemo,
   LoadingBarChartDemo,
   TimeRangeSelectionChartDemo,
+  ChartExampleDemo,
   TooltipFollowCursorDemo,
   TooltipBoundaryDemo,
 } from "~/components/demos/Chart/ChartDemo";
@@ -126,6 +127,22 @@ import {
 
   <ComponentExample demo="TimeRangeSelectionChartDemo">
     <TimeRangeSelectionChartDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+## Tooltip footer
+
+<p>
+  Use the <code>tooltipFooter</code> prop to add brief supporting content below
+  the values in standard series tooltips. It works with every timeseries chart
+  configuration, including line, bar, gradient, threshold, and custom-axis
+  charts.
+</p>
+
+  <ComponentExample demo="ChartExampleDemo">
+    <ChartExampleDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -135,7 +135,7 @@ import {
 ## Tooltip footer
 
 <p>
-  Use the <code>tooltipFooter</code> prop to add brief supporting content below
+  Use the <code>tooltipFooter</code> prop to add brief supporting text below
   the values in standard series tooltips. It works with every timeseries chart
   configuration, including line, bar, gradient, threshold, and custom-axis
   charts.

--- a/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
@@ -24,12 +24,12 @@ const createMockEcharts = (mockChart = createMockChart()) => ({
 });
 
 describe("TimeseriesChart", () => {
-  it("does not reserve footer space for boolean React nodes", () => {
+  it("does not reserve footer space for an empty string", () => {
     const { container } = render(
       <TooltipContent
         state={{ type: "series", ts: 1, rows: [], hiddenCount: 0 }}
         formatTimestamp={() => "Now"}
-        footer={false}
+        footer=""
       />,
     );
 
@@ -122,7 +122,7 @@ describe("TimeseriesChart", () => {
           },
         ]}
         markers={[marker]}
-        tooltipFooter={<span>Five-minute rolling window</span>}
+        tooltipFooter="Five-minute rolling window"
       />,
     );
 
@@ -138,7 +138,7 @@ describe("TimeseriesChart", () => {
     expect(
       row.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(footer.parentElement?.className).toContain("text-kumo-subtle");
+    expect(footer.className).toContain("text-kumo-subtle");
 
     const mouseover = mockChart.on.mock.calls.find(
       (call) => call[0] === "mouseover",

--- a/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
@@ -8,6 +8,7 @@ import {
 import { renderToString } from "react-dom/server";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { TimeseriesChart } from "./TimeseriesChart";
+import { TooltipContent } from "./timeseries-tooltip";
 
 const createMockChart = () => ({
   setOption: vi.fn(),
@@ -23,6 +24,18 @@ const createMockEcharts = (mockChart = createMockChart()) => ({
 });
 
 describe("TimeseriesChart", () => {
+  it("does not reserve footer space for boolean React nodes", () => {
+    const { container } = render(
+      <TooltipContent
+        state={{ type: "series", ts: 1, rows: [], hiddenCount: 0 }}
+        formatTimestamp={() => "Now"}
+        footer={false}
+      />,
+    );
+
+    expect(container.querySelector(".text-kumo-subtle")).toBeNull();
+  });
+
   it("server-renders without browser globals", () => {
     const mockEcharts = createMockEcharts();
     const originalWindow = globalThis.window;
@@ -91,6 +104,63 @@ describe("TimeseriesChart", () => {
     fireEvent.mouseMove(window, { clientX: 101, clientY: 50 });
 
     expect(screen.queryByText("Requests")).toBeNull();
+  });
+
+  it("renders supplemental content below series values in every tooltip", async () => {
+    const mockChart = createMockChart();
+    const mockEcharts = createMockEcharts(mockChart);
+    const marker = { timestamp: 1, label: "Deployment" };
+
+    render(
+      <TimeseriesChart
+        echarts={mockEcharts as any}
+        data={[
+          {
+            name: "Requests",
+            color: "#4290F0",
+            data: [[1, 10]],
+          },
+        ]}
+        markers={[marker]}
+        tooltipFooter={<span>Five-minute rolling window</span>}
+      />,
+    );
+
+    const updateAxisPointer = mockChart.on.mock.calls.find(
+      (call) => call[0] === "updateaxispointer",
+    )?.[1];
+    expect(updateAxisPointer).toBeTypeOf("function");
+
+    await act(() => updateAxisPointer({ axesInfo: [{ value: 1 }] }));
+
+    const row = await screen.findByText("Requests");
+    const footer = screen.getByText("Five-minute rolling window");
+    expect(
+      row.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(footer.parentElement?.className).toContain("text-kumo-subtle");
+
+    const mouseover = mockChart.on.mock.calls.find(
+      (call) => call[0] === "mouseover",
+    )?.[1];
+    expect(mouseover).toBeTypeOf("function");
+
+    await act(() =>
+      mouseover({
+        componentType: "markLine",
+        data: { tooltip: { marker: { ...marker, markers: [marker] } } },
+      }),
+    );
+
+    expect(await screen.findByText("Deployment")).not.toBeNull();
+    expect(screen.getByText("Five-minute rolling window")).not.toBeNull();
+    expect(
+      screen
+        .getByText("Requests")
+        .compareDocumentPosition(
+          screen.getByText("Five-minute rolling window"),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("reactivates brush-to-zoom after a notMerge option update", async () => {

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -9,7 +9,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type ReactNode,
 } from "react";
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import { Chart, ChartEvents, KumoChartOption } from "./EChart";
@@ -95,11 +94,11 @@ export interface TimeseriesChartProps {
    */
   tooltipValueFormat?: (value: number) => string;
   /**
-   * Footer content rendered below the series rows in the tooltip.
+   * Footer text rendered below the series rows in the tooltip.
    * Intended for brief context such as data freshness or aggregation details.
    * Available for every `TimeseriesChart` configuration.
    */
-  tooltipFooter?: ReactNode;
+  tooltipFooter?: string;
   /**
    * Controls which series are shown in the tooltip.
    * - `"all"` — show all series at the hovered timestamp (default)

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 import { Chart, ChartEvents, KumoChartOption } from "./EChart";
@@ -93,6 +94,12 @@ export interface TimeseriesChartProps {
    * deprecated `yAxisTickLabelFormat` prop.
    */
   tooltipValueFormat?: (value: number) => string;
+  /**
+   * Footer content rendered below the series rows in the tooltip.
+   * Intended for brief context such as data freshness or aggregation details.
+   * Available for every `TimeseriesChart` configuration.
+   */
+  tooltipFooter?: ReactNode;
   /**
    * Controls which series are shown in the tooltip.
    * - `"all"` — show all series at the hovered timestamp (default)
@@ -235,6 +242,7 @@ export const TimeseriesChart = forwardRef<
     yAxisName,
     yAxisTickCount,
     tooltipValueFormat,
+    tooltipFooter,
     onTimeRangeChange,
     height = 350,
     incomplete,
@@ -767,6 +775,7 @@ export const TimeseriesChart = forwardRef<
                 state={tooltipState}
                 formatValue={formatFn}
                 formatTimestamp={formatTimestamp}
+                footer={tooltipFooter}
               />
             </TooltipPrimitive.Popup>
           </TooltipPrimitive.Positioner>

--- a/packages/kumo/src/components/chart/timeseries-tooltip.tsx
+++ b/packages/kumo/src/components/chart/timeseries-tooltip.tsx
@@ -1,4 +1,5 @@
 import { memo, type ReactNode } from "react";
+import { Text } from "../text";
 import type { TimeseriesMarker } from "./timeseries-markers";
 
 export interface TooltipRow {
@@ -61,7 +62,9 @@ export const TooltipContent = memo(function TooltipContent({
         </>
       )}
       {hasFooter && (
-        <div className="mt-1 text-xs text-kumo-subtle">{footer}</div>
+        <Text variant="secondary" size="xs" DANGEROUS_className="mt-1">
+          {footer}
+        </Text>
       )}
     </>
   );

--- a/packages/kumo/src/components/chart/timeseries-tooltip.tsx
+++ b/packages/kumo/src/components/chart/timeseries-tooltip.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode } from "react";
+import { memo } from "react";
 import { Text } from "../text";
 import type { TimeseriesMarker } from "./timeseries-markers";
 
@@ -30,7 +30,7 @@ export interface TooltipContentProps {
   state: TooltipState;
   formatValue?: (v: number) => string;
   formatTimestamp: (ts: number | string | Date) => string;
-  footer?: ReactNode;
+  footer?: string;
 }
 
 export const TooltipContent = memo(function TooltipContent({
@@ -39,8 +39,6 @@ export const TooltipContent = memo(function TooltipContent({
   formatTimestamp,
   footer,
 }: TooltipContentProps) {
-  const hasFooter = footer != null && typeof footer !== "boolean";
-
   return (
     <>
       {state.type === "marker" ? (
@@ -61,7 +59,7 @@ export const TooltipContent = memo(function TooltipContent({
           />
         </>
       )}
-      {hasFooter && (
+      {footer && (
         <Text variant="secondary" size="xs" DANGEROUS_className="mt-1">
           {footer}
         </Text>

--- a/packages/kumo/src/components/chart/timeseries-tooltip.tsx
+++ b/packages/kumo/src/components/chart/timeseries-tooltip.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, type ReactNode } from "react";
 import type { TimeseriesMarker } from "./timeseries-markers";
 
 export interface TooltipRow {
@@ -29,33 +29,40 @@ export interface TooltipContentProps {
   state: TooltipState;
   formatValue?: (v: number) => string;
   formatTimestamp: (ts: number | string | Date) => string;
+  footer?: ReactNode;
 }
 
 export const TooltipContent = memo(function TooltipContent({
   state,
   formatValue,
   formatTimestamp,
+  footer,
 }: TooltipContentProps) {
-  if (state.type === "marker") {
-    return (
-      <MarkerTooltipContent
-        state={state}
-        formatValue={formatValue}
-        formatTimestamp={formatTimestamp}
-      />
-    );
-  }
+  const hasFooter = footer != null && typeof footer !== "boolean";
 
   return (
     <>
-      <div className="mb-1 text-xs font-semibold text-kumo-default">
-        {formatTimestamp(state.ts)}
-      </div>
-      <SeriesTooltipRows
-        rows={state.rows}
-        hiddenCount={state.hiddenCount}
-        formatValue={formatValue}
-      />
+      {state.type === "marker" ? (
+        <MarkerTooltipContent
+          state={state}
+          formatValue={formatValue}
+          formatTimestamp={formatTimestamp}
+        />
+      ) : (
+        <>
+          <div className="mb-1 text-xs font-semibold text-kumo-default">
+            {formatTimestamp(state.ts)}
+          </div>
+          <SeriesTooltipRows
+            rows={state.rows}
+            hiddenCount={state.hiddenCount}
+            formatValue={formatValue}
+          />
+        </>
+      )}
+      {hasFooter && (
+        <div className="mt-1 text-xs text-kumo-subtle">{footer}</div>
+      )}
     </>
   );
 });

--- a/packages/kumo/src/components/chart/timeseries-tooltip.tsx
+++ b/packages/kumo/src/components/chart/timeseries-tooltip.tsx
@@ -60,9 +60,11 @@ export const TooltipContent = memo(function TooltipContent({
         </>
       )}
       {footer && (
-        <Text variant="secondary" size="xs" DANGEROUS_className="mt-1">
-          {footer}
-        </Text>
+        <div className="mt-1">
+          <Text variant="secondary" size="xs">
+            {footer}
+          </Text>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
### Summary

Adds a footer to the TimeseriesChart tooltip, for any extra information, or ReactNode that users might want to add.

<img width="687" height="548" alt="file-cf8876b0f7dfb9106ba11022e4e55ecc" src="https://github.com/user-attachments/assets/f5496a34-a940-46bf-add3-8213c2aa2e49" />

The footer works across all TimeseriesChart configurations that render a tooltip, including standard series and marker tooltips.

This PR also includes focused tests, documentation, an example, and a minor changeset.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: I do not have collaborator access required to run Bonk
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/kumo/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
