### PR TITLE
feat(layer-dialog): add responsive layer dialog

### DIFF
--- a/.changeset/strict-layer-dialog.md
+++ b/.changeset/strict-layer-dialog.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add a strict responsive LayerDialog component with automatic dismissal composition, alert-dialog semantics, and mobile drawer behavior.

--- a/.changeset/strict-layer-dialog.md
+++ b/.changeset/strict-layer-dialog.md
@@ -2,4 +2,4 @@
 "@cloudflare/kumo": minor
 ---
 
-Add a strict responsive LayerDialog component with automatic dismissal composition, alert-dialog semantics, and mobile drawer behavior.
+Add a strict responsive LayerDialog component with automatic dismissal composition, alert-dialog semantics, mobile drawer behavior, and application-wide defaults for its built-in close and cancel copy through `KumoLocaleProvider`.

--- a/packages/kumo-docs-astro/src/components/SidebarNav.tsx
+++ b/packages/kumo-docs-astro/src/components/SidebarNav.tsx
@@ -62,6 +62,7 @@ const componentItems: NavItem[] = [
   { label: "InputGroup", href: "/components/input-group" },
   { label: "Label", href: "/components/label" },
   { label: "Layer Card", href: "/components/layer-card" },
+  { label: "Layer Dialog", href: "/components/layer-dialog" },
   { label: "Link", href: "/components/link" },
   { label: "Loader", href: "/components/loader" },
   { label: "Meter", href: "/components/meter" },

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -168,6 +168,7 @@ export function LayerDialogAlertDemo() {
           <LayerDialog.Actions.Primary
             disabled={confirmation !== workerName}
             onClick={() => undefined}
+            variant="destructive"
           >
             Delete Worker
           </LayerDialog.Actions.Primary>

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -113,7 +113,7 @@ export function LayerDialogCancelDemo() {
             />
           </div>
         </LayerDialog.Body>
-        <LayerDialog.Actions dismissLabel="cancel">
+        <LayerDialog.Actions dismissLabel="Cancel">
           <LayerDialog.Actions.Primary
             disabled={!email || !name}
             onClick={() => undefined}

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -273,9 +273,7 @@ export function LayerDialogSizeDemo() {
       </div>
       <LayerDialog.Root open={open} onOpenChange={setOpen}>
         <LayerDialog.Content size={size}>
-          <LayerDialog.Title>
-            Review deployment configuration
-          </LayerDialog.Title>
+          <LayerDialog.Title>Review deployment configuration</LayerDialog.Title>
           <LayerDialog.Body>
             <Text variant="secondary">
               Confirm the service details and routing configuration before this

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -5,6 +5,7 @@ import {
   LayerDialog,
   Text,
   type KumoLayerDialogSize,
+  type KumoLayerDialogVerticalAlign,
 } from "@cloudflare/kumo";
 
 function LongContent() {
@@ -250,6 +251,52 @@ export function LayerDialogTopAlignDemo() {
         </LayerDialog.Body>
       </LayerDialog.Content>
     </LayerDialog.Root>
+  );
+}
+
+export function LayerDialogMaxHeightDemo() {
+  const [verticalAlign, setVerticalAlign] =
+    useState<KumoLayerDialogVerticalAlign>("center");
+  const [open, setOpen] = useState(false);
+
+  const openAt = (align: KumoLayerDialogVerticalAlign) => {
+    setVerticalAlign(align);
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={() => openAt("center")}>Centered, tall content</Button>
+        <Button onClick={() => openAt("top")}>Top-aligned, tall content</Button>
+      </div>
+      <LayerDialog.Root open={open} onOpenChange={setOpen}>
+        <LayerDialog.Content verticalAlign={verticalAlign}>
+          <LayerDialog.Title>Audit log</LayerDialog.Title>
+          <LayerDialog.Description>
+            The dialog grows with its content until it reaches the viewport cap,
+            then only the body scrolls.
+          </LayerDialog.Description>
+          <LayerDialog.Body>
+            <ol className="flex flex-col gap-2">
+              {Array.from({ length: 40 }, (_, index) => (
+                <li
+                  key={index}
+                  className="rounded-lg border border-kumo-line px-3 py-2 text-kumo-subtle"
+                >
+                  Entry {index + 1}
+                </li>
+              ))}
+            </ol>
+          </LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>
+              Export log
+            </LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Root>
+    </>
   );
 }
 

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -9,21 +9,16 @@ import {
 
 function LongContent() {
   return (
-    <>
-      <Text variant="secondary">
-        Browse available shortcuts without changing a setting.
-      </Text>
-      <div className="mt-6 rounded-lg border border-kumo-line p-4 text-kumo-subtle">
+    <div className="flex flex-col gap-5">
+      <div className="rounded-lg border border-kumo-line p-4 text-kumo-subtle">
         Navigation and command shortcuts
       </div>
-      <div className="mt-6">
-        <Text variant="secondary">
-          The title frame stays visible, receives a divider once content
-          scrolls, and the scroll mask indicates more content below.
-        </Text>
-      </div>
+      <Text variant="secondary">
+        The title frame stays visible, receives a divider once content scrolls,
+        and the scroll mask indicates more content below.
+      </Text>
       <div className="h-96" />
-    </>
+    </div>
   );
 }
 
@@ -35,6 +30,9 @@ export function LayerDialogInformationalDemo() {
       />
       <LayerDialog.Content>
         <LayerDialog.Title>Keyboard shortcuts</LayerDialog.Title>
+        <LayerDialog.Description>
+          Browse available shortcuts without changing a setting.
+        </LayerDialog.Description>
         <LayerDialog.Body>
           <LongContent />
         </LayerDialog.Body>
@@ -54,11 +52,11 @@ export function LayerDialogActionDemo() {
       />
       <LayerDialog.Content>
         <LayerDialog.Title>Configure custom hostname</LayerDialog.Title>
+        <LayerDialog.Description>
+          Route requests for this hostname to your Worker.
+        </LayerDialog.Description>
         <LayerDialog.Body>
-          <Text variant="secondary">
-            Route requests for this hostname to your Worker.
-          </Text>
-          <div className="mt-6 flex flex-col gap-5">
+          <div className="flex flex-col gap-5">
             <Input
               label="Hostname"
               onChange={(event) => setHostname(event.target.value)}
@@ -95,12 +93,12 @@ export function LayerDialogCancelDemo() {
       />
       <LayerDialog.Content>
         <LayerDialog.Title>Edit profile</LayerDialog.Title>
+        <LayerDialog.Description>
+          Update the profile information shown to your teammates. Changes are
+          not saved until you confirm.
+        </LayerDialog.Description>
         <LayerDialog.Body>
-          <Text variant="secondary">
-            Update the profile information shown to your teammates. Changes are
-            not saved until you confirm.
-          </Text>
-          <div className="mt-6 flex flex-col gap-5">
+          <div className="flex flex-col gap-5">
             <Input
               label="Display name"
               onChange={(event) => setName(event.target.value)}
@@ -142,20 +140,17 @@ export function LayerDialogAlertDemo() {
       />
       <LayerDialog.Content>
         <LayerDialog.Title>Delete Worker</LayerDialog.Title>
+        <LayerDialog.Description>
+          Deleting <strong className="text-kumo-default">{workerName}</strong>{" "}
+          is permanent.
+        </LayerDialog.Description>
         <LayerDialog.Body>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-3">
-              <Text variant="secondary">
-                Deleting{" "}
-                <strong className="text-kumo-default">{workerName}</strong> is
-                permanent.
-              </Text>
-              <Text variant="secondary">
-                This deletes the Worker, deployments, and configuration. If this
-                Worker consumes Queues, those connections are removed first.
-                Queues, D1 databases, and messages stay in your account.
-              </Text>
-            </div>
+          <div className="flex flex-col gap-5">
+            <Text variant="secondary">
+              This deletes the Worker, deployments, and configuration. If this
+              Worker consumes Queues, those connections are removed first.
+              Queues, D1 databases, and messages stay in your account.
+            </Text>
             <Input
               label={
                 <>
@@ -190,10 +185,14 @@ export function LayerDialogPendingDemo() {
       />
       <LayerDialog.Content>
         <LayerDialog.Title>Save a setting</LayerDialog.Title>
+        <LayerDialog.Description>
+          While saving, Close, Escape, backdrop, and mobile swipe dismissals are
+          blocked together.
+        </LayerDialog.Description>
         <LayerDialog.Body>
           <Text variant="secondary">
-            While saving, Close, Escape, backdrop, and mobile swipe dismissals
-            are blocked together.
+            Programmatic closes still work, so a successful save can dismiss the
+            dialog through `actionsRef` or a controlled `open` prop.
           </Text>
         </LayerDialog.Body>
         <LayerDialog.Actions>
@@ -274,12 +273,12 @@ export function LayerDialogSizeDemo() {
       <LayerDialog.Root open={open} onOpenChange={setOpen}>
         <LayerDialog.Content size={size}>
           <LayerDialog.Title>Review deployment configuration</LayerDialog.Title>
+          <LayerDialog.Description>
+            Confirm the service details and routing configuration before this
+            deployment is created.
+          </LayerDialog.Description>
           <LayerDialog.Body>
-            <Text variant="secondary">
-              Confirm the service details and routing configuration before this
-              deployment is created.
-            </Text>
-            <div className="mt-6 grid gap-5 sm:grid-cols-2">
+            <div className="grid gap-5 sm:grid-cols-2">
               <Input label="Service name" defaultValue="production-api" />
               <Input label="Environment" defaultValue="Production" />
               <Input label="Hostname" defaultValue="api.example.com" />

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
-import { Button, Input, LayerDialog, Text } from "@cloudflare/kumo";
+import {
+  Button,
+  Input,
+  LayerDialog,
+  Text,
+  type KumoLayerDialogSize,
+} from "@cloudflare/kumo";
 
 function LongContent() {
   return (
@@ -249,31 +255,46 @@ export function LayerDialogTopAlignDemo() {
 }
 
 export function LayerDialogSizeDemo() {
+  const [open, setOpen] = useState(false);
+  const [size, setSize] = useState<KumoLayerDialogSize>("base");
+
+  const openAtSize = (nextSize: KumoLayerDialogSize) => {
+    setSize(nextSize);
+    setOpen(true);
+  };
+
   return (
-    <LayerDialog.Root>
-      <LayerDialog.Trigger
-        render={(props) => <Button {...props}>Review configuration</Button>}
-      />
-      <LayerDialog.Content size="lg">
-        <LayerDialog.Title>Review deployment configuration</LayerDialog.Title>
-        <LayerDialog.Body>
-          <Text variant="secondary">
-            Confirm the service details and routing configuration before this
-            deployment is created.
-          </Text>
-          <div className="mt-6 grid gap-5 sm:grid-cols-2">
-            <Input label="Service name" defaultValue="production-api" />
-            <Input label="Environment" defaultValue="Production" />
-            <Input label="Hostname" defaultValue="api.example.com" />
-            <Input label="Compatibility date" defaultValue="2026-09-09" />
-          </div>
-        </LayerDialog.Body>
-        <LayerDialog.Actions>
-          <LayerDialog.Actions.Primary>
-            Create deployment
-          </LayerDialog.Actions.Primary>
-        </LayerDialog.Actions>
-      </LayerDialog.Content>
-    </LayerDialog.Root>
+    <>
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={() => openAtSize("sm")}>Small</Button>
+        <Button onClick={() => openAtSize("base")}>Default</Button>
+        <Button onClick={() => openAtSize("lg")}>Large</Button>
+        <Button onClick={() => openAtSize("xl")}>Extra large</Button>
+      </div>
+      <LayerDialog.Root open={open} onOpenChange={setOpen}>
+        <LayerDialog.Content size={size}>
+          <LayerDialog.Title>
+            Review deployment configuration
+          </LayerDialog.Title>
+          <LayerDialog.Body>
+            <Text variant="secondary">
+              Confirm the service details and routing configuration before this
+              deployment is created.
+            </Text>
+            <div className="mt-6 grid gap-5 sm:grid-cols-2">
+              <Input label="Service name" defaultValue="production-api" />
+              <Input label="Environment" defaultValue="Production" />
+              <Input label="Hostname" defaultValue="api.example.com" />
+              <Input label="Compatibility date" defaultValue="2026-09-09" />
+            </div>
+          </LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>
+              Create deployment
+            </LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Root>
+    </>
   );
 }

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -1,0 +1,249 @@
+import { useState } from "react";
+import { Button, Input, LayerDialog, Text } from "@cloudflare/kumo";
+
+function LongContent() {
+  return (
+    <>
+      <Text variant="secondary">
+        Browse available shortcuts without changing a setting.
+      </Text>
+      <div className="mt-6 rounded-lg border border-kumo-line p-4 text-kumo-subtle">
+        Navigation and command shortcuts
+      </div>
+      <div className="mt-6">
+        <Text variant="secondary">
+          The title frame stays visible, receives a divider once content
+          scrolls, and the scroll mask indicates more content below.
+        </Text>
+      </div>
+      <div className="h-96" />
+    </>
+  );
+}
+
+export function LayerDialogInformationalDemo() {
+  return (
+    <LayerDialog.Root>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Open keyboard shortcuts</Button>}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Keyboard shortcuts</LayerDialog.Title>
+        <LayerDialog.Body>
+          <LongContent />
+        </LayerDialog.Body>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}
+
+export function LayerDialogActionDemo() {
+  const [name, setName] = useState("Production API");
+  const [hostname, setHostname] = useState("api.example.com");
+
+  return (
+    <LayerDialog.Root>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Open settings</Button>}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Configure custom hostname</LayerDialog.Title>
+        <LayerDialog.Body>
+          <Text variant="secondary">
+            Route requests for this hostname to your Worker.
+          </Text>
+          <div className="mt-6 flex flex-col gap-5">
+            <Input
+              label="Hostname"
+              onChange={(event) => setHostname(event.target.value)}
+              value={hostname}
+            />
+            <Input
+              label="Display name"
+              onChange={(event) => setName(event.target.value)}
+              value={name}
+            />
+          </div>
+        </LayerDialog.Body>
+        <LayerDialog.Actions>
+          <LayerDialog.Actions.Primary
+            disabled={!hostname || !name}
+            onClick={() => undefined}
+          >
+            Save hostname
+          </LayerDialog.Actions.Primary>
+        </LayerDialog.Actions>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}
+
+export function LayerDialogCancelDemo() {
+  const [email, setEmail] = useState("alex@example.com");
+  const [name, setName] = useState("Alex Morgan");
+
+  return (
+    <LayerDialog.Root>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Edit profile</Button>}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Edit profile</LayerDialog.Title>
+        <LayerDialog.Body>
+          <Text variant="secondary">
+            Update the profile information shown to your teammates. Changes are
+            not saved until you confirm.
+          </Text>
+          <div className="mt-6 flex flex-col gap-5">
+            <Input
+              label="Display name"
+              onChange={(event) => setName(event.target.value)}
+              value={name}
+            />
+            <Input
+              label="Email address"
+              onChange={(event) => setEmail(event.target.value)}
+              type="email"
+              value={email}
+            />
+          </div>
+        </LayerDialog.Body>
+        <LayerDialog.Actions dismissLabel="cancel">
+          <LayerDialog.Actions.Primary
+            disabled={!email || !name}
+            onClick={() => undefined}
+          >
+            Save changes
+          </LayerDialog.Actions.Primary>
+        </LayerDialog.Actions>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}
+
+export function LayerDialogAlertDemo() {
+  const workerName = "example-worker";
+  const [confirmation, setConfirmation] = useState("");
+
+  return (
+    <LayerDialog.Alert>
+      <LayerDialog.Trigger
+        render={(props) => (
+          <Button variant="secondary-destructive" {...props}>
+            Delete Worker
+          </Button>
+        )}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Delete Worker</LayerDialog.Title>
+        <LayerDialog.Body>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3">
+              <Text variant="secondary">
+                Deleting{" "}
+                <strong className="text-kumo-default">{workerName}</strong> is
+                permanent.
+              </Text>
+              <Text variant="secondary">
+                This deletes the Worker, deployments, and configuration. If this
+                Worker consumes Queues, those connections are removed first.
+                Queues, D1 databases, and messages stay in your account.
+              </Text>
+            </div>
+            <Input
+              label={
+                <>
+                  Type <strong>{workerName}</strong> to confirm
+                </>
+              }
+              onChange={(event) => setConfirmation(event.target.value)}
+              placeholder={workerName}
+              value={confirmation}
+            />
+          </div>
+        </LayerDialog.Body>
+        <LayerDialog.Actions>
+          <LayerDialog.Actions.Primary
+            disabled={confirmation !== workerName}
+            onClick={() => undefined}
+          >
+            Delete Worker
+          </LayerDialog.Actions.Primary>
+        </LayerDialog.Actions>
+      </LayerDialog.Content>
+    </LayerDialog.Alert>
+  );
+}
+
+export function LayerDialogPendingDemo() {
+  const [pending, setPending] = useState(false);
+  return (
+    <LayerDialog.Root dismissDisabled={pending}>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Save a setting</Button>}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Save a setting</LayerDialog.Title>
+        <LayerDialog.Body>
+          <Text variant="secondary">
+            While saving, Close, Escape, backdrop, and mobile swipe dismissals
+            are blocked together.
+          </Text>
+        </LayerDialog.Body>
+        <LayerDialog.Actions>
+          <LayerDialog.Actions.Primary
+            loading={pending}
+            onClick={() => {
+              setPending(true);
+              window.setTimeout(() => setPending(false), 1500);
+            }}
+          >
+            Save changes
+          </LayerDialog.Actions.Primary>
+        </LayerDialog.Actions>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}
+
+export function LayerDialogCleanupDemo() {
+  const [open, setOpen] = useState(false);
+  const [cleanupCount, setCleanupCount] = useState(0);
+  return (
+    <LayerDialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) setCleanupCount((count) => count + 1);
+        setOpen(nextOpen);
+      }}
+    >
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Open draft</Button>}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Draft settings</LayerDialog.Title>
+        <LayerDialog.Body>
+          <Text variant="secondary">
+            Cleanup has run {cleanupCount} time{cleanupCount === 1 ? "" : "s"}.
+          </Text>
+        </LayerDialog.Body>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}
+
+export function LayerDialogTopAlignDemo() {
+  return (
+    <LayerDialog.Root>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Open top-aligned dialog</Button>}
+      />
+      <LayerDialog.Content verticalAlign="top">
+        <LayerDialog.Title>Top-aligned dialog</LayerDialog.Title>
+        <LayerDialog.Body>
+          <Text variant="secondary">Mobile dialogs remain bottom sheets.</Text>
+        </LayerDialog.Body>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -247,3 +247,33 @@ export function LayerDialogTopAlignDemo() {
     </LayerDialog.Root>
   );
 }
+
+export function LayerDialogSizeDemo() {
+  return (
+    <LayerDialog.Root>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Review configuration</Button>}
+      />
+      <LayerDialog.Content size="lg">
+        <LayerDialog.Title>Review deployment configuration</LayerDialog.Title>
+        <LayerDialog.Body>
+          <Text variant="secondary">
+            Confirm the service details and routing configuration before this
+            deployment is created.
+          </Text>
+          <div className="mt-6 grid gap-5 sm:grid-cols-2">
+            <Input label="Service name" defaultValue="production-api" />
+            <Input label="Environment" defaultValue="Production" />
+            <Input label="Hostname" defaultValue="api.example.com" />
+            <Input label="Compatibility date" defaultValue="2026-09-09" />
+          </div>
+        </LayerDialog.Body>
+        <LayerDialog.Actions>
+          <LayerDialog.Actions.Primary>
+            Create deployment
+          </LayerDialog.Actions.Primary>
+        </LayerDialog.Actions>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}

--- a/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/LayerDialogDemo.tsx
@@ -142,7 +142,10 @@ export function LayerDialogAlertDemo() {
       <LayerDialog.Content>
         <LayerDialog.Title>Delete Worker</LayerDialog.Title>
         <LayerDialog.Description>
-          Deleting <strong className="text-kumo-default">{workerName}</strong>{" "}
+          Deleting{" "}
+          <strong className="font-medium text-kumo-default">
+            {workerName}
+          </strong>{" "}
           is permanent.
         </LayerDialog.Description>
         <LayerDialog.Body>
@@ -155,7 +158,11 @@ export function LayerDialogAlertDemo() {
             <Input
               label={
                 <>
-                  Type <strong>{workerName}</strong> to confirm
+                  Type{" "}
+                  <strong className="font-medium text-kumo-default">
+                    {workerName}
+                  </strong>{" "}
+                  to confirm
                 </>
               }
               onChange={(event) => setConfirmation(event.target.value)}

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -97,7 +97,7 @@ Consumers cannot mix these layouts or add more primary actions. Use the X for re
 
 <ComponentSection>
 ## Informational dialog
-`Title` and `Description` always live in the bordered body surface. The title frame remains visible while the body scrolls, gains a bottom border after scrolling, and has the sole automatic X dismissal action. Once the body scrolls past the top, the description folds away beneath the title to give the content more room, and unfolds again at the top. The content edge mask signals overflow.
+`Title` and `Description` always live in the bordered body surface. The title frame remains visible while the body scrolls and has the sole automatic X dismissal action. Once the body scrolls past the top, the description folds away beneath the title to give the content more room, and unfolds again at the top. The content edge mask signals overflow.
 <ComponentExample demo="LayerDialogInformationalDemo"><LayerDialogInformationalDemo client:load /></ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -1,0 +1,62 @@
+---
+layout: ~/layouts/MdxDocLayout.astro
+title: "Layer Dialog"
+description: "A strict responsive dialog composition with a sticky title inside its scrollable body."
+sourceFile: "components/layer-dialog"
+---
+
+import ComponentExample from "~/components/docs/ComponentExample.astro";
+import ComponentSection from "~/components/docs/ComponentSection.astro";
+import { LayerDialogActionDemo, LayerDialogAlertDemo, LayerDialogCancelDemo, LayerDialogCleanupDemo, LayerDialogInformationalDemo, LayerDialogPendingDemo, LayerDialogTopAlignDemo } from "~/components/demos/LayerDialogDemo";
+
+<ComponentSection>
+## Composition rules
+`LayerDialog` chooses its dismissal UI automatically:
+
+- Without `Actions`: show an X in the title and no footer.
+- With `Actions`: remove the X and show a footer with **Close** or **Cancel** and one primary action.
+
+Consumers cannot mix these layouts or add more primary actions. Use the X for read-only content, `Actions` when the user must commit a change, and `LayerDialog.Alert` for destructive or critical confirmations.
+</ComponentSection>
+
+<ComponentSection>
+## Informational dialog
+`Title` always lives in the bordered body surface. Its padded title rectangle remains visible while the body scrolls, gains a bottom border after scrolling, and has the sole automatic X dismissal action. The content edge mask signals overflow.
+<ComponentExample demo="LayerDialogInformationalDemo"><LayerDialogInformationalDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Standard action
+Adding `Actions` selects a fixed footer with exactly one Kumo primary action and an automatic **Close** button. Consumers cannot add custom footer controls, change button variants/sizes, or add extra CTAs.
+<ComponentExample demo="LayerDialogActionDemo"><LayerDialogActionDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Cancellation wording
+Use `dismissLabel="cancel"` only when the workflow has an explicit cancellation outcome. The component continues to own its copy, handler, placement, and styling.
+<ComponentExample demo="LayerDialogCancelDemo"><LayerDialogCancelDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Confirmation and destructive actions
+`LayerDialog.Alert` supplies `role="alertdialog"`, an automatic **Cancel**, no X, a destructive primary action, and blocks backdrop, Escape, and swipe dismissal.
+<ComponentExample demo="LayerDialogAlertDemo"><LayerDialogAlertDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Pending work
+`dismissDisabled` blocks every dismissal method together while asynchronous work is in flight. The single primary action owns its separate loading or disabled state.
+<ComponentExample demo="LayerDialogPendingDemo"><LayerDialogPendingDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Cleanup
+Put cleanup in `onOpenChange`, rather than in a dismissal click handler, so it runs for X, Close, Escape, backdrop, and swipe.
+<ComponentExample demo="LayerDialogCleanupDemo"><LayerDialogCleanupDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Desktop placement
+Desktop dialogs center by default. Use the narrow `verticalAlign="top"` override only when its content benefits from top alignment; mobile remains a bottom sheet.
+<ComponentExample demo="LayerDialogTopAlignDemo"><LayerDialogTopAlignDemo client:load /></ComponentExample>
+</ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -109,7 +109,7 @@ Adding `Actions` selects a fixed footer with exactly one Kumo primary action and
 
 <ComponentSection>
 ## Cancellation wording
-Use `dismissLabel="cancel"` only when the workflow has an explicit cancellation outcome. The component continues to own its copy, handler, placement, and styling.
+Use `dismissLabel="Cancel"` only when the workflow has an explicit cancellation outcome. The component continues to own the button's handler, placement, and styling.
 <ComponentExample demo="LayerDialogCancelDemo"><LayerDialogCancelDemo client:load /></ComponentExample>
 </ComponentSection>
 
@@ -134,6 +134,19 @@ Put cleanup in `onOpenChange`, rather than in a dismissal click handler, so it r
 </ComponentSection>
 
 <ComponentSection>
+## Localization
+
+The dialog renders two strings of its own. Everything else comes from your content, so translating a dialog means passing two props:
+
+- `closeLabel` on `Content` names the automatic X button for assistive technology. Default: "Close dialog".
+- `dismissLabel` on `Actions` is the footer button's text. Default: "Close", or "Cancel" inside an `Alert`.
+
+```tsx
+<LayerDialog.Content closeLabel="Dialog schließen">
+  ...
+  <LayerDialog.Actions dismissLabel="Abbrechen">
+```
+
 ## Desktop width
 Desktop dialogs use `size="base"` (576px) by default. Use `sm` (448px), `lg` (672px), or `xl` (768px) when the content needs a different width. Mobile dialogs remain full-width at every size.
 <ComponentExample demo="LayerDialogSizeDemo"><LayerDialogSizeDemo client:load /></ComponentExample>

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -7,7 +7,7 @@ sourceFile: "components/layer-dialog"
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import { LayerDialogActionDemo, LayerDialogAlertDemo, LayerDialogCancelDemo, LayerDialogCleanupDemo, LayerDialogInformationalDemo, LayerDialogPendingDemo, LayerDialogTopAlignDemo } from "~/components/demos/LayerDialogDemo";
+import { LayerDialogActionDemo, LayerDialogAlertDemo, LayerDialogCancelDemo, LayerDialogCleanupDemo, LayerDialogInformationalDemo, LayerDialogPendingDemo, LayerDialogSizeDemo, LayerDialogTopAlignDemo } from "~/components/demos/LayerDialogDemo";
 
 <ComponentSection>
 ## Composition rules
@@ -53,6 +53,12 @@ Use `dismissLabel="cancel"` only when the workflow has an explicit cancellation 
 ## Cleanup
 Put cleanup in `onOpenChange`, rather than in a dismissal click handler, so it runs for X, Close, Escape, backdrop, and swipe.
 <ComponentExample demo="LayerDialogCleanupDemo"><LayerDialogCleanupDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Desktop width
+Desktop dialogs use `size="base"` (576px) by default. Use `sm` (448px), `lg` (672px), or `xl` (768px) when the content needs a different width. Mobile dialogs remain full-width at every size.
+<ComponentExample demo="LayerDialogSizeDemo"><LayerDialogSizeDemo client:load /></ComponentExample>
 </ComponentSection>
 
 <ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -97,7 +97,7 @@ Consumers cannot mix these layouts or add more primary actions. Use the X for re
 
 <ComponentSection>
 ## Informational dialog
-`Title` and `Description` always live in the bordered body surface. The title frame remains visible while the body scrolls, gains a bottom border after scrolling, and has the sole automatic X dismissal action. The content edge mask signals overflow.
+`Title` and `Description` always live in the bordered body surface. The title frame remains visible while the body scrolls, gains a bottom border after scrolling, and has the sole automatic X dismissal action. Once the body scrolls past the top, the description folds away beneath the title to give the content more room, and unfolds again at the top. The content edge mask signals overflow.
 <ComponentExample demo="LayerDialogInformationalDemo"><LayerDialogInformationalDemo client:load /></ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -3,25 +3,100 @@ layout: ~/layouts/MdxDocLayout.astro
 title: "Layer Dialog"
 description: "A strict responsive dialog composition with a sticky title inside its scrollable body."
 sourceFile: "components/layer-dialog"
+baseUIComponent: "drawer"
 ---
 
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import ComponentSection from "~/components/docs/ComponentSection.astro";
-import { LayerDialogActionDemo, LayerDialogAlertDemo, LayerDialogCancelDemo, LayerDialogCleanupDemo, LayerDialogInformationalDemo, LayerDialogPendingDemo, LayerDialogSizeDemo, LayerDialogTopAlignDemo } from "~/components/demos/LayerDialogDemo";
+import PropsTable from "~/components/docs/PropsTable.astro";
+import {
+  LayerDialogActionDemo,
+  LayerDialogAlertDemo,
+  LayerDialogCancelDemo,
+  LayerDialogCleanupDemo,
+  LayerDialogInformationalDemo,
+  LayerDialogPendingDemo,
+  LayerDialogSizeDemo,
+  LayerDialogTopAlignDemo,
+} from "~/components/demos/LayerDialogDemo";
+
+{/* Hero Demo */}
+
+<ComponentSection>
+  <ComponentExample demo="LayerDialogActionDemo">
+    <LayerDialogActionDemo client:load />
+  </ComponentExample>
+</ComponentSection>
+
+{/* Installation */}
+
+<ComponentSection>
+
+## Installation
+
+### Barrel
+
+```tsx
+import { LayerDialog } from "@cloudflare/kumo";
+```
+
+### Granular
+
+```tsx
+import { LayerDialog } from "@cloudflare/kumo/components/layer-dialog";
+```
+
+</ComponentSection>
+
+{/* Usage */}
+
+<ComponentSection>
+
+## Usage
+
+```tsx
+import { Button, LayerDialog } from "@cloudflare/kumo";
+
+export default function Example() {
+  return (
+    <LayerDialog.Root>
+      <LayerDialog.Trigger
+        render={(props) => <Button {...props}>Open settings</Button>}
+      />
+      <LayerDialog.Content>
+        <LayerDialog.Title>Configure custom hostname</LayerDialog.Title>
+        <LayerDialog.Description>
+          Route requests for this hostname to your Worker.
+        </LayerDialog.Description>
+        <LayerDialog.Body>{/* form fields */}</LayerDialog.Body>
+        <LayerDialog.Actions>
+          <LayerDialog.Actions.Primary onClick={save}>
+            Save hostname
+          </LayerDialog.Actions.Primary>
+        </LayerDialog.Actions>
+      </LayerDialog.Content>
+    </LayerDialog.Root>
+  );
+}
+```
+
+</ComponentSection>
 
 <ComponentSection>
 ## Composition rules
-`LayerDialog` chooses its dismissal UI automatically:
+`LayerDialog.Content` accepts exactly one `Title`, one `Body`, an optional `Description`, and an optional `Actions`. It chooses its dismissal UI automatically:
 
-- Without `Actions`: show an X in the title and no footer.
+- Without `Actions`: show an X in the title frame and no footer.
 - With `Actions`: remove the X and show a footer with **Close** or **Cancel** and one primary action.
 
 Consumers cannot mix these layouts or add more primary actions. Use the X for read-only content, `Actions` when the user must commit a change, and `LayerDialog.Alert` for destructive or critical confirmations.
+
+`Description` renders directly beneath the title inside the sticky title frame and becomes the dialog's accessible description. Without one, the body copy describes the dialog instead.
 </ComponentSection>
 
 <ComponentSection>
 ## Informational dialog
-`Title` always lives in the bordered body surface. Its padded title rectangle remains visible while the body scrolls, gains a bottom border after scrolling, and has the sole automatic X dismissal action. The content edge mask signals overflow.
+`Title` and `Description` always live in the bordered body surface. The title frame remains visible while the body scrolls, gains a bottom border after scrolling, and has the sole automatic X dismissal action. The content edge mask signals overflow.
 <ComponentExample demo="LayerDialogInformationalDemo"><LayerDialogInformationalDemo client:load /></ComponentExample>
 </ComponentSection>
 
@@ -39,13 +114,13 @@ Use `dismissLabel="cancel"` only when the workflow has an explicit cancellation 
 
 <ComponentSection>
 ## Confirmation and destructive actions
-`LayerDialog.Alert` supplies `role="alertdialog"`, an automatic **Cancel**, no X, a destructive primary action, and blocks backdrop, Escape, and swipe dismissal.
+`LayerDialog.Alert` follows Base UI's alert dialog: it supplies `role="alertdialog"`, an automatic **Cancel**, no X, a destructive primary action, is always modal, and blocks backdrop and swipe dismissal. Escape still cancels, matching the ARIA alert dialog pattern.
 <ComponentExample demo="LayerDialogAlertDemo"><LayerDialogAlertDemo client:load /></ComponentExample>
 </ComponentSection>
 
 <ComponentSection>
 ## Pending work
-`dismissDisabled` blocks every dismissal method together while asynchronous work is in flight. The single primary action owns its separate loading or disabled state.
+`dismissDisabled` blocks every user-initiated dismissal together while asynchronous work is in flight. Programmatic closes, through `actionsRef.current.close()` or a controlled `open` prop, still work so a successful action can dismiss the dialog. The single primary action owns its separate loading or disabled state.
 <ComponentExample demo="LayerDialogPendingDemo"><LayerDialogPendingDemo client:load /></ComponentExample>
 </ComponentSection>
 
@@ -65,4 +140,86 @@ Desktop dialogs use `size="base"` (576px) by default. Use `sm` (448px), `lg` (67
 ## Desktop placement
 Desktop dialogs center by default. Use the narrow `verticalAlign="top"` override only when its content benefits from top alignment; mobile remains a bottom sheet.
 <ComponentExample demo="LayerDialogTopAlignDemo"><LayerDialogTopAlignDemo client:load /></ComponentExample>
+</ComponentSection>
+
+{/* API Reference */}
+
+<ComponentSection>
+
+## API Reference
+
+### LayerDialog.Root
+
+<p>
+  Controls the open state. Accepts every Base UI Drawer root prop, including
+  `open`, `defaultOpen`, `onOpenChange`, `modal`, and `actionsRef`. Doesn't
+  render its own HTML element.
+</p>
+<div class="mb-4 overflow-hidden rounded-lg border border-kumo-hairline">
+  <table class="w-full text-sm">
+    <thead class="bg-kumo-elevated">
+      <tr>
+        <th class="px-4 py-2 text-left font-medium">Prop</th>
+        <th class="px-4 py-2 text-left font-medium">Type</th>
+        <th class="px-4 py-2 text-left font-medium">Default</th>
+        <th class="px-4 py-2 text-left font-medium">Description</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-kumo-hairline">
+      <tr>
+        <td class="px-4 py-2 font-mono text-xs">dismissDisabled</td>
+        <td class="px-4 py-2 font-mono text-xs">boolean</td>
+        <td class="px-4 py-2 font-mono text-xs">false</td>
+        <td class="px-4 py-2 text-kumo-subtle">
+          Blocks X, Close, Escape, backdrop, and swipe dismissal while work is
+          pending. Programmatic closes are never blocked.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### LayerDialog.Alert
+
+<p>
+  Same props as `LayerDialog.Root`. Forces `modal`, blocks pointer dismissal,
+  renders `role="alertdialog"`, and requires `LayerDialog.Actions`.
+</p>
+
+### LayerDialog.Trigger
+
+<p>A button that opens the dialog when clicked.</p>
+<PropsTable component="LayerDialog.Trigger" />
+
+### LayerDialog.Content
+
+<p>Portals the backdrop and popup and validates the composition.</p>
+<PropsTable component="LayerDialog.Content" />
+
+### LayerDialog.Title
+
+<p>A heading that labels the dialog for accessibility.</p>
+<PropsTable component="LayerDialog.Title" />
+
+### LayerDialog.Description
+
+<p>
+  Optional supporting copy beneath the title. Becomes the dialog's accessible
+  description.
+</p>
+<PropsTable component="LayerDialog.Description" />
+
+### LayerDialog.Body
+
+<p>The scrollable content region.</p>
+<PropsTable component="LayerDialog.Body" />
+
+### LayerDialog.Actions
+
+<p>
+  A footer with an automatic dismiss button and exactly one
+  `LayerDialog.Actions.Primary`.
+</p>
+<PropsTable component="LayerDialog.Actions" />
+
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -15,6 +15,7 @@ import {
   LayerDialogCancelDemo,
   LayerDialogCleanupDemo,
   LayerDialogInformationalDemo,
+  LayerDialogMaxHeightDemo,
   LayerDialogPendingDemo,
   LayerDialogSizeDemo,
   LayerDialogTopAlignDemo,
@@ -140,6 +141,12 @@ Desktop dialogs use `size="base"` (576px) by default. Use `sm` (448px), `lg` (67
 ## Desktop placement
 Desktop dialogs center by default. Use the narrow `verticalAlign="top"` override only when its content benefits from top alignment; mobile remains a bottom sheet.
 <ComponentExample demo="LayerDialogTopAlignDemo"><LayerDialogTopAlignDemo client:load /></ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+## Maximum height
+Height is derived from content and capped by the viewport. Following Base UI's inside-scroll pattern, the viewport reserves the vertical breathing room for each placement and the popup fills it, so a top-aligned dialog can never extend past the bottom edge. Past the cap, only the body scrolls while the title frame and actions stay pinned. Mobile sheets cap at 85% of the viewport instead. There are no height props: consumers control height only through the content they render.
+<ComponentExample demo="LayerDialogMaxHeightDemo"><LayerDialogMaxHeightDemo client:load /></ComponentExample>
 </ComponentSection>
 
 {/* API Reference */}

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -103,7 +103,7 @@ Consumers cannot mix these layouts or add more primary actions. Use the X for re
 
 <ComponentSection>
 ## Standard action
-Adding `Actions` selects a fixed footer with exactly one Kumo primary action and an automatic **Close** button. Consumers cannot add custom footer controls, change button variants/sizes, or add extra CTAs.
+Adding `Actions` selects a fixed footer with exactly one Kumo primary action and an automatic **Close** button. Consumers cannot add custom footer controls, change button sizes, or add extra CTAs. The primary action accepts `variant="primary"` (default) or `variant="destructive"`.
 <ComponentExample demo="LayerDialogActionDemo"><LayerDialogActionDemo client:load /></ComponentExample>
 </ComponentSection>
 
@@ -115,7 +115,9 @@ Use `dismissLabel="cancel"` only when the workflow has an explicit cancellation 
 
 <ComponentSection>
 ## Confirmation and destructive actions
-`LayerDialog.Alert` follows Base UI's alert dialog: it supplies `role="alertdialog"`, an automatic **Cancel**, no X, a destructive primary action, is always modal, and blocks backdrop and swipe dismissal. Escape still cancels, matching the ARIA alert dialog pattern.
+`LayerDialog.Alert` follows Base UI's alert dialog: it supplies `role="alertdialog"`, an automatic **Cancel**, no X, is always modal, and blocks backdrop and swipe dismissal. Escape still cancels, matching the ARIA alert dialog pattern.
+Pass `variant="destructive"` to the primary action when the confirmation is irreversible. Alerts that confirm a non-destructive but critical step keep the default primary styling.
+
 <ComponentExample demo="LayerDialogAlertDemo"><LayerDialogAlertDemo client:load /></ComponentExample>
 </ComponentSection>
 
@@ -228,5 +230,43 @@ Height is derived from content and capped by the viewport. Following Base UI's i
   `LayerDialog.Actions.Primary`.
 </p>
 <PropsTable component="LayerDialog.Actions" />
+
+### LayerDialog.Actions.Primary
+
+<p>
+  The single primary action. Renders a Kumo `Button` and accepts standard
+  button attributes such as `onClick`, `disabled`, and `type`.
+</p>
+<div class="mb-4 overflow-hidden rounded-lg border border-kumo-hairline">
+  <table class="w-full text-sm">
+    <thead class="bg-kumo-elevated">
+      <tr>
+        <th class="px-4 py-2 text-left font-medium">Prop</th>
+        <th class="px-4 py-2 text-left font-medium">Type</th>
+        <th class="px-4 py-2 text-left font-medium">Default</th>
+        <th class="px-4 py-2 text-left font-medium">Description</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-kumo-hairline">
+      <tr>
+        <td class="px-4 py-2 font-mono text-xs">variant</td>
+        <td class="px-4 py-2 font-mono text-xs">"primary" | "destructive"</td>
+        <td class="px-4 py-2 font-mono text-xs">"primary"</td>
+        <td class="px-4 py-2 text-kumo-subtle">
+          Visual emphasis of the action. Use `destructive` when confirming an
+          irreversible action such as a delete.
+        </td>
+      </tr>
+      <tr>
+        <td class="px-4 py-2 font-mono text-xs">loading</td>
+        <td class="px-4 py-2 font-mono text-xs">boolean</td>
+        <td class="px-4 py-2 font-mono text-xs">false</td>
+        <td class="px-4 py-2 text-kumo-subtle">
+          Shows a spinner and disables the action while work is pending.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 </ComponentSection>

--- a/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
+++ b/packages/kumo-docs-astro/src/pages/components/layer-dialog.mdx
@@ -109,7 +109,9 @@ Adding `Actions` selects a fixed footer with exactly one Kumo primary action and
 
 <ComponentSection>
 ## Cancellation wording
-Use `dismissLabel="Cancel"` only when the workflow has an explicit cancellation outcome. The component continues to own the button's handler, placement, and styling.
+When `LayerDialog.Actions` is present, LayerDialog renders a secondary button that dismisses the dialog. Its default label is "Close", or "Cancel" for `LayerDialog.Alert`.
+
+Use `dismissLabel` only when this dialog needs more specific wording, such as "Keep editing" or "Discard changes". The label does not change the button's behavior: it always closes the dialog.
 <ComponentExample demo="LayerDialogCancelDemo"><LayerDialogCancelDemo client:load /></ComponentExample>
 </ComponentSection>
 
@@ -136,16 +138,22 @@ Put cleanup in `onOpenChange`, rather than in a dismissal click handler, so it r
 <ComponentSection>
 ## Localization
 
-The dialog renders two strings of its own. Everything else comes from your content, so translating a dialog means passing two props:
+The dialog renders two strings of its own. Configure their application-wide defaults with `KumoLocaleProvider`:
 
-- `closeLabel` on `Content` names the automatic X button for assistive technology. Default: "Close dialog".
-- `dismissLabel` on `Actions` is the footer button's text. Default: "Close", or "Cancel" inside an `Alert`.
+- `layerDialog.close` is used for the automatic X button and the default footer dismiss button. Default: "Close".
+- `layerDialog.cancel` is used for the default footer dismiss button inside an `Alert`.
 
 ```tsx
-<LayerDialog.Content closeLabel="Dialog schließen">
-  ...
-  <LayerDialog.Actions dismissLabel="Abbrechen">
+<KumoLocaleProvider
+  translations={{
+    layerDialog: { close: "Schließen", cancel: "Abbrechen" },
+  }}
+>
+  <App />
+</KumoLocaleProvider>
 ```
+
+Use `closeLabel` on `Content` or `dismissLabel` on `Actions` when one dialog needs custom copy; explicit props override provider defaults.
 
 ## Desktop width
 Desktop dialogs use `size="base"` (576px) by default. Use `sm` (448px), `lg` (672px), or `xl` (768px) when the content needs a different width. Mobile dialogs remain full-width at every size.

--- a/packages/kumo/package.json
+++ b/packages/kumo/package.json
@@ -156,6 +156,10 @@
       "types": "./dist/components/layer-card.d.ts",
       "import": "./dist/components/layer-card.js"
     },
+    "./components/layer-dialog": {
+      "types": "./dist/components/layer-dialog.d.ts",
+      "import": "./dist/components/layer-dialog.js"
+    },
     "./components/link": {
       "types": "./dist/components/link.d.ts",
       "import": "./dist/components/link.js"

--- a/packages/kumo/scripts/component-registry/discovery.ts
+++ b/packages/kumo/scripts/component-registry/discovery.ts
@@ -65,6 +65,7 @@ export const CATEGORY_MAP: Record<string, string> = {
   tabs: "Navigation",
   // Overlay
   dialog: "Overlay",
+  "layer-dialog": "Overlay",
   dropdown: "Overlay",
   popover: "Overlay",
   tooltip: "Overlay",

--- a/packages/kumo/src/components/layer-dialog/index.ts
+++ b/packages/kumo/src/components/layer-dialog/index.ts
@@ -8,6 +8,7 @@ export {
   type LayerDialogPrimaryProps,
   type LayerDialogRootProps,
   type LayerDialogTitleProps,
+  type KumoLayerDialogPrimaryVariant,
   type KumoLayerDialogSize,
   type KumoLayerDialogVerticalAlign,
 } from "./layer-dialog";

--- a/packages/kumo/src/components/layer-dialog/index.ts
+++ b/packages/kumo/src/components/layer-dialog/index.ts
@@ -5,5 +5,6 @@ export {
   type LayerDialogPrimaryProps,
   type LayerDialogRootProps,
   type LayerDialogTitleProps,
+  type KumoLayerDialogSize,
   type KumoLayerDialogVerticalAlign,
 } from "./layer-dialog";

--- a/packages/kumo/src/components/layer-dialog/index.ts
+++ b/packages/kumo/src/components/layer-dialog/index.ts
@@ -1,0 +1,9 @@
+export {
+  LayerDialog,
+  type LayerDialogActionsProps,
+  type LayerDialogContentProps,
+  type LayerDialogPrimaryProps,
+  type LayerDialogRootProps,
+  type LayerDialogTitleProps,
+  type KumoLayerDialogVerticalAlign,
+} from "./layer-dialog";

--- a/packages/kumo/src/components/layer-dialog/index.ts
+++ b/packages/kumo/src/components/layer-dialog/index.ts
@@ -1,7 +1,10 @@
 export {
   LayerDialog,
+  type LayerDialogProps,
   type LayerDialogActionsProps,
+  type LayerDialogBodyProps,
   type LayerDialogContentProps,
+  type LayerDialogDescriptionProps,
   type LayerDialogPrimaryProps,
   type LayerDialogRootProps,
   type LayerDialogTitleProps,

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -158,13 +158,13 @@ describe("LayerDialog", () => {
     outsideButton.remove();
   });
 
-  it("keeps the alert dismissal label set to Cancel", () => {
+  it("defaults the alert dismissal label to Cancel", () => {
     const { getByRole, queryByRole } = render(
       <LayerDialog.Alert open>
         <LayerDialog.Content>
           <LayerDialog.Title>Delete resource</LayerDialog.Title>
           <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
-          <LayerDialog.Actions dismissLabel="close">
+          <LayerDialog.Actions>
             <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
           </LayerDialog.Actions>
         </LayerDialog.Content>
@@ -401,6 +401,33 @@ describe("LayerDialog dismissal", () => {
     expect(emphasisToken(getByRole("button", { name: "Delete" }))).toBe(
       "var(--color-kumo-danger)",
     );
+  });
+
+  it("takes translated text for the two strings it renders itself", () => {
+    const { getByRole, rerender } = render(
+      <LayerDialog.Root open>
+        <LayerDialog.Content closeLabel="Dialog schließen">
+          <LayerDialog.Title>Einstellungen</LayerDialog.Title>
+          <LayerDialog.Body>Inhalt</LayerDialog.Body>
+        </LayerDialog.Content>
+      </LayerDialog.Root>,
+    );
+    expect(getByRole("button", { name: "Dialog schließen" })).toBeDefined();
+
+    rerender(
+      <LayerDialog.Alert open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Löschen</LayerDialog.Title>
+          <LayerDialog.Body>Unwiderruflich.</LayerDialog.Body>
+          <LayerDialog.Actions dismissLabel="Abbrechen">
+            <LayerDialog.Actions.Primary variant="destructive">
+              Löschen
+            </LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+    expect(getByRole("button", { name: "Abbrechen" })).toBeDefined();
   });
 
   it("describes the popup with its body when no Description is given", () => {

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -1,5 +1,11 @@
-import { render, within } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { KumoPortalProvider } from "../../utils/portal-provider";
 import {
   KUMO_LAYER_DIALOG_DEFAULT_VARIANTS,
@@ -13,6 +19,7 @@ describe("LayerDialog", () => {
     expect(LayerDialog.Alert).toBeDefined();
     expect(LayerDialog.Content).toBeDefined();
     expect(LayerDialog.Title).toBeDefined();
+    expect(LayerDialog.Description).toBeDefined();
     expect(LayerDialog.Body).toBeDefined();
     expect(LayerDialog.Actions).toBeDefined();
   });
@@ -26,6 +33,43 @@ describe("LayerDialog", () => {
       "lg",
       "xl",
     ]);
+  });
+
+  it("falls back to default variants for unknown size and alignment", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { getByRole } = render(
+      <LayerDialog.Root open>
+        <LayerDialog.Content
+          size={"huge" as never}
+          verticalAlign={"middle" as never}
+        >
+          <LayerDialog.Title>Fallback</LayerDialog.Title>
+          <LayerDialog.Body>Body</LayerDialog.Body>
+        </LayerDialog.Content>
+      </LayerDialog.Root>,
+    );
+
+    expect(getByRole("dialog").className).toContain(
+      KUMO_LAYER_DIALOG_VARIANTS.size.base.classes,
+    );
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it("rejects more than one description", () => {
+    expect(() =>
+      render(
+        <LayerDialog.Root open>
+          <LayerDialog.Content>
+            <LayerDialog.Title>Title</LayerDialog.Title>
+            <LayerDialog.Description>One</LayerDialog.Description>
+            <LayerDialog.Description>Two</LayerDialog.Description>
+            <LayerDialog.Body>Body</LayerDialog.Body>
+          </LayerDialog.Content>
+        </LayerDialog.Root>,
+      ),
+    ).toThrow("LayerDialog.Content requires");
   });
 
   it("requires explicit actions for alert dialogs", () => {
@@ -100,5 +144,144 @@ describe("LayerDialog", () => {
 
     expect(getByRole("button", { name: "Cancel" })).toBeDefined();
     expect(queryByRole("button", { name: "Close" })).toBeNull();
+  });
+});
+
+describe("LayerDialog dismissal", () => {
+  it("lets an alert close programmatically after its primary action", async () => {
+    const actionsRef = { current: null as null | { close: () => void } };
+    const onOpenChange = vi.fn();
+
+    const { queryByRole } = render(
+      <LayerDialog.Alert
+        actionsRef={actionsRef as never}
+        defaultOpen
+        onOpenChange={onOpenChange}
+      >
+        <LayerDialog.Content>
+          <LayerDialog.Title>Delete resource</LayerDialog.Title>
+          <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+
+    expect(queryByRole("alertdialog")).not.toBeNull();
+    act(() => actionsRef.current?.close());
+
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "imperative-action" }),
+    );
+    await waitFor(() => expect(queryByRole("alertdialog")).toBeNull());
+  });
+
+  it("blocks user dismissal but not programmatic closes while dismissDisabled", () => {
+    const actionsRef = { current: null as null | { close: () => void } };
+    const onOpenChange = vi.fn();
+
+    const { getByRole } = render(
+      <LayerDialog.Root
+        actionsRef={actionsRef as never}
+        defaultOpen
+        dismissDisabled
+        onOpenChange={onOpenChange}
+      >
+        <LayerDialog.Content>
+          <LayerDialog.Title>Saving</LayerDialog.Title>
+          <LayerDialog.Body>Please wait.</LayerDialog.Body>
+        </LayerDialog.Content>
+      </LayerDialog.Root>,
+    );
+
+    fireEvent.keyDown(getByRole("dialog"), { key: "Escape" });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    act(() => actionsRef.current?.close());
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "imperative-action" }),
+    );
+  });
+
+  it("does not turn a nested Root into an alert", () => {
+    const { getAllByRole, getByRole } = render(
+      <LayerDialog.Alert open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Delete resource</LayerDialog.Title>
+          <LayerDialog.Body>
+            <LayerDialog.Root open>
+              <LayerDialog.Content>
+                <LayerDialog.Title>What gets deleted</LayerDialog.Title>
+                <LayerDialog.Body>Everything.</LayerDialog.Body>
+              </LayerDialog.Content>
+            </LayerDialog.Root>
+          </LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+
+    expect(getAllByRole("alertdialog", { hidden: true })).toHaveLength(1);
+    expect(getByRole("dialog", { hidden: true })).toBeDefined();
+    expect(
+      getByRole("button", { hidden: true, name: "Close dialog" }),
+    ).toBeDefined();
+  });
+
+  it("describes the popup with its Description slot when present", () => {
+    const { getByRole } = render(
+      <LayerDialog.Root open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Configure hostname</LayerDialog.Title>
+          <LayerDialog.Description>
+            Route requests to your Worker.
+          </LayerDialog.Description>
+          <LayerDialog.Body>Form fields</LayerDialog.Body>
+        </LayerDialog.Content>
+      </LayerDialog.Root>,
+    );
+
+    const popup = getByRole("dialog");
+    const describedBy = popup.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const description = document.getElementById(describedBy!);
+    expect(description?.textContent).toBe("Route requests to your Worker.");
+    // The description lives in the title frame, beside the title, not in the
+    // scrollable body.
+    const title = document.getElementById(
+      popup.getAttribute("aria-labelledby")!,
+    );
+    expect(description?.parentElement).toBe(title?.parentElement);
+  });
+
+  it("describes the popup with its body when no Description is given", () => {
+    const { getByRole } = render(
+      <LayerDialog.Alert open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Delete resource</LayerDialog.Title>
+          <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+
+    const popup = getByRole("alertdialog");
+    const labelledBy = popup.getAttribute("aria-labelledby");
+    const describedBy = popup.getAttribute("aria-describedby");
+    expect(labelledBy).toBeTruthy();
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe(
+      "Delete resource",
+    );
+    expect(document.getElementById(describedBy!)?.textContent).toBe(
+      "This action cannot be undone.",
+    );
   });
 });

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { LayerDialog } from "./layer-dialog";
+
+describe("LayerDialog", () => {
+  it("exports its strict compound component slots", () => {
+    expect(LayerDialog.Root).toBeDefined();
+    expect(LayerDialog.Alert).toBeDefined();
+    expect(LayerDialog.Content).toBeDefined();
+    expect(LayerDialog.Title).toBeDefined();
+    expect(LayerDialog.Body).toBeDefined();
+    expect(LayerDialog.Actions).toBeDefined();
+  });
+
+  it("requires explicit actions for alert dialogs", () => {
+    expect(() =>
+      render(
+        <LayerDialog.Alert open>
+          <LayerDialog.Content>
+            <LayerDialog.Title>Delete resource</LayerDialog.Title>
+            <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
+          </LayerDialog.Content>
+        </LayerDialog.Alert>,
+      ),
+    ).toThrow("LayerDialog.Alert requires");
+  });
+});

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -285,7 +285,84 @@ describe("LayerDialog dismissal", () => {
     const title = document.getElementById(
       popup.getAttribute("aria-labelledby")!,
     );
-    expect(description?.parentElement).toBe(title?.parentElement);
+    expect(title?.parentElement?.contains(description)).toBe(true);
+  });
+
+  it("condenses the description on scroll only when enough overflow survives", () => {
+    const { getByRole } = render(
+      <LayerDialog.Root open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Audit log</LayerDialog.Title>
+          <LayerDialog.Description>Long list below.</LayerDialog.Description>
+          <LayerDialog.Body>Entries</LayerDialog.Body>
+        </LayerDialog.Content>
+      </LayerDialog.Root>,
+    );
+
+    const popup = getByRole("dialog");
+    const description = document.getElementById(
+      popup.getAttribute("aria-describedby")!,
+    )!;
+    const collapsible = description.closest("[class*='grid-rows-']")!;
+    const clip = collapsible.firstElementChild as HTMLElement;
+    const viewport = popup.querySelector<HTMLElement>(
+      "[role='presentation'][style*='overflow']",
+    )!;
+
+    // jsdom has no layout, so stub the geometry the scroll handler reads.
+    const setGeometry = (
+      scrollTop: number,
+      scrollHeight: number,
+      clientHeight: number,
+    ) => {
+      Object.defineProperty(viewport, "scrollTop", {
+        configurable: true,
+        value: scrollTop,
+      });
+      Object.defineProperty(viewport, "scrollHeight", {
+        configurable: true,
+        value: scrollHeight,
+      });
+      Object.defineProperty(viewport, "clientHeight", {
+        configurable: true,
+        value: clientHeight,
+      });
+    };
+    Object.defineProperty(clip, "offsetHeight", {
+      configurable: true,
+      value: 24,
+    });
+
+    // Barely overflowing: collapsing a 24px description would leave only
+    // 6px of scroll range, which clamps scrollTop under the threshold and
+    // would re-expand the description in a loop. Stay expanded.
+    setGeometry(40, 330, 300);
+    fireEvent.scroll(viewport);
+    expect(collapsible.className).toContain("grid-rows-[1fr]");
+    expect(collapsible.hasAttribute("data-condensed")).toBe(false);
+
+    // Plenty of overflow: condense, and keep the description in the DOM so
+    // aria-describedby still resolves.
+    setGeometry(40, 900, 300);
+    fireEvent.scroll(viewport);
+    expect(collapsible.className).toContain("grid-rows-[0fr]");
+    expect(collapsible.getAttribute("data-condensed")).toBe("true");
+    expect(popup.getAttribute("aria-describedby")).toBe(description.id);
+
+    // Once condensed, any scroll past the threshold keeps it condensed even
+    // if the measured clip height is now 0 mid-transition.
+    Object.defineProperty(clip, "offsetHeight", {
+      configurable: true,
+      value: 0,
+    });
+    setGeometry(20, 900, 324);
+    fireEvent.scroll(viewport);
+    expect(collapsible.className).toContain("grid-rows-[0fr]");
+
+    // Scrolling back to the top expands again.
+    setGeometry(0, 900, 324);
+    fireEvent.scroll(viewport);
+    expect(collapsible.className).toContain("grid-rows-[1fr]");
   });
 
   it("describes the popup with its body when no Description is given", () => {

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -1,5 +1,6 @@
-import { render } from "@testing-library/react";
+import { render, within } from "@testing-library/react";
 import { describe, expect, it } from "vite-plus/test";
+import { KumoPortalProvider } from "../../utils/portal-provider";
 import { LayerDialog } from "./layer-dialog";
 
 describe("LayerDialog", () => {
@@ -23,5 +24,49 @@ describe("LayerDialog", () => {
         </LayerDialog.Alert>,
       ),
     ).toThrow("LayerDialog.Alert requires");
+  });
+
+  it("uses the portal container from KumoPortalProvider", () => {
+    const portalContainer = document.createElement("div");
+    document.body.append(portalContainer);
+
+    const { unmount } = render(
+      <KumoPortalProvider container={portalContainer}>
+        <LayerDialog.Root open>
+          <LayerDialog.Content>
+            <LayerDialog.Title>Portal title</LayerDialog.Title>
+            <LayerDialog.Body>Portal body</LayerDialog.Body>
+          </LayerDialog.Content>
+        </LayerDialog.Root>
+      </KumoPortalProvider>,
+    );
+
+    expect(within(portalContainer).getByText("Portal title")).toBeDefined();
+
+    unmount();
+    portalContainer.remove();
+  });
+
+  it("keeps alert dialogs modal when modal is false", () => {
+    const outsideButton = document.createElement("button");
+    document.body.append(outsideButton);
+
+    const { unmount } = render(
+      <LayerDialog.Alert open modal={false}>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Delete resource</LayerDialog.Title>
+          <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+
+    expect(outsideButton.getAttribute("data-base-ui-inert")).toBe("");
+    expect(outsideButton.getAttribute("aria-hidden")).toBe("true");
+
+    unmount();
+    outsideButton.remove();
   });
 });

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -35,6 +35,35 @@ describe("LayerDialog", () => {
     ]);
   });
 
+  it("derives the desktop height cap from viewport padding, not a hardcoded calc", () => {
+    // Every alignment must reserve vertical padding on the viewport, and the
+    // popup must fill that padded box. A hardcoded `calc(100dvh - Nrem)` on
+    // the popup can drift from the alignment padding and overflow the screen.
+    for (const config of Object.values(
+      KUMO_LAYER_DIALOG_VARIANTS.verticalAlign,
+    )) {
+      expect(config.classes).toMatch(/sm:(py|pb)-\d/);
+    }
+
+    const { getByRole, unmount } = render(
+      <LayerDialog.Root open>
+        <LayerDialog.Content verticalAlign="top">
+          <LayerDialog.Title>Tall</LayerDialog.Title>
+          <LayerDialog.Body>Body</LayerDialog.Body>
+        </LayerDialog.Content>
+      </LayerDialog.Root>,
+    );
+
+    const popup = getByRole("dialog");
+    const viewport = popup.parentElement!;
+    expect(viewport.className).toContain("sm:pt-16");
+    expect(viewport.className).toContain("sm:pb-6");
+    expect(popup.className).toContain("sm:max-h-full");
+    expect(popup.className).not.toMatch(/sm:max-h-\[calc/);
+    expect(popup.firstElementChild?.className).toContain("sm:max-h-full");
+    unmount();
+  });
+
   it("falls back to default variants for unknown size and alignment", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -1,7 +1,11 @@
 import { render, within } from "@testing-library/react";
 import { describe, expect, it } from "vite-plus/test";
 import { KumoPortalProvider } from "../../utils/portal-provider";
-import { LayerDialog } from "./layer-dialog";
+import {
+  KUMO_LAYER_DIALOG_DEFAULT_VARIANTS,
+  KUMO_LAYER_DIALOG_VARIANTS,
+  LayerDialog,
+} from "./layer-dialog";
 
 describe("LayerDialog", () => {
   it("exports its strict compound component slots", () => {
@@ -11,6 +15,17 @@ describe("LayerDialog", () => {
     expect(LayerDialog.Title).toBeDefined();
     expect(LayerDialog.Body).toBeDefined();
     expect(LayerDialog.Actions).toBeDefined();
+  });
+
+  it("uses a larger constrained desktop width by default", () => {
+    expect(KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.size).toBe("base");
+    expect(KUMO_LAYER_DIALOG_VARIANTS.size.base.classes).toBe("sm:max-w-xl");
+    expect(Object.keys(KUMO_LAYER_DIALOG_VARIANTS.size)).toEqual([
+      "sm",
+      "base",
+      "lg",
+      "xl",
+    ]);
   });
 
   it("requires explicit actions for alert dialogs", () => {

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -334,9 +334,7 @@ describe("LayerDialog dismissal", () => {
 
     expect(getAllByRole("alertdialog", { hidden: true })).toHaveLength(1);
     expect(getByRole("dialog", { hidden: true })).toBeDefined();
-    expect(
-      getByRole("button", { hidden: true, name: "Close" }),
-    ).toBeDefined();
+    expect(getByRole("button", { hidden: true, name: "Close" })).toBeDefined();
   });
 
   it("describes the popup with its Description slot when present", () => {

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -365,6 +365,44 @@ describe("LayerDialog dismissal", () => {
     expect(collapsible.className).toContain("grid-rows-[1fr]");
   });
 
+  it("keeps the primary action neutral unless destructive is requested", () => {
+    // Button variants share classes and differ by the inline emphasis token.
+    const emphasisToken = (button: HTMLElement) =>
+      button.style.getPropertyValue("--kumo-button-emphasis-gradient-end");
+
+    const { getByRole, rerender } = render(
+      <LayerDialog.Alert open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Deploy to production</LayerDialog.Title>
+          <LayerDialog.Body>Traffic switches immediately.</LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary>Deploy</LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+    expect(emphasisToken(getByRole("button", { name: "Deploy" }))).toBe(
+      "var(--color-kumo-brand)",
+    );
+
+    rerender(
+      <LayerDialog.Alert open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Delete resource</LayerDialog.Title>
+          <LayerDialog.Body>This cannot be undone.</LayerDialog.Body>
+          <LayerDialog.Actions>
+            <LayerDialog.Actions.Primary variant="destructive">
+              Delete
+            </LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+    expect(emphasisToken(getByRole("button", { name: "Delete" }))).toBe(
+      "var(--color-kumo-danger)",
+    );
+  });
+
   it("describes the popup with its body when no Description is given", () => {
     const { getByRole } = render(
       <LayerDialog.Alert open>

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { KumoPortalProvider } from "../../utils/portal-provider";
+import { KumoLocaleProvider } from "../../utils/locale-provider";
 import {
   KUMO_LAYER_DIALOG_DEFAULT_VARIANTS,
   KUMO_LAYER_DIALOG_VARIANTS,
@@ -174,6 +175,82 @@ describe("LayerDialog", () => {
     expect(getByRole("button", { name: "Cancel" })).toBeDefined();
     expect(queryByRole("button", { name: "Close" })).toBeNull();
   });
+
+  it("uses provider translations for generated dismissal copy", () => {
+    const closeDialog = render(
+      <KumoLocaleProvider
+        translations={{ layerDialog: { close: "Fermer", cancel: "Annuler" } }}
+      >
+        <LayerDialog.Root open>
+          <LayerDialog.Content>
+            <LayerDialog.Title>Information</LayerDialog.Title>
+            <LayerDialog.Body>Body</LayerDialog.Body>
+          </LayerDialog.Content>
+        </LayerDialog.Root>
+      </KumoLocaleProvider>,
+    );
+
+    expect(closeDialog.getByRole("button", { name: "Fermer" })).toBeDefined();
+    closeDialog.unmount();
+
+    const alertDialog = render(
+      <KumoLocaleProvider
+        translations={{ layerDialog: { close: "Fermer", cancel: "Annuler" } }}
+      >
+        <LayerDialog.Alert open>
+          <LayerDialog.Content>
+            <LayerDialog.Title>Delete resource</LayerDialog.Title>
+            <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
+            <LayerDialog.Actions>
+              <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
+            </LayerDialog.Actions>
+          </LayerDialog.Content>
+        </LayerDialog.Alert>
+      </KumoLocaleProvider>,
+    );
+
+    expect(alertDialog.getByRole("button", { name: "Annuler" })).toBeDefined();
+  });
+
+  it("lets explicit labels override provider translations", () => {
+    const closeDialog = render(
+      <KumoLocaleProvider
+        translations={{ layerDialog: { close: "Fermer", cancel: "Annuler" } }}
+      >
+        <LayerDialog.Root open>
+          <LayerDialog.Content closeLabel="Dismiss dialog">
+            <LayerDialog.Title>Information</LayerDialog.Title>
+            <LayerDialog.Body>Body</LayerDialog.Body>
+          </LayerDialog.Content>
+        </LayerDialog.Root>
+      </KumoLocaleProvider>,
+    );
+
+    expect(
+      closeDialog.getByRole("button", { name: "Dismiss dialog" }),
+    ).toBeDefined();
+    closeDialog.unmount();
+
+    const actionsDialog = render(
+      <KumoLocaleProvider
+        translations={{ layerDialog: { close: "Fermer", cancel: "Annuler" } }}
+      >
+        <LayerDialog.Root open>
+          <LayerDialog.Content>
+            <LayerDialog.Title>Information</LayerDialog.Title>
+            <LayerDialog.Body>Body</LayerDialog.Body>
+            <LayerDialog.Actions dismissLabel="Keep editing">
+              <LayerDialog.Actions.Primary>Save</LayerDialog.Actions.Primary>
+            </LayerDialog.Actions>
+          </LayerDialog.Content>
+        </LayerDialog.Root>
+      </KumoLocaleProvider>,
+    );
+
+    expect(
+      actionsDialog.getByRole("button", { name: "Keep editing" }),
+    ).toBeDefined();
+  });
 });
 
 describe("LayerDialog dismissal", () => {
@@ -258,7 +335,7 @@ describe("LayerDialog dismissal", () => {
     expect(getAllByRole("alertdialog", { hidden: true })).toHaveLength(1);
     expect(getByRole("dialog", { hidden: true })).toBeDefined();
     expect(
-      getByRole("button", { hidden: true, name: "Close dialog" }),
+      getByRole("button", { hidden: true, name: "Close" }),
     ).toBeDefined();
   });
 

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.test.tsx
@@ -69,4 +69,21 @@ describe("LayerDialog", () => {
     unmount();
     outsideButton.remove();
   });
+
+  it("keeps the alert dismissal label set to Cancel", () => {
+    const { getByRole, queryByRole } = render(
+      <LayerDialog.Alert open>
+        <LayerDialog.Content>
+          <LayerDialog.Title>Delete resource</LayerDialog.Title>
+          <LayerDialog.Body>This action cannot be undone.</LayerDialog.Body>
+          <LayerDialog.Actions dismissLabel="close">
+            <LayerDialog.Actions.Primary>Delete</LayerDialog.Actions.Primary>
+          </LayerDialog.Actions>
+        </LayerDialog.Content>
+      </LayerDialog.Alert>,
+    );
+
+    expect(getByRole("button", { name: "Cancel" })).toBeDefined();
+    expect(queryByRole("button", { name: "Close" })).toBeNull();
+  });
 });

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   isValidElement,
   useContext,
+  useRef,
   useState,
   type ComponentPropsWithoutRef,
   type ReactElement,
@@ -349,13 +350,38 @@ export interface LayerDialogBodyProps {
   children: ReactNode;
 }
 
+/** Scroll distance before the header shows its divider and condenses. */
+const SCROLL_THRESHOLD = 8;
+/** Overflow that must remain after the description collapses (see handleScroll). */
+const CONDENSE_MIN_OVERFLOW = 16;
+
 function LayerDialogBody({ children }: LayerDialogBodyProps) {
   const [hasScrolled, setHasScrolled] = useState(false);
+  const [condensed, setCondensed] = useState(false);
+  const descriptionClipRef = useRef<HTMLDivElement>(null);
   const dismissDisabled = useContext(DismissDisabledContext);
   const { title, description, showCloseButton } = useContext(BodySlotsContext);
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
-    setHasScrolled(event.currentTarget.scrollTop > 8);
+    const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
+    const scrolled = scrollTop > SCROLL_THRESHOLD;
+    setHasScrolled(scrolled);
+
+    if (!scrolled) {
+      setCondensed(false);
+      return;
+    }
+    if (condensed) return;
+
+    // Collapsing the description hands its height to the viewport, which
+    // shrinks the scroll range. If the content only barely overflows, that
+    // shrink would clamp scrollTop back under the threshold and re-expand the
+    // description, so only condense when enough overflow survives the collapse.
+    // Scroll events fire after layout, so this offsetHeight read is free.
+    const descriptionHeight = descriptionClipRef.current?.offsetHeight ?? 0;
+    const overflowAfterCollapse =
+      scrollHeight - clientHeight - descriptionHeight;
+    if (overflowAfterCollapse > CONDENSE_MIN_OVERFLOW) setCondensed(true);
   };
 
   // Without an explicit Description slot, the body copy describes the dialog
@@ -376,9 +402,26 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
             : "border-b border-transparent",
         )}
       >
-        <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex min-w-0 flex-col">
           {title}
-          {description}
+          {description && (
+            // grid-template-rows 1fr -> 0fr animates an auto-height row, which
+            // plain height cannot. The description stays in the DOM so
+            // aria-describedby keeps working while it is clipped.
+            <div
+              className={cn(
+                "grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none",
+                condensed
+                  ? "grid-rows-[0fr] opacity-0"
+                  : "grid-rows-[1fr] opacity-100",
+              )}
+              data-condensed={condensed || undefined}
+            >
+              <div ref={descriptionClipRef} className="min-h-0 overflow-hidden">
+                <div className="pt-1">{description}</div>
+              </div>
+            </div>
+          )}
         </div>
         {showCloseButton && <LayerDialogIconClose disabled={dismissDisabled} />}
       </div>

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -44,11 +44,11 @@ export const KUMO_LAYER_DIALOG_VARIANTS = {
   },
   verticalAlign: {
     top: {
-      classes: "sm:items-start sm:pt-16",
+      classes: "sm:items-start sm:pt-16 sm:pb-6",
       description: "Align the desktop dialog near the top of the viewport",
     },
     center: {
-      classes: "sm:items-center",
+      classes: "sm:items-center sm:py-6",
       description: "Center the desktop dialog vertically",
     },
   },
@@ -266,6 +266,12 @@ function LayerDialogContent({
   return (
     <DrawerBase.Portal container={container}>
       <DrawerBase.Backdrop className="fixed inset-0 bg-kumo-recessed opacity-80 transition-opacity duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:opacity-0 data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:opacity-0 data-[swiping]:duration-0 motion-reduce:transition-none sm:duration-200 sm:data-[ending-style]:duration-200" />
+      {/*
+        Desktop sizing contract: the viewport owns the vertical breathing room
+        (via the verticalAlign variant) and the popup fills it with
+        `max-h-full`, so the cap can never drift from the alignment padding.
+        Mobile sheets are bottom-anchored and capped at 85dvh instead.
+      */}
       <DrawerBase.Viewport
         className={cn(
           "fixed inset-0 flex items-end justify-center sm:px-4",
@@ -278,11 +284,11 @@ function LayerDialogContent({
         <DrawerBase.Popup
           render={isAlert ? <div role="alertdialog" /> : <div />}
           className={cn(
-            "fixed inset-x-0 bottom-0 flex max-h-[85dvh] min-h-0 w-full max-w-none [transform:translate3d(0,var(--drawer-swipe-movement-y,0px),0)] transform-gpu overflow-visible transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-[ending-style]:[transform:translate3d(0,100%,0)] data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:[transform:translate3d(0,100%,0)] data-[swiping]:duration-0 data-[swiping]:select-none motion-reduce:transition-none sm:static sm:max-h-[calc(100dvh-3rem)] sm:[transform:translate3d(0,0,0)] sm:duration-200 sm:data-[ending-style]:[transform:translate3d(0,8px,0)] sm:data-[ending-style]:opacity-0 sm:data-[ending-style]:duration-200 sm:data-[starting-style]:[transform:translate3d(0,8px,0)] sm:data-[starting-style]:opacity-0",
+            "fixed inset-x-0 bottom-0 flex max-h-[85dvh] min-h-0 w-full max-w-none [transform:translate3d(0,var(--drawer-swipe-movement-y,0px),0)] transform-gpu overflow-visible transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-[ending-style]:[transform:translate3d(0,100%,0)] data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:[transform:translate3d(0,100%,0)] data-[swiping]:duration-0 data-[swiping]:select-none motion-reduce:transition-none sm:static sm:max-h-full sm:[transform:translate3d(0,0,0)] sm:duration-200 sm:data-[ending-style]:[transform:translate3d(0,8px,0)] sm:data-[ending-style]:opacity-0 sm:data-[ending-style]:duration-200 sm:data-[starting-style]:[transform:translate3d(0,8px,0)] sm:data-[starting-style]:opacity-0",
             sizeConfig.classes,
           )}
         >
-          <LayerCard className="flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 shadow-[0_20px_25px_-5px_rgb(0_0_0/0.03),0_8px_10px_-6px_rgb(0_0_0/0.03)] max-sm:border-t max-sm:border-kumo-hairline max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
+          <LayerCard className="flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 shadow-[0_20px_25px_-5px_rgb(0_0_0/0.03),0_8px_10px_-6px_rgb(0_0_0/0.03)] max-sm:border-t max-sm:border-kumo-hairline max-sm:shadow-xs max-sm:ring-0 sm:max-h-full sm:rounded-xl">
             {!isDesktop && !isAlert && (
               <div aria-hidden className="flex justify-center pt-1.5 pb-3">
                 <div className="h-1 w-10 rounded-full bg-kumo-fill" />

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -218,7 +218,7 @@ function LayerDialogContent({
       <DrawerBase.Backdrop className="fixed inset-0 bg-kumo-recessed opacity-80 transition-opacity duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:opacity-0 data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:opacity-0 data-[swiping]:duration-0 motion-reduce:transition-none sm:duration-200 sm:data-[ending-style]:duration-200" />
       <DrawerBase.Viewport
         className={cn(
-          "fixed inset-0 flex items-end justify-center",
+          "fixed inset-0 flex items-end justify-center sm:px-4",
           KUMO_LAYER_DIALOG_VARIANTS.verticalAlign[verticalAlign].classes,
         )}
         data-base-ui-swipe-ignore={
@@ -232,7 +232,7 @@ function LayerDialogContent({
             KUMO_LAYER_DIALOG_VARIANTS.size[size].classes,
           )}
         >
-          <LayerCard className="shadow-m flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
+          <LayerCard className="shadow-m flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 max-sm:border-t max-sm:border-kumo-hairline max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
             {!isDesktop && !isAlert && (
               <div aria-hidden className="flex justify-center pt-1.5 pb-3">
                 <div className="h-1 w-10 rounded-full bg-kumo-fill" />

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -352,7 +352,7 @@ const LayerDialogActions = Object.assign(
   }: LayerDialogActionsProps) {
     const dismissDisabled = useContext(DismissDisabledContext);
     const isAlert = useContext(AlertContext);
-    const label = dismissLabel ?? (isAlert ? "cancel" : "close");
+    const label = isAlert ? "cancel" : (dismissLabel ?? "close");
 
     if (!isValidElement(children) || children.type !== LayerDialogPrimary) {
       throw new Error(

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -1,0 +1,398 @@
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type ReactNode,
+  type UIEvent,
+} from "react";
+import { Drawer as DrawerBase } from "@base-ui/react/drawer";
+import { ScrollArea as ScrollAreaBase } from "@base-ui/react/scroll-area";
+import { useMediaQuery } from "@base-ui/react/unstable-use-media-query";
+import { X } from "@phosphor-icons/react";
+import { Button } from "../button/button";
+import { LayerCard } from "../layer-card/layer-card";
+import { Text } from "../text/text";
+import { cn } from "../../utils/cn";
+
+export const KUMO_LAYER_DIALOG_VARIANTS = {
+  verticalAlign: {
+    top: {
+      classes: "sm:items-start sm:pt-16",
+      description: "Align the desktop dialog near the top of the viewport",
+    },
+    center: {
+      classes: "sm:items-center",
+      description: "Center the desktop dialog vertically",
+    },
+  },
+} as const;
+
+export const KUMO_LAYER_DIALOG_DEFAULT_VARIANTS = {
+  verticalAlign: "center",
+} as const;
+
+export type KumoLayerDialogVerticalAlign =
+  keyof typeof KUMO_LAYER_DIALOG_VARIANTS.verticalAlign;
+
+const DesktopContext = createContext(false);
+const DismissDisabledContext = createContext(false);
+const AlertContext = createContext(false);
+
+type RootProps = ComponentPropsWithoutRef<typeof DrawerBase.Root>;
+
+export type LayerDialogRootProps = RootProps & {
+  /** Prevent every user-initiated dismissal while dialog work is pending. */
+  dismissDisabled?: boolean;
+};
+
+function LayerDialogRoot({
+  children,
+  dismissDisabled = false,
+  onOpenChange,
+  disablePointerDismissal,
+  ...props
+}: LayerDialogRootProps) {
+  const isDesktop = useMediaQuery("(min-width: 640px)", {
+    defaultMatches: false,
+  });
+  const isAlert = useContext(AlertContext);
+
+  const handleOpenChange: NonNullable<RootProps["onOpenChange"]> = (
+    open,
+    eventDetails,
+  ) => {
+    if (
+      !open &&
+      (dismissDisabled || (isAlert && eventDetails.reason !== "close-press"))
+    ) {
+      eventDetails.cancel();
+      return;
+    }
+
+    onOpenChange?.(open, eventDetails);
+  };
+
+  const rootProps = {
+    ...props,
+    disablePointerDismissal:
+      disablePointerDismissal || dismissDisabled || isAlert,
+    onOpenChange: handleOpenChange,
+  };
+
+  return (
+    <DesktopContext.Provider value={isDesktop}>
+      <DismissDisabledContext.Provider value={dismissDisabled}>
+        <DrawerBase.Root {...rootProps}>{children}</DrawerBase.Root>
+      </DismissDisabledContext.Provider>
+    </DesktopContext.Provider>
+  );
+}
+
+LayerDialogRoot.displayName = "LayerDialog.Root";
+
+/** A confirmation dialog that requires the user to choose an explicit action. */
+function LayerDialogAlert(props: LayerDialogRootProps) {
+  return (
+    <AlertContext.Provider value>
+      <LayerDialogRoot {...props} />
+    </AlertContext.Provider>
+  );
+}
+
+LayerDialogAlert.displayName = "LayerDialog.Alert";
+
+export type LayerDialogTriggerProps = ComponentPropsWithoutRef<
+  typeof DrawerBase.Trigger
+>;
+
+function LayerDialogTrigger(props: LayerDialogTriggerProps) {
+  return <DrawerBase.Trigger {...props} />;
+}
+
+LayerDialogTrigger.displayName = "LayerDialog.Trigger";
+
+export interface LayerDialogContentProps {
+  children: ReactNode;
+  /** Desktop-only positioning. Mobile dialogs always remain bottom sheets. */
+  verticalAlign?: KumoLayerDialogVerticalAlign;
+}
+
+function LayerDialogContent({
+  children,
+  verticalAlign = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.verticalAlign,
+}: LayerDialogContentProps) {
+  const isDesktop = useContext(DesktopContext);
+  const dismissDisabled = useContext(DismissDisabledContext);
+  const isAlert = useContext(AlertContext);
+  const childArray = Children.toArray(children);
+  const title = childArray.find(
+    (child) => isValidElement(child) && child.type === LayerDialogTitle,
+  );
+  const body = childArray.find(
+    (child) => isValidElement(child) && child.type === LayerDialogBody,
+  );
+  const actions = childArray.find(
+    (child) => isValidElement(child) && child.type === LayerDialogActions,
+  );
+  const titleCount = childArray.filter(
+    (child) => isValidElement(child) && child.type === LayerDialogTitle,
+  ).length;
+  const bodyCount = childArray.filter(
+    (child) => isValidElement(child) && child.type === LayerDialogBody,
+  ).length;
+  const actionsCount = childArray.filter(
+    (child) => isValidElement(child) && child.type === LayerDialogActions,
+  ).length;
+  const hasInvalidChildren = childArray.some(
+    (child) =>
+      !isValidElement(child) ||
+      (child.type !== LayerDialogTitle &&
+        child.type !== LayerDialogBody &&
+        child.type !== LayerDialogActions),
+  );
+
+  if (
+    hasInvalidChildren ||
+    !title ||
+    !body ||
+    (isAlert && !actions) ||
+    titleCount !== 1 ||
+    bodyCount !== 1 ||
+    actionsCount > 1
+  ) {
+    throw new Error(
+      isAlert
+        ? "LayerDialog.Alert requires exactly one direct LayerDialog.Title, LayerDialog.Body, and LayerDialog.Actions."
+        : "LayerDialog.Content requires exactly one direct LayerDialog.Title and LayerDialog.Body, with an optional direct LayerDialog.Actions.",
+    );
+  }
+
+  const renderedBody = cloneElement(
+    body as ReactElement<LayerDialogBodyProps>,
+    { title, showCloseButton: !actions },
+  );
+
+  return (
+    <DrawerBase.Portal>
+      <DrawerBase.Backdrop className="fixed inset-0 bg-kumo-recessed opacity-80 transition-opacity duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:opacity-0 data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:opacity-0 data-[swiping]:duration-0 motion-reduce:transition-none sm:duration-200 sm:data-[ending-style]:duration-200" />
+      <DrawerBase.Viewport
+        className={cn(
+          "fixed inset-0 flex items-end justify-center",
+          KUMO_LAYER_DIALOG_VARIANTS.verticalAlign[verticalAlign].classes,
+        )}
+        data-base-ui-swipe-ignore={
+          isDesktop || dismissDisabled || isAlert ? "" : undefined
+        }
+      >
+        <DrawerBase.Popup
+          render={isAlert ? <div role="alertdialog" /> : <div />}
+          className="fixed inset-x-0 bottom-0 flex max-h-[85dvh] min-h-0 w-full max-w-none [transform:translate3d(0,var(--drawer-swipe-movement-y,0px),0)] transform-gpu overflow-visible transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-[ending-style]:[transform:translate3d(0,100%,0)] data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:[transform:translate3d(0,100%,0)] data-[swiping]:duration-0 data-[swiping]:select-none motion-reduce:transition-none sm:static sm:max-h-[calc(100dvh-3rem)] sm:max-w-md sm:[transform:translate3d(0,0,0)] sm:duration-200 sm:data-[ending-style]:[transform:translate3d(0,8px,0)] sm:data-[ending-style]:opacity-0 sm:data-[ending-style]:duration-200 sm:data-[starting-style]:[transform:translate3d(0,8px,0)] sm:data-[starting-style]:opacity-0"
+        >
+          <LayerCard className="shadow-m flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
+            {!isDesktop && !isAlert && (
+              <div aria-hidden className="flex justify-center pt-1.5 pb-3">
+                <div className="h-1 w-10 rounded-full bg-kumo-fill" />
+              </div>
+            )}
+            <DrawerBase.Content className="flex min-h-0 flex-col overflow-visible">
+              {renderedBody}
+              {actions}
+            </DrawerBase.Content>
+          </LayerCard>
+        </DrawerBase.Popup>
+      </DrawerBase.Viewport>
+    </DrawerBase.Portal>
+  );
+}
+
+LayerDialogContent.displayName = "LayerDialog.Content";
+
+export interface LayerDialogTitleProps {
+  children: ReactNode;
+}
+
+function LayerDialogTitle({ children }: LayerDialogTitleProps) {
+  const title = (props: ComponentPropsWithoutRef<"h2">) => (
+    <Text {...props} as="h2" variant="heading3">
+      {children}
+    </Text>
+  );
+
+  return <DrawerBase.Title render={title} />;
+}
+
+LayerDialogTitle.displayName = "LayerDialog.Title";
+
+export interface LayerDialogBodyProps {
+  children: ReactNode;
+  title?: ReactNode;
+  showCloseButton?: boolean;
+}
+
+function LayerDialogBody({
+  children,
+  title,
+  showCloseButton = false,
+}: LayerDialogBodyProps) {
+  const [hasScrolled, setHasScrolled] = useState(false);
+  const dismissDisabled = useContext(DismissDisabledContext);
+
+  const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+    setHasScrolled(event.currentTarget.scrollTop > 8);
+  };
+
+  return (
+    <LayerCard.Primary className="min-h-0 flex-1 !gap-0 overflow-hidden border border-kumo-line !p-0 !ring-0">
+      <div
+        className={cn(
+          "z-10 flex shrink-0 items-center justify-between gap-4 bg-kumo-base px-4 py-4 transition-[border-color]",
+          hasScrolled
+            ? "border-b border-kumo-line"
+            : "border-b border-transparent",
+        )}
+      >
+        <div className="min-w-0">{title}</div>
+        {showCloseButton && <LayerDialogIconClose disabled={dismissDisabled} />}
+      </div>
+      <ScrollAreaBase.Root className="relative flex min-h-0 flex-1 flex-col">
+        <ScrollAreaBase.Viewport
+          className="min-h-0 flex-1 overscroll-contain [mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]"
+          onScroll={handleScroll}
+        >
+          <ScrollAreaBase.Content className="px-4 pb-4">
+            {children}
+          </ScrollAreaBase.Content>
+        </ScrollAreaBase.Viewport>
+        <ScrollAreaBase.Scrollbar
+          keepMounted
+          orientation="vertical"
+          className="my-1.5 mr-0.5 hidden w-2 p-px opacity-0 transition-opacity data-[has-overflow-y]:block data-[hovering]:opacity-100 data-[scrolling]:opacity-100"
+        >
+          <ScrollAreaBase.Thumb className="w-full rounded-full bg-kumo-contrast opacity-10 transition-opacity hover:opacity-20 active:opacity-30" />
+        </ScrollAreaBase.Scrollbar>
+      </ScrollAreaBase.Root>
+    </LayerCard.Primary>
+  );
+}
+
+LayerDialogBody.displayName = "LayerDialog.Body";
+
+function LayerDialogIconClose({ disabled }: { disabled: boolean }) {
+  const close = (closeProps: ComponentPropsWithoutRef<"button">) => (
+    <Button
+      {...closeProps}
+      aria-label="Close dialog"
+      disabled={disabled}
+      icon={X}
+      shape="square"
+      size="sm"
+      variant="ghost"
+    />
+  );
+
+  return <DrawerBase.Close render={close} />;
+}
+
+export type LayerDialogPrimaryProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  "children" | "className"
+> & {
+  children: ReactNode;
+  loading?: boolean;
+};
+
+export interface LayerDialogActionsProps {
+  children: ReactElement<LayerDialogPrimaryProps>;
+  /** Use cancellation wording for a workflow that has an explicit cancel outcome. */
+  dismissLabel?: "close" | "cancel";
+}
+
+function LayerDialogPrimary({
+  children,
+  loading,
+  ...props
+}: LayerDialogPrimaryProps) {
+  const isAlert = useContext(AlertContext);
+
+  return (
+    <Button
+      {...props}
+      loading={loading}
+      variant={isAlert ? "destructive" : "primary"}
+    >
+      {children}
+    </Button>
+  );
+}
+
+LayerDialogPrimary.displayName = "LayerDialog.Actions.Primary";
+
+const LayerDialogActions = Object.assign(
+  function LayerDialogActions({
+    children,
+    dismissLabel,
+  }: LayerDialogActionsProps) {
+    const dismissDisabled = useContext(DismissDisabledContext);
+    const isAlert = useContext(AlertContext);
+    const label = dismissLabel ?? (isAlert ? "cancel" : "close");
+
+    if (!isValidElement(children) || children.type !== LayerDialogPrimary) {
+      throw new Error(
+        "LayerDialog.Actions requires exactly one direct LayerDialog.Actions.Primary.",
+      );
+    }
+
+    return (
+      <div className="flex w-full shrink-0 items-center justify-between gap-2 pt-2 pb-1">
+        <LayerDialogDismiss disabled={dismissDisabled} label={label} />
+        {children}
+      </div>
+    );
+  },
+  {
+    Primary: LayerDialogPrimary,
+    displayName: "LayerDialog.Actions",
+  },
+);
+
+function LayerDialogDismiss({
+  disabled,
+  label,
+}: {
+  disabled: boolean;
+  label: "close" | "cancel";
+}) {
+  const close = (closeProps: ComponentPropsWithoutRef<"button">) => (
+    <Button {...closeProps} disabled={disabled} variant="ghost">
+      {label === "cancel" ? "Cancel" : "Close"}
+    </Button>
+  );
+
+  return <DrawerBase.Close render={close} />;
+}
+
+const LayerDialog = Object.assign(LayerDialogRoot, {
+  Root: LayerDialogRoot,
+  Alert: LayerDialogAlert,
+  Trigger: LayerDialogTrigger,
+  Content: LayerDialogContent,
+  Title: LayerDialogTitle,
+  Body: LayerDialogBody,
+  Actions: LayerDialogActions,
+});
+
+export {
+  LayerDialog,
+  LayerDialogRoot,
+  LayerDialogAlert,
+  LayerDialogTrigger,
+  LayerDialogContent,
+  LayerDialogTitle,
+  LayerDialogBody,
+  LayerDialogActions,
+};

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -378,7 +378,7 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
       </div>
       <ScrollAreaBase.Root className="relative flex min-h-0 flex-1 flex-col">
         <ScrollAreaBase.Viewport
-          className="min-h-0 flex-1 overscroll-contain [mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]"
+          className="min-h-0 flex-1 overscroll-none [mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]"
           onScroll={handleScroll}
         >
           <ScrollAreaBase.Content className="px-4 pb-4">

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -1,6 +1,5 @@
 import {
   Children,
-  cloneElement,
   createContext,
   isValidElement,
   useContext,
@@ -18,6 +17,7 @@ import { Button } from "../button/button";
 import { LayerCard } from "../layer-card/layer-card";
 import { Text } from "../text/text";
 import { cn } from "../../utils/cn";
+import { resolveVariant } from "../../utils/resolve-variant";
 import {
   usePortalContainer,
   type PortalContainer,
@@ -67,6 +67,23 @@ const DesktopContext = createContext(false);
 const DismissDisabledContext = createContext(false);
 const AlertContext = createContext(false);
 
+/**
+ * Slots that `LayerDialog.Content` hands to `LayerDialog.Body` so the title
+ * frame, optional description, and automatic X render inside the body surface.
+ * Private on purpose: consumers compose these as siblings, never as Body props.
+ */
+interface BodySlots {
+  title: ReactNode;
+  description: ReactNode;
+  showCloseButton: boolean;
+}
+
+const BodySlotsContext = createContext<BodySlots>({
+  title: null,
+  description: null,
+  showCloseButton: false,
+});
+
 type RootProps = ComponentPropsWithoutRef<typeof DrawerBase.Root>;
 
 export type LayerDialogRootProps = RootProps & {
@@ -74,17 +91,34 @@ export type LayerDialogRootProps = RootProps & {
   dismissDisabled?: boolean;
 };
 
-function LayerDialogRoot({
+/** Props for `LayerDialog` / `LayerDialog.Root`. */
+export type LayerDialogProps = LayerDialogRootProps;
+
+/**
+ * Close reasons that originate from the user. Programmatic closes
+ * (`actionsRef.current.close()`, controlled `open` changes) are never blocked.
+ */
+const USER_DISMISSAL_REASONS: ReadonlySet<string> = new Set([
+  "close-press",
+  "close-watcher",
+  "escape-key",
+  "outside-press",
+  "swipe",
+  "trigger-press",
+]);
+
+function LayerDialogRootImpl({
+  alert,
   children,
   dismissDisabled = false,
   onOpenChange,
   disablePointerDismissal,
+  modal,
   ...props
-}: LayerDialogRootProps) {
+}: LayerDialogRootProps & { alert: boolean }) {
   const isDesktop = useMediaQuery("(min-width: 640px)", {
     defaultMatches: false,
   });
-  const isAlert = useContext(AlertContext);
 
   const handleOpenChange: NonNullable<RootProps["onOpenChange"]> = (
     open,
@@ -92,7 +126,8 @@ function LayerDialogRoot({
   ) => {
     if (
       !open &&
-      (dismissDisabled || (isAlert && eventDetails.reason !== "close-press"))
+      dismissDisabled &&
+      USER_DISMISSAL_REASONS.has(eventDetails.reason)
     ) {
       eventDetails.cancel();
       return;
@@ -101,32 +136,36 @@ function LayerDialogRoot({
     onOpenChange?.(open, eventDetails);
   };
 
+  // Mirrors Base UI's AlertDialog.Root: alerts are always modal and never
+  // dismiss on outside press, while Escape still closes them.
   const rootProps = {
     ...props,
     disablePointerDismissal:
-      disablePointerDismissal || dismissDisabled || isAlert,
-    modal: isAlert ? true : props.modal,
+      alert || dismissDisabled || disablePointerDismissal,
+    modal: alert ? true : modal,
     onOpenChange: handleOpenChange,
   };
 
   return (
-    <DesktopContext.Provider value={isDesktop}>
-      <DismissDisabledContext.Provider value={dismissDisabled}>
-        <DrawerBase.Root {...rootProps}>{children}</DrawerBase.Root>
-      </DismissDisabledContext.Provider>
-    </DesktopContext.Provider>
+    <AlertContext.Provider value={alert}>
+      <DesktopContext.Provider value={isDesktop}>
+        <DismissDisabledContext.Provider value={dismissDisabled}>
+          <DrawerBase.Root {...rootProps}>{children}</DrawerBase.Root>
+        </DismissDisabledContext.Provider>
+      </DesktopContext.Provider>
+    </AlertContext.Provider>
   );
+}
+
+function LayerDialogRoot(props: LayerDialogRootProps) {
+  return <LayerDialogRootImpl {...props} alert={false} />;
 }
 
 LayerDialogRoot.displayName = "LayerDialog.Root";
 
 /** A confirmation dialog that requires the user to choose an explicit action. */
 function LayerDialogAlert(props: LayerDialogRootProps) {
-  return (
-    <AlertContext.Provider value>
-      <LayerDialogRoot {...props} />
-    </AlertContext.Provider>
-  );
+  return <LayerDialogRootImpl {...props} alert />;
 }
 
 LayerDialogAlert.displayName = "LayerDialog.Alert";
@@ -154,6 +193,19 @@ export interface LayerDialogContentProps {
   verticalAlign?: KumoLayerDialogVerticalAlign;
 }
 
+type SlotType =
+  | typeof LayerDialogTitle
+  | typeof LayerDialogDescription
+  | typeof LayerDialogBody
+  | typeof LayerDialogActions;
+
+function collectSlot(children: ReactNode[], type: SlotType) {
+  const matches = children.filter(
+    (child) => isValidElement(child) && child.type === type,
+  );
+  return { element: matches[0], count: matches.length };
+}
+
 function LayerDialogContent({
   children,
   container: containerProp,
@@ -166,52 +218,50 @@ function LayerDialogContent({
   const dismissDisabled = useContext(DismissDisabledContext);
   const isAlert = useContext(AlertContext);
   const childArray = Children.toArray(children);
-  const title = childArray.find(
-    (child) => isValidElement(child) && child.type === LayerDialogTitle,
-  );
-  const body = childArray.find(
-    (child) => isValidElement(child) && child.type === LayerDialogBody,
-  );
-  const actions = childArray.find(
-    (child) => isValidElement(child) && child.type === LayerDialogActions,
-  );
-  const titleCount = childArray.filter(
-    (child) => isValidElement(child) && child.type === LayerDialogTitle,
-  ).length;
-  const bodyCount = childArray.filter(
-    (child) => isValidElement(child) && child.type === LayerDialogBody,
-  ).length;
-  const actionsCount = childArray.filter(
-    (child) => isValidElement(child) && child.type === LayerDialogActions,
-  ).length;
+  const title = collectSlot(childArray, LayerDialogTitle);
+  const description = collectSlot(childArray, LayerDialogDescription);
+  const body = collectSlot(childArray, LayerDialogBody);
+  const actions = collectSlot(childArray, LayerDialogActions);
   const hasInvalidChildren = childArray.some(
     (child) =>
       !isValidElement(child) ||
       (child.type !== LayerDialogTitle &&
+        child.type !== LayerDialogDescription &&
         child.type !== LayerDialogBody &&
         child.type !== LayerDialogActions),
   );
 
   if (
     hasInvalidChildren ||
-    !title ||
-    !body ||
-    (isAlert && !actions) ||
-    titleCount !== 1 ||
-    bodyCount !== 1 ||
-    actionsCount > 1
+    title.count !== 1 ||
+    body.count !== 1 ||
+    description.count > 1 ||
+    actions.count > 1 ||
+    (isAlert && actions.count !== 1)
   ) {
     throw new Error(
       isAlert
-        ? "LayerDialog.Alert requires exactly one direct LayerDialog.Title, LayerDialog.Body, and LayerDialog.Actions."
-        : "LayerDialog.Content requires exactly one direct LayerDialog.Title and LayerDialog.Body, with an optional direct LayerDialog.Actions.",
+        ? "LayerDialog.Alert requires exactly one direct LayerDialog.Title, LayerDialog.Body, and LayerDialog.Actions, with an optional direct LayerDialog.Description."
+        : "LayerDialog.Content requires exactly one direct LayerDialog.Title and LayerDialog.Body, with an optional direct LayerDialog.Description and LayerDialog.Actions.",
     );
   }
 
-  const renderedBody = cloneElement(
-    body as ReactElement<LayerDialogBodyProps>,
-    { title, showCloseButton: !actions },
+  const sizeConfig = resolveVariant(
+    KUMO_LAYER_DIALOG_VARIANTS.size,
+    size,
+    KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.size,
   );
+  const verticalAlignConfig = resolveVariant(
+    KUMO_LAYER_DIALOG_VARIANTS.verticalAlign,
+    verticalAlign,
+    KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.verticalAlign,
+  );
+
+  const bodySlots: BodySlots = {
+    title: title.element,
+    description: description.element ?? null,
+    showCloseButton: actions.count === 0,
+  };
 
   return (
     <DrawerBase.Portal container={container}>
@@ -219,7 +269,7 @@ function LayerDialogContent({
       <DrawerBase.Viewport
         className={cn(
           "fixed inset-0 flex items-end justify-center sm:px-4",
-          KUMO_LAYER_DIALOG_VARIANTS.verticalAlign[verticalAlign].classes,
+          verticalAlignConfig.classes,
         )}
         data-base-ui-swipe-ignore={
           isDesktop || dismissDisabled || isAlert ? "" : undefined
@@ -229,18 +279,20 @@ function LayerDialogContent({
           render={isAlert ? <div role="alertdialog" /> : <div />}
           className={cn(
             "fixed inset-x-0 bottom-0 flex max-h-[85dvh] min-h-0 w-full max-w-none [transform:translate3d(0,var(--drawer-swipe-movement-y,0px),0)] transform-gpu overflow-visible transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-[ending-style]:[transform:translate3d(0,100%,0)] data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:[transform:translate3d(0,100%,0)] data-[swiping]:duration-0 data-[swiping]:select-none motion-reduce:transition-none sm:static sm:max-h-[calc(100dvh-3rem)] sm:[transform:translate3d(0,0,0)] sm:duration-200 sm:data-[ending-style]:[transform:translate3d(0,8px,0)] sm:data-[ending-style]:opacity-0 sm:data-[ending-style]:duration-200 sm:data-[starting-style]:[transform:translate3d(0,8px,0)] sm:data-[starting-style]:opacity-0",
-            KUMO_LAYER_DIALOG_VARIANTS.size[size].classes,
+            sizeConfig.classes,
           )}
         >
-          <LayerCard className="shadow-m flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 max-sm:border-t max-sm:border-kumo-hairline max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
+          <LayerCard className="flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 shadow-[0_20px_25px_-5px_rgb(0_0_0/0.03),0_8px_10px_-6px_rgb(0_0_0/0.03)] max-sm:border-t max-sm:border-kumo-hairline max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
             {!isDesktop && !isAlert && (
               <div aria-hidden className="flex justify-center pt-1.5 pb-3">
                 <div className="h-1 w-10 rounded-full bg-kumo-fill" />
               </div>
             )}
             <DrawerBase.Content className="flex min-h-0 flex-col overflow-visible">
-              {renderedBody}
-              {actions}
+              <BodySlotsContext.Provider value={bodySlots}>
+                {body.element}
+              </BodySlotsContext.Provider>
+              {actions.element}
             </DrawerBase.Content>
           </LayerCard>
         </DrawerBase.Popup>
@@ -267,35 +319,61 @@ function LayerDialogTitle({ children }: LayerDialogTitleProps) {
 
 LayerDialogTitle.displayName = "LayerDialog.Title";
 
-export interface LayerDialogBodyProps {
+export interface LayerDialogDescriptionProps {
   children: ReactNode;
-  title?: ReactNode;
-  showCloseButton?: boolean;
 }
 
-function LayerDialogBody({
-  children,
-  title,
-  showCloseButton = false,
-}: LayerDialogBodyProps) {
+/**
+ * Optional supporting copy rendered directly beneath the title inside the
+ * sticky title frame. Also becomes the dialog's accessible description.
+ */
+function LayerDialogDescription({ children }: LayerDialogDescriptionProps) {
+  const description = (props: ComponentPropsWithoutRef<"p">) => (
+    <Text {...props} as="p" variant="secondary">
+      {children}
+    </Text>
+  );
+
+  return <DrawerBase.Description render={description} />;
+}
+
+LayerDialogDescription.displayName = "LayerDialog.Description";
+
+export interface LayerDialogBodyProps {
+  children: ReactNode;
+}
+
+function LayerDialogBody({ children }: LayerDialogBodyProps) {
   const [hasScrolled, setHasScrolled] = useState(false);
   const dismissDisabled = useContext(DismissDisabledContext);
+  const { title, description, showCloseButton } = useContext(BodySlotsContext);
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
     setHasScrolled(event.currentTarget.scrollTop > 8);
   };
 
+  // Without an explicit Description slot, the body copy describes the dialog
+  // so assistive tech still announces the consequence text for alerts.
+  const content = description ? (
+    children
+  ) : (
+    <DrawerBase.Description render={<div />}>{children}</DrawerBase.Description>
+  );
+
   return (
     <LayerCard.Primary className="min-h-0 flex-1 !gap-0 overflow-hidden border border-kumo-line !p-0 !ring-0">
       <div
         className={cn(
-          "z-10 flex shrink-0 items-center justify-between gap-4 bg-kumo-base px-4 py-4 transition-[border-color]",
+          "z-10 flex shrink-0 items-start justify-between gap-4 bg-kumo-base px-4 py-4 transition-[border-color]",
           hasScrolled
             ? "border-b border-kumo-line"
             : "border-b border-transparent",
         )}
       >
-        <div className="min-w-0">{title}</div>
+        <div className="flex min-w-0 flex-col gap-1">
+          {title}
+          {description}
+        </div>
         {showCloseButton && <LayerDialogIconClose disabled={dismissDisabled} />}
       </div>
       <ScrollAreaBase.Root className="relative flex min-h-0 flex-1 flex-col">
@@ -304,7 +382,7 @@ function LayerDialogBody({
           onScroll={handleScroll}
         >
           <ScrollAreaBase.Content className="px-4 pb-4">
-            {children}
+            {content}
           </ScrollAreaBase.Content>
         </ScrollAreaBase.Viewport>
         <ScrollAreaBase.Scrollbar
@@ -421,6 +499,7 @@ const LayerDialog = Object.assign(LayerDialogRoot, {
   Trigger: LayerDialogTrigger,
   Content: LayerDialogContent,
   Title: LayerDialogTitle,
+  Description: LayerDialogDescription,
   Body: LayerDialogBody,
   Actions: LayerDialogActions,
 });
@@ -432,6 +511,7 @@ export {
   LayerDialogTrigger,
   LayerDialogContent,
   LayerDialogTitle,
+  LayerDialogDescription,
   LayerDialogBody,
   LayerDialogActions,
 };

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -470,7 +470,15 @@ export type LayerDialogPrimaryProps = Omit<
 > & {
   children: ReactNode;
   loading?: boolean;
+  /**
+   * Visual emphasis of the primary action. Use `destructive` when confirming
+   * an irreversible action such as a delete.
+   * @default "primary"
+   */
+  variant?: KumoLayerDialogPrimaryVariant;
 };
+
+export type KumoLayerDialogPrimaryVariant = "primary" | "destructive";
 
 export interface LayerDialogActionsProps {
   children: ReactElement<LayerDialogPrimaryProps>;
@@ -481,16 +489,11 @@ export interface LayerDialogActionsProps {
 function LayerDialogPrimary({
   children,
   loading,
+  variant = "primary",
   ...props
 }: LayerDialogPrimaryProps) {
-  const isAlert = useContext(AlertContext);
-
   return (
-    <Button
-      {...props}
-      loading={loading}
-      variant={isAlert ? "destructive" : "primary"}
-    >
+    <Button {...props} loading={loading} variant={variant}>
       {children}
     </Button>
   );

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -23,6 +23,7 @@ import {
   usePortalContainer,
   type PortalContainer,
 } from "../../utils/portal-provider";
+import { useKumoLocale } from "../../utils/locale-provider";
 
 export const KUMO_LAYER_DIALOG_VARIANTS = {
   size: {
@@ -195,9 +196,9 @@ export interface LayerDialogContentProps {
   /** Desktop-only positioning. Mobile dialogs always remain bottom sheets. */
   verticalAlign?: KumoLayerDialogVerticalAlign;
   /**
-   * Accessible name of the automatic X button. Translate it for
-   * non-English products.
-   * @default "Close dialog"
+   * Accessible name of the automatic X button. Overrides the `close`
+   * translation from KumoLocaleProvider.
+   * @default "Close"
    */
   closeLabel?: string;
 }
@@ -217,11 +218,12 @@ function collectSlot(children: ReactNode[], type: SlotType) {
 
 function LayerDialogContent({
   children,
-  closeLabel = "Close dialog",
+  closeLabel,
   container: containerProp,
   size = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.size,
   verticalAlign = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.verticalAlign,
 }: LayerDialogContentProps) {
+  const { layerDialog } = useKumoLocale();
   const contextContainer = usePortalContainer();
   const container = containerProp ?? contextContainer ?? undefined;
   const isDesktop = useContext(DesktopContext);
@@ -271,7 +273,7 @@ function LayerDialogContent({
     title: title.element,
     description: description.element ?? null,
     showCloseButton: actions.count === 0,
-    closeLabel,
+    closeLabel: closeLabel ?? layerDialog.close,
   };
 
   return (
@@ -532,7 +534,9 @@ const LayerDialogActions = Object.assign(
   }: LayerDialogActionsProps) {
     const dismissDisabled = useContext(DismissDisabledContext);
     const isAlert = useContext(AlertContext);
-    const label = dismissLabel ?? (isAlert ? "Cancel" : "Close");
+    const { layerDialog } = useKumoLocale();
+    const label =
+      dismissLabel ?? (isAlert ? layerDialog.cancel : layerDialog.close);
 
     if (!isValidElement(children) || children.type !== LayerDialogPrimary) {
       throw new Error(

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -18,6 +18,10 @@ import { Button } from "../button/button";
 import { LayerCard } from "../layer-card/layer-card";
 import { Text } from "../text/text";
 import { cn } from "../../utils/cn";
+import {
+  usePortalContainer,
+  type PortalContainer,
+} from "../../utils/portal-provider";
 
 export const KUMO_LAYER_DIALOG_VARIANTS = {
   verticalAlign: {
@@ -81,6 +85,7 @@ function LayerDialogRoot({
     ...props,
     disablePointerDismissal:
       disablePointerDismissal || dismissDisabled || isAlert,
+    modal: isAlert ? true : props.modal,
     onOpenChange: handleOpenChange,
   };
 
@@ -118,14 +123,22 @@ LayerDialogTrigger.displayName = "LayerDialog.Trigger";
 
 export interface LayerDialogContentProps {
   children: ReactNode;
+  /**
+   * Container element for the portal. Overrides `KumoPortalProvider` context.
+   * @default document.body (or KumoPortalProvider container if set)
+   */
+  container?: PortalContainer;
   /** Desktop-only positioning. Mobile dialogs always remain bottom sheets. */
   verticalAlign?: KumoLayerDialogVerticalAlign;
 }
 
 function LayerDialogContent({
   children,
+  container: containerProp,
   verticalAlign = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.verticalAlign,
 }: LayerDialogContentProps) {
+  const contextContainer = usePortalContainer();
+  const container = containerProp ?? contextContainer ?? undefined;
   const isDesktop = useContext(DesktopContext);
   const dismissDisabled = useContext(DismissDisabledContext);
   const isAlert = useContext(AlertContext);
@@ -178,7 +191,7 @@ function LayerDialogContent({
   );
 
   return (
-    <DrawerBase.Portal>
+    <DrawerBase.Portal container={container}>
       <DrawerBase.Backdrop className="fixed inset-0 bg-kumo-recessed opacity-80 transition-opacity duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:opacity-0 data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:opacity-0 data-[swiping]:duration-0 motion-reduce:transition-none sm:duration-200 sm:data-[ending-style]:duration-200" />
       <DrawerBase.Viewport
         className={cn(
@@ -218,7 +231,7 @@ export interface LayerDialogTitleProps {
 
 function LayerDialogTitle({ children }: LayerDialogTitleProps) {
   const title = (props: ComponentPropsWithoutRef<"h2">) => (
-    <Text {...props} as="h2" variant="heading3">
+    <Text {...props} as="h2" variant="heading">
       {children}
     </Text>
   );

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -328,7 +328,12 @@ export interface LayerDialogTitleProps {
 
 function LayerDialogTitle({ children }: LayerDialogTitleProps) {
   const title = (props: ComponentPropsWithoutRef<"h2">) => (
-    <Text {...props} as="h2" variant="heading">
+    <Text
+      {...props}
+      as="h2"
+      variant="heading"
+      DANGEROUS_className="font-medium"
+    >
       {children}
     </Text>
   );
@@ -362,13 +367,12 @@ export interface LayerDialogBodyProps {
   children: ReactNode;
 }
 
-/** Scroll distance before the header shows its divider and condenses. */
+/** Scroll distance before the header description condenses. */
 const SCROLL_THRESHOLD = 8;
 /** Overflow that must remain after the description collapses (see handleScroll). */
 const CONDENSE_MIN_OVERFLOW = 16;
 
 function LayerDialogBody({ children }: LayerDialogBodyProps) {
-  const [hasScrolled, setHasScrolled] = useState(false);
   const [condensed, setCondensed] = useState(false);
   const descriptionClipRef = useRef<HTMLDivElement>(null);
   const dismissDisabled = useContext(DismissDisabledContext);
@@ -378,7 +382,6 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
     const scrolled = scrollTop > SCROLL_THRESHOLD;
-    setHasScrolled(scrolled);
 
     if (!scrolled) {
       setCondensed(false);
@@ -406,15 +409,8 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
   );
 
   return (
-    <LayerCard.Primary className="min-h-0 flex-1 !gap-0 overflow-hidden border border-kumo-line !p-0 !ring-0">
-      <div
-        className={cn(
-          "z-10 flex shrink-0 items-start justify-between gap-4 bg-kumo-base px-4 py-4 transition-[border-color]",
-          hasScrolled
-            ? "border-b border-kumo-line"
-            : "border-b border-transparent",
-        )}
-      >
+    <LayerCard.Primary className="min-h-0 flex-1 gap-0 p-0">
+      <div className="z-10 flex shrink-0 items-start justify-between gap-4 rounded-t-lg bg-kumo-base px-4.5 py-4">
         <div className="flex min-w-0 flex-col">
           {title}
           {description && (
@@ -445,7 +441,7 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
           className="min-h-0 flex-1 overscroll-none [mask-image:linear-gradient(to_bottom,transparent_0,black_min(24px,var(--scroll-area-overflow-y-start,24px)),black_calc(100%-min(24px,var(--scroll-area-overflow-y-end,24px))),transparent_100%)]"
           onScroll={handleScroll}
         >
-          <ScrollAreaBase.Content className="px-4 pb-4">
+          <ScrollAreaBase.Content className="px-4.5 pb-4.5">
             {content}
           </ScrollAreaBase.Content>
         </ScrollAreaBase.Viewport>
@@ -474,8 +470,9 @@ function LayerDialogIconClose({
     <Button
       {...closeProps}
       aria-label={label}
+      className="-mt-1.5 -mr-1.5 rounded-lg"
       disabled={disabled}
-      icon={X}
+      icon={<X size={15} />}
       shape="square"
       size="sm"
       variant="ghost"
@@ -545,7 +542,7 @@ const LayerDialogActions = Object.assign(
     }
 
     return (
-      <div className="flex w-full shrink-0 items-center justify-between gap-2 pt-2 pb-1">
+      <div className="flex w-full shrink-0 items-center justify-between gap-2 pt-1.75">
         <LayerDialogDismiss disabled={dismissDisabled} label={label} />
         {children}
       </div>
@@ -565,7 +562,12 @@ function LayerDialogDismiss({
   label: string;
 }) {
   const close = (closeProps: ComponentPropsWithoutRef<"button">) => (
-    <Button {...closeProps} disabled={disabled} variant="ghost">
+    <Button
+      {...closeProps}
+      className="hover:bg-kumo-fill/50"
+      disabled={disabled}
+      variant="ghost"
+    >
       {label}
     </Button>
   );

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -24,6 +24,24 @@ import {
 } from "../../utils/portal-provider";
 
 export const KUMO_LAYER_DIALOG_VARIANTS = {
+  size: {
+    sm: {
+      classes: "sm:max-w-md",
+      description: "Compact desktop dialog width (448px)",
+    },
+    base: {
+      classes: "sm:max-w-xl",
+      description: "Default desktop dialog width (576px)",
+    },
+    lg: {
+      classes: "sm:max-w-2xl",
+      description: "Large desktop dialog width (672px)",
+    },
+    xl: {
+      classes: "sm:max-w-3xl",
+      description: "Extra large desktop dialog width (768px)",
+    },
+  },
   verticalAlign: {
     top: {
       classes: "sm:items-start sm:pt-16",
@@ -37,9 +55,11 @@ export const KUMO_LAYER_DIALOG_VARIANTS = {
 } as const;
 
 export const KUMO_LAYER_DIALOG_DEFAULT_VARIANTS = {
+  size: "base",
   verticalAlign: "center",
 } as const;
 
+export type KumoLayerDialogSize = keyof typeof KUMO_LAYER_DIALOG_VARIANTS.size;
 export type KumoLayerDialogVerticalAlign =
   keyof typeof KUMO_LAYER_DIALOG_VARIANTS.verticalAlign;
 
@@ -128,6 +148,8 @@ export interface LayerDialogContentProps {
    * @default document.body (or KumoPortalProvider container if set)
    */
   container?: PortalContainer;
+  /** Desktop-only width. Mobile dialogs always remain full-width. */
+  size?: KumoLayerDialogSize;
   /** Desktop-only positioning. Mobile dialogs always remain bottom sheets. */
   verticalAlign?: KumoLayerDialogVerticalAlign;
 }
@@ -135,6 +157,7 @@ export interface LayerDialogContentProps {
 function LayerDialogContent({
   children,
   container: containerProp,
+  size = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.size,
   verticalAlign = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.verticalAlign,
 }: LayerDialogContentProps) {
   const contextContainer = usePortalContainer();
@@ -204,7 +227,10 @@ function LayerDialogContent({
       >
         <DrawerBase.Popup
           render={isAlert ? <div role="alertdialog" /> : <div />}
-          className="fixed inset-x-0 bottom-0 flex max-h-[85dvh] min-h-0 w-full max-w-none [transform:translate3d(0,var(--drawer-swipe-movement-y,0px),0)] transform-gpu overflow-visible transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-[ending-style]:[transform:translate3d(0,100%,0)] data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:[transform:translate3d(0,100%,0)] data-[swiping]:duration-0 data-[swiping]:select-none motion-reduce:transition-none sm:static sm:max-h-[calc(100dvh-3rem)] sm:max-w-md sm:[transform:translate3d(0,0,0)] sm:duration-200 sm:data-[ending-style]:[transform:translate3d(0,8px,0)] sm:data-[ending-style]:opacity-0 sm:data-[ending-style]:duration-200 sm:data-[starting-style]:[transform:translate3d(0,8px,0)] sm:data-[starting-style]:opacity-0"
+          className={cn(
+            "fixed inset-x-0 bottom-0 flex max-h-[85dvh] min-h-0 w-full max-w-none [transform:translate3d(0,var(--drawer-swipe-movement-y,0px),0)] transform-gpu overflow-visible transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-[ending-style]:[transform:translate3d(0,100%,0)] data-[ending-style]:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-[starting-style]:[transform:translate3d(0,100%,0)] data-[swiping]:duration-0 data-[swiping]:select-none motion-reduce:transition-none sm:static sm:max-h-[calc(100dvh-3rem)] sm:[transform:translate3d(0,0,0)] sm:duration-200 sm:data-[ending-style]:[transform:translate3d(0,8px,0)] sm:data-[ending-style]:opacity-0 sm:data-[ending-style]:duration-200 sm:data-[starting-style]:[transform:translate3d(0,8px,0)] sm:data-[starting-style]:opacity-0",
+            KUMO_LAYER_DIALOG_VARIANTS.size[size].classes,
+          )}
         >
           <LayerCard className="shadow-m flex max-h-[85dvh] min-h-0 w-full flex-col overflow-hidden rounded-none bg-kumo-elevated p-1.5 max-sm:shadow-xs max-sm:ring-0 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl">
             {!isDesktop && !isAlert && (

--- a/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
+++ b/packages/kumo/src/components/layer-dialog/layer-dialog.tsx
@@ -77,12 +77,14 @@ interface BodySlots {
   title: ReactNode;
   description: ReactNode;
   showCloseButton: boolean;
+  closeLabel: string;
 }
 
 const BodySlotsContext = createContext<BodySlots>({
   title: null,
   description: null,
   showCloseButton: false,
+  closeLabel: "",
 });
 
 type RootProps = ComponentPropsWithoutRef<typeof DrawerBase.Root>;
@@ -192,6 +194,12 @@ export interface LayerDialogContentProps {
   size?: KumoLayerDialogSize;
   /** Desktop-only positioning. Mobile dialogs always remain bottom sheets. */
   verticalAlign?: KumoLayerDialogVerticalAlign;
+  /**
+   * Accessible name of the automatic X button. Translate it for
+   * non-English products.
+   * @default "Close dialog"
+   */
+  closeLabel?: string;
 }
 
 type SlotType =
@@ -209,6 +217,7 @@ function collectSlot(children: ReactNode[], type: SlotType) {
 
 function LayerDialogContent({
   children,
+  closeLabel = "Close dialog",
   container: containerProp,
   size = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.size,
   verticalAlign = KUMO_LAYER_DIALOG_DEFAULT_VARIANTS.verticalAlign,
@@ -262,6 +271,7 @@ function LayerDialogContent({
     title: title.element,
     description: description.element ?? null,
     showCloseButton: actions.count === 0,
+    closeLabel,
   };
 
   return (
@@ -360,7 +370,8 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
   const [condensed, setCondensed] = useState(false);
   const descriptionClipRef = useRef<HTMLDivElement>(null);
   const dismissDisabled = useContext(DismissDisabledContext);
-  const { title, description, showCloseButton } = useContext(BodySlotsContext);
+  const { title, description, showCloseButton, closeLabel } =
+    useContext(BodySlotsContext);
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
@@ -423,7 +434,9 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
             </div>
           )}
         </div>
-        {showCloseButton && <LayerDialogIconClose disabled={dismissDisabled} />}
+        {showCloseButton && (
+          <LayerDialogIconClose disabled={dismissDisabled} label={closeLabel} />
+        )}
       </div>
       <ScrollAreaBase.Root className="relative flex min-h-0 flex-1 flex-col">
         <ScrollAreaBase.Viewport
@@ -448,11 +461,17 @@ function LayerDialogBody({ children }: LayerDialogBodyProps) {
 
 LayerDialogBody.displayName = "LayerDialog.Body";
 
-function LayerDialogIconClose({ disabled }: { disabled: boolean }) {
+function LayerDialogIconClose({
+  disabled,
+  label,
+}: {
+  disabled: boolean;
+  label: string;
+}) {
   const close = (closeProps: ComponentPropsWithoutRef<"button">) => (
     <Button
       {...closeProps}
-      aria-label="Close dialog"
+      aria-label={label}
       disabled={disabled}
       icon={X}
       shape="square"
@@ -482,8 +501,13 @@ export type KumoLayerDialogPrimaryVariant = "primary" | "destructive";
 
 export interface LayerDialogActionsProps {
   children: ReactElement<LayerDialogPrimaryProps>;
-  /** Use cancellation wording for a workflow that has an explicit cancel outcome. */
-  dismissLabel?: "close" | "cancel";
+  /**
+   * Text of the automatic dismiss button. Say "Cancel" only when the
+   * workflow has a real cancel outcome. Translate it for non-English
+   * products.
+   * @default "Close" ("Cancel" inside LayerDialog.Alert)
+   */
+  dismissLabel?: string;
 }
 
 function LayerDialogPrimary({
@@ -508,7 +532,7 @@ const LayerDialogActions = Object.assign(
   }: LayerDialogActionsProps) {
     const dismissDisabled = useContext(DismissDisabledContext);
     const isAlert = useContext(AlertContext);
-    const label = isAlert ? "cancel" : (dismissLabel ?? "close");
+    const label = dismissLabel ?? (isAlert ? "Cancel" : "Close");
 
     if (!isValidElement(children) || children.type !== LayerDialogPrimary) {
       throw new Error(
@@ -534,11 +558,11 @@ function LayerDialogDismiss({
   label,
 }: {
   disabled: boolean;
-  label: "close" | "cancel";
+  label: string;
 }) {
   const close = (closeProps: ComponentPropsWithoutRef<"button">) => (
     <Button {...closeProps} disabled={disabled} variant="ghost">
-      {label === "cancel" ? "Cancel" : "Close"}
+      {label}
     </Button>
   );
 

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -341,6 +341,14 @@ export {
   type TagInputLabels,
   type TagInputProps,
 } from "./components/tag-input";
+export {
+  LayerDialog,
+  type LayerDialogActionsProps,
+  type LayerDialogContentProps,
+  type LayerDialogPrimaryProps,
+  type LayerDialogRootProps,
+  type KumoLayerDialogVerticalAlign,
+} from "./components/layer-dialog";
 // PLOP_INJECT_EXPORT
 
 // Utils

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -368,6 +368,12 @@ export {
   KumoPortalProvider,
   type PortalContainer,
 } from "./utils/portal-provider";
+export {
+  KumoLocaleProvider,
+  type KumoLocaleProviderProps,
+  type KumoTranslations,
+  type KumoTranslationsPartial,
+} from "./utils/locale-provider";
 
 // Registry types (for consuming packages to type registry JSON)
 export type {

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -351,6 +351,7 @@ export {
   type LayerDialogPrimaryProps,
   type LayerDialogRootProps,
   type LayerDialogTitleProps,
+  type KumoLayerDialogPrimaryVariant,
   type KumoLayerDialogSize,
   type KumoLayerDialogVerticalAlign,
 } from "./components/layer-dialog";

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -347,6 +347,7 @@ export {
   type LayerDialogContentProps,
   type LayerDialogPrimaryProps,
   type LayerDialogRootProps,
+  type KumoLayerDialogSize,
   type KumoLayerDialogVerticalAlign,
 } from "./components/layer-dialog";
 // PLOP_INJECT_EXPORT

--- a/packages/kumo/src/index.ts
+++ b/packages/kumo/src/index.ts
@@ -343,10 +343,14 @@ export {
 } from "./components/tag-input";
 export {
   LayerDialog,
+  type LayerDialogProps,
   type LayerDialogActionsProps,
+  type LayerDialogBodyProps,
   type LayerDialogContentProps,
+  type LayerDialogDescriptionProps,
   type LayerDialogPrimaryProps,
   type LayerDialogRootProps,
+  type LayerDialogTitleProps,
   type KumoLayerDialogSize,
   type KumoLayerDialogVerticalAlign,
 } from "./components/layer-dialog";

--- a/packages/kumo/src/utils/index.ts
+++ b/packages/kumo/src/utils/index.ts
@@ -5,3 +5,9 @@ export {
   type LinkComponentProps,
 } from "./link-provider";
 export { KumoPortalProvider, type PortalContainer } from "./portal-provider";
+export {
+  KumoLocaleProvider,
+  type KumoLocaleProviderProps,
+  type KumoTranslations,
+  type KumoTranslationsPartial,
+} from "./locale-provider";

--- a/packages/kumo/src/utils/locale-provider.tsx
+++ b/packages/kumo/src/utils/locale-provider.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+export interface KumoTranslations {
+  layerDialog: {
+    close: string;
+    cancel: string;
+  };
+}
+
+export type KumoTranslationsPartial = {
+  [Key in keyof KumoTranslations]?: Partial<KumoTranslations[Key]>;
+};
+
+const defaultTranslations: KumoTranslations = {
+  layerDialog: {
+    close: "Close",
+    cancel: "Cancel",
+  },
+};
+
+const KumoLocaleContext = createContext<KumoTranslations>(defaultTranslations);
+
+export interface KumoLocaleProviderProps {
+  children: ReactNode;
+  /**
+   * Partial overrides for Kumo's built-in English copy. Components without an
+   * override continue to use their English defaults.
+   */
+  translations?: KumoTranslationsPartial;
+}
+
+/**
+ * Supplies translations for Kumo-owned UI copy. Explicit component props take
+ * precedence over these defaults.
+ */
+export function KumoLocaleProvider({
+  children,
+  translations,
+}: KumoLocaleProviderProps) {
+  const value = useMemo<KumoTranslations>(
+    () => ({
+      layerDialog: {
+        ...defaultTranslations.layerDialog,
+        ...translations?.layerDialog,
+      },
+    }),
+    [translations],
+  );
+
+  return (
+    <KumoLocaleContext.Provider value={value}>
+      {children}
+    </KumoLocaleContext.Provider>
+  );
+}
+
+/** @internal Used by Kumo components to resolve translated built-in copy. */
+export function useKumoLocale(): KumoTranslations {
+  return useContext(KumoLocaleContext);
+}

--- a/packages/kumo/vite.config.ts
+++ b/packages/kumo/vite.config.ts
@@ -65,6 +65,10 @@ const packEntries = {
     __dirname,
     "src/components/layer-card/index.ts",
   ),
+  "components/layer-dialog": resolve(
+    __dirname,
+    "src/components/layer-dialog/index.ts",
+  ),
   "components/label": resolve(__dirname, "src/components/label/index.ts"),
   "components/loader": resolve(__dirname, "src/components/loader/index.ts"),
   "components/menubar": resolve(__dirname, "src/components/menubar/index.ts"),


### PR DESCRIPTION
## Summary

- add a strict `LayerDialog` component built on Base UI Drawer
- derive dismissal UI from composition: an automatic X without actions, or a fixed Close/Cancel plus one primary action with actions
- support centered or top-aligned desktop dialogs and full-width mobile bottom sheets with swipe behavior
- add sticky title treatment, scroll masking, dismissal locking, forced modal `alertdialog` semantics, and custom portal-container support
- add `KumoLocaleProvider` for application-wide LayerDialog `close` and `cancel` defaults; explicit `closeLabel` and `dismissLabel` props still take precedence
- document the API with seven live previews covering informational, action, cancellation, destructive, pending, cleanup, and alignment flows

## Validation

- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo test` — 55 files and 1,320 tests passed
- `pnpm --filter @cloudflare/kumo exec vp test run src/components/layer-dialog/layer-dialog.test.tsx` — 19 passed
- `pnpm --filter @cloudflare/kumo build`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck` — 0 errors

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: this new interactive component requires design and interaction review
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because: