### PR TITLE
feat(chart): add y-axis minimum interval

### DIFF
--- a/.changeset/silly-integers-relax.md
+++ b/.changeset/silly-integers-relax.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/kumo": minor
+---
+
+Add an optional `yAxisMinInterval` prop to `TimeseriesChart` for discrete data.

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -111,6 +111,40 @@ export function BasicLineChartDemo() {
   );
 }
 
+/**
+ * Discrete request-count chart with whole-number y-axis ticks.
+ */
+export function IntegerYAxisChartDemo() {
+  const isDarkMode = useIsDarkMode();
+
+  const data = useMemo(
+    () => [
+      {
+        name: "Requests",
+        data: buildSeriesData(0, 12, 60_000, 0.1).map(
+          ([timestamp, value]): [number, number] => [
+            timestamp,
+            Math.round(value),
+          ],
+        ),
+        color: ChartPalette.semantic("Neutral", isDarkMode),
+      },
+    ],
+    [isDarkMode],
+  );
+
+  return (
+    <TimeseriesChart
+      echarts={echarts}
+      isDarkMode={isDarkMode}
+      data={data}
+      xAxisName="Time (UTC)"
+      yAxisName="Requests"
+      yAxisMinInterval={1}
+    />
+  );
+}
+
 export function ReferenceMarkersChartDemo() {
   const isDarkMode = useIsDarkMode();
 

--- a/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
+++ b/packages/kumo-docs-astro/src/components/demos/Chart/ChartDemo.tsx
@@ -117,21 +117,21 @@ export function BasicLineChartDemo() {
 export function IntegerYAxisChartDemo() {
   const isDarkMode = useIsDarkMode();
 
-  const data = useMemo(
-    () => [
+  const data = useMemo(() => {
+    const end = Date.now();
+    const values = [0, 1, 3, 2, 5, 4, 7, 3, 6, 2, 4, 1];
+
+    return [
       {
         name: "Requests",
-        data: buildSeriesData(0, 12, 60_000, 0.1).map(
-          ([timestamp, value]): [number, number] => [
-            timestamp,
-            Math.round(value),
-          ],
-        ),
+        data: values.map((value, index): [number, number] => [
+          end - (values.length - index - 1) * 60_000,
+          value,
+        ]),
         color: ChartPalette.semantic("Neutral", isDarkMode),
       },
-    ],
-    [isDarkMode],
-  );
+    ];
+  }, [isDarkMode]);
 
   return (
     <TimeseriesChart

--- a/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
+++ b/packages/kumo-docs-astro/src/pages/charts/timeseries.mdx
@@ -9,6 +9,7 @@ import ComponentSection from "~/components/docs/ComponentSection.astro";
 import ComponentExample from "~/components/docs/ComponentExample.astro";
 import {
   BasicLineChartDemo,
+  IntegerYAxisChartDemo,
   BarChartDemo,
   ReferenceMarkersChartDemo,
   ThresholdsChartDemo,
@@ -38,6 +39,21 @@ import {
 
   <ComponentExample demo="BasicLineChartDemo">
     <BasicLineChartDemo client:visible />
+  </ComponentExample>
+</ComponentSection>
+
+<ComponentSection>
+
+## Discrete Count Data
+
+<p>
+  Set <code>yAxisMinInterval={1}</code> for discrete values such as request
+  counts. This prevents fractional y-axis tick marks while leaving the default
+  axis behavior unchanged for rates and other continuous values.
+</p>
+
+  <ComponentExample demo="IntegerYAxisChartDemo">
+    <IntegerYAxisChartDemo client:visible />
   </ComponentExample>
 </ComponentSection>
 

--- a/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.test.tsx
@@ -24,6 +24,49 @@ const createMockEcharts = (mockChart = createMockChart()) => ({
 });
 
 describe("TimeseriesChart", () => {
+  it("leaves the y-axis interval unconstrained by default", async () => {
+    const mockChart = createMockChart();
+
+    render(
+      <TimeseriesChart
+        echarts={createMockEcharts(mockChart) as any}
+        data={[]}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mockChart.setOption).toHaveBeenCalledWith(
+        expect.objectContaining({
+          yAxis: expect.not.objectContaining({
+            minInterval: expect.anything(),
+          }),
+        }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("passes yAxisMinInterval to ECharts", async () => {
+    const mockChart = createMockChart();
+
+    render(
+      <TimeseriesChart
+        echarts={createMockEcharts(mockChart) as any}
+        data={[]}
+        yAxisMinInterval={1}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mockChart.setOption).toHaveBeenCalledWith(
+        expect.objectContaining({
+          yAxis: expect.objectContaining({ minInterval: 1 }),
+        }),
+        expect.anything(),
+      ),
+    );
+  });
+
   it("does not reserve footer space for an empty string", () => {
     const { container } = render(
       <TooltipContent

--- a/packages/kumo/src/components/chart/TimeseriesChart.tsx
+++ b/packages/kumo/src/components/chart/TimeseriesChart.tsx
@@ -87,6 +87,11 @@ export interface TimeseriesChartProps {
   /** Number of ticks to display on the y-axis */
   yAxisTickCount?: number;
   /**
+   * Minimum interval between y-axis ticks. Set to `1` for discrete count data
+   * so ECharts does not render fractional tick marks.
+   */
+  yAxisMinInterval?: number;
+  /**
    * Custom formatter for tooltip values.
    * Receives the raw y-value and returns a display string.
    * When omitted, the raw value is shown. Takes precedence over the
@@ -240,6 +245,7 @@ export const TimeseriesChart = forwardRef<
     yAxisTickLabelFormat,
     yAxisName,
     yAxisTickCount,
+    yAxisMinInterval,
     tooltipValueFormat,
     tooltipFooter,
     onTimeRangeChange,
@@ -532,6 +538,9 @@ export const TimeseriesChart = forwardRef<
           },
         },
         splitNumber: yAxisTickCount,
+        ...(yAxisMinInterval !== undefined && {
+          minInterval: yAxisMinInterval,
+        }),
         ...(thresholdExtent && {
           min: (value: { min: number }) =>
             Math.min(value.min, thresholdExtent.min),
@@ -555,6 +564,7 @@ export const TimeseriesChart = forwardRef<
     yAxisTickFormat,
     yAxisName,
     yAxisTickCount,
+    yAxisMinInterval,
     incompleteBefore,
     incompleteAfter,
     type,


### PR DESCRIPTION
## Summary

<img width="803" height="523" alt="Screenshot 2026-09-11 at 10 50 03 AM" src="https://github.com/user-attachments/assets/6c0a220b-3010-4ea3-8e15-0b40cccb5077" />

- add an opt-in `yAxisMinInterval` prop to `TimeseriesChart`
- forward it to ECharts as `minInterval`
- preserve the existing unconstrained default for every current consumer
- add focused tests for both the opt-in and default behavior
- document discrete count axes with an executable request-count example

## Validation

- `pnpm vp fmt packages/kumo/src/components/chart/TimeseriesChart.tsx packages/kumo/src/components/chart/TimeseriesChart.test.tsx .changeset/silly-integers-relax.md`
- `pnpm --filter @cloudflare/kumo exec vp test run src/components/chart/TimeseriesChart.test.tsx`
- `pnpm --filter @cloudflare/kumo lint`
- `pnpm --filter @cloudflare/kumo typecheck`
- `pnpm --filter @cloudflare/kumo-docs-astro codegen:demos`
- `pnpm --filter @cloudflare/kumo-docs-astro lint`
- `pnpm --filter @cloudflare/kumo-docs-astro typecheck`
- `pnpm changeset status`

- Reviews
- [ ] bonk has reviewed the change
- [x] automated review not possible because: this is a small public API addition requiring maintainer API-design review.
- Tests
- [x] Tests included/updated
- [ ] Automated tests not possible - manual testing has been completed as follows:
- [ ] Additional testing not necessary because: