### PR TITLE
docs(installation): call out isolation: isolate for portaled popups

### DIFF
--- a/packages/kumo-docs-astro/src/pages/installation.mdx
+++ b/packages/kumo-docs-astro/src/pages/installation.mdx
@@ -142,6 +142,42 @@ import "@cloudflare/kumo/styles/standalone";
 
 The standalone build includes all Tailwind utilities and Kumo component styles pre-compiled. No Tailwind configuration needed!
 
+## Isolate Your App Root
+
+Kumo's floating components (`Select`, `Combobox`, `Dropdown`, `Popover`, `Tooltip`, `Dialog`, and others) render their popups in a portal at the end of `document.body`. Because Kumo doesn't apply a `z-index` to these popups, any positive `z-index` in your own layout (a sticky header, for example) can paint above an open popup.
+
+To prevent this, add `isolation: isolate` to your application's root element, as [Base UI recommends](https://base-ui.com/react/overview/quick-start#portals):
+
+```css
+/* The element that wraps your entire app, e.g. #root or #app */
+.root {
+  isolation: isolate;
+}
+```
+
+Or with Tailwind:
+
+```tsx
+<div id="root" className="isolate">
+  {/* Your app */}
+</div>
+```
+
+This creates a separate stacking context for your app's content, so portaled popups always appear on top regardless of the `z-index` values used inside your layout.
+
+<Callout type="info">
+  If you find yourself reaching for `z-index` to get a Kumo popup to show above
+  your own UI, that's a sign something is off. The fix is almost always
+  isolating your app root as shown above, not raising the popup's `z-index` or
+  targeting Base UI's internal data attributes.
+</Callout>
+
+<Callout type="warning">
+  **Important:** Apply `isolation: isolate` to the element that wraps your app's
+  content — not to `<body>` or the portal container itself. Isolating the body
+  would put the portals inside the same stacking context and defeat the purpose.
+</Callout>
+
 ## Usage Example
 
 Here's a complete example of using Kumo components with Tailwind CSS:

--- a/packages/kumo-docs-astro/src/pages/installation.mdx
+++ b/packages/kumo-docs-astro/src/pages/installation.mdx
@@ -163,19 +163,13 @@ Or with Tailwind:
 </div>
 ```
 
-This creates a separate stacking context for your app's content, so portaled popups always appear on top regardless of the `z-index` values used inside your layout.
+This creates a separate stacking context for your app's content, so portaled popups always appear on top regardless of the `z-index` values used inside your layout. Apply it to the element that wraps your app's content, not to `<body>` — isolating the body would put the portals inside the same stacking context and defeat the purpose.
 
 <Callout type="info">
   If you find yourself reaching for `z-index` to get a Kumo popup to show above
   your own UI, that's a sign something is off. The fix is almost always
   isolating your app root as shown above, not raising the popup's `z-index` or
   targeting Base UI's internal data attributes.
-</Callout>
-
-<Callout type="warning">
-  **Important:** Apply `isolation: isolate` to the element that wraps your app's
-  content — not to `<body>` or the portal container itself. Isolating the body
-  would put the portals inside the same stacking context and defeat the purpose.
 </Callout>
 
 ## Usage Example


### PR DESCRIPTION
Follow-up to #759 (https://github.com/cloudflare/kumo/issues/759#issuecomment-5644092551).

Kumo's floating components (Select, Combobox, Dropdown, Popover, Tooltip, Dialog, …) portal to `document.body` without a `z-index`, so any positive `z-index` in consumer layout — a sticky header, for example — can paint above an open popup.

This adds an **"Isolate Your App Root"** section to the Installation page that:

- Explains why the problem occurs
- Shows the [Base UI recommended fix](https://base-ui.com/react/overview/quick-start#portals) (`isolation: isolate` on the app root) in both plain CSS and Tailwind (`isolate`) form
- Calls out that reaching for `z-index` to fix popup stacking is a sign something is off — isolate the root instead of raising the popup's `z-index` or targeting Base UI's internal data attributes
- Notes to apply it to the app wrapper, not `<body>`, since isolating the body defeats the purpose

Docs only, no code changes.

---

- Reviews
  - [ ] bonk has reviewed the change
  - [x] automated review not possible because: docs-only change to a single `.mdx` page, no code to review
- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: docs-only change, no runtime behavior affected