### PR TITLE
feat(sidebar): add scrollItemIntoView

### DIFF
--- a/.changeset/sidebar-scroll-item-into-view.md
+++ b/.changeset/sidebar-scroll-item-into-view.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Add `scrollItemIntoView()` to preserve the position of visible sidebar items while honoring alignment for offscreen items.

--- a/packages/kumo-docs-astro/src/pages/components/sidebar.astro
+++ b/packages/kumo-docs-astro/src/pages/components/sidebar.astro
@@ -259,6 +259,7 @@ const { state, isPeeking } = useSidebar();
         <Heading level={3}>Scroll to Item</Heading>
         <p>
           Tag nav items with <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">itemId</code>, then call <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">useSidebar().scrollToItem(id, options)</code> to bring one into view.
+          Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">scrollItemIntoView(id, options)</code> to preserve the current position when the item is already fully visible.
           <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">align</code> is <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">"start"</code>, <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">"center"</code>, <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">"end"</code>, or <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">"auto"</code> (default — no-op if visible). <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">behavior</code> defaults to <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">"auto"</code> (instant) so cross-app landings don't animate on entry; pass <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">"smooth"</code> for in-app "jump to section" flows. Honors <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">prefers-reduced-motion</code>. Works correctly with <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Sidebar.SlidingViews</code> — items are resolved from a per-provider registry, not a DOM query.
         </p>
         <p>

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -1093,6 +1093,8 @@ describe("Sidebar scrollToItem", () => {
     ["preserves a visible item", 100, 0, 0],
     ["start-aligns an item below the viewport", 800, 0, 800],
     ["start-aligns an item above the viewport", -400, 500, 100],
+    ["start-aligns an item clipped below the viewport", 380, 0, 380],
+    ["start-aligns an item clipped above the viewport", -20, 500, 480],
   ])("%s", async (_, itemTop, initialScrollTop, expectedScrollTop) => {
     function Ctrl() {
       const { scrollItemIntoView } = useSidebar();

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -1089,6 +1089,45 @@ describe("Sidebar scrollToItem", () => {
     expect(readScrollTop(viewport)).toBe(800);
   });
 
+  it.each([
+    ["preserves a visible item", 100, 0, 0],
+    ["start-aligns an item below the viewport", 800, 0, 800],
+    ["start-aligns an item above the viewport", -400, 500, 100],
+  ])("%s", async (_, itemTop, initialScrollTop, expectedScrollTop) => {
+    function Ctrl() {
+      const { scrollItemIntoView } = useSidebar();
+      return (
+        <button
+          type="button"
+          data-testid="ctrl"
+          onClick={() => scrollItemIntoView("zero-trust", { align: "start" })}
+        />
+      );
+    }
+
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuButton itemId="zero-trust">
+              Zero Trust
+            </SidebarMenuButton>
+          </SidebarMenu>
+        </SidebarContent>
+        <Ctrl />
+      </TestSidebar>,
+    );
+
+    const viewport = getViewport();
+    setViewportGeometry(viewport, 2000, 400);
+    stubViewportOrigin(viewport);
+    stubItemGeometry(findItem("zero-trust"), itemTop, 40);
+    viewport.scrollTop = initialScrollTop;
+
+    await userEvent.click(screen.getByTestId("ctrl"));
+    expect(readScrollTop(viewport)).toBe(expectedScrollTop);
+  });
+
   it("centers the target when align is 'center'", async () => {
     function Ctrl() {
       const { scrollToItem } = useSidebar();

--- a/packages/kumo/src/components/sidebar/sidebar.test.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.test.tsx
@@ -1012,6 +1012,8 @@ describe("Sidebar scrollToItem", () => {
     el: HTMLElement,
     offsetTop: number,
     height: number,
+    scale = 1,
+    viewportTop = 0,
   ) {
     Object.defineProperty(el, "offsetTop", {
       configurable: true,
@@ -1024,31 +1026,35 @@ describe("Sidebar scrollToItem", () => {
     Object.defineProperty(el, "getBoundingClientRect", {
       configurable: true,
       value: () => ({
-        top: offsetTop,
+        top: viewportTop + offsetTop * scale,
         left: 0,
-        bottom: offsetTop + height,
+        bottom: viewportTop + (offsetTop + height) * scale,
         right: 0,
         width: 0,
-        height,
+        height: height * scale,
         x: 0,
-        y: offsetTop,
+        y: viewportTop + offsetTop * scale,
         toJSON: () => ({}),
       }),
     });
   }
 
-  function stubViewportOrigin(viewport: HTMLDivElement) {
+  function stubViewportOrigin(viewport: HTMLDivElement, scale = 1, top = 0) {
+    Object.defineProperty(viewport, "offsetHeight", {
+      configurable: true,
+      value: viewport.clientHeight,
+    });
     Object.defineProperty(viewport, "getBoundingClientRect", {
       configurable: true,
       value: () => ({
-        top: 0,
+        top,
         left: 0,
-        bottom: viewport.clientHeight,
+        bottom: top + viewport.clientHeight * scale,
         right: 0,
         width: 0,
-        height: viewport.clientHeight,
+        height: viewport.clientHeight * scale,
         x: 0,
-        y: 0,
+        y: top,
         toJSON: () => ({}),
       }),
     });
@@ -1128,6 +1134,74 @@ describe("Sidebar scrollToItem", () => {
 
     await userEvent.click(screen.getByTestId("ctrl"));
     expect(readScrollTop(viewport)).toBe(expectedScrollTop);
+  });
+
+  it.each([
+    ["uses default auto alignment", undefined, 440],
+    ["center-aligns an offscreen item", { align: "center" } as const, 620],
+    ["end-aligns an offscreen item", { align: "end" } as const, 440],
+  ])("%s", async (_, options, expectedScrollTop) => {
+    function Ctrl() {
+      const { scrollItemIntoView } = useSidebar();
+      return (
+        <button
+          type="button"
+          data-testid="ctrl"
+          onClick={() => scrollItemIntoView("target", options)}
+        />
+      );
+    }
+
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuButton itemId="target">Target</SidebarMenuButton>
+          </SidebarMenu>
+        </SidebarContent>
+        <Ctrl />
+      </TestSidebar>,
+    );
+
+    const viewport = getViewport();
+    setViewportGeometry(viewport, 2000, 400);
+    stubViewportOrigin(viewport);
+    stubItemGeometry(findItem("target"), 800, 40);
+
+    await userEvent.click(screen.getByTestId("ctrl"));
+    expect(readScrollTop(viewport)).toBe(expectedScrollTop);
+  });
+
+  it("normalizes scaled geometry before start-aligning the target", async () => {
+    function Ctrl() {
+      const { scrollItemIntoView } = useSidebar();
+      return (
+        <button
+          type="button"
+          data-testid="ctrl"
+          onClick={() => scrollItemIntoView("target", { align: "start" })}
+        />
+      );
+    }
+
+    render(
+      <TestSidebar defaultOpen>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuButton itemId="target">Target</SidebarMenuButton>
+          </SidebarMenu>
+        </SidebarContent>
+        <Ctrl />
+      </TestSidebar>,
+    );
+
+    const viewport = getViewport();
+    setViewportGeometry(viewport, 2000, 400);
+    stubViewportOrigin(viewport, 0.5, 100);
+    stubItemGeometry(findItem("target"), 800, 40, 0.5, 100);
+
+    await userEvent.click(screen.getByTestId("ctrl"));
+    expect(readScrollTop(viewport)).toBe(800);
   });
 
   it("centers the target when align is 'center'", async () => {

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -172,6 +172,14 @@ export interface SidebarContextValue {
    * @param options.behavior — `"auto"` for instant, `"smooth"` for animated (default `"auto"`)
    */
   scrollToItem: (id: string, options?: SidebarScrollToItemOptions) => void;
+  /**
+   * Scroll a tagged nav item only when it is outside its sidebar viewport.
+   * Explicit alignment controls where an offscreen item lands.
+   */
+  scrollItemIntoView: (
+    id: string,
+    options?: SidebarScrollToItemOptions,
+  ) => void;
 }
 
 /**
@@ -443,6 +451,27 @@ function SidebarProvider({
     [],
   );
 
+  const scrollItemIntoView = useCallback(
+    (id: string, options: SidebarScrollToItemOptions = {}) => {
+      const target = itemsRef.current.get(id);
+      if (!target) return;
+      const viewport = target.closest<HTMLElement>('[data-sidebar="viewport"]');
+      if (!viewport) return;
+
+      const targetRect = target.getBoundingClientRect();
+      const viewportRect = viewport.getBoundingClientRect();
+      if (
+        targetRect.top >= viewportRect.top &&
+        targetRect.bottom <= viewportRect.bottom
+      ) {
+        return;
+      }
+
+      scrollToItem(id, options);
+    },
+    [scrollToItem],
+  );
+
   // eslint-disable-next-line react-hooks/exhaustive-deps -- all values are
   // either stable (props, setters) or derived from state that triggers re-render
   const contextValue = useMemo<SidebarContextValue>(
@@ -472,6 +501,7 @@ function SidebarProvider({
       animationDuration,
       registerItem,
       scrollToItem,
+      scrollItemIntoView,
     }),
     [state, open, openMobile, isMobile, width, isResizing, isPeeking],
   );

--- a/packages/kumo/src/components/sidebar/sidebar.tsx
+++ b/packages/kumo/src/components/sidebar/sidebar.tsx
@@ -412,8 +412,13 @@ function SidebarProvider({
       // which walks the ancestor chain and scrolls the document too.
       const targetRect = target.getBoundingClientRect();
       const viewportRect = viewport.getBoundingClientRect();
+      const viewportScaleY =
+        viewport.offsetHeight > 0 && viewportRect.height > 0
+          ? viewportRect.height / viewport.offsetHeight
+          : 1;
       const itemScrollOffset =
-        targetRect.top - viewportRect.top + viewport.scrollTop;
+        (targetRect.top - viewportRect.top) / viewportScaleY +
+        viewport.scrollTop;
 
       let desired: number;
       if (align === "center") {


### PR DESCRIPTION
## Summary

Adds `scrollItemIntoView(id, options?)` to `useSidebar()`. It preserves the viewport position when an item is fully visible. It applies the requested alignment when an item is clipped.

Normalizes transformed viewport coordinates before calculating scroll offsets. This keeps alignment correct when consumer shells scale the sidebar.

## Why

Sidebar consumers must start-align offscreen active groups without moving groups users can already see. CSS transforms scale measured rectangles, but `scrollTop` remains in layout coordinates. Without normalization, transformed sidebars undershoot the requested position.

The method reuses `scrollToItem()` for scrolling. This preserves viewport isolation and reduced-motion behavior.

## Testing

- `pnpm --filter @cloudflare/kumo exec vp test run --project=unit src/components/sidebar/sidebar.test.tsx` - 66 tests pass
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo build` - attw and publint pass
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`
- Verified visible, offscreen, and transformed navigation behavior in Zero Trust and Stratus

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: this imperative DOM API needs human review of its visibility semantics
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because: