### PR TITLE
fix(combobox): match Select double chevron

### DIFF
--- a/.changeset/unify-combobox-select-chevrons.md
+++ b/.changeset/unify-combobox-select-chevrons.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": patch
+---
+
+Use the up/down double chevron in Combobox value and input triggers to match Select.

--- a/packages/kumo-figma/src/generators/combobox.ts
+++ b/packages/kumo-figma/src/generators/combobox.ts
@@ -435,15 +435,10 @@ async function createComboboxComponent(
 
   trigger.appendChild(placeholderText);
 
-  // Create chevron down icon
-  const chevronIconName = "ph-caret-down";
+  // Create up/down chevron icon
+  const chevronIconName = "ph-caret-up-down";
   const chevron = getButtonIcon(chevronIconName, "sm");
   chevron.name = "Chevron";
-
-  // Rotate chevron 180° when open (pointing up)
-  if (open) {
-    chevron.rotation = 180;
-  }
 
   // Apply icon color based on state
   const iconColorToken =

--- a/packages/kumo/src/components/combobox/combobox.tsx
+++ b/packages/kumo/src/components/combobox/combobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox as ComboboxBase } from "@base-ui/react/combobox";
-import { CaretDownIcon, CheckIcon, XIcon } from "@phosphor-icons/react";
+import { CaretUpDownIcon, CheckIcon, XIcon } from "@phosphor-icons/react";
 import {
   Fragment,
   createContext,
@@ -313,7 +313,7 @@ function TriggerValue({
           iconStyles.iconRight,
         )}
       >
-        <CaretDownIcon size={iconStyles.iconSize} className="fill-current" />
+        <CaretUpDownIcon size={iconStyles.iconSize} className="fill-current" />
       </ComboboxBase.Icon>
     </ComboboxBase.Trigger>
   );
@@ -409,7 +409,10 @@ function TriggerInput({
         )}
       >
         <ComboboxBase.Icon className="flex items-center">
-          <CaretDownIcon size={iconStyles.iconSize} className="fill-current" />
+          <CaretUpDownIcon
+            size={iconStyles.iconSize}
+            className="fill-current"
+          />
         </ComboboxBase.Icon>
       </ComboboxBase.Trigger>
     </div>


### PR DESCRIPTION
Combobox and Select showed different dropdown indicators when placed next to each other. Use Select's up/down double chevron in both `Combobox.TriggerValue` and `Combobox.TriggerInput`, and update the Figma generator to match. Includes a patch changeset.

Validation:

- 57 Select and Combobox component tests passed.
- 34 Combobox Figma generator tests passed.
- Library typecheck, targeted format/lint/type checks, and changeset validation passed.
- Select and Combobox were visually checked in the local docs site.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: upstream Bonk credentials are unavailable locally; an independent local code review found no issues.
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only changes the dropdown icon; existing component and generator tests pass, and the result was checked visually.
