### PR TITLE
[kumo-docs-astro] Prevent resource list demo overflow

### DIFF
--- a/packages/kumo-docs-astro/src/components/demos/ResourceListDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/ResourceListDemo.tsx
@@ -39,11 +39,11 @@ function ResourceListPage({
           </p>
         </div>
 
-        <div className="flex flex-col-reverse gap-6 xl:flex-row xl:gap-8">
-          <div className="min-w-0 grow">{children}</div>
+        <div className="flex flex-col-reverse gap-6 xl:grid xl:grid-cols-[1fr_2fr] xl:gap-8">
+          <div className="min-w-0">{children}</div>
 
           {(usage || additionalContent) && (
-            <div className="top-22 flex h-fit w-full shrink-0 flex-col gap-4 xl:sticky xl:w-[380px]">
+            <div className="top-22 flex h-fit w-full min-w-0 flex-col gap-4 xl:sticky">
               {usage}
               {additionalContent && (
                 <div className={usage ? "mt-6" : ""}>{additionalContent}</div>
@@ -82,6 +82,7 @@ export function ResourceListWithUsageDemo() {
             Generate an API key to authenticate your requests
           </p>
           <Code
+            className="overflow-x-auto"
             lang="bash"
             code='curl -H "Authorization: Bearer YOUR_API_KEY" https://api.example.com'
           />
@@ -105,6 +106,7 @@ export function ResourceListCompleteDemo() {
         <Surface className="p-4">
           <h3 className="mb-2 font-semibold">Usage Example</h3>
           <Code
+            className="overflow-x-auto"
             lang="ts"
             code={`// Read from KV
 const value = await KV.get('key');
@@ -125,11 +127,11 @@ await KV.put('key', 'value');`}
     >
       <div className="space-y-4">
         <Surface className="p-6">
-          <h4 className="mb-2 font-semibold">production-kv</h4>
+          <h4 className="mb-2 truncate font-semibold">production-kv</h4>
           <p className="text-sm text-kumo-subtle">Created 2 days ago</p>
         </Surface>
         <Surface className="p-6">
-          <h4 className="mb-2 font-semibold">staging-kv</h4>
+          <h4 className="mb-2 truncate font-semibold">staging-kv</h4>
           <p className="text-sm text-kumo-subtle">Created 1 week ago</p>
         </Surface>
       </div>


### PR DESCRIPTION
## Summary

- Keep resource names within their cards at narrow desktop widths.
- Make long code samples horizontally scrollable.

## Videos

### Resource names
https://github.com/user-attachments/assets/cac9053a-a830-410c-8c03-e916814a833b


### Code sample
https://github.com/user-attachments/assets/62bc2b01-34fb-413e-abc7-e176714b94c8



## Testing

- `pnpm format:check`
- `pnpm --filter @cloudflare/kumo-docs-astro lint`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`
- `pnpm --filter @cloudflare/kumo-docs-astro build`
- Verified both overflow cases locally at the affected desktop widths.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: I do not have access to Bonk.
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: Verified both overflow cases locally at the affected desktop widths.
  - [ ] Additional testing not necessary because:
